### PR TITLE
Remove return value allocation of Mat::setTo

### DIFF
--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -2491,11 +2491,12 @@ namespace OpenCvSharp
         {
             ThrowIfDisposed();
             IntPtr maskPtr = Cv2.ToPtr(mask);
-            IntPtr retPtr = NativeMethods.core_Mat_setTo_Scalar(ptr, value, maskPtr);
+
+            NativeMethods.core_Mat_setTo_Scalar(ptr, value, maskPtr);
+
             GC.KeepAlive(this);
-            Mat retVal = new Mat(retPtr);
             GC.KeepAlive(mask);
-            return retVal;
+            return this;
         }
 
         /// <summary>
@@ -2511,12 +2512,13 @@ namespace OpenCvSharp
                 throw new ArgumentNullException(nameof(value));
             value.ThrowIfDisposed();
             IntPtr maskPtr = Cv2.ToPtr(mask);
-            IntPtr retPtr = NativeMethods.core_Mat_setTo_InputArray(ptr, value.CvPtr, maskPtr);
+
+            NativeMethods.core_Mat_setTo_InputArray(ptr, value.CvPtr, maskPtr);
+
             GC.KeepAlive(this);
             GC.KeepAlive(value);
             GC.KeepAlive(mask);
-            Mat retVal = new Mat(retPtr);
-            return retVal;
+            return this;
         }
 
         #endregion

--- a/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
+++ b/src/OpenCvSharp/PInvoke/core/NativeMethods_core_Mat.cs
@@ -151,9 +151,9 @@ namespace OpenCvSharp
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern IntPtr core_Mat_rowRange_toMatExpr(IntPtr self, int startRow, int endRow);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern IntPtr core_Mat_setTo_Scalar(IntPtr self, Scalar value, IntPtr mask);
+        public static extern void core_Mat_setTo_Scalar(IntPtr self, Scalar value, IntPtr mask);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern IntPtr core_Mat_setTo_InputArray(IntPtr self, IntPtr value, IntPtr mask);
+        public static extern void core_Mat_setTo_InputArray(IntPtr self, IntPtr value, IntPtr mask);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern Size core_Mat_size(IntPtr self);
         [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/src/OpenCvSharpExtern/core_Mat.h
+++ b/src/OpenCvSharpExtern/core_Mat.h
@@ -355,22 +355,19 @@ CVAPI(int) core_Mat_rows(cv::Mat *self)
     return self->rows;
 }
 
-CVAPI(cv::Mat*) core_Mat_setTo_Scalar(cv::Mat *self, MyCvScalar value, cv::Mat *mask)
+CVAPI(void) core_Mat_setTo_Scalar(cv::Mat *self, MyCvScalar value, cv::Mat *mask)
 {
     // crash
     // core_Mat_setTo_Scalar(cv::Mat *self, MyCvScalar value, cv::InputArray *mask)
 
-    cv::Mat ret;
     if (mask == NULL)
-        ret = self->setTo(cpp(value));
+        self->setTo(cpp(value));
     else 
-        ret = self->setTo(cpp(value), entity(mask));
-    return new cv::Mat(ret);
+        self->setTo(cpp(value), entity(mask));
 }
-CVAPI(cv::Mat*) core_Mat_setTo_InputArray(cv::Mat *self, cv::_InputArray *value, cv::Mat *mask)
+CVAPI(void) core_Mat_setTo_InputArray(cv::Mat *self, cv::_InputArray *value, cv::Mat *mask)
 {
-    cv::Mat ret = self->setTo(*value, entity(mask));
-    return new cv::Mat(ret);
+    self->setTo(*value, entity(mask));
 }
 
 CVAPI(MyCvSize) core_Mat_size(cv::Mat *self)

--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -41,10 +41,13 @@ namespace OpenCvSharp.Tests.Core
             using (Mat resultImage = graySrc.Clone())
             using (Mat mask = graySrc.InRange(100, 200))
             {
-                resultImage.SetTo(0, mask);
+                var ret = resultImage.SetTo(0, mask);
                 ShowImagesWhenDebugMode(resultImage);
-                resultImage.SetTo(0, null); 
+                Assert.True(ReferenceEquals(resultImage, ret));
+
+                ret = resultImage.SetTo(0, null); 
                 ShowImagesWhenDebugMode(resultImage);
+                Assert.True(ReferenceEquals(resultImage, ret));
             }
         }
 


### PR DESCRIPTION
to avoid memory leak