### PR TITLE
call cv::destroyWindow in Window.Dispose()

### DIFF
--- a/src/OpenCvSharp/Modules/highgui/Window.cs
+++ b/src/OpenCvSharp/Modules/highgui/Window.cs
@@ -197,6 +197,10 @@ namespace OpenCvSharp
             {
                 callbackHandle.Dispose();
             }
+
+            NativeMethods.HandleException(
+                NativeMethods.highgui_destroyWindow(name));
+
             base.DisposeManaged();
         }
 

--- a/test/OpenCvSharp.Tests/highgui/HighGuiTest.cs
+++ b/test/OpenCvSharp.Tests/highgui/HighGuiTest.cs
@@ -17,6 +17,24 @@ namespace OpenCvSharp.Tests.HighGui
             int val = Cv2.WaitKeyEx(1);
             Assert.Equal(-1, val);
         }
+
+        [ExplicitFact]
+        public void Window()
+        {
+            using var img = new Mat("_data/image/mandrill.png");
+
+            using (var window = new Window("window01"))
+            {
+                window.ShowImage(img);
+                Cv2.WaitKey();
+            }
+            using (var window = new Window("window02"))
+            {
+                Cv2.CvtColor(img, img, ColorConversionCodes.BGR2GRAY);
+                window.ShowImage(img);
+                Cv2.WaitKey();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix #1173 