### PR TITLE
wrong result when coordinates are normalized between 0 and 1

### DIFF
--- a/src/OpenCvSharp/Modules/core/Struct/Rect2d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Rect2d.cs
@@ -80,8 +80,8 @@ namespace OpenCvSharp
             {
                 X = left,
                 Y = top,
-                Width = right - left + 1,
-                Height = bottom - top + 1
+                Width = right - left,
+                Height = bottom - top
             };
 
             if (r.Width < 0)

--- a/src/OpenCvSharp/Modules/core/Struct/Rect2f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Rect2f.cs
@@ -67,8 +67,8 @@ namespace OpenCvSharp
             {
                 X = left,
                 Y = top,
-                Width = right - left + 1,
-                Height = bottom - top + 1
+                Width = right - left,
+                Height = bottom - top
             };
 
             if (r.Width < 0)

--- a/test/OpenCvSharp.Tests/core/Rect2dTest.cs
+++ b/test/OpenCvSharp.Tests/core/Rect2dTest.cs
@@ -131,7 +131,7 @@ namespace OpenCvSharp.Tests.Core
         {
             var rect = Rect2d.FromLTRB(1, 2, 3, 4);
 
-            Assert.Equal(new Rect2d(1, 2, 3, 3), rect);
+            Assert.Equal(new Rect2d(1, 2, 2, 2), rect);
         }
     }
 }

--- a/test/OpenCvSharp.Tests/core/Rect2fTest.cs
+++ b/test/OpenCvSharp.Tests/core/Rect2fTest.cs
@@ -131,7 +131,7 @@ namespace OpenCvSharp.Tests.Core
         {
             var rect = Rect2f.FromLTRB(1, 2, 3, 4);
 
-            Assert.Equal(new Rect2f(1, 2, 3, 3), rect);
+            Assert.Equal(new Rect2f(1, 2, 2, 2), rect);
         }
     }
 }


### PR DESCRIPTION
sometime we might need coordinates normalized [0,1] after inference, we will get wrong result if plus 1