### PR TITLE
Fix #653 - Face.Facemark.Fit output

### DIFF
--- a/src/OpenCvSharp/Modules/face/Facemark/Facemark.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/Facemark.cs
@@ -34,25 +34,26 @@ namespace OpenCvSharp.Face
         public virtual bool Fit(
             InputArray image,
             InputArray faces,
-            InputOutputArray landmarks)
+            out Point2f[][] landmarks)
         {
             ThrowIfDisposed();
             if (image == null)
                 throw new ArgumentNullException(nameof(image));
             if (faces == null)
                 throw new ArgumentNullException(nameof(faces));
-            if (landmarks == null)
-                throw new ArgumentNullException(nameof(landmarks));
             image.ThrowIfDisposed();
             faces.ThrowIfDisposed();
-            landmarks.ThrowIfNotReady();
 
-             NativeMethods.HandleException(
-                 NativeMethods.face_Facemark_fit(ptr, image.CvPtr, faces.CvPtr, landmarks.CvPtr, out var ret));
+            int ret;
+            using (var landmarx = new VectorOfVectorPoint2f())
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_Facemark_fit(ptr, image.CvPtr, faces.CvPtr, landmarx.CvPtr, out ret));
+                landmarks = landmarx.ToArray();
+            }
 
             GC.KeepAlive(this);
             GC.KeepAlive(image);
-            landmarks.Fix();
 
             return ret != 0;
         }

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -15,11 +15,12 @@ CVAPI(ExceptionStatus) face_Facemark_loadModel(cv::face::Facemark *obj, const ch
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) face_Facemark_fit(
-    cv::face::Facemark *obj, 
+CVAPI(ExceptionStatus)
+face_Facemark_fit(
+    cv::face::Facemark *obj,
     cv::_InputArray *image,
     cv::_InputArray *faces,
-    cv::_InputOutputArray *landmarks,
+    std::vector<std::vector<cv::Point2f>> *landmarks,
     int *returnValue)
 {
     BEGIN_WRAP


### PR DESCRIPTION
Fixes #653
As suggested by @0x0aNL [here](https://github.com/VahidN/OpenCVSharp-Samples/issues/10#issuecomment-520380701), I fixed Facemark.Fit and corresponding function in OpenCvSharpExtern/face_Facemark.h.  
```cs
OpenCvSharp.Face.Facemark faceMark = OpenCvSharp.Face.FacemarkLBF.Create();
faceMark.LoadModel("lbfmodel.yaml");

// faceRects is an array of Rect - bonding boxes of faces detected in image
InputArray facesArray = InputArray.Create(facesRects); 
Point2f[][] landmarks;
faceMark.Fit(image, facesArray, out landmarks);
```
![facemarks](https://user-images.githubusercontent.com/4735184/78859080-2bf16980-79e3-11ea-9a54-3159da154753.jpg)
