### PR TITLE
ResourceTracker is misspelled, replace ResourcesTracker with Resource…

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ class Program
 
 As mentioned above, objects of classes, such as Mat and MatExpr, have unmanaged resources and need to be manually released by calling the Dispose() method. Worst of all, the +, -, *, and other operators create new objects each time, and these objects need to be disposed, or there will be memory leaks. Despite having the using syntax, the code still looks very verbose.
 
-Therefore, a ResourceTracker class is provided. The ResourceTracker implements the IDisposable interface, and when the Dispose() method is called, all resources tracked by the ResourceTracker are disposed. The T() method of ResourceTracker can trace an object or an array of objects, and the method NewMat() is like T(new Mat(...). All the objects that need to be released can be wrapped with T().For example: t.T(255 - t.T(picMat * 0.8)) . Example code is as following:
+Therefore, a ResourcesTracker class is provided. The ResourcesTracker implements the IDisposable interface, and when the Dispose() method is called, all resources tracked by the ResourcesTracker are disposed. The T() method of ResourcesTracker can trace an object or an array of objects, and the method NewMat() is like T(new Mat(...). All the objects that need to be released can be wrapped with T().For example: t.T(255 - t.T(picMat * 0.8)) . Example code is as following:
 
 ```csharp
-//The namespace of "ResourceTracker" is "OpenCvSharp.Util", so please add "using OpenCvSharp.Util; " to your code.
+//The namespace of "ResourcesTracker" is "OpenCvSharp.Util", so please add "using OpenCvSharp.Util; " to your code.
 
-using (ResourceTracker t = new ResourceTracker())
+using (ResourcesTracker t = new ResourcesTracker())
 {
 	Mat mat1 = t.NewMat(new Size(100, 100), MatType.CV_8UC3,new Scalar(0));
 	Mat mat3 = t.T(255-t.T(mat1*0.8));


### PR DESCRIPTION
…Tracker
Sorry, to make it more semantic, in the pull request, I renamed ResourceTracker to ResourcesTracker, which makes the Resource in plural form. However, I forgot to change them in the pull request for readme.md. So this pull request is to rename all the ResourceTracker  to ResourcesTracker.
I'm sorry for the inconvenience .