### PR TITLE
Install libOpenCvSharpExtern.so for UNIX

### DIFF
--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -20,8 +20,10 @@ target_link_libraries(OpenCvSharpExtern PRIVATE ${OPENCV_A_FILES})
 target_link_libraries(OpenCvSharpExtern PRIVATE ${OPENCV_DYLIB_FILES})
 endif()
 
-#install(TARGETS OpenCvSharpExtern
+if(UNIX)
+install(TARGETS OpenCvSharpExtern
 #        RUNTIME DESTINATION bin
-#        LIBRARY DESTINATION lib
+        LIBRARY DESTINATION lib
 #        ARCHIVE DESTINATION lib/static
-#)
+)
+endif()


### PR DESCRIPTION
Please support `sudo make install` for UNIX.