### PR TITLE
Add missing 'objdetect.CascadeClassifier.read'

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/objdetect/NativeMethods_objdetect_CascadeClassfier.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/objdetect/NativeMethods_objdetect_CascadeClassfier.cs
@@ -13,6 +13,9 @@ namespace OpenCvSharp.Internal
     static partial class NativeMethods
     {
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern ExceptionStatus objdetect_CascadeClassifier_read(IntPtr obj, IntPtr fn, out int returnValue);
+
+        [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern ExceptionStatus objdetect_CascadeClassifier_new(out IntPtr returnValue);
 
         [Pure, DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true, ExactSpelling = true)]

--- a/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
+++ b/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
@@ -88,6 +88,25 @@ namespace OpenCvSharp
         }
 
         /// <summary>
+        /// Reads a classifier parameters from a file storage
+        /// </summary>
+        /// <param name="fn"></param>
+        public virtual bool Read(FileNode fn)
+        {
+            if (ptr == IntPtr.Zero)
+                throw new ObjectDisposedException(GetType().Name);
+            if (fn == null)
+                throw new ArgumentNullException(nameof(fn));
+
+            NativeMethods.HandleException(
+                NativeMethods.objdetect_CascadeClassifier_read(ptr, fn.CvPtr, out var ret));
+            GC.KeepAlive(this);
+            GC.KeepAlive(fn);
+
+            return ret != 0;
+        }
+
+        /// <summary>
         /// Detects objects of different sizes in the input image. The detected objects are returned as a list of rectangles.
         /// </summary>
         /// <param name="image">Matrix of the type CV_8U containing an image where objects are detected.</param>

--- a/src/OpenCvSharpExtern/objdetect.h
+++ b/src/OpenCvSharpExtern/objdetect.h
@@ -43,6 +43,14 @@ CVAPI(ExceptionStatus) objdetect_CascadeClassifier_load(
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) objdetect_CascadeClassifier_read(
+    cv::CascadeClassifier* obj, cv::FileNode* fn, int* returnValue)
+{
+    BEGIN_WRAP
+        * returnValue = obj->read(*fn) ? 1 : 0;
+    END_WRAP
+}
+
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_detectMultiScale1(
     cv::CascadeClassifier *obj,
     cv::Mat *image, std::vector<cv::Rect> *objects,


### PR DESCRIPTION
Add missing method 'Read' for 'CascadeClassifier' in 'Objdetect'.

Tried to get wasm up and running with face detection but it blows up on me.
CvDnn.BlobFromImage for Dnn-based detection and cascadeClassifier.DetectMultiScale (probably due trying to load a physical file in the cascadeClassifier instance)).
Maybe FileNode can be provided inmemory/virtual filesystem so that we do not have to touch filesystem stuff that break wasm library?

