### PR TITLE
Fix parameter type in GetMouseWheelDelta

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_highgui.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_highgui.cs
@@ -244,7 +244,7 @@ namespace OpenCvSharp
         /// </summary>
         /// <param name="flags">The mouse callback flags parameter.</param>
         /// <returns></returns>
-        public static int GetMouseWheelDelta(MouseEventTypes flags)
+        public static int GetMouseWheelDelta(MouseEventFlags flags)
         {
             NativeMethods.HandleException(
                 NativeMethods.highgui_getMouseWheelDelta((int)flags, out var ret));


### PR DESCRIPTION
Fixed the type of parameter 'flags' in function 'GetMouseWheelDelta' to be same as the type of parameter 'flags' in delegate 'MouseCallback'.