### PR TITLE
WIP Support for Ubuntu 22.04 Jelly Jam Native Packege

### DIFF
--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,7 +51,6 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
-            libswresample-dev \
             x264 \
             libtesseract-dev 
 

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,7 +51,7 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
-            libavresample1-dev \
+            libresample1-dev \
             x264 \
             libtesseract-dev 
 

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -43,7 +43,7 @@ jobs:
             libavcodec-dev \
             libavformat-dev \
             libswscale-dev \
-            libdc1394-22-dev \
+            libdc1394-dev \
             libxine2-dev \
             libv4l-dev \
             libtheora-dev \

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,6 +51,7 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
+            libavresample1-dev \
             x264 \
             libtesseract-dev 
 

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,7 +51,7 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
-            libresample1-dev \
+            libswresample-dev
             x264 \
             libtesseract-dev 
 

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     steps:
       - uses: actions/checkout@v2
@@ -146,14 +146,14 @@ jobs:
         run: |
           yyyymmdd=`date '+%Y%m%d'`
           echo $yyyymmdd
-          sed -E --in-place=.bak "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
-          cat ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
-          dotnet pack ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
+          sed -E --in-place=.bak "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.22.04-x64.nuspec
+          cat ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.22.04-x64.nuspec
+          dotnet pack ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.22.04-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
           ls ${GITHUB_WORKSPACE}/artifacts_ubuntu
 
       - uses: actions/upload-artifact@v1
         with:
-          name: artifacts_ubuntu_20
+          name: artifacts_ubuntu_22
           path: artifacts_ubuntu
         
       - name: Test
@@ -165,6 +165,6 @@ jobs:
           sudo cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.so /usr/lib/
           # ls ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/net6.0/
           # ls
-          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net6.0 --runtime ubuntu.20.04-x64 --logger "trx;LogFileName=test-results.trx" < /dev/null
+          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net6.0 --runtime ubuntu.22.04-x64 --logger "trx;LogFileName=test-results.trx" < /dev/null
           # ls
           # ls TestResults

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,7 +51,6 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
-            libavresample-dev \
             x264 \
             libtesseract-dev 
 

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -1,0 +1,170 @@
+name: Ubuntu 22.04
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+  push:
+    branches:
+      - master
+      - ubuntu22
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  OPENCV_VERSION: 4.6.0
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          
+      - name: Install dependencies
+        run: |
+          pwd
+          echo ${GITHUB_WORKSPACE}
+          current_path=$(pwd)
+          sudo apt-get update -y 
+          sudo apt-get install -y  --no-install-recommends \
+            apt-transport-https \
+            software-properties-common \
+            wget \
+            unzip \
+            ca-certificates \
+            build-essential \
+            cmake \
+            git \
+            libtbb-dev \
+            libatlas-base-dev \
+            libgtk2.0-dev \
+            libavcodec-dev \
+            libavformat-dev \
+            libswscale-dev \
+            libdc1394-22-dev \
+            libxine2-dev \
+            libv4l-dev \
+            libtheora-dev \
+            libvorbis-dev \
+            libxvidcore-dev \
+            libopencore-amrnb-dev \
+            libopencore-amrwb-dev \
+            libavresample-dev \
+            x264 \
+            libtesseract-dev 
+
+      - name: Cache OpenCV
+        id: opencv-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/opencv_ubuntu/
+          key: opencv-${{ env.OPENCV_VERSION }}-rev1
+          
+      - name: Build OpenCV
+        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip -Oopencv-${OPENCV_VERSION}.zip && unzip opencv-${OPENCV_VERSION}.zip
+          wget https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip -Oopencv_contrib-${OPENCV_VERSION}.zip && unzip opencv_contrib-${OPENCV_VERSION}.zip
+          cd opencv-${OPENCV_VERSION} && mkdir build && cd build
+          cmake \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D ENABLE_CXX11=ON \
+            -D BUILD_EXAMPLES=OFF \
+            -D BUILD_DOCS=OFF \
+            -D BUILD_PERF_TESTS=OFF \
+            -D BUILD_TESTS=OFF \
+            -D BUILD_JAVA=OFF \
+            -D BUILD_opencv_apps=OFF \
+            -D BUILD_opencv_barcode=OFF \
+            -D BUILD_opencv_java_bindings_generator=OFF \
+            -D BUILD_opencv_python_bindings_generator=OFF \
+            -D BUILD_opencv_python_tests=OFF \
+            -D BUILD_opencv_ts=OFF \
+            -D BUILD_opencv_js=OFF \
+            -D BUILD_opencv_js_bindings_generator=OFF \
+            -D BUILD_opencv_bioinspired=OFF \
+            -D BUILD_opencv_ccalib=OFF \
+            -D BUILD_opencv_datasets=OFF \
+            -D BUILD_opencv_dnn_objdetect=OFF \
+            -D BUILD_opencv_dpm=OFF \
+            -D BUILD_opencv_fuzzy=OFF \
+            -D BUILD_opencv_gapi=ON \
+            -D BUILD_opencv_intensity_transform=OFF \
+            -D BUILD_opencv_mcc=OFF \
+            -D BUILD_opencv_objc_bindings_generator=OFF \
+            -D BUILD_opencv_rapid=OFF \
+            -D BUILD_opencv_reg=OFF \
+            -D BUILD_opencv_stereo=OFF \
+            -D BUILD_opencv_structured_light=OFF \
+            -D BUILD_opencv_surface_matching=OFF \
+            -D BUILD_opencv_wechat_qrcode=ON \
+            -D BUILD_opencv_videostab=OFF \
+            -D WITH_GSTREAMER=OFF \
+            -D WITH_ADE=OFF \
+            -D OPENCV_ENABLE_NONFREE=ON \
+            -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_ubuntu ..
+          make -j2
+          make install
+          sudo ldconfig
+          cd ${GITHUB_WORKSPACE}
+          ls
+      
+      - name: Build OpenCvSharpExtern
+        run: |                    
+          ls ${GITHUB_WORKSPACE}/opencv_ubuntu
+          echo "-----"
+          ls ${GITHUB_WORKSPACE}/opencv_ubuntu/lib
+          echo "-----"
+          mkdir src/build && cd $_
+          cmake -D CMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/opencv_ubuntu ..
+          make -j2
+          ls OpenCvSharpExtern
+          cp OpenCvSharpExtern/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/nuget/
+          ldd OpenCvSharpExtern/libOpenCvSharpExtern.so
+
+      - name: Check OpenCvSharpExtern
+        run: |
+          cd ${GITHUB_WORKSPACE}/nuget/
+          ldd libOpenCvSharpExtern.so
+          nm libOpenCvSharpExtern.so
+          echo -ne "#include <stdio.h> \n int core_Mat_sizeof(); int main(){ int i = core_Mat_sizeof(); printf(\"sizeof(Mat) = %d\", i); return 0; }" > test.c
+          gcc -I./ -L./ test.c -o test -lOpenCvSharpExtern
+          LD_LIBRARY_PATH=. ./test
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Create NuGet package
+        env: 
+          BETA: ""
+        run: |
+          yyyymmdd=`date '+%Y%m%d'`
+          echo $yyyymmdd
+          sed -E --in-place=.bak "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
+          cat ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
+          dotnet pack ${GITHUB_WORKSPACE}/nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
+          ls ${GITHUB_WORKSPACE}/artifacts_ubuntu
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: artifacts_ubuntu_20
+          path: artifacts_ubuntu
+        
+      - name: Test
+        run: |
+          cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
+          dotnet build -c Release -f net6.0
+          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/net6.0/
+          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/
+          sudo cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.so /usr/lib/
+          # ls ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/net6.0/
+          # ls
+          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net6.0 --runtime ubuntu.20.04-x64 --logger "trx;LogFileName=test-results.trx" < /dev/null
+          # ls
+          # ls TestResults

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -51,7 +51,7 @@ jobs:
             libxvidcore-dev \
             libopencore-amrnb-dev \
             libopencore-amrwb-dev \
-            libswresample-dev
+            libswresample-dev \
             x264 \
             libtesseract-dev 
 


### PR DESCRIPTION
Added [.github/workflows/ubuntu22.yml](https://github.com/shimat/opencvsharp/compare/master...Evelios:ubuntu22?expand=1#diff-f2ffe19e8d71769ca25fde1e5c55df220ff2388ed9d184c5a14dff03c7f29ff6) with the following changes
* Runs on `ubuntu-22.04` from `ubuntu-22.04`
* `libswresample-dev` used instead of the deprecated package `libawresample-dev`
* `libdc1394-dev` used instead of the deprecated `libdc1394-22-dev`