### PR TITLE
Fix memory issue in MatOfT

### DIFF
--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -45,6 +45,11 @@ namespace OpenCvSharp
             ptr = NativeMethods.core_Mat_new1();
         }
 
+        protected Mat(Mat m)
+        {
+            ptr = NativeMethods.core_Mat_new12(m.ptr);
+        }
+
 #if LANG_JP
 /// <summary>
 /// 画像ファイルから読み込んで初期化 (cv::imread)

--- a/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
@@ -13,8 +13,6 @@ namespace OpenCvSharp
         where TElem : struct
         where TInherit : Mat, new()
     {
-        private Mat sourceMat;
-
         #region Init & Disposal
 
 #if LANG_JP
@@ -59,10 +57,8 @@ namespace OpenCvSharp
         /// <param name="mat">Managed Mat object</param>
 #endif
         protected Mat(Mat mat)
-            : base(mat.CvPtr)
+            : base(mat)
         {
-            // 作成元への参照を残す。元がGCに回収されないように。
-            sourceMat = mat;
         }
 
 #if LANG_JP
@@ -431,31 +427,6 @@ namespace OpenCvSharp
         protected Mat(IEnumerable<int> sizes, MatType type, Scalar s)
             : base(sizes, type, s)
         {
-        }
-
-        /// <summary>
-        /// Releases managed resources
-        /// </summary>
-        protected override void DisposeManaged()
-        {
-            // https://github.com/shimat/opencvsharp/commit/803542a68b60a60f2355105d052bbcee91447fbd#commitcomment-24105696
-
-            if (sourceMat != null)
-            {
-                sourceMat = null;
-                ptr = IntPtr.Zero;
-            }
-
-            base.DisposeManaged();
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources
-        /// </summary>
-        protected override void DisposeUnmanaged()
-        {
-            // Must override this and do nothing; and not call base.DisposeUnmanaged() because this class allows accessing data from an associated Mat. If not then when the sourceMat gets
-            // destroyed and this instance gets destroyed later, it will cause memory corruption as native delete is called twice.
         }
 
         #endregion

--- a/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
+++ b/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
@@ -36,6 +36,8 @@ namespace OpenCvSharp
         public static extern IntPtr core_Mat_new10(int ndims, [MarshalAs(UnmanagedType.LPArray)] int[] sizes, int type);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern IntPtr core_Mat_new11(int ndims, [MarshalAs(UnmanagedType.LPArray)] int[] sizes, int type, Scalar s);
+        [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern IntPtr core_Mat_new12(IntPtr mat);
         
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern IntPtr core_Mat_new_FromIplImage(IntPtr img, int copyData);

--- a/src/OpenCvSharpExtern/core_Mat.h
+++ b/src/OpenCvSharpExtern/core_Mat.h
@@ -55,6 +55,10 @@ CVAPI(cv::Mat*) core_Mat_new11(int ndims, int* sizes, int type, MyCvScalar s)
 {
     return new cv::Mat(ndims, sizes, type, cpp(s));
 }
+CVAPI(cv::Mat*) core_Mat_new12(cv::Mat *mat)
+{
+	return new cv::Mat(*mat);
+}
 
 CVAPI(cv::Mat*) core_Mat_new_FromIplImage(IplImage *img, int copyData)
 {


### PR DESCRIPTION
When any successor of MatOfT (e.g. MatOfFloat) is created not using another Mat (e.g. using new MatOfFloat(128, 128)) then it is not deleted properly on C++ side, causing memory leaks in unmanaged memory. 

The reason is that DisposeUnmanaged does nothing in MatOfT, but the constructor allocates the memory!

Fixed in a way that DisposeUnmanaged and DisposeManaged is not overriden and called properly as for other Mats. SourceMat is removed. To handle the problem when MatOfT is created from another Mat, the cv::Mat(const Mat & m) constructor is called on C++ side, which will result in increment of a refcount on related C++ Mat so when desctructor is called multiple times it is not a problem, because the first call will just decrement the refcount.

Tested with VisualStudio 2017 memory profiler (managed + unmanaged) and it seems that it solves our previous problems with MatOfFloat memory leaks.