### PR TITLE
- OpenCVException is now serializeable, to be able to send it to differ…

### DIFF
--- a/src/OpenCvSharp/Fundamentals/OpenCVException.cs
+++ b/src/OpenCvSharp/Fundamentals/OpenCVException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace OpenCvSharp
 {
@@ -11,6 +12,7 @@ namespace OpenCvSharp
     /// The default exception to be thrown by OpenCV 
     /// </summary>
 #endif
+    [Serializable]
     public class OpenCVException : Exception
     {
         #region Properties
@@ -93,6 +95,27 @@ namespace OpenCvSharp
             ErrMsg = errMsg;
             FileName = fileName;
             Line = line;
+        }
+
+
+        protected OpenCVException(System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+            Status = (ErrorCode)info.GetInt32(nameof(Status));
+            FuncName = info.GetString(nameof(FuncName));
+            FileName = info.GetString(nameof(FileName));
+            ErrMsg = info.GetString(nameof(ErrMsg));
+            Line = info.GetInt32(nameof(Line));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Status), Status);
+            info.AddValue(nameof(FuncName), FuncName);
+            info.AddValue(nameof(FileName), FileName);
+            info.AddValue(nameof(ErrMsg), ErrMsg);
+            info.AddValue(nameof(Line), Line);
         }
     }
 }


### PR DESCRIPTION
One more change related to AppDomains..
The callback of "redirectError" can only be hooked to one AppDomain. Therefore if an exception occurs in a different AppDomain the Framework will try to serialize the exception between the AppDomains.
If "OpenCVException" is serializable, all exceptions ( thrown by the default "ErrorHandlerThrowException")  will appear normally in the related AppDomain. Otherwise they will only work correct in the AppDomain which owns the error handler, all AppDomains different from that will receive serialization exception.

