### PR TITLE
fix #1051 - Rect.FromLTRB should not add +1 to Width and Height

### DIFF
--- a/src/OpenCvSharp/Modules/core/Struct/Rect.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Rect.cs
@@ -89,8 +89,8 @@ namespace OpenCvSharp
             {
                 X = left,
                 Y = top,
-                Width = right - left + 1,
-                Height = bottom - top + 1
+                Width = right - left,
+                Height = bottom - top
             };
 
             if (r.Width < 0)

--- a/test/OpenCvSharp.Tests/core/RectTest.cs
+++ b/test/OpenCvSharp.Tests/core/RectTest.cs
@@ -129,9 +129,26 @@ namespace OpenCvSharp.Tests
         [Fact]
         public void FromLTRB()
         {
-            var rect = Rect.FromLTRB(1, 2, 3, 4);
+            Rect source = Rect.FromLTRB(1, 2, 3, 4);
 
-            Assert.Equal(new Rect(1, 2, 3, 3), rect);
+            var rect = Rect.FromLTRB(source.Left, source.Top, source.Right, source.Bottom);
+
+            Assert.Equal(source, rect);
+        }
+
+        [Fact]
+        public void FromLTRBTestCoordinates()
+        {
+            var left = 10;
+            var top = 20;
+            var right = 30;
+            var bottom = 40;
+            var rect = Rect.FromLTRB(left, top, right, bottom);
+
+            Assert.Equal(left, rect.Left);
+            Assert.Equal(top, rect.Top);
+            Assert.Equal(right, rect.Right);
+            Assert.Equal(bottom, rect.Bottom);
         }
     }
 }


### PR DESCRIPTION
This makes Rect.FromLTRB behave like System.Drawing.Rectangle.Rect.FromLTRB

Fix #1051