### PR TITLE
add VideoCapture overloads

### DIFF
--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -1418,6 +1418,56 @@ namespace OpenCvSharp
         /// <param name="image">the video frame is returned here. If no frames has been grabbed the image will be empty.</param>
         /// <param name="flag">it could be a frame index or a driver specific flag</param>
         /// <returns></returns>
+        public bool Retrieve(OutputArray image, int flag = 0)
+        {
+            ThrowIfDisposed();
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+            image.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_retrieve_OutputArray(ptr, image.CvPtr, flag, out var ret));
+
+            GC.KeepAlive(this);
+            image.Fix();
+            return ret != 0;
+        }
+
+        /// <summary>
+        /// Decodes and returns the grabbed video frame.
+        /// 
+        /// The method decodes and returns the just grabbed frame. If no frames has been grabbed
+        /// (camera has been disconnected, or there are no more frames in video file), the method returns false
+        /// and the function returns an empty image (with %cv::Mat, test it with Mat::empty()).
+        /// </summary>
+        /// <param name="image">the video frame is returned here. If no frames has been grabbed the image will be empty.</param>
+        /// <param name="streamIdx">non-zero streamIdx is only valid for multi-head camera live streams</param>
+        /// <returns></returns>
+        public bool Retrieve(OutputArray image, CameraChannels streamIdx)
+        {
+            ThrowIfDisposed();
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+            image.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_retrieve_OutputArray(ptr, image.CvPtr, (int)streamIdx, out var ret));
+
+            GC.KeepAlive(this);
+            image.Fix();
+            return ret != 0;
+        }
+        
+        /// <summary>
+        /// Decodes and returns the grabbed video frame.
+        ///
+        /// The method decodes and returns the just grabbed frame. If no frames has been grabbed
+        /// (camera has been disconnected, or there are no more frames in video file), the method returns false
+        /// and the function returns an empty image (with %cv::Mat, test it with Mat::empty()).
+        /// </summary>
+        /// <param name="image">the video frame is returned here. If no frames has been grabbed the image will be empty.</param>
+        /// <param name="flag">it could be a frame index or a driver specific flag</param>
+        /// <returns></returns>
         public bool Retrieve(Mat image, int flag = 0)
         {
             ThrowIfDisposed();
@@ -1426,7 +1476,7 @@ namespace OpenCvSharp
             image.ThrowIfDisposed();
 
             NativeMethods.HandleException(
-                NativeMethods.videoio_VideoCapture_retrieve(ptr, image.CvPtr, flag, out var ret));
+                NativeMethods.videoio_VideoCapture_retrieve_Mat(ptr, image.CvPtr, flag, out var ret));
 
             GC.KeepAlive(this);
             GC.KeepAlive(image);
@@ -1443,7 +1493,7 @@ namespace OpenCvSharp
         /// <param name="image">the video frame is returned here. If no frames has been grabbed the image will be empty.</param>
         /// <param name="streamIdx">non-zero streamIdx is only valid for multi-head camera live streams</param>
         /// <returns></returns>
-        public bool Retrieve(Mat image, CameraChannels streamIdx = CameraChannels.OpenNI_DepthMap)
+        public bool Retrieve(Mat image, CameraChannels streamIdx)
         {
             ThrowIfDisposed();
             if (image == null)
@@ -1451,7 +1501,7 @@ namespace OpenCvSharp
             image.ThrowIfDisposed();
 
             NativeMethods.HandleException(
-                NativeMethods.videoio_VideoCapture_retrieve(ptr, image.CvPtr, (int)streamIdx, out var ret));
+                NativeMethods.videoio_VideoCapture_retrieve_Mat(ptr, image.CvPtr, (int)streamIdx, out var ret));
 
             GC.KeepAlive(this);
             GC.KeepAlive(image);
@@ -1494,10 +1544,34 @@ namespace OpenCvSharp
             image.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.videoio_VideoCapture_read(ptr, image.CvPtr, out var ret));
+                NativeMethods.videoio_VideoCapture_read_OutputArray(ptr, image.CvPtr, out var ret));
 
             GC.KeepAlive(this);
             image.Fix();
+            return ret != 0;
+        }
+        
+        /// <summary>
+        /// Grabs, decodes and returns the next video frame.
+        ///
+        /// The method/function combines VideoCapture::grab() and VideoCapture::retrieve() in one call. This is the
+        /// most convenient method for reading video files or capturing data from decode and returns the just
+        /// grabbed frame. If no frames has been grabbed (camera has been disconnected, or there are no more
+        /// frames in video file), the method returns false and the function returns empty image (with %cv::Mat, test it with Mat::empty()).
+        /// </summary>
+        /// <returns>`false` if no frames has been grabbed</returns>
+        public bool Read(Mat image)
+        {
+            ThrowIfDisposed();
+            if(image == null)
+                throw new ArgumentNullException(nameof(image));
+            image.ThrowIfDisposed();
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_read_Mat(ptr, image.CvPtr, out var ret));
+
+            GC.KeepAlive(this);
+            GC.KeepAlive(image);
             return ret != 0;
         }
 

--- a/src/OpenCvSharp/PInvoke/NativeMethods/NativeMethods_videoio.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods/NativeMethods_videoio.cs
@@ -42,7 +42,9 @@ namespace OpenCvSharp
         public static extern ExceptionStatus videoio_VideoCapture_grab(IntPtr obj, out int returnValue);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus videoio_VideoCapture_retrieve(IntPtr obj, IntPtr image, int flag, out int returnValue);
+        public static extern ExceptionStatus videoio_VideoCapture_retrieve_OutputArray(IntPtr obj, IntPtr image, int flag, out int returnValue);
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoCapture_retrieve_Mat(IntPtr obj, IntPtr image, int flag, out int returnValue);
         
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus videoio_VideoCapture_operatorRightShift_Mat(IntPtr obj, IntPtr image);
@@ -51,7 +53,9 @@ namespace OpenCvSharp
         //public static extern ExceptionStatus videoio_VideoCapture_operatorRightShift_UMat(IntPtr obj, IntPtr image);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus videoio_VideoCapture_read(IntPtr obj, IntPtr image, out int returnValue);
+        public static extern ExceptionStatus videoio_VideoCapture_read_OutputArray(IntPtr obj, IntPtr image, out int returnValue);
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoCapture_read_Mat(IntPtr obj, IntPtr image, out int returnValue);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus videoio_VideoCapture_set(IntPtr obj, int propId, double value, out int returnValue);

--- a/src/OpenCvSharpExtern/videoio.h
+++ b/src/OpenCvSharpExtern/videoio.h
@@ -68,7 +68,14 @@ CVAPI(ExceptionStatus) videoio_VideoCapture_grab(cv::VideoCapture *obj, int *ret
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) videoio_VideoCapture_retrieve(cv::VideoCapture *obj, cv::_OutputArray *image, int flag, int *returnValue)
+CVAPI(ExceptionStatus) videoio_VideoCapture_retrieve_OutputArray(cv::VideoCapture *obj, cv::_OutputArray *image, int flag, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->retrieve(*image, flag) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) videoio_VideoCapture_retrieve_Mat(cv::VideoCapture *obj, cv::Mat *image, int flag, int *returnValue)
 {
     BEGIN_WRAP
     *returnValue = obj->retrieve(*image, flag) ? 1 : 0;
@@ -88,7 +95,13 @@ CVAPI(ExceptionStatus) videoio_VideoCapture_operatorRightShift_Mat(cv::VideoCapt
     END_WRAP
 }*/
 
-CVAPI(ExceptionStatus) videoio_VideoCapture_read(cv::VideoCapture *obj, cv::_OutputArray *image, int *returnValue)
+CVAPI(ExceptionStatus) videoio_VideoCapture_read_OutputArray(cv::VideoCapture *obj, cv::_OutputArray *image, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->read(*image) ? 1 : 0;
+    END_WRAP
+}
+CVAPI(ExceptionStatus) videoio_VideoCapture_read_Mat(cv::VideoCapture *obj, cv::Mat *image, int *returnValue)
 {
     BEGIN_WRAP
     *returnValue = obj->read(*image) ? 1 : 0;

--- a/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
+++ b/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
@@ -7,7 +7,7 @@ namespace OpenCvSharp.Tests.VideoIO
     public class VideoCaptureTest : TestBase
     {
         [Fact]
-        public void OpenImageSequence()
+        public void ReadImageSequence()
         {
             using var capture = new VideoCapture("_data/image/blob/shapes%d.png");
             using var image1 = new Mat("_data/image/blob/shapes1.png", ImreadModes.Color);
@@ -26,6 +26,49 @@ namespace OpenCvSharp.Tests.VideoIO
             Assert.True(capture.Read(frame2));
             Assert.True(capture.Read(frame3));
             Assert.False(capture.Read(frame4));
+            Assert.False(frame1.Empty());
+            Assert.False(frame2.Empty());
+            Assert.False(frame3.Empty());
+            Assert.True(frame4.Empty());
+
+            Cv2.CvtColor(frame1, frame1, ColorConversionCodes.BGRA2BGR);
+            Cv2.CvtColor(frame2, frame2, ColorConversionCodes.BGRA2BGR);
+            Cv2.CvtColor(frame3, frame3, ColorConversionCodes.BGRA2BGR);
+            ImageEquals(image1, frame1);
+            ImageEquals(image2, frame2);
+            ImageEquals(image3, frame3);
+
+            if (Debugger.IsAttached)
+            {
+                Window.ShowImages(frame1, frame2, frame3, frame4);
+            }
+        }
+        
+        [Fact]
+        public void GrabAndRetrieveImageSequence()
+        {
+            using var capture = new VideoCapture("_data/image/blob/shapes%d.png");
+            using var image1 = new Mat("_data/image/blob/shapes1.png", ImreadModes.Color);
+            using var image2 = new Mat("_data/image/blob/shapes2.png", ImreadModes.Color);
+            using var image3 = new Mat("_data/image/blob/shapes3.png", ImreadModes.Color);
+
+            Assert.True(capture.IsOpened());
+            Assert.Equal("CV_IMAGES", capture.GetBackendName());
+            Assert.Equal(3, capture.FrameCount);
+
+            using var frame1 = new Mat();
+            using var frame2 = new Mat();
+            using var frame3 = new Mat();
+            using var frame4 = new Mat();
+            Assert.True(capture.Grab());
+            Assert.True(capture.Retrieve(frame1));
+            Assert.True(capture.Grab());
+            Assert.True(capture.Retrieve(frame2));
+            Assert.True(capture.Grab());
+            Assert.True(capture.Retrieve(frame3));
+            Assert.False(capture.Grab());
+            Assert.False(capture.Retrieve(frame4));
+
             Assert.False(frame1.Empty());
             Assert.False(frame2.Empty());
             Assert.False(frame3.Empty());


### PR DESCRIPTION
Fix #854 

Add `Retrieve(Mat)` and `Read(Mat)` overload methods to prevent memory leaks