### PR TITLE
- Wraped GetDelegateForFunctionPointer into a try catch block

### DIFF
--- a/src/OpenCvSharp/PInvoke/NativeMethods.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods.cs
@@ -106,14 +106,18 @@ namespace OpenCvSharp
             {
 #if net20 || net40
                 ErrorHandlerDefault = (CvErrorCallback)Marshal.GetDelegateForFunctionPointer(
-                    current, typeof(CvErrorCallback));
+                    currentHandler, typeof(CvErrorCallback));
 #else
                 ErrorHandlerDefault = Marshal.GetDelegateForFunctionPointer<CvErrorCallback>(currentHandler);
 #endif
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                ErrorHandlerDefault = null;
+                ErrorHandlerDefault = null;             
+                try { Console.WriteLine(e.Message); }
+                catch { }
+                try { Debug.WriteLine(e.Message); }
+                catch { }                
             }
         }
 

--- a/src/OpenCvSharp/PInvoke/NativeMethods.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods.cs
@@ -111,7 +111,7 @@ namespace OpenCvSharp
                 ErrorHandlerDefault = Marshal.GetDelegateForFunctionPointer<CvErrorCallback>(currentHandler);
 #endif
             }
-            catch (Exception e)
+            catch (NotSupportedException e)
             {
                 ErrorHandlerDefault = null;             
                 try { Console.WriteLine(e.Message); }

--- a/src/OpenCvSharp/PInvoke/NativeMethods.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods.cs
@@ -91,18 +91,32 @@ namespace OpenCvSharp
             IntPtr current = redirectError(ErrorHandlerThrowException, zero, ref zero);
             if (current != IntPtr.Zero)
             {
-#if net20 || net40
-                ErrorHandlerDefault = (CvErrorCallback)Marshal.GetDelegateForFunctionPointer(
-                    current, typeof(CvErrorCallback));
-#else
-                ErrorHandlerDefault = Marshal.GetDelegateForFunctionPointer<CvErrorCallback>(current);
-#endif
+                SetDefaultHandler(current);
             }
             else
             {
                 ErrorHandlerDefault = null;
             }
         }
+
+
+        private static void SetDefaultHandler(IntPtr currentHandler)
+        {
+            try
+            {
+#if net20 || net40
+                ErrorHandlerDefault = (CvErrorCallback)Marshal.GetDelegateForFunctionPointer(
+                    current, typeof(CvErrorCallback));
+#else
+                ErrorHandlerDefault = Marshal.GetDelegateForFunctionPointer<CvErrorCallback>(currentHandler);
+#endif
+            }
+            catch (Exception)
+            {
+                ErrorHandlerDefault = null;
+            }
+        }
+
 
         /// <summary>
         /// Checks whether PInvoke functions can be called


### PR DESCRIPTION
If you have OpenCVSharp running in two or more AppDomains "redirectError" will return the pointer from the ErrorHandler of the first AppDomain, which registered its error handler, as "current". 
If "Marshal.GetDelegateForFunctionPointer" then is called on an error handler from a different AppDomain it will throw an exception!
This exception should at least be caught, because it is otherwise not possible to use OpenCVShar within different AppDomains.
