### PR TITLE
Update macOS build action

### DIFF
--- a/.github/workflows/macos10.yml
+++ b/.github/workflows/macos10.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
 
-    runs-on: macos
+    runs-on: macos-10.15
     
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
They changed names of macOS runners. Should be 'macos-latest' or 'macos-10.15' now.