### PR TITLE
Updated DNN Target / Backend enum to include new support for CUDA

### DIFF
--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -493,6 +493,7 @@ namespace OpenCvSharp.Dnn
             OPENCL_FP16,
             MYRIAD,
             VULKAN,
+            FPGA, 
             CUDA,
             CUDA_FP16
 #pragma warning restore CS1591

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -477,7 +477,8 @@ namespace OpenCvSharp.Dnn
             HALIDE,
             INFERENCE_ENGINE,
             OPENCV,
-            VKCOM
+            VKCOM,
+            CUDA
 #pragma warning restore CS1591
         }
 
@@ -491,7 +492,9 @@ namespace OpenCvSharp.Dnn
             OPENCL,
             OPENCL_FP16,
             MYRIAD,
-            VULKAN
+            VULKAN,
+            CUDA,
+            CUDA_FP16
 #pragma warning restore CS1591
         }
 


### PR DESCRIPTION
Recently OpenCV merged a pull request [https://github.com/opencv/opencv/pull/14827](https://github.com/opencv/opencv/pull/14827) which extends the DNN portion of OpenCV to include CUDA acceleration.  I have tested and confirmed this works on the Nvidia Nano ARM64 and this repo. This enum is just to match what is currently the active enum in OpenCV [Current enums](https://github.com/opencv/opencv/blob/613c12e59015f4bd7909916ceee195edd7ef88d0/modules/dnn/include/opencv2/dnn/dnn.hpp#L65) 