### PR TITLE
macOS build: workflow, build fixes, native NuGet package and test changes

### DIFF
--- a/.github/workflows/macos10.yml
+++ b/.github/workflows/macos10.yml
@@ -1,0 +1,86 @@
+name: macOS 10.15
+
+on: [push]
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  OPENCV_VERSION: 4.3.0
+
+jobs:
+  build:
+
+    runs-on: macos
+    
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      
+      - name: Install build dependencies
+        run: | 
+          brew install wget pkg-config mono-libgdiplus gtk+ ffmpeg glog yasm harfbuzz jpeg libpng libtiff openexr openjpeg metis openblas opencore-amr protobuf tbb webp
+
+      - name: Build OpenCV
+        run: |
+          wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip -Oopencv-${OPENCV_VERSION}.zip && unzip opencv-${OPENCV_VERSION}.zip
+          wget https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip -Oopencv_contrib-${OPENCV_VERSION}.zip && unzip opencv_contrib-${OPENCV_VERSION}.zip
+          cd opencv-${OPENCV_VERSION} && mkdir build && cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules -DBUILD_SHARED_LIBS=OFF -DENABLE_CXX11=ON -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_EXAMPLES=OFF  -DBUILD_JAVA=OFF -DBUILD_opencv_java=OFF -DBUILD_opencv_python=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_js=OFF -DBUILD_opencv_app=OFF -DWITH_GSTREAMER=OFF -DWITH_EIGEN=OFF -DOPENCV_ENABLE_NONFREE=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_macos ..
+          make -j2
+          make install
+          cd ${GITHUB_WORKSPACE}
+          ls
+       
+      - name: Build OpenCvSharpExtern
+        run: |                    
+          mkdir src/build && cd $_
+          cmake -DCMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/opencv_macos ..
+          make -j2
+          ls 
+          ls OpenCvSharpExtern
+          cp OpenCvSharpExtern/libOpenCvSharpExtern.dylib ${GITHUB_WORKSPACE}/nuget/
+
+      - name: Check OpenCvSharpExtern
+        run: |
+          cd ${GITHUB_WORKSPACE}/nuget/
+          otool -L libOpenCvSharpExtern.dylib
+          nm libOpenCvSharpExtern.dylib
+          echo -ne "#include <stdio.h> \n int core_Mat_sizeof(); int main(){ int i = core_Mat_sizeof(); printf(\"sizeof(Mat) = %d\", i); return 0; }" > test.c
+          gcc -I./ -L./ test.c -o test -lOpenCvSharpExtern
+          LD_LIBRARY_PATH=. ./test     
+          
+      - name: Create NuGet package
+        env: 
+         BETA: ""
+        run: |
+          yyyymmdd=`date '+%Y%m%d'`
+          echo $yyyymmdd
+          sed -E -i=.bak "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.macos.10.15-x64.nuspec
+          cat ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.macos.10.15-x64.nuspec
+          dotnet pack ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.macos.10.15-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_macos
+          ls ${GITHUB_WORKSPACE}/artifacts_macos       
+       
+      - uses: actions/upload-artifact@v1
+        with:
+          name: artifacts_macos_10
+          path: artifacts_macos
+
+      - name: Test
+        run: |
+          cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
+          ls
+          dotnet build -c Release -f netcoreapp3.0
+          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/netcoreapp3.0/
+          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/
+          ls ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/netcoreapp3.0/
+          ls
+          sudo cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib /usr/local/lib/
+          LD_LIBRARY_PATH=. 
+          dotnet test OpenCvSharp.Tests.csproj -c Release -f netcoreapp3.0 --runtime osx-x64 --logger "trx;LogFileName=test-results.trx"
+          ls
+          ls TestResults
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: artifacts_macos_10_test_results
+          path: test/OpenCvSharp.Tests/TestResults/test-results.trx

--- a/nuget/OpenCvSharp4.runtime.macos.10.15-x64.csproj
+++ b/nuget/OpenCvSharp4.runtime.macos.10.15-x64.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;</TargetFrameworks>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NuspecFile>OpenCvSharp4.runtime.macos.10.15-x64.nuspec</NuspecFile>
+    <NuspecProperties></NuspecProperties>
+    <NuspecBasePath></NuspecBasePath>
+    <!--<IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>-->
+  </PropertyGroup>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.macos.10.15-x64.nuspec
+++ b/nuget/OpenCvSharp4.runtime.macos.10.15-x64.nuspec
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>OpenCvSharp4.runtime.macos.10.15-x64</id>
+        <version>4.3.0.20191030</version>
+        <title>OpenCvSharp native bindings for macOS.10.15-x64</title>
+        <authors>shimat,vladkol</authors>
+        <license type="expression">BSD-3-Clause</license>
+        <!--<licenseUrl>https://opensource.org/licenses/BSD-3-Clause</licenseUrl>-->
+        <projectUrl>https://github.com/shimat/opencvsharp</projectUrl>
+        <iconUrl>https://raw.githubusercontent.com/shimat/opencvsharp/master/nuget/icon/opencvsharp.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Internal implementation package for OpenCvSharp to work on macOS 10</description>
+        <summary>Internal implementation package for OpenCvSharp to work on macOS 10.15</summary>
+        <releaseNotes></releaseNotes>
+        <copyright>Copyright 2008-2020</copyright>
+        <tags>Image Processing OpenCV Wrapper FFI opencvsharp</tags>
+        <dependencies>
+            <group targetFramework="netstandard2.0"></group>
+            <group targetFramework="netstandard2.1"></group>
+            <group targetFramework="netcoreapp2.1"></group>
+        </dependencies>
+        <frameworkAssemblies>
+        </frameworkAssemblies>
+    </metadata>
+    <files>
+        <file src="libOpenCvSharpExtern.dylib" target="runtimes/osx-x64/native" />
+    </files>
+</package>

--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.0)
 
 include_directories(${OpenCV_INCLUDE_DIR})
 link_directories(${OpenCV_LIBRARY_DIR} ${OpenCV_LIBRARIES})
+IF(APPLE)
+    # Fix linking on 10.14+. See https://stackoverflow.com/questions/54068035
+    link_directories(/usr/local/lib)
+ENDIF()
 
 file(GLOB OPENCVSHARP_FILES *.cpp)
 

--- a/test/OpenCvSharp.Tests/core/UtilityTest.cs
+++ b/test/OpenCvSharp.Tests/core/UtilityTest.cs
@@ -16,13 +16,18 @@ namespace OpenCvSharp.Tests.Core
         [Fact]
         public void GetAndSetNumThreads()
         {
-            int threads = Cv2.GetNumThreads();
+            // GCD framework on Apple platforms causes different behaviour of SetNumThreads 
+            // https://docs.opencv.org/3.4/db/de0/group__core__utils.html#gae78625c3c2aa9e0b83ed31b73c6549c0
+            if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                int threads = Cv2.GetNumThreads();
             
-            Cv2.SetNumThreads(threads + 1);
-            Assert.Equal(threads + 1, Cv2.GetNumThreads());
+                Cv2.SetNumThreads(threads + 1);
+                Assert.Equal(threads + 1, Cv2.GetNumThreads());
 
-            Cv2.SetNumThreads(threads);
-            Assert.Equal(threads, Cv2.GetNumThreads());
+                Cv2.SetNumThreads(threads);
+                Assert.Equal(threads, Cv2.GetNumThreads());
+            }
         }
         
         [Fact]


### PR DESCRIPTION
1. GitHub action **build workflow for macOS**. 
2. **macOS native NuGet package** and NuGet .csproj. 
3. Minor change in OpenCvSharpExtern/CMakeLists.txt so the build script finds libraries installed via Homebrew. 
4. Skip GetAndSetNumThreads on macOS because [GCD framework on Apple platforms causes a different behavior of SetNumThreads](https://docs.opencv.org/3.4/db/de0/group__core__utils.html#gae78625c3c2aa9e0b83ed31b73c6549c0) - and [GCD](https://developer.apple.com/documentation/DISPATCH) is the recommended multicore framework on Apple platforms.