### PR TITLE
#329: Mat.Diag(Mat) does not reutrn a square diagonal matrix

### DIFF
--- a/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
+++ b/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
@@ -103,6 +103,8 @@ namespace OpenCvSharp
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern IntPtr core_Mat_diag2(IntPtr self, int d);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern IntPtr core_Mat_diag3(IntPtr self);
+        [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern double core_Mat_dot(IntPtr self, IntPtr m);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ulong core_Mat_elemSize(IntPtr self);

--- a/src/OpenCvSharp/modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/modules/core/Mat/Mat.cs
@@ -655,7 +655,9 @@ namespace OpenCvSharp
         /// <returns></returns>
         public static Mat Diag(Mat d)
         {
-            return d.Diag();
+            IntPtr retPtr = NativeMethods.core_Mat_diag3(d.CvPtr);
+            Mat retVal = new Mat(retPtr);
+            return retVal;
         }
 
         #endregion

--- a/src/OpenCvSharpExtern/core_Mat.h
+++ b/src/OpenCvSharpExtern/core_Mat.h
@@ -221,6 +221,11 @@ CVAPI(cv::Mat*) core_Mat_diag2(cv::Mat *self, int d)
     cv::Mat ret = self->diag(d);
     return new cv::Mat(ret);
 }
+CVAPI(cv::Mat*) core_Mat_diag3(cv::Mat *self)
+{
+	cv::Mat ret = cv::Mat::diag(*self);
+	return new cv::Mat(ret);
+}
 
 CVAPI(double) core_Mat_dot(cv::Mat *self, cv::Mat *m)
 {


### PR DESCRIPTION
Add core_Mat_diag3 to call cv::Mat::diag(Mat&) and fix OpenCVSharp.Mat.Diag(Mat) bug