### PR TITLE
OpenCv 4.1.0 ColormapTypes

### DIFF
--- a/src/OpenCvSharp/Modules/imgproc/Enum/ColormapTypes.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Enum/ColormapTypes.cs
@@ -21,5 +21,13 @@ namespace OpenCvSharp
         Hsv = 9,
         Pink = 10,
         Hot = 11,
+        Parula = 12,
+        Magma = 13,
+        Inferno = 14,
+        Plasma = 15,
+        Viridis = 16,
+        Cividis = 17,
+        Twilight = 18,
+        TwilightShifted = 19
     }
 }


### PR DESCRIPTION
OpenCV supports 20 types of colormap from 4.1.0 but we can't use it because an enum type in this library is not up-to-date.

Edit: I could use other color maps if I cast value explicitly. This PR is for convenience.