### PR TITLE
Added wrappers for cv::createStitcherScans method

### DIFF
--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -100,6 +100,18 @@ namespace OpenCvSharp
             return new Stitcher(p);
         }
 
+
+        /// <summary>
+        /// Creates a stitcher with the default parameters with scan mode
+        /// </summary>
+        /// <param name="tryUseGpu">Flag indicating whether GPU should be used 
+        /// whenever it's possible.</param>
+        public static Stitcher CreateScans(bool tryUseGpu = false)
+        {
+            IntPtr p = NativeMethods.stitching_createStitcherScans(tryUseGpu ? 1 : 0);
+            return new Stitcher(p);
+        }
+
         /// <summary>
         /// Releases managed resources
         /// </summary>

--- a/src/OpenCvSharp/PInvoke/NativeMethods_stitching.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods_stitching.cs
@@ -11,6 +11,9 @@ namespace OpenCvSharp
         public static extern IntPtr stitching_createStitcher(int try_use_cpu);
 
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern IntPtr stitching_createStitcherScans(int try_use_cpu);
+
+        [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void stitching_Ptr_Stitcher_delete(IntPtr obj);
 
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/src/OpenCvSharpExtern/stitching.h
+++ b/src/OpenCvSharpExtern/stitching.h
@@ -9,6 +9,12 @@ CVAPI(cv::Ptr<cv::Stitcher>*) stitching_createStitcher(const int try_use_gpu)
     return new cv::Ptr<cv::Stitcher>(ptr);
 }
 
+CVAPI(cv::Ptr<cv::Stitcher>*) stitching_createStitcherScans(const int try_use_gpu)
+{
+    cv::Ptr<cv::Stitcher> ptr = cv::createStitcherScans(try_use_gpu != 0);
+    return new cv::Ptr<cv::Stitcher>(ptr);
+}
+
 CVAPI(void) stitching_Ptr_Stitcher_delete(cv::Ptr<cv::Stitcher> *obj)
 {
     delete obj;

--- a/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
@@ -31,6 +31,28 @@ namespace OpenCvSharp.Tests.Stitching
             }
         }
 
+        [Fact]
+        public void StitchingScanImagesCorrect()
+        {
+            Mat[] images = SelectStitchingImages(200, 200, 12);
+
+            using (var stitcher = Stitcher.CreateScans(false))
+            using (var pano = new Mat())
+            {
+                Console.Write("Stitching for scan images start...");
+                var status = stitcher.Stitch(images, pano);
+                Console.WriteLine(" finish (status:{0})", status);
+                Assert.Equal(Stitcher.Status.OK, status);
+
+                ShowImagesWhenDebugMode(pano);
+            }
+
+            foreach (Mat image in images)
+            {
+                image.Dispose();
+            }
+        }
+
         private Mat[] SelectStitchingImages(int width, int height, int count)
         {
             var mats = new List<Mat>();


### PR DESCRIPTION
Wrappers for cv::createStitcherScans is missing from the implementation, in our use case, using createStitcherScans pipeline saved 50% of processing time and also produced the correct result, so I would like to submit a PR to add the wrappers of stitching pipeline for scan images.