### PR TITLE
enable hardware acceleration of VideoCapture and VideoWriter

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
@@ -23,6 +23,13 @@ namespace OpenCvSharp.Internal
         public static extern ExceptionStatus videoio_VideoCapture_new3(int device, int apiPreference, out IntPtr returnValue);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoCapture_new4(
+            [MarshalAs(UnmanagedType.LPStr)] string filename, int apiPreference, [In] int[] @params, int paramsLength, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoCapture_new5(int device, int apiPreference, [In] int[] @params, int paramsLength, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus videoio_VideoCapture_delete(IntPtr obj);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -92,6 +99,16 @@ namespace OpenCvSharp.Internal
         public static extern ExceptionStatus videoio_VideoWriter_new3(
             [MarshalAs(UnmanagedType.LPStr)] string filename, int apiPreference, int fourcc, double fps,
             Size frameSize, int isColor, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoWriter_new4(
+            [MarshalAs(UnmanagedType.LPStr)] string filename, int fourcc, double fps,
+            Size frameSize, [In] int[] @params, int paramsLength, out IntPtr returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus videoio_VideoWriter_new5(
+            [MarshalAs(UnmanagedType.LPStr)] string filename, int apiPreference, int fourcc, double fps,
+            Size frameSize, [In] int[] @params, int paramsLength, out IntPtr returnValue);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus videoio_VideoWriter_delete(IntPtr obj);

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoAccelerationType.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoAccelerationType.cs
@@ -1,0 +1,39 @@
+﻿
+namespace OpenCvSharp
+{
+    /// <summary>
+    /// Video Acceleration type
+    /// Used as value in #CAP_PROP_HW_ACCELERATION and #VIDEOWRITER_PROP_HW_ACCELERATION
+    /// note In case of FFmpeg backend, it translated to enum AVHWDeviceType (https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/hwcontext.h)
+    /// </summary>
+    public enum VideoAccelerationType
+    {
+        /// <summary>
+        /// Do not require any specific H/W acceleration, prefer software processing.
+        /// Reading of this value means that special H/W accelerated handling is not added or not detected by OpenCV.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Prefer to use H/W acceleration. If no one supported, then fallback to software processing.
+        /// note H/W acceleration may require special configuration of used environment.
+        /// note Results in encoding scenario may differ between software and hardware accelerated encoders.
+        /// </summary>
+        Any = 1,
+
+        /// <summary>
+        /// DirectX 11
+        /// </summary>
+        D3D11 = 2,
+
+        /// <summary>
+        /// VAAPI
+        /// </summary>
+        VAAPI = 3,
+
+        /// <summary>
+        /// libmfx (Intel MediaSDK/oneVPL)
+        /// </summary>
+        MFX = 4,
+    }
+}

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoCapturePara.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoCapturePara.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace OpenCvSharp
+{
+    /// <summary>
+    /// Parameters of VideoCature for hardware acceleration
+    /// Please check the link below for current HW acceleration types support matrix
+    /// https://github.com/opencv/opencv/wiki/Video-IO-hardware-acceleration
+    /// </summary>
+    [Serializable]
+    public record VideoCapturePara
+    {
+        /// <summary>
+        /// Used as value in #CAP_PROP_HW_ACCELERATION and #VIDEOWRITER_PROP_HW_ACCELERATION
+        /// note In case of FFmpeg backend, it translated to enum AVHWDeviceType (https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/hwcontext.h)
+        /// </summary>
+        public VideoAccelerationType AccelerationType { get; }
+
+        /// <summary>
+        /// Hardware device index (select GPU if multiple available). Device enumeration is acceleration type specific.
+        /// </summary>
+        public int HwDeviceIndex { get; }
+
+        /// <summary>
+        /// Constructor, parameter of VideoCature for hardware acceleration
+        /// </summary>
+        public VideoCapturePara()
+        {
+            AccelerationType = VideoAccelerationType.Any;
+            HwDeviceIndex = -1;
+        }
+
+        /// <summary>
+        /// Constructor, parameter of VideoCature for hardware acceleration
+        /// </summary>
+        /// <param name="videoAcceleration">Video Acceleration type</param>
+        /// <param name="deviceIndex">Hardware device index </param>
+        public VideoCapturePara(VideoAccelerationType videoAcceleration, int deviceIndex)
+        {
+            AccelerationType = videoAcceleration;
+            HwDeviceIndex = deviceIndex;
+        }
+
+        /// <summary>
+        /// Get parameters of VideoCature for hardware acceleration
+        /// </summary>
+        public int[] Parameters => new[] { (int)VideoCaptureProperties.HwAcceleration, (int)AccelerationType,
+            (int)VideoCaptureProperties.HwDevice, HwDeviceIndex };
+    }
+}

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoCaptureProperties.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoCaptureProperties.cs
@@ -262,6 +262,18 @@ namespace OpenCvSharp
         /// </summary>
         OrientationAuto = 49,
 
+        /// <summary>
+        /// (open-only) Hardware acceleration type (see VideoAccelerationType). 
+        /// Setting supported only via params parameter in cv::VideoCapture constructor / .open() method. 
+        /// Default value is backend-specific.
+        /// </summary>
+        HwAcceleration = 50,
+
+        /// <summary>
+        /// (open-only) Hardware device index (select GPU if multiple available). Device enumeration is acceleration type specific.
+        /// </summary>
+        HwDevice = 51,
+
         #endregion
 
         #region OpenNI

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoWriterPara.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoWriterPara.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace OpenCvSharp
+{
+    /// <summary>
+    /// Parameters of VideoWriter for hardware acceleration
+    /// Please check the link below for current HW acceleration types support matrix
+    /// https://github.com/opencv/opencv/wiki/Video-IO-hardware-acceleration
+    /// </summary>
+    [Serializable]
+    public record VideoWriterPara
+    {
+        /// <summary>
+        /// Used as value in #CAP_PROP_HW_ACCELERATION and #VIDEOWRITER_PROP_HW_ACCELERATION
+        /// note In case of FFmpeg backend, it translated to enum AVHWDeviceType (https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/hwcontext.h)
+        /// </summary>
+        public VideoAccelerationType AccelerationType { get; }
+
+        /// <summary>
+        /// Hardware device index (select GPU if multiple available). Device enumeration is acceleration type specific.
+        /// </summary>
+        public int HwDeviceIndex { get; }
+
+        /// <summary>
+        /// Constructor, parameter of VideoWriter for hardware acceleration
+        /// </summary>
+        public VideoWriterPara()
+        {
+            AccelerationType = VideoAccelerationType.Any;
+            HwDeviceIndex = -1;
+        }
+
+        /// <summary>
+        /// Constructor, parameter of VideoWriter for hardware acceleration
+        /// </summary>
+        /// <param name="videoAcceleration">Video Acceleration type</param>
+        /// <param name="deviceIndex">Hardware device index </param>
+        public VideoWriterPara(VideoAccelerationType videoAcceleration, int deviceIndex)
+        {
+            AccelerationType = videoAcceleration;
+            HwDeviceIndex = deviceIndex;
+        }
+
+        /// <summary>
+        /// Get parameters of VideoWriter for hardware acceleration
+        /// </summary>
+        public int[] Parameters => new[] { (int)VideoWriterProperties.HwAcceleration, (int)AccelerationType,
+            (int)VideoWriterProperties.HwDevice, HwDeviceIndex };
+    }
+}

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoWriterProperties.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoWriterProperties.cs
@@ -21,5 +21,28 @@ namespace OpenCvSharp
         /// Number of stripes for parallel encoding. -1 for auto detection.
         /// </summary>
         NStripes = 3,
+
+        /// <summary>
+        /// If it is not zero, the encoder will expect and encode color frames, otherwise it will work with grayscale frames.
+        /// </summary>
+        IsColor = 4,
+
+        /// <summary>
+        /// Defaults to CV_8U.
+        /// </summary>
+        Depth = 5,
+
+        /// <summary>
+        /// (open-only) Hardware acceleration type (see VideoAccelerationType). 
+        /// Setting supported only via params parameter in cv::VideoCapture constructor / .open() method. 
+        /// Default value is backend-specific.
+        /// </summary>
+        HwAcceleration = 6,
+
+        /// <summary>
+        /// (open-only) Hardware device index (select GPU if multiple available). Device enumeration is acceleration type specific.
+        /// </summary>
+        HwDevice = 7,
+
     }
 }

--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -64,11 +64,8 @@ namespace OpenCvSharp
         /// <param name="prms">The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`. 
         /// See cv::VideoCaptureProperties</param>
         /// <returns></returns>
-        public VideoCapture(int index, VideoCaptureAPIs apiPreference, int[]? prms = null)
+        public VideoCapture(int index, VideoCaptureAPIs apiPreference, int[] prms)
         {
-            if (prms == null)
-                prms = Array.Empty<int>();
-
             NativeMethods.HandleException(
                 NativeMethods.videoio_VideoCapture_new5(index, (int)apiPreference, prms, prms.Length, out ptr));
 
@@ -153,12 +150,10 @@ namespace OpenCvSharp
         /// <param name="prms">The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`. 
         /// See cv::VideoCaptureProperties</param>
         /// <returns></returns>
-        public VideoCapture(string fileName, VideoCaptureAPIs apiPreference, int[]? prms = null)
+        public VideoCapture(string fileName, VideoCaptureAPIs apiPreference, int[] prms)
         {
             if (string.IsNullOrEmpty(fileName))
                 throw new ArgumentNullException(nameof(fileName));
-            if (prms == null)
-                prms = Array.Empty<int>();
 
             NativeMethods.HandleException(
                 NativeMethods.videoio_VideoCapture_new4(fileName, (int)apiPreference, prms, prms.Length, out ptr));

--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -55,6 +55,52 @@ namespace OpenCvSharp
         }
 
         /// <summary>
+        /// Opens a camera for video capturing with API Preference and parameters
+        /// </summary>
+        /// <param name="index">id of the video capturing device to open. To open default camera using default backend just pass 0.
+        /// (to backward compatibility usage of camera_id + domain_offset (CAP_*) is valid when apiPreference is CAP_ANY)</param>
+        /// <param name="apiPreference">preferred Capture API backends to use. Can be used to enforce a specific reader implementation
+        /// if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.</param>
+        /// <param name="prms">The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`. 
+        /// See cv::VideoCaptureProperties</param>
+        /// <returns></returns>
+        public VideoCapture(int index, VideoCaptureAPIs apiPreference, int[]? prms = null)
+        {
+            if (prms == null)
+                prms = Array.Empty<int>();
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_new5(index, (int)apiPreference, prms, prms.Length, out ptr));
+
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoCapture");
+
+            captureType = CaptureType.Camera;
+        }
+
+        /// <summary>
+        /// Opens a camera for video capturing with API Preference and parameters
+        /// </summary>
+        /// <param name="index">id of the video capturing device to open. To open default camera using default backend just pass 0.
+        /// (to backward compatibility usage of camera_id + domain_offset (CAP_*) is valid when apiPreference is CAP_ANY)</param>
+        /// <param name="apiPreference">preferred Capture API backends to use. Can be used to enforce a specific reader implementation
+        /// if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.</param>
+        /// <param name="prms">Parameters of VideoCature for hardware acceleration</param>
+        /// <returns></returns>
+        public VideoCapture(int index, VideoCaptureAPIs apiPreference, VideoCapturePara prms)
+        {
+            var p = prms.Parameters;
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_new5(index, (int)apiPreference, p, p.Length, out ptr));
+
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoCapture");
+
+            captureType = CaptureType.Camera;
+        }
+
+        /// <summary>
         /// Opens a camera for video capturing
         /// </summary>
         /// <param name="index">id of the video capturing device to open. To open default camera using default backend just pass 0.
@@ -90,6 +136,64 @@ namespace OpenCvSharp
             if (ptr == IntPtr.Zero)
                 throw new OpenCvSharpException("Failed to create VideoCapture");
             
+            captureType = CaptureType.File;
+        }
+
+        /// <summary>
+        /// Opens a video file or a capturing device or an IP video stream for video capturing with API Preference
+        /// </summary>
+        /// <param name="fileName">it can be:
+        /// - name of video file (eg. `video.avi`)
+        /// - or image sequence (eg. `img_%02d.jpg`, which will read samples like `img_00.jpg, img_01.jpg, img_02.jpg, ...`)
+        /// - or URL of video stream (eg. `protocol://host:port/script_name?script_params|auth`).
+        /// Note that each video stream or IP camera feed has its own URL scheme. Please refer to the
+        /// documentation of source stream to know the right URL.</param>
+        /// <param name="apiPreference">apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
+        /// implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.</param>
+        /// <param name="prms">The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`. 
+        /// See cv::VideoCaptureProperties</param>
+        /// <returns></returns>
+        public VideoCapture(string fileName, VideoCaptureAPIs apiPreference, int[]? prms = null)
+        {
+            if (string.IsNullOrEmpty(fileName))
+                throw new ArgumentNullException(nameof(fileName));
+            if (prms == null)
+                prms = Array.Empty<int>();
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_new4(fileName, (int)apiPreference, prms, prms.Length, out ptr));
+
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoCapture");
+
+            captureType = CaptureType.File;
+        }
+
+        /// <summary>
+        /// Opens a video file or a capturing device or an IP video stream for video capturing with API Preference
+        /// </summary>
+        /// <param name="fileName">it can be:
+        /// - name of video file (eg. `video.avi`)
+        /// - or image sequence (eg. `img_%02d.jpg`, which will read samples like `img_00.jpg, img_01.jpg, img_02.jpg, ...`)
+        /// - or URL of video stream (eg. `protocol://host:port/script_name?script_params|auth`).
+        /// Note that each video stream or IP camera feed has its own URL scheme. Please refer to the
+        /// documentation of source stream to know the right URL.</param>
+        /// <param name="apiPreference">apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
+        /// implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.</param>
+        /// <param name="prms">Parameters of VideoCature for hardware acceleration</param>
+        /// <returns></returns>
+        public VideoCapture(string fileName, VideoCaptureAPIs apiPreference, VideoCapturePara prms)
+        {
+            if (string.IsNullOrEmpty(fileName))
+                throw new ArgumentNullException(nameof(fileName));
+            var p = prms.Parameters;
+
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_new4(fileName, (int)apiPreference, p, p.Length, out ptr));
+
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoCapture");
+
             captureType = CaptureType.File;
         }
 

--- a/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
@@ -72,6 +72,102 @@ namespace OpenCvSharp
         }
 
         /// <summary>
+        /// Creates video writer structure. 
+        /// </summary>
+        /// <param name="fileName">Name of the output video file. </param>
+        /// <param name="fourcc">4-character code of codec used to compress the frames. For example, "PIM1" is MPEG-1 codec, "MJPG" is motion-jpeg codec etc. 
+        /// Under Win32 it is possible to pass null in order to choose compression method and additional compression parameters from dialog. </param>
+        /// <param name="fps">Frame rate of the created video stream. </param>
+        /// <param name="frameSize">Size of video frames. </param>
+        /// <param name="prms">The `params` parameter allows to specify extra encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
+        /// see cv::VideoWriterProperties</param>
+        /// <returns></returns>
+        public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, int[]? prms = null)
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            Fps = fps;
+            FrameSize = frameSize;
+            if (prms == null)
+                prms = Array.Empty<int>();
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoWriter_new4(fileName, (int)fourcc, fps, frameSize, prms, prms.Length, out ptr));
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoWriter");
+        }
+
+        /// <summary>
+        /// Creates video writer structure. 
+        /// </summary>
+        /// <param name="fileName">Name of the output video file. </param>
+        /// <param name="fourcc">4-character code of codec used to compress the frames. For example, "PIM1" is MPEG-1 codec, "MJPG" is motion-jpeg codec etc. 
+        /// Under Win32 it is possible to pass null in order to choose compression method and additional compression parameters from dialog. </param>
+        /// <param name="fps">Frame rate of the created video stream. </param>
+        /// <param name="frameSize">Size of video frames. </param>
+        /// <param name="prms">Parameters of VideoWriter for hardware acceleration</param>
+        /// <returns></returns>
+        public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, VideoWriterPara prms)
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            Fps = fps;
+            FrameSize = frameSize;
+            var p = prms.Parameters;
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoWriter_new4(fileName, (int)fourcc, fps, frameSize, p, p.Length, out ptr));
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoWriter");
+        }
+
+        /// <summary>
+        /// Creates video writer structure. 
+        /// </summary>
+        /// <param name="fileName">Name of the output video file. </param>
+        /// <param name="apiPreference">allows to specify API backends to use. Can be used to enforce a specific reader implementation
+        /// if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_GSTREAMER.</param>
+        /// <param name="fourcc">4-character code of codec used to compress the frames. For example, "PIM1" is MPEG-1 codec, "MJPG" is motion-jpeg codec etc. 
+        /// Under Win32 it is possible to pass null in order to choose compression method and additional compression parameters from dialog. </param>
+        /// <param name="fps">Frame rate of the created video stream. </param>
+        /// <param name="frameSize">Size of video frames. </param>
+        /// <param name="prms">The `params` parameter allows to specify extra encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
+        /// see cv::VideoWriterProperties</param>
+        /// <returns></returns>
+        public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, int[]? prms = null)
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            Fps = fps;
+            FrameSize = frameSize;
+            if (prms == null)
+                prms = Array.Empty<int>();
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoWriter_new5(fileName, (int)apiPreference, (int)fourcc, fps, frameSize, prms, prms.Length, out ptr));
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoWriter");
+        }
+
+        /// <summary>
+        /// Creates video writer structure. 
+        /// </summary>
+        /// <param name="fileName">Name of the output video file. </param>
+        /// <param name="apiPreference">allows to specify API backends to use. Can be used to enforce a specific reader implementation
+        /// if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_GSTREAMER.</param>
+        /// <param name="fourcc">4-character code of codec used to compress the frames. For example, "PIM1" is MPEG-1 codec, "MJPG" is motion-jpeg codec etc. 
+        /// Under Win32 it is possible to pass null in order to choose compression method and additional compression parameters from dialog. </param>
+        /// <param name="fps">Frame rate of the created video stream. </param>
+        /// <param name="frameSize">Size of video frames. </param>
+        /// <param name="prms">Parameters of VideoWriter for hardware acceleration</param>
+        /// <returns></returns>
+        public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, VideoWriterPara prms)
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            Fps = fps;
+            FrameSize = frameSize;
+            var p = prms.Parameters;
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoWriter_new5(fileName, (int)apiPreference, (int)fourcc, fps, frameSize, p, p.Length, out ptr));
+            if (ptr == IntPtr.Zero)
+                throw new OpenCvSharpException("Failed to create VideoWriter");
+        }
+
+        /// <summary>
         /// Initializes from native pointer
         /// </summary>
         /// <param name="ptr">CvVideoWriter*</param>

--- a/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
@@ -82,13 +82,11 @@ namespace OpenCvSharp
         /// <param name="prms">The `params` parameter allows to specify extra encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
         /// see cv::VideoWriterProperties</param>
         /// <returns></returns>
-        public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, int[]? prms = null)
+        public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, int[] prms)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             Fps = fps;
             FrameSize = frameSize;
-            if (prms == null)
-                prms = Array.Empty<int>();
             NativeMethods.HandleException(
                 NativeMethods.videoio_VideoWriter_new4(fileName, (int)fourcc, fps, frameSize, prms, prms.Length, out ptr));
             if (ptr == IntPtr.Zero)
@@ -130,13 +128,11 @@ namespace OpenCvSharp
         /// <param name="prms">The `params` parameter allows to specify extra encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
         /// see cv::VideoWriterProperties</param>
         /// <returns></returns>
-        public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, int[]? prms = null)
+        public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, int[] prms)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             Fps = fps;
             FrameSize = frameSize;
-            if (prms == null)
-                prms = Array.Empty<int>();
             NativeMethods.HandleException(
                 NativeMethods.videoio_VideoWriter_new5(fileName, (int)apiPreference, (int)fourcc, fps, frameSize, prms, prms.Length, out ptr));
             if (ptr == IntPtr.Zero)

--- a/src/OpenCvSharpExtern/videoio.h
+++ b/src/OpenCvSharpExtern/videoio.h
@@ -28,6 +28,24 @@ CVAPI(ExceptionStatus) videoio_VideoCapture_new3(int device, int apiPreference, 
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) videoio_VideoCapture_new4(const char* filename, int apiPreference, int* params, int paramsLength, cv::VideoCapture** returnValue)
+{
+    BEGIN_WRAP
+        std::vector<int> paramsVec;
+        paramsVec.assign(params, params + paramsLength);
+        * returnValue = new cv::VideoCapture(filename, apiPreference, paramsVec);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) videoio_VideoCapture_new5(int device, int apiPreference, int* params, int paramsLength, cv::VideoCapture** returnValue)
+{
+    BEGIN_WRAP
+        std::vector<int> paramsVec;
+        paramsVec.assign(params, params + paramsLength);
+        * returnValue = new cv::VideoCapture(device, apiPreference, paramsVec);
+    END_WRAP
+}
+
+
 CVAPI(ExceptionStatus) videoio_VideoCapture_delete(cv::VideoCapture *obj)
 {
     BEGIN_WRAP
@@ -187,6 +205,30 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_new3(
 {
     BEGIN_WRAP
     *returnValue = new cv::VideoWriter(filename, apiPreference, fourcc, fps, cpp(frameSize), isColor != 0);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) videoio_VideoWriter_new4(
+    const char* filename,
+    int fourcc, double fps,
+    MyCvSize frameSize, int* params, int paramsLength,
+    cv::VideoWriter** returnValue)
+{
+    BEGIN_WRAP
+        std::vector<int> paramsVec;
+        paramsVec.assign(params, params + paramsLength);
+        * returnValue = new cv::VideoWriter(filename, fourcc, fps, cpp(frameSize), paramsVec);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) videoio_VideoWriter_new5(
+    const char* filename, int apiPreference,
+    int fourcc, double fps,
+    MyCvSize frameSize, int* params, int paramsLength,
+    cv::VideoWriter** returnValue)
+{
+    BEGIN_WRAP
+        std::vector<int> paramsVec;
+        paramsVec.assign(params, params + paramsLength);
+        * returnValue = new cv::VideoWriter(filename, apiPreference, fourcc, fps, cpp(frameSize), paramsVec);
     END_WRAP
 }
 


### PR DESCRIPTION
- add missing native methods for hardware acceleration
- add methods of video Capture/Writer for hardware acceleration
- add some missing properties of video Capture/Writer
- add video Capture/Writer parameter for hardware acceleration

Current HW acceleration types support matrix, for more details please check the [link](https://github.com/opencv/opencv/wiki/Video-IO-hardware-acceleration#video-io-hardware-acceleration) 

please review!