### PR TITLE
Support netstandard2.0

### DIFF
--- a/nuget/OpenCvSharp3-AnyCPU.nuspec
+++ b/nuget/OpenCvSharp3-AnyCPU.nuspec
@@ -18,11 +18,8 @@
             <group targetFramework="net20" />
             <group targetFramework="net40" />
             <group targetFramework="net46" />
-            <group targetFramework="netstandard1.6">
-                <dependency id="NETStandard.Library" version="1.6.1" />
-            </group>
-            <group targetFramework="netcoreapp1.0">
-                <dependency id="NETStandard.Library" version="1.6.1" />
+            <group targetFramework="netstandard2.0">
+                <dependency id="System.Drawing.Common" version="4.5.0-preview2-26406-04" />
             </group>
         </dependencies>
         <frameworkAssemblies>
@@ -73,19 +70,12 @@
         <file src="..\src\OpenCvSharp.UserInterface\bin\Release\net46\OpenCvSharp.UserInterface.pdb" target="lib\net46" />
         <file src="..\src\OpenCvSharp.UserInterface\bin\Release\net46\OpenCvSharp.UserInterface.xml" target="lib\net46" />
 
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.dll" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.pdb" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.xml" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.dll" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.pdb" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.xml" target="lib\netstandard1.6" />
-
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.dll" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.pdb" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.xml" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.dll" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.pdb" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.xml" target="lib\netcoreapp1.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.pdb" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.xml" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.dll" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.pdb" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.xml" target="lib\netstandard2.0" />
 
         <file src="..\src\Release\x64\OpenCvSharpExtern.dll" target="NativeDlls\x64\OpenCvSharpExtern.dll" />
         <file src="..\opencv_files_341\x64\vc15\bin\opencv_ffmpeg341_64.dll" target="NativeDlls\x64\opencv_ffmpeg341_64.dll" />

--- a/nuget/OpenCvSharp3-WithoutDll.nuspec
+++ b/nuget/OpenCvSharp3-WithoutDll.nuspec
@@ -18,11 +18,8 @@
             <group targetFramework="net20" />
             <group targetFramework="net40" />
             <group targetFramework="net46" />
-            <group targetFramework="netstandard1.6">
-                <dependency id="NETStandard.Library" version="1.6.1" />
-            </group>
-            <group targetFramework="netcoreapp1.0">
-                <dependency id="NETStandard.Library" version="1.6.1" />
+            <group targetFramework="netstandard2.0">
+                <dependency id="System.Drawing.Common" version="4.5.0-preview2-26406-04" />
             </group>
         </dependencies>
         <frameworkAssemblies>
@@ -71,19 +68,12 @@
         <file src="..\src\OpenCvSharp.UserInterface\bin\Release\net46\OpenCvSharp.UserInterface.pdb" target="lib\net46" />
         <file src="..\src\OpenCvSharp.UserInterface\bin\Release\net46\OpenCvSharp.UserInterface.xml" target="lib\net46" />
 
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.dll" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.pdb" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.xml" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.dll" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.pdb" target="lib\netstandard1.6" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.xml" target="lib\netstandard1.6" />
-
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.dll" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.pdb" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp\bin\Release\netcoreapp1.0\OpenCvSharp.xml" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.dll" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.pdb" target="lib\netcoreapp1.0" />
-        <file src="..\src\OpenCvSharp.Blob\bin\Release\netcoreapp1.0\OpenCvSharp.Blob.xml" target="lib\netcoreapp1.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.pdb" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.xml" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.dll" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.pdb" target="lib\netstandard2.0" />
+        <file src="..\src\OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.xml" target="lib\netstandard2.0" />
 
         <!--<file src="tools\init.ps1" target="tools\init.ps1" />
         <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />-->

--- a/src/OpenCvSharp.Blob/CvContourPolygon.cs
+++ b/src/OpenCvSharp.Blob/CvContourPolygon.cs
@@ -356,15 +356,11 @@ namespace OpenCvSharp.Blob
         /// <param name="fileName">File name.</param>
         public void WriteAsCsv(string fileName)
         {
-#if uwp
-            throw new NotImplementedException();
-#else
             using (var stream = new FileStream(fileName, FileMode.Create))
             using (var writer = new StreamWriter(stream))
             {
                 writer.Write(ToString());
             }
-#endif
         }
 
 #endregion
@@ -388,15 +384,11 @@ namespace OpenCvSharp.Blob
         /// <param name="fill">Fill color</param>
         public void WriteAsSvg(string fileName, Scalar stroke, Scalar fill)
         {
-#if uwp
-            throw new NotImplementedException();
-#else
             using (var stream = new FileStream(fileName, FileMode.Create))
             using (var writer = new StreamWriter(stream))
             {
                 writer.WriteLine(ToSvg(stroke, fill));
             }
-#endif
         }
 
         /// <summary>

--- a/src/OpenCvSharp.Blob/OpenCvSharp.Blob.csproj
+++ b/src/OpenCvSharp.Blob/OpenCvSharp.Blob.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netcoreapp1.0;net20;net40;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20;net40;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenCvSharp.Blob</AssemblyName>
@@ -9,8 +9,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>OpenCvSharp.Blob</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.5</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -29,25 +27,25 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);netcoreapp10</DefineConstants>
-  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net20' ">
     <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net20</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);net40</DefineConstants>
+    <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net40</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);net46</DefineConstants>
+    <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net46</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);netstandard20</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/OpenCvSharp.Extensions/BitmapSourceConverter.cs
+++ b/src/OpenCvSharp.Extensions/BitmapSourceConverter.cs
@@ -1,5 +1,5 @@
 ﻿#if !netstandard20
-    using System;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;

--- a/src/OpenCvSharp.Extensions/BitmapSourceConverter.cs
+++ b/src/OpenCvSharp.Extensions/BitmapSourceConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !netstandard20
+    using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -323,3 +324,4 @@ namespace OpenCvSharp.Extensions
         #endregion
     }
 }
+#endif

--- a/src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj
+++ b/src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net46</TargetFrameworks>
+    <TargetFrameworks>net40;net46;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenCvSharp.Extensions</AssemblyName>
@@ -37,6 +37,10 @@
     <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net46</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);netstandard20</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -47,6 +51,12 @@
     <Reference Include="WindowsBase" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.5.0-preview2-26406-04</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/OpenCvSharp.Extensions/WriteableBitmapConverter.cs
+++ b/src/OpenCvSharp.Extensions/WriteableBitmapConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !netstandard20
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Media;
@@ -369,3 +370,4 @@ namespace OpenCvSharp.Extensions
         #endregion
     }
 }
+#endif

--- a/src/OpenCvSharp.ReleaseMaker/MainForm.cs
+++ b/src/OpenCvSharp.ReleaseMaker/MainForm.cs
@@ -12,8 +12,6 @@ namespace OpenCvSharp.ReleaseMaker
     /// </summary>
     public partial class MainForm : Form
     {
-        private const string VisualStudioVersion = "2017";
-
         private static readonly IReadOnlyDictionary<string, string[]> dllFiles = new Dictionary<string, string[]>
         {
             {
@@ -47,6 +45,7 @@ namespace OpenCvSharp.ReleaseMaker
                     @"OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll",
                     @"OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll.config",
                     @"OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.dll",
+                    @"OpenCvSharp.Extensions\bin\Release\netstandard2.0\OpenCvSharp.Extensions.dll",
                 }
             }
         };

--- a/src/OpenCvSharp.ReleaseMaker/MainForm.cs
+++ b/src/OpenCvSharp.ReleaseMaker/MainForm.cs
@@ -12,7 +12,7 @@ namespace OpenCvSharp.ReleaseMaker
     /// </summary>
     public partial class MainForm : Form
     {
-        private const string VisualStudioVersion = "2015";
+        private const string VisualStudioVersion = "2017";
 
         private static readonly IReadOnlyDictionary<string, string[]> dllFiles = new Dictionary<string, string[]>
         {
@@ -42,11 +42,11 @@ namespace OpenCvSharp.ReleaseMaker
                     @"OpenCvSharp.UserInterface\bin\Release\net46\OpenCvSharp.UserInterface.dll",
                 }
             },{
-                "netstandard1.6", new[]
+                "netstandard2.0", new[]
                 {
-                    @"OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.dll",
-                    @"OpenCvSharp\bin\Release\netstandard1.6\OpenCvSharp.dll.config",
-                    @"OpenCvSharp.Blob\bin\Release\netstandard1.6\OpenCvSharp.Blob.dll",
+                    @"OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll",
+                    @"OpenCvSharp\bin\Release\netstandard2.0\OpenCvSharp.dll.config",
+                    @"OpenCvSharp.Blob\bin\Release\netstandard2.0\OpenCvSharp.Blob.dll",
                 }
             }
         };

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -249,10 +249,8 @@ namespace OpenCvSharp
         {
             if (fileName == null)
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("", fileName);
-#endif
 
             var buf = new StringBuilder(1 << 16);
             NativeMethods.core_FileStorage_getDefaultObjectName(fileName, buf, buf.Capacity);

--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -285,7 +285,7 @@ namespace OpenCvSharp
                 throw new ArgumentException();
 
             // Primitive types
-#if netcore50 || uap10 || uwp
+#if false
             if (t == typeof(byte))
                 return MatType.CV_8UC1;
             if (t == typeof(sbyte))
@@ -301,7 +301,7 @@ namespace OpenCvSharp
             if (t == typeof(double))
                 return MatType.CV_64FC1;
 #else
-            TypeCode code = System.Type.GetTypeCode(t);
+            var code = System.Type.GetTypeCode(t);
             switch (code)
             {
                 case TypeCode.Byte:

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -64,10 +64,10 @@ namespace OpenCvSharp
         {
             if (string.IsNullOrEmpty(fileName))
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
+
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("", fileName);
-#endif
+
             ptr = NativeMethods.imgcodecs_imread(fileName, (int) flags);
         }
 

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace OpenCvSharp.Face
 {
@@ -189,7 +190,11 @@ namespace OpenCvSharp.Face
             /// <summary>
             /// 
             /// </summary>
+#if net20 || net40
             public float[] Scales
+#else
+            public IReadOnlyList<float> Scales
+#endif
             {
                 get
                 {

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace OpenCvSharp.Face
 {
@@ -303,7 +304,11 @@ namespace OpenCvSharp.Face
             /// <summary>
             /// 
             /// </summary>
+#if net20 || net40
             public int[] FeatsM
+#else
+            public IReadOnlyList<int> FeatsM
+#endif
             {
                 get
                 {
@@ -327,7 +332,11 @@ namespace OpenCvSharp.Face
             /// <summary>
             /// 
             /// </summary>
+#if net20 || net40
             public double[] RadiusM
+#else
+            public IReadOnlyList<double> RadiusM
+#endif
             {
                 get
                 {
@@ -351,7 +360,11 @@ namespace OpenCvSharp.Face
             /// <summary>
             /// index of facemark points on pupils of left and right eye
             /// </summary>
+#if net20 || net40
             public int[] Pupils0
+#else
+            public IReadOnlyList<int> Pupils0
+#endif
             {
                 get
                 {
@@ -375,7 +388,11 @@ namespace OpenCvSharp.Face
             /// <summary>
             /// index of facemark points on pupils of left and right eye
             /// </summary>
+#if net20 || net40
             public int[] Pupils1
+#else
+            public IReadOnlyList<int> Pupils1
+#endif
             {
                 get
                 {

--- a/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
+++ b/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
@@ -29,10 +29,9 @@ namespace OpenCvSharp
         {
             if (String.IsNullOrEmpty(fileName))
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("\""+ fileName + "\"not found", fileName);
-#endif
+
             ptr = NativeMethods.objdetect_CascadeClassifier_newFromFile(fileName);
         }
 
@@ -73,10 +72,9 @@ namespace OpenCvSharp
             ThrowIfDisposed();
             if (String.IsNullOrEmpty(fileName))
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("\"" + fileName + "\"not found", fileName);
-#endif
+
             var res = NativeMethods.objdetect_CascadeClassifier_load(ptr, fileName) != 0;
             GC.KeepAlive(this);
             return res;

--- a/src/OpenCvSharp/Modules/superres/FrameSource.cs
+++ b/src/OpenCvSharp/Modules/superres/FrameSource.cs
@@ -36,10 +36,9 @@ namespace OpenCvSharp
         {
             if (String.IsNullOrEmpty("fileName"))
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("", fileName);
-#endif
+
             IntPtr ptr = NativeMethods.superres_createFrameSource_Video(fileName);
             return FrameSourceImpl.FromPtr(ptr);
         }
@@ -53,10 +52,9 @@ namespace OpenCvSharp
         {
             if (String.IsNullOrEmpty("fileName"))
                 throw new ArgumentNullException(nameof(fileName));
-#if !uwp
             if (!File.Exists(fileName))
                 throw new FileNotFoundException("", fileName);
-#endif
+
             IntPtr ptr = NativeMethods.superres_createFrameSource_Video_CUDA(fileName);
             return FrameSourceImpl.FromPtr(ptr);
         }

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--
-    <TargetFrameworks>netstandard1.6;netcoreapp1.0;net20;net40;net46</TargetFrameworks>
-    -->
     <TargetFrameworks>netstandard2.0;net20;net40;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--
     <TargetFrameworks>netstandard1.6;netcoreapp1.0;net20;net40;net46</TargetFrameworks>
+    -->
+    <TargetFrameworks>netstandard2.0;net20;net40;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenCvSharp</AssemblyName>
@@ -9,10 +12,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>OpenCvSharp</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.6.1</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.5</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -39,9 +38,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);netcoreapp10</DefineConstants>
-  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.Security" />
+    <Reference Include="System.Web" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net20' ">
     <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net20</DefineConstants>
@@ -55,15 +57,12 @@
     <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net46</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);netstandard20</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release-JP' ">
     <DefineConstants>$(DefineConstants);LANG_JP</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Security" />
-    <Reference Include="System.Web" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
 </Project>

--- a/src/OpenCvSharp/PInvoke/NativeMethods.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods.cs
@@ -91,7 +91,7 @@ namespace OpenCvSharp
             IntPtr current = redirectError(ErrorHandlerThrowException, zero, ref zero);
             if (current != IntPtr.Zero)
             {
-#if net20 || net40 || uwp
+#if net20 || net40
                 ErrorHandlerDefault = (CvErrorCallback)Marshal.GetDelegateForFunctionPointer(
                     current, typeof(CvErrorCallback));
 #else
@@ -120,10 +120,8 @@ namespace OpenCvSharp
             catch (DllNotFoundException e)
             {
                 var exception = PInvokeHelper.CreateException(e);
-#if !uwp && !uap10
                 try{Console.WriteLine(exception.Message);}
                 catch{}
-#endif
                 try{Debug.WriteLine(exception.Message);}
                 catch{}
                 throw exception;
@@ -131,10 +129,8 @@ namespace OpenCvSharp
             catch (BadImageFormatException e)
             {
                 var exception = PInvokeHelper.CreateException(e);
-#if !uwp && !uap10
                 try { Console.WriteLine(exception.Message); }
                 catch { }
-#endif
                 try { Debug.WriteLine(exception.Message); }
                 catch { }
                 throw exception;
@@ -142,10 +138,8 @@ namespace OpenCvSharp
             catch (Exception e)
             {
                 Exception ex = e.InnerException ?? e;
-#if !uwp && !uap10
                 try{ Console.WriteLine(ex.Message); }
                 catch{}
-#endif
                 try { Debug.WriteLine(ex.Message); }
                 catch{}
                 throw;

--- a/src/OpenCvSharp/PInvoke/WindowsLibraryLoader.cs
+++ b/src/OpenCvSharp/PInvoke/WindowsLibraryLoader.cs
@@ -138,7 +138,6 @@ namespace OpenCvSharp
                     }
 
                     // Try loading from executing assembly domain
-#if !netcore50 && !uap10 && !uwp
 #if DOTNET_FRAMEWORK
                     Assembly executingAssembly = Assembly.GetExecutingAssembly();
 #else
@@ -147,7 +146,6 @@ namespace OpenCvSharp
                     baseDirectory = Path.GetDirectoryName(executingAssembly.Location);
                     dllHandle = LoadLibraryInternal(dllName, baseDirectory, processArch);
                     if (dllHandle != IntPtr.Zero) return;
-#endif
 
                     // Fallback to current app domain
                     // TODO
@@ -159,18 +157,14 @@ namespace OpenCvSharp
 
                     // Gets the pathname of the base directory that the assembly resolver uses to probe for assemblies.
                     // https://github.com/dotnet/corefx/issues/2221
-#if !net20 && !net40 && !uwp
+#if !net20 && !net40
                     baseDirectory = AppContext.BaseDirectory;
                     dllHandle = LoadLibraryInternal(dllName, baseDirectory, processArch);
                     if (dllHandle != IntPtr.Zero) return;
 #endif
 
-#if uwp
-                    baseDirectory = "";
-#else
                     // Finally try the working directory
                     baseDirectory = Path.GetFullPath(System.IO.Directory.GetCurrentDirectory());
-#endif
                     dllHandle = LoadLibraryInternal(dllName, baseDirectory, processArch);
                     if (dllHandle != IntPtr.Zero) return;
 
@@ -209,11 +203,8 @@ namespace OpenCvSharp
         private ProcessArchitectureInfo GetProcessArchitecture()
         {
             // BUGBUG: Will this always be reliable?
-#if uwp
-            string processArchitecture = "";
-#else
             string processArchitecture = Environment.GetEnvironmentVariable(ProcessorArchitecture);
-#endif
+
             var processInfo = new ProcessArchitectureInfo();
             if (!String.IsNullOrEmpty(processArchitecture))
             {
@@ -266,12 +257,7 @@ namespace OpenCvSharp
             // Show where we're trying to load the file from
             Debug.WriteLine(String.Format("Trying to load native library \"{0}\"...", fileName));
 
-#if uwp || uap10
-#pragma warning disable 0162
-            if (true) // TODO
-#else
             if (File.Exists(fileName))
-#endif
             {
                 // Attempt to load dll
                 try

--- a/src/OpenCvSharp/Util/DynamicInvoker.cs
+++ b/src/OpenCvSharp/Util/DynamicInvoker.cs
@@ -115,7 +115,7 @@ namespace OpenCvSharp.Util
             FunctionName = functionName;
             IsDisposed = false;
 
-#if net20 || net40 || uwp
+#if net20 || net40
             Call = (T)(object)Marshal.GetDelegateForFunctionPointer(PtrProc, typeof(T));
 #else
             Call = Marshal.GetDelegateForFunctionPointer<T>(PtrProc);

--- a/src/OpenCvSharp/Util/MarshalHelper.cs
+++ b/src/OpenCvSharp/Util/MarshalHelper.cs
@@ -19,30 +19,20 @@ namespace OpenCvSharp.Util
             {
                 return Marshal.SizeOf(typeof(T));
             }
-            else
-            {
-                return IntPtr.Size;
-            }
+            return IntPtr.Size;
 #else
             if (typeof(T).GetTypeInfo().IsValueType)
             {
-#if uwp
-                return Marshal.SizeOf(typeof(T));
-#else
                 return Marshal.SizeOf<T>();
+            }
+            return IntPtr.Size;
 #endif
-            }
-            else
-            {
-                return IntPtr.Size;
-            }
-#endif
-            }
+        }
 
         public static T PtrToStructure<T>(IntPtr p)
             where T : struct 
         {
-#if net20 || net40 || uwp
+#if net20 || net40
             return (T)Marshal.PtrToStructure(p, typeof(T));
 #else
             return Marshal.PtrToStructure<T>(p);

--- a/src/OpenCvSharp/Util/MemoryHelper.cs
+++ b/src/OpenCvSharp/Util/MemoryHelper.cs
@@ -33,7 +33,7 @@ namespace OpenCvSharp.Util
 #endif
         public static unsafe void CopyMemory(void* outDest, void* inSrc, uint inNumOfBytes)
         {
-#if net20 || net40 || uwp
+#if net20 || net40
             // 転送先をuint幅にalignする
             const uint align = sizeof(uint) - 1;
             uint offset = (uint)outDest & align;
@@ -65,21 +65,33 @@ namespace OpenCvSharp.Util
         }
         public static unsafe void CopyMemory(void* outDest, void* inSrc, int inNumOfBytes)
         {
+#if net20 || net40
             CopyMemory(outDest, inSrc, (uint)inNumOfBytes);
+#else
+            Buffer.MemoryCopy(inSrc, outDest, inNumOfBytes, inNumOfBytes);
+#endif
         }
         public static unsafe void CopyMemory(IntPtr outDest, IntPtr inSrc, uint inNumOfBytes)
         {
+#if net20 || net40
             CopyMemory(outDest.ToPointer(), inSrc.ToPointer(), inNumOfBytes);
+#else
+            Buffer.MemoryCopy(inSrc.ToPointer(), outDest.ToPointer(), inNumOfBytes, inNumOfBytes);
+#endif
         }
         public static unsafe void CopyMemory(IntPtr outDest, IntPtr inSrc, int inNumOfBytes)
         {
+#if net20 || net40
             CopyMemory(outDest.ToPointer(), inSrc.ToPointer(), (uint)inNumOfBytes);
+#else
+            Buffer.MemoryCopy(inSrc.ToPointer(), outDest.ToPointer(), inNumOfBytes, inNumOfBytes);
+#endif
         }
         //[DllImport("kernel32")]
         //public static unsafe extern void CopyMemory(void* outDest, void* inSrc, [MarshalAs(UnmanagedType.U4)] int inNumOfBytes);
         //[DllImport("kernel32")]
         //public static extern void CopyMemory(IntPtr outDest, IntPtr inSrc, [MarshalAs(UnmanagedType.U4)] int inNumOfBytes);
-#endregion
+        #endregion
 
         #region ZeroMemory
 #if LANG_JP

--- a/src/OpenCvSharp/Util/StringArrayAddress.cs
+++ b/src/OpenCvSharp/Util/StringArrayAddress.cs
@@ -4,35 +4,24 @@ using System.Text;
 
 namespace OpenCvSharp.Util
 {
+    /// <inheritdoc />
     /// <summary>
     /// Class to get address of string array
     /// </summary>
     public class StringArrayAddress : ArrayAddress2<byte>
     {
+        /// <inheritdoc />
         /// <summary>
-        /// 
         /// </summary>
-        /// <param name="stringArray"></param>
-        public StringArrayAddress(string[] stringArray)
+        /// <param name="stringEnumerable"></param>
+        public StringArrayAddress(IEnumerable<string> stringEnumerable)
         {
             var byteList = new List<byte[]>();
-            for (int i = 0; i < stringArray.Length; i++)
+            foreach (var s in stringEnumerable)
             {
-#if uwp
-                byteList.Add(Encoding.UTF8.GetBytes(stringArray[i])); // TODO
-#else
-                byteList.Add(Encoding.ASCII.GetBytes(stringArray[i]));
-#endif
+                byteList.Add(Encoding.ASCII.GetBytes(s));
             }
             Initialize(byteList.ToArray());
-        }
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="enumerable"></param>
-        public StringArrayAddress(IEnumerable<string> enumerable)
-            : this(EnumerableEx.ToArray(enumerable))
-        {
         }
     }
 }

--- a/src/OpenCvSharp/Util/TypeHelper.cs
+++ b/src/OpenCvSharp/Util/TypeHelper.cs
@@ -36,7 +36,7 @@ namespace OpenCvSharp.Util
                 return (T) (object) ptr;
             }
 
-#if net20 || net40 || uwp
+#if net20 || net40
             return (T)Marshal.PtrToStructure(ptr, typeof(T));
 #else
             return Marshal.PtrToStructure<T>(ptr);

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -30,7 +30,7 @@ CVAPI(uchar*) vector_uchar_getPointer(vector<uchar>* vector)
 }
 CVAPI(void) vector_vector_uchar_copy(vector<uchar> *vector, uchar *dst)
 {
-    size_t length = sizeof(uchar)* vector->size();
+    const size_t length = sizeof(uchar)* vector->size();
     memcpy(dst, &(vector->at(0)), length);
 }
 CVAPI(void) vector_uchar_delete(vector<uchar>* vector)
@@ -62,7 +62,7 @@ CVAPI(char*) vector_char_getPointer(vector<char>* vector)
 }
 CVAPI(void) vector_vector_char_copy(vector<char> *vector, char *dst)
 {
-    size_t length = sizeof(char)* vector->size();
+    const size_t length = sizeof(char)* vector->size();
     memcpy(dst, &(vector->at(0)), length);
 }
 CVAPI(void) vector_char_delete(vector<char>* vector)
@@ -640,7 +640,7 @@ CVAPI(void) vector_vector_KeyPoint_copy(vector<vector<cv::KeyPoint> > *vec, cv::
     {
         vector<cv::KeyPoint> &elem = vec->at(i);
         void *src = &elem[0];
-        size_t length = sizeof(cv::KeyPoint) * elem.size();
+        const size_t length = sizeof(cv::KeyPoint) * elem.size();
         memcpy(dst[i], src, length);
     }
 }
@@ -720,7 +720,7 @@ CVAPI(void) vector_vector_Point_copy(vector<vector<cv::Point> > *vec, cv::Point 
     {
         vector<cv::Point> &elem = vec->at(i);
         void *src = &elem[0];
-        size_t length = sizeof(cv::Point) * elem.size();
+        const size_t length = sizeof(cv::Point) * elem.size();
         memcpy(dst[i], src, length);
     }
 }
@@ -760,7 +760,7 @@ CVAPI(void) vector_vector_Point2f_copy(vector<vector<cv::Point2f> > *vec, cv::Po
     {
         vector<cv::Point2f> &elem = vec->at(i);
         void *src = &elem[0];
-        size_t length = sizeof(cv::Point2f) * elem.size();
+        const size_t length = sizeof(cv::Point2f) * elem.size();
         memcpy(dst[i], src, length);
     }
 }

--- a/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
+++ b/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>OpenCvSharp.Tests</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>OpenCvSharp.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeIdentifiers>win10-x64;win7-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.6.1</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.5</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -27,10 +24,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenCvSharp\OpenCvSharp.csproj" />
     <ProjectReference Include="..\..\src\OpenCvSharp.Blob\OpenCvSharp.Blob.csproj" />
+    <ProjectReference Include="..\..\src\OpenCvSharp.Extensions\OpenCvSharp.Extensions.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <ProjectReference Include="..\..\src\OpenCvSharp.Extensions\OpenCvSharp.Extensions.csproj" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
@@ -50,6 +47,10 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);DOTNET_FRAMEWORK;net46</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp20' ">
+    <DefineConstants>$(DefineConstants);netcoreapp20</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/test/OpenCvSharp.Tests/extensions/BitmapConverterTest.cs
+++ b/test/OpenCvSharp.Tests/extensions/BitmapConverterTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using OpenCvSharp.Extensions;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Extensions
+{
+    public class BitmapConverterTest : TestBase
+    {
+        [Fact]
+        public void BitmapSource8Bit()
+        {
+            Scalar blueColor8 = new Scalar(200, 0, 0);
+            Scalar greenColor8 = new Scalar(0, 200, 0);
+            Scalar redColor8 = new Scalar(0, 0, 200);
+
+            using (var mat = new Mat(1, 1, MatType.CV_8UC3, blueColor8))
+            {
+                var bitmap = BitmapConverter.ToBitmap(mat);
+                AssertPixelValue8bpp(blueColor8, bitmap);
+            }
+            using (var mat = new Mat(1, 1, MatType.CV_8UC3, greenColor8))
+            {
+                var bitmap = BitmapConverter.ToBitmap(mat);
+                AssertPixelValue8bpp(greenColor8, bitmap);
+            }
+            using (var mat = new Mat(1, 1, MatType.CV_8UC3, redColor8))
+            {
+                var bitmap = BitmapConverter.ToBitmap(mat);
+                AssertPixelValue8bpp(redColor8, bitmap);
+            }
+        }
+
+        private void AssertPixelValue8bpp(Scalar expectedValue, Bitmap bitmap)
+        {
+            if (bitmap.Width != 1 || bitmap.Height != 1)
+                throw new Exception("1x1 image only");
+
+            var pixels = new byte[3];
+            var bitmapData = bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+            Marshal.Copy(bitmapData.Scan0, pixels, 0, 3);
+            bitmap.UnlockBits(bitmapData);
+
+            Console.WriteLine("Expected: ({0},{1},{2})", expectedValue.Val0, expectedValue.Val1, expectedValue.Val2);
+            Console.WriteLine("Actual: ({0},{1},{2})", pixels[0], pixels[1], pixels[2]);
+            Assert.Equal(expectedValue.Val0, Convert.ToDouble(pixels[0]), 9);
+            Assert.Equal(expectedValue.Val1, Convert.ToDouble(pixels[1]), 9);
+            Assert.Equal(expectedValue.Val2, Convert.ToDouble(pixels[2]), 9);
+        }
+    }
+}


### PR DESCRIPTION
- Remove `netstandard1.6` and `netcoreapp1.0` support
- OpenCvSharp.Extensions is available on netstandard2.0
  - Close #392
