### PR TITLE
Nick binalization

### DIFF
--- a/sample/CStyleSamplesCS/Samples/BinarizationMethods.cs
+++ b/sample/CStyleSamplesCS/Samples/BinarizationMethods.cs
@@ -23,6 +23,7 @@ namespace CStyleSamplesCS
             using (var imgNiblack = new IplImage(imgSrc.Size, BitDepth.U8, 1))
             using (var imgSauvola = new IplImage(imgSrc.Size, BitDepth.U8, 1))
             using (var imgBernsen = new IplImage(imgSrc.Size, BitDepth.U8, 1))
+            using (var imgNick = new IplImage(imgSrc.Size, BitDepth.U8, 1))
             {
                 //Cv.Smooth(imgSrc, imgGauss, SmoothType.Gaussian, 9);
                 //Cv.EqualizeHist(imgGauss, imgGauss);
@@ -30,14 +31,14 @@ namespace CStyleSamplesCS
                 Stopwatch sw = Stopwatch.StartNew();
                 {
                     const int Size = 31;
-                    const double K = 0.2;
+                    const double K = -0.2;
                     Binarizer.NiblackFast(imgGauss, imgNiblack, Size, K);
                 }
                 Console.WriteLine("Niblack: {0}ms", sw.ElapsedMilliseconds);
                 sw.Reset(); sw.Start();
                 {
                     const int Size = 31;
-                    const double K = 0.9;
+                    const double K = 0.2;
                     const double R = 32;
                     Binarizer.SauvolaFast(imgGauss, imgSauvola, Size, K, R);
                 }
@@ -50,12 +51,20 @@ namespace CStyleSamplesCS
                     Binarizer.Bernsen(imgGauss, imgBernsen, Size, ContrastMin, BgThreshold);
                 }
                 Console.WriteLine("bernsen: {0}ms", sw.ElapsedMilliseconds);
+                sw.Reset(); sw.Start();
+                {
+                    const int Size = 31;
+                    const double K = -0.14;
+                    Binarizer.Nick(imgGauss, imgNick, Size, K);
+                }
+                Console.WriteLine("nick: {0}ms", sw.ElapsedMilliseconds);
 
                 using (new CvWindow("src", imgSrc))
                 //using (new CvWindow("gauss", imgGauss))
                 using (new CvWindow("niblack", imgNiblack))
                 using (new CvWindow("sauvola", imgSauvola))
                 using (new CvWindow("bernsen", imgBernsen))
+                using (new CvWindow("nick", imgNick))
                 {
                     Cv.WaitKey();
                 }

--- a/sample/CStyleSamplesCS/Samples/BinarizationMethods.cs
+++ b/sample/CStyleSamplesCS/Samples/BinarizationMethods.cs
@@ -18,6 +18,8 @@ namespace CStyleSamplesCS
     {
         public BinarizationMethods()
         {
+            const int Size = 61;
+
             using (var imgSrc = new IplImage(FilePath.Image.Binarization, LoadMode.GrayScale))
             using (var imgGauss = imgSrc.Clone())
             using (var imgNiblack = new IplImage(imgSrc.Size, BitDepth.U8, 1))
@@ -30,22 +32,19 @@ namespace CStyleSamplesCS
 
                 Stopwatch sw = Stopwatch.StartNew();
                 {
-                    const int Size = 31;
                     const double K = -0.2;
                     Binarizer.NiblackFast(imgGauss, imgNiblack, Size, K);
                 }
                 Console.WriteLine("Niblack: {0}ms", sw.ElapsedMilliseconds);
                 sw.Reset(); sw.Start();
                 {
-                    const int Size = 31;
                     const double K = 0.2;
-                    const double R = 32;
+                    const double R = 64;
                     Binarizer.SauvolaFast(imgGauss, imgSauvola, Size, K, R);
                 }
                 Console.WriteLine("Sauvola: {0}ms", sw.ElapsedMilliseconds); 
                 sw.Reset(); sw.Start();
                 {
-                    const int Size = 31;
                     const byte ContrastMin = 15;
                     const byte BgThreshold = 127;
                     Binarizer.Bernsen(imgGauss, imgBernsen, Size, ContrastMin, BgThreshold);
@@ -53,7 +52,6 @@ namespace CStyleSamplesCS
                 Console.WriteLine("bernsen: {0}ms", sw.ElapsedMilliseconds);
                 sw.Reset(); sw.Start();
                 {
-                    const int Size = 31;
                     const double K = -0.14;
                     Binarizer.Nick(imgGauss, imgNick, Size, K);
                 }


### PR DESCRIPTION
Niblack のノイズ耐性版である二値化の Nick を追加しました。
エッジをクリアに出すことができ、パラメーターは少なく扱いやすい特徴があります。

参考
「Comparison of Niblack inspired Binarization methods for ancient documents」
http://www.math-info.univ-paris5.fr/~vincent/articles/DRR_nick_binarization_09.pdf