### PR TITLE
FetNumberOfCpus() -> GetNumberOfCpus()

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -87,7 +87,7 @@ namespace OpenCvSharp
         /// 
         /// </summary>
         /// <returns></returns>
-        public static int FetNumberOfCpus()
+        public static int GetNumberOfCpus()
         {
             return NativeMethods.core_getNumberOfCPUs();
         }


### PR DESCRIPTION
いつも大変便利に使わせていただいております．

関数名がおかしかったので，報告しました．（単なるタイプミスだと思いますが）
修正箇所はタイトルの通りです．