### PR TITLE
Fixed heap corruption due to using Mat and MatOfT.

### DIFF
--- a/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
@@ -449,14 +449,23 @@ namespace OpenCvSharp
             base.DisposeManaged();
         }
 
-        #endregion
+		/// <summary>
+		/// Releases unmanaged resources
+		/// </summary>
+		protected override void DisposeUnmanaged()
+		{
+			// Must override this and do nothing; and not call base.DisposeUnmanaged() because this class allows accessing data from an associated Mat. If not then when the sourceMat gets
+			// destroyed and this instance gets destroyed later, it will cause memory corruption as native delete is called twice.
+		}
 
-        #region Abstract Methods
-        /// <summary>
-        /// Gets type-specific indexer for accessing each element
-        /// </summary>
-        /// <returns></returns>
-        public abstract MatIndexer<TElem> GetIndexer();
+		#endregion
+
+		#region Abstract Methods
+		/// <summary>
+		/// Gets type-specific indexer for accessing each element
+		/// </summary>
+		/// <returns></returns>
+		public abstract MatIndexer<TElem> GetIndexer();
 
         /// <summary>
         /// Gets read-only enumerator


### PR DESCRIPTION
See https://github.com/shimat/opencvsharp/issues/471