### PR TITLE
Move Tracker implementation from tracking to video

### DIFF
--- a/src/OpenCvSharp/Modules/video/Tracker.cs
+++ b/src/OpenCvSharp/Modules/video/Tracker.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace OpenCvSharp.Tracking
+namespace OpenCvSharp
 {
     /// <summary>
     /// Base abstract class for the long-term tracker
@@ -44,7 +44,7 @@ namespace OpenCvSharp.Tracking
 
             image.ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.tracking_Tracker_init(ptr, image.CvPtr, boundingBox));
+                NativeMethods.video_Tracker_init(ptr, image.CvPtr, boundingBox));
             GC.KeepAlive(this);
             GC.KeepAlive(image);
         }
@@ -66,7 +66,7 @@ namespace OpenCvSharp.Tracking
 
             image.ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.tracking_Tracker_update(ptr, image.CvPtr, ref boundingBox, out var ret));
+                NativeMethods.video_Tracker_update(ptr, image.CvPtr, ref boundingBox, out var ret));
             GC.KeepAlive(this);
             GC.KeepAlive(image);
 

--- a/src/OpenCvSharp/Modules/video/TrackerGOTURN.cs
+++ b/src/OpenCvSharp/Modules/video/TrackerGOTURN.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace OpenCvSharp.Tracking
+namespace OpenCvSharp
 {
     /// <inheritdoc />
     /// <summary>
@@ -40,7 +40,7 @@ namespace OpenCvSharp.Tracking
         public static TrackerGOTURN Create()
         {
             NativeMethods.HandleException(
-                NativeMethods.tracking_TrackerGOTURN_create1(out var p));
+                NativeMethods.video_TrackerGOTURN_create1(out var p));
             return new TrackerGOTURN(p);
         }
 
@@ -55,7 +55,7 @@ namespace OpenCvSharp.Tracking
             unsafe
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_TrackerGOTURN_create2(&parameters, out var p));
+                    NativeMethods.video_TrackerGOTURN_create2(&parameters, out var p));
                 return new TrackerGOTURN(p);
             }
         }
@@ -69,7 +69,7 @@ namespace OpenCvSharp.Tracking
             public override IntPtr Get()
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_Ptr_TrackerGOTURN_get(ptr, out var ret));
+                    NativeMethods.video_Ptr_TrackerGOTURN_get(ptr, out var ret));
                 GC.KeepAlive(this);
                 return ret;
             }
@@ -77,7 +77,7 @@ namespace OpenCvSharp.Tracking
             protected override void DisposeUnmanaged()
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_Ptr_TrackerGOTURN_delete(ptr));
+                    NativeMethods.video_Ptr_TrackerGOTURN_delete(ptr));
                 base.DisposeUnmanaged();
             }
         }

--- a/src/OpenCvSharp/Modules/video/TrackerMIL.cs
+++ b/src/OpenCvSharp/Modules/video/TrackerMIL.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
+using OpenCvSharp.Tracking;
 
-namespace OpenCvSharp.Tracking
+namespace OpenCvSharp
 {
     /// <inheritdoc />
     /// <summary>
@@ -27,7 +28,7 @@ namespace OpenCvSharp.Tracking
         public static TrackerMIL Create()
         {
             NativeMethods.HandleException(
-                NativeMethods.tracking_TrackerMIL_create1(out var p));
+                NativeMethods.video_TrackerMIL_create1(out var p));
             return new TrackerMIL(p);
         }
 
@@ -41,7 +42,7 @@ namespace OpenCvSharp.Tracking
             unsafe
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_TrackerMIL_create2(&parameters, out var p));
+                    NativeMethods.video_TrackerMIL_create2(&parameters, out var p));
                 return new TrackerMIL(p);
             }
         }
@@ -55,7 +56,7 @@ namespace OpenCvSharp.Tracking
             public override IntPtr Get()
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_Ptr_TrackerMIL_get(ptr, out var ret));
+                    NativeMethods.video_Ptr_TrackerMIL_get(ptr, out var ret));
                 GC.KeepAlive(this);
                 return ret;
             }
@@ -63,7 +64,7 @@ namespace OpenCvSharp.Tracking
             protected override void DisposeUnmanaged()
             {
                 NativeMethods.HandleException(
-                    NativeMethods.tracking_Ptr_TrackerMIL_delete(ptr));
+                    NativeMethods.video_Ptr_TrackerMIL_delete(ptr));
                 base.DisposeUnmanaged();
             }
         }

--- a/src/OpenCvSharp/PInvoke/NativeMethods/traking/NativeMethods_tracking.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods/traking/NativeMethods_tracking.cs
@@ -15,19 +15,6 @@ namespace OpenCvSharp
 {
     static partial class NativeMethods
     {
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Tracker_init(IntPtr obj, IntPtr image, Rect boundingBox);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Tracker_update(IntPtr obj, IntPtr image, ref Rect boundingBox, out int returnValue);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_Tracker_delete(IntPtr ptr);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_Tracker_get(IntPtr ptr, out IntPtr returnValue);
-
-
         // TrackerKCF
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -41,36 +28,6 @@ namespace OpenCvSharp
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus tracking_Ptr_TrackerKCF_get(IntPtr ptr, out IntPtr returnValue);
-
-
-        // TrackerMIL
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_TrackerMIL_create1(out IntPtr returnValue);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern unsafe ExceptionStatus tracking_TrackerMIL_create2(TrackerMIL.Params* parameters, out IntPtr returnValue);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_TrackerMIL_delete(IntPtr ptr);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_TrackerMIL_get(IntPtr ptr, out IntPtr returnValue);
-        
-
-        // TrackerGOTURN
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_TrackerGOTURN_create1(out IntPtr returnValue);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern unsafe ExceptionStatus tracking_TrackerGOTURN_create2(TrackerGOTURN.Params* parameters, out IntPtr returnValue);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_TrackerGOTURN_delete(IntPtr ptr);
-
-        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern ExceptionStatus tracking_Ptr_TrackerGOTURN_get(IntPtr ptr, out IntPtr returnValue);
 
 
         // TrackerCSRT

--- a/src/OpenCvSharp/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
+++ b/src/OpenCvSharp/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using OpenCvSharp.Tracking;
 
 #pragma warning disable 1591
 #pragma warning disable CA1401 // P/Invokes should not be visible
@@ -105,6 +106,48 @@ namespace OpenCvSharp
         public static extern ExceptionStatus video_KalmanFilter_gain(IntPtr obj, out IntPtr returnValue);
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus video_KalmanFilter_errorCovPost(IntPtr obj, out IntPtr returnValue);
+
+        #endregion
+
+        #region Tracker
+
+        // Tracker
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Tracker_init(IntPtr obj, IntPtr image, Rect boundingBox);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Tracker_update(IntPtr obj, IntPtr image, ref Rect boundingBox, out int returnValue);
+        
+
+        // TrackerMIL
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_TrackerMIL_create1(out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern unsafe ExceptionStatus video_TrackerMIL_create2(TrackerMIL.Params* parameters, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Ptr_TrackerMIL_delete(IntPtr ptr);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Ptr_TrackerMIL_get(IntPtr ptr, out IntPtr returnValue);
+
+
+        // TrackerGOTURN
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_TrackerGOTURN_create1(out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern unsafe ExceptionStatus video_TrackerGOTURN_create2(TrackerGOTURN.Params* parameters, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Ptr_TrackerGOTURN_delete(IntPtr ptr);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus video_Ptr_TrackerGOTURN_get(IntPtr ptr, out IntPtr returnValue);
 
         #endregion
 

--- a/src/OpenCvSharpExtern/tracking.h
+++ b/src/OpenCvSharpExtern/tracking.h
@@ -8,44 +8,6 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) tracking_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const MyCvRect boundingBox)
-{
-    BEGIN_WRAP
-    tracker->init(*image, cpp(boundingBox));
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, MyCvRect* boundingBox, int *returnValue)
-{
-    BEGIN_WRAP
-    cv::Rect bb = cpp(*boundingBox);
-    const bool ret = tracker->update(*image, bb);
-    if (ret)
-    {
-        boundingBox->x = bb.x;
-        boundingBox->y = bb.y;
-        boundingBox->width = bb.width;
-        boundingBox->height = bb.height;
-    }
-
-    *returnValue = ret ? 1 : 0;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_Tracker_delete(cv::Ptr<cv::Tracker> *ptr)
-{
-    BEGIN_WRAP
-    delete ptr;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_Tracker_get(cv::Ptr<cv::Tracker> *ptr, cv::Tracker **returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = ptr->get();
-    END_WRAP
-}
-
 
 // TrackerKCF
 
@@ -77,72 +39,6 @@ CVAPI(ExceptionStatus) tracking_Ptr_TrackerKCF_get(cv::Ptr<cv::TrackerKCF> *ptr,
     *returnValue = ptr->get();
     END_WRAP
 }
-
-
-// TrackerMIL
-
-CVAPI(ExceptionStatus) tracking_TrackerMIL_create1(cv::Ptr<cv::TrackerMIL> **returnValue)
-{
-    BEGIN_WRAP
-    const auto p = cv::TrackerMIL::create();
-    *returnValue = clone(p);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_TrackerMIL_create2(cv::TrackerMIL::Params *parameters, cv::Ptr<cv::TrackerMIL> **returnValue)
-{
-    BEGIN_WRAP
-    const auto p = cv::TrackerMIL::create(*parameters);
-    *returnValue = clone(p);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_TrackerMIL_delete(cv::Ptr<cv::TrackerMIL> *ptr)
-{
-    BEGIN_WRAP
-    delete ptr;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_TrackerMIL_get(cv::Ptr<cv::TrackerMIL> *ptr, cv::TrackerMIL **returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = ptr->get();
-    END_WRAP
-}
-
-
-// TrackerGOTURN
-
-CVAPI(ExceptionStatus) tracking_TrackerGOTURN_create1(cv::Ptr<cv::TrackerGOTURN> **returnValue)
-{
-    BEGIN_WRAP
-    const auto p = cv::TrackerGOTURN::create();
-    *returnValue = clone(p);
-    END_WRAP
-}
-CVAPI(ExceptionStatus) tracking_TrackerGOTURN_create2(cv::TrackerGOTURN::Params *parameters, cv::Ptr<cv::TrackerGOTURN> **returnValue)
-{
-    BEGIN_WRAP
-    const auto p = cv::TrackerGOTURN::create(*parameters);
-    *returnValue = clone(p);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_TrackerGOTURN_delete(cv::Ptr<cv::TrackerGOTURN> *ptr)
-{
-    BEGIN_WRAP
-    delete ptr;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) tracking_Ptr_TrackerGOTURN_get(cv::Ptr<cv::TrackerGOTURN> *ptr, cv::TrackerGOTURN **returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = ptr->get();
-    END_WRAP
-}
-
 
 // TrackerCSRT
 

--- a/src/OpenCvSharpExtern/video_tracking.h
+++ b/src/OpenCvSharpExtern/video_tracking.h
@@ -245,14 +245,14 @@ CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPost(cv::KalmanFilter *obj, cv
 
 // Tracker
 
-CVAPI(ExceptionStatus) tracking_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const MyCvRect boundingBox)
+CVAPI(ExceptionStatus) video_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const MyCvRect boundingBox)
 {
     BEGIN_WRAP
     tracker->init(*image, cpp(boundingBox));
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) tracking_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, MyCvRect* boundingBox, int* returnValue)
+CVAPI(ExceptionStatus) video_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, MyCvRect* boundingBox, int* returnValue)
 {
     BEGIN_WRAP
     cv::Rect bb = cpp(*boundingBox);

--- a/src/OpenCvSharpExtern/video_tracking.h
+++ b/src/OpenCvSharpExtern/video_tracking.h
@@ -241,6 +241,102 @@ CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPost(cv::KalmanFilter *obj, cv
 #pragma endregion
 
 
+#pragma region Tracker
+
+// Tracker
+
+CVAPI(ExceptionStatus) tracking_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const MyCvRect boundingBox)
+{
+    BEGIN_WRAP
+    tracker->init(*image, cpp(boundingBox));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) tracking_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, MyCvRect* boundingBox, int* returnValue)
+{
+    BEGIN_WRAP
+    cv::Rect bb = cpp(*boundingBox);
+    const bool ret = tracker->update(*image, bb);
+    if (ret)
+    {
+        boundingBox->x = bb.x;
+        boundingBox->y = bb.y;
+        boundingBox->width = bb.width;
+        boundingBox->height = bb.height;
+    }
+
+    *returnValue = ret ? 1 : 0;
+    END_WRAP
+}
+
+
+// TrackerMIL
+
+CVAPI(ExceptionStatus) video_TrackerMIL_create1(cv::Ptr<cv::TrackerMIL>** returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::TrackerMIL::create();
+    *returnValue = clone(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) video_TrackerMIL_create2(cv::TrackerMIL::Params* parameters, cv::Ptr<cv::TrackerMIL>** returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::TrackerMIL::create(*parameters);
+    *returnValue = clone(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_delete(cv::Ptr<cv::TrackerMIL>* ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_get(cv::Ptr<cv::TrackerMIL>* ptr, cv::TrackerMIL** returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+
+// TrackerGOTURN
+
+CVAPI(ExceptionStatus) tracking_TrackerGOTURN_create1(cv::Ptr<cv::TrackerGOTURN>** returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::TrackerGOTURN::create();
+    *returnValue = clone(p);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) tracking_TrackerGOTURN_create2(cv::TrackerGOTURN::Params* parameters, cv::Ptr<cv::TrackerGOTURN>** returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::TrackerGOTURN::create(*parameters);
+    *returnValue = clone(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) tracking_Ptr_TrackerGOTURN_delete(cv::Ptr<cv::TrackerGOTURN>* ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) tracking_Ptr_TrackerGOTURN_get(cv::Ptr<cv::TrackerGOTURN>* ptr, cv::TrackerGOTURN** returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+
+#pragma endregion
+
 // TODO
 #pragma region DenseOpticalFlow
 


### PR DESCRIPTION
- https://github.com/opencv/opencv/blob/master/modules/video/include/opencv2/video/tracking.hpp
- https://github.com/opencv/opencv_contrib/blob/master/modules/tracking/include/opencv2/tracking.hpp

In OpenCV4.5.1, Tracker, TrackerMIL and TrackerGOTURN move from contrib tracking to video.

Fix #1136 