### PR TITLE
VideoCapture.WaitAny

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
@@ -72,6 +72,11 @@ namespace OpenCvSharp.Internal
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus videoio_VideoCapture_getExceptionMode(IntPtr obj, out int returnValue);
 
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoCapture_waitAny(
+            IntPtr[] streams, nuint streamsSize,
+            IntPtr readyIndex, long timeoutNs, out int returnValue);
+
 
         // VideoWriter
 

--- a/src/OpenCvSharpExtern/videoio.h
+++ b/src/OpenCvSharpExtern/videoio.h
@@ -146,6 +146,19 @@ CVAPI(ExceptionStatus) videoio_VideoCapture_getExceptionMode(cv::VideoCapture *o
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) videoio_VideoCapture_waitAny(
+    cv::VideoCapture** streams, const size_t streamsSize,
+    std::vector<int> *readyIndex, const int64 timeoutNs, int *returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::VideoCapture> streamsVec(streamsSize);
+    for (size_t i = 0; i < streamsSize; i++)
+        streamsVec[i] = *streams[i];
+
+    *returnValue = cv::VideoCapture::waitAny(streamsVec, *readyIndex, timeoutNs) ? 1 : 0;
+    END_WRAP
+}
+
 #pragma endregion
 
 #pragma region VideoWriter

--- a/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
+++ b/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
@@ -43,7 +43,7 @@ namespace OpenCvSharp.Tests.VideoIO
                 Window.ShowImages(frame1, frame2, frame3, frame4);
             }
         }
-        
+
         [Fact]
         public void GrabAndRetrieveImageSequence()
         {
@@ -97,6 +97,33 @@ namespace OpenCvSharp.Tests.VideoIO
 
             capture.SetExceptionMode(true);
             Assert.True(capture.GetExceptionMode());
+        }
+
+        [PlatformSpecificFact("Windows")]
+        public void WaitAnyWindows()
+        {
+            using var capture = new VideoCapture("_data/image/blob/shapes%d.png");
+            Assert.True(capture.IsOpened());
+
+            var ex = Assert.Throws<OpenCVException>(() =>
+            {
+                var result = VideoCapture.WaitAny(new[] {capture}, out var readyIndex, 0);
+            });
+            Assert.Equal("VideoCapture::waitAny() is supported by V4L backend only", ex.ErrMsg);
+        }
+
+        [PlatformSpecificFact("Linux")]
+        public void WaitAnyLinux()
+        {
+            using var capture = new VideoCapture("_data/image/blob/shapes%d.png", VideoCaptureAPIs.V4L2);
+            Assert.True(capture.IsOpened());
+
+            var result = VideoCapture.WaitAny(new[] {capture}, out var readyIndex, 0);
+            Assert.True(result);
+            Assert.Equal(new[]{0}, readyIndex);
+
+            Assert.True(capture.IsOpened());
+            Assert.True(capture.Grab());
         }
     }
 #endif


### PR DESCRIPTION
Close #1167 

I am afraid that the specified `VideoCapture` instance will be released at the same time as the `vector<VideoCapture>` instance is released.