### PR TITLE
fix building with gcc 4.8, where c++11 is not default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(OpenCvSharpExtern)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 #set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # remove MinSizeRel & RelWithDebInfo


### PR DESCRIPTION
add -std=c++11 option