### PR TITLE
MS Multithread-Module DLL flags appeared in make-files

### DIFF
--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -11,10 +11,12 @@ if(OpenCV_FOUND)
 	include_directories(${OpenCV_INCLUDE_DIRS})
 	#set(LIBS ${LIBS} ${OpenCV_LIBRARIES})
 
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+
 
 	if(CMAKE_GENERATOR MATCHES "Visual Studio")
+		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+		
 		set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib")
 	endif()
 


### PR DESCRIPTION
The Multithread-Module DLL flags  /MT (& MTd), which are MS cl related, were not within the condition for visual studio projects.  Therefore faulty make files were generated under Linux systems, since the /MT flag was included within the make files. 
I moved the two set commands to the "Visual Studio" gernerator condition, and tested to build on M$ and Linux, seems to work.