### PR TITLE
Fixed behavior of Mat.clone for empty Mat

### DIFF
--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -1453,6 +1453,10 @@ namespace OpenCvSharp
         public Mat Clone()
         {
             ThrowIfDisposed();
+            
+            if (Empty())            
+                return new Mat(Size(), Type());     
+
             NativeMethods.HandleException(
                 NativeMethods.core_Mat_clone(ptr, out var ret));
             GC.KeepAlive(this);

--- a/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
@@ -399,6 +399,11 @@ namespace OpenCvSharp
         /// <returns></returns>
         public new Mat<TElem> Clone()
         {
+            ThrowIfDisposed();
+
+            if (Empty())            
+                return new Mat<TElem>(Size());            
+
             using var result = base.Clone();
             return Wrap(result);
         }

--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -1143,5 +1143,65 @@ namespace OpenCvSharp.Tests.Core
             using var m2 = Mat.FromStream(stream, ImreadModes.Unchanged);
             Assert.Equal(m.Size(), m2.Size());
         }
+
+        /// <summary>
+        /// https://github.com/shimat/opencvsharp/issues/1288
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void TypeOfMatByteClone(int size)
+        {
+            {
+                using var expected = new Mat(size, size, MatType.CV_8U);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+            {
+                using var expected = new Mat<byte>(size, size);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+        }
+
+        /// <summary>
+        /// https://github.com/shimat/opencvsharp/issues/1288
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void TypeOfMatIntClone(int size)
+        {
+            {
+                using var expected = new Mat(size, size, MatType.CV_32S);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+            {
+                using var expected = new Mat<int>(size, size);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+        }
+
+        /// <summary>
+        /// https://github.com/shimat/opencvsharp/issues/1288
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void TypeOfMatDoubleClone(int size)
+        {
+            {
+                using var expected = new Mat(size, size, MatType.CV_64F);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+            {
+                using var expected = new Mat<double>(size, size);
+                using var actual = expected.Clone();            
+                Assert.Equal(expected.Type(), actual.Type());
+            }
+        }
     }
 }


### PR DESCRIPTION
This problem can be seen as a specification of OpenCV.

Close #1288