### PR TITLE
Fix loss of precision in OpenCvSharp.Size2d constructor

### DIFF
--- a/src/OpenCvSharp/Modules/core/Struct/Size2d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Size2d.cs
@@ -38,8 +38,8 @@ namespace OpenCvSharp
         /// <param name="height"></param>
         public Size2d(double width, double height)
         {
-            Width = (int) width;
-            Height = (int) height;
+            Width = width;
+            Height = height;
         }
 
         #region Operators


### PR DESCRIPTION
The `OpenCvSharp.Size2d` constructor that takes two `double` arguments casts the arguments to `int` before setting its fields. This pull request aims to fix this.