### PR TITLE
Cv2.RotatedRectangle(r1, r2, Point2f[] intersection) throws exception

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -3909,7 +3909,7 @@ namespace OpenCvSharp
         {
             using (var intersectingRegionVec = new VectorOfPoint2f())
             {
-                int ret = NativeMethods.imgproc_rotatedRectangleIntersection_OutputArray(
+                int ret = NativeMethods.imgproc_rotatedRectangleIntersection_vector(
                     rect1, rect2, intersectingRegionVec.CvPtr);
                 intersectingRegion = intersectingRegionVec.ToArray();
                 return (RectanglesIntersectTypes) ret;


### PR DESCRIPTION
Cv2.RotatedRectangle(r1, r2, Point2f[] calls wrong NativeMethod function, resulting in an exception. (reported as issue #411)