### PR TITLE
change build action of windows native dlls to "Content" fixes issue #737

### DIFF
--- a/nuget/OpenCvSharp4.runtime.win.props
+++ b/nuget/OpenCvSharp4.runtime.win.props
@@ -3,23 +3,23 @@
 		<NativeDlls>$(MSBuildThisFileDirectory)..\..\runtimes</NativeDlls>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="$(NativeDlls)\win-x86\native\OpenCvSharpExtern.dll">
+		<Content Include="$(NativeDlls)\win-x86\native\OpenCvSharpExtern.dll">
 			<Link>dll\x86\OpenCvSharpExtern.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="$(NativeDlls)\win-x86\native\opencv_ffmpeg410.dll">
-			<Link>dll\x86\opencv_ffmpeg410.dll</Link>
+		</Content>
+		<Content Include="$(NativeDlls)\win-x86\native\opencv_videoio_ffmpeg411.dll">
+			<Link>dll\x86\opencv_videoio_ffmpeg411.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
+		</Content>
 	</ItemGroup>
 	<ItemGroup>
-		<None Include="$(NativeDlls)\win-x64\native\OpenCvSharpExtern.dll">
+		<Content Include="$(NativeDlls)\win-x64\native\OpenCvSharpExtern.dll">
 			<Link>dll\x64\OpenCvSharpExtern.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="$(NativeDlls)\win-x64\native\opencv_ffmpeg410_64.dll">
-			<Link>dll\x64\opencv_ffmpeg410_64.dll</Link>
+		</Content>
+		<Content Include="$(NativeDlls)\win-x64\native\opencv_videoio_ffmpeg411_64.dll">
+			<Link>dll\x64\opencv_videoio_ffmpeg411_64.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
+		</Content>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Note that I also had to change the dll names. They had already been updated in the nuspec file, but hadn't been updated in the props file.

I tested this by packing a prerelease nupkg file and publishing it locally. I was then able to follow the reproduction steps of issue #737 except use the prerelease package instead.

I did not change the package version in the nuspec because I didn't know if it would be appropriate to do so and what I should change it to.