### PR TITLE
fix TrackerKCF.Update crash

### DIFF
--- a/src/OpenCvSharp/Modules/tracking/TrackerKCF.cs
+++ b/src/OpenCvSharp/Modules/tracking/TrackerKCF.cs
@@ -119,25 +119,25 @@ namespace OpenCvSharp.Tracking
             /// <summary>
             /// activate the resize feature to improve the processing speed
             /// </summary>
-            [MarshalAs(UnmanagedType.Bool)]
+            [MarshalAs(UnmanagedType.U1)]
             public bool Resize;
 
             /// <summary>
             /// split the training coefficients into two matrices
             /// </summary>
-            [MarshalAs(UnmanagedType.Bool)]
+            [MarshalAs(UnmanagedType.U1)]
             public bool SplitCoeff;
 
             /// <summary>
             /// wrap around the kernel values
             /// </summary>
-            [MarshalAs(UnmanagedType.Bool)]
+            [MarshalAs(UnmanagedType.U1)]
             public bool WrapKernel;
 
             /// <summary>
             /// activate the pca method to compress the features
             /// </summary>
-            [MarshalAs(UnmanagedType.Bool)]
+            [MarshalAs(UnmanagedType.U1)]
             public bool CompressFeature;
 
             /// <summary>


### PR DESCRIPTION
Related to https://github.com/shimat/opencvsharp/issues/459 but another problem, I caught OpenCvSharp.OpenCVException from ` OpenCvSharp.Tracking.Tracker.Update` method with TrackerKCF that was created with custom tracker parameter.

```
OpenCvSharp.OpenCVException: type == (((6) & ((1 << 3) - 1)) + (((2)-1) << 3))
 OpenCvSharp.NativeMethods.<>c.<.cctor>b__1581_0(ErrorCode status, String funcName, String errMsg, String fileName, Int32 line, IntPtr userdata)
 OpenCvSharp.NativeMethods.tracking_Tracker_update(IntPtr obj, IntPtr image, Rect2d& boundingBox)
 OpenCvSharp.Tracking.Tracker.Update(Mat image, Rect2d& boundingBox)
```

It was not happened on openCVSharp 3.3.1.20171117 but after upgrade to 3.4.1.20180319, that method always throw exceptions.

After several investigations, I found that TrackerKCF.Params struct has mismatched layout.
Layout attribute ` [MarshalAs(UnmanagedType.Bool)]` means marshal as `BOOL`, which is actually `int` in Win32, but the corresponding struct field in OpenCV was `bool`.
So let's use `UnmanagedType.U1`.