### PR TITLE
Fix null pointer error

### DIFF
--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -232,8 +232,9 @@ public class VideoCapture : DisposableCvObject
     /// </summary>
     protected override void DisposeUnmanaged()
     {
-        NativeMethods.HandleException(
-            NativeMethods.videoio_VideoCapture_delete(ptr));
+        if (ptr != IntPtr.Zero)
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_delete(ptr));
         base.DisposeUnmanaged();
     }
 


### PR DESCRIPTION
Fix null pointer error

Error messages：
Unhandled exception. System.TypeInitializationException: The type initializer for 'OpenCvSharp.Internal.NativeMethods' threw an exception.
 ---> System.DllNotFoundException: Unable to load shared library 'OpenCvSharpExtern' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libOpenCvSharpExtern: cannot open shared object file: No such file or directory
   at OpenCvSharp.Internal.NativeMethods.redirectError(CvErrorCallback errCallback, IntPtr userdata, IntPtr& prevUserdata)
   at OpenCvSharp.Internal.ExceptionHandler.RegisterExceptionCallback()
   at OpenCvSharp.Internal.NativeMethods.LoadLibraries(IEnumerable`1 additionalPaths)
   at OpenCvSharp.Internal.NativeMethods..cctor()
   --- End of inner exception stack trace ---
   at OpenCvSharp.Internal.NativeMethods.videoio_VideoCapture_delete(IntPtr obj)
   at OpenCvSharp.VideoCapture.DisposeUnmanaged()
   at OpenCvSharp.DisposableObject.Dispose(Boolean disposing)
   at OpenCvSharp.DisposableObject.Finalize()