### PR TITLE
Fix incorrect rvec and tvec when using useExtrinsicGuess

### DIFF
--- a/src/OpenCvSharpExtern/calib3d.h
+++ b/src/OpenCvSharpExtern/calib3d.h
@@ -204,7 +204,7 @@ CVAPI(ExceptionStatus) calib3d_solvePnP_vector(cv::Point3f *objectPoints, int ob
         distCoeffsMat = cv::Mat(distCoeffsLength, 1, CV_64FC1, distCoeffs);
 
     const cv::Matx<double, 3, 3> cameraMatrixMat(cameraMatrix);
-    cv::Matx<double, 3, 1> rvecMat, tvecMat;
+    cv::Matx<double, 3, 1> rvecMat(rvec), tvecMat(tvec);
     cv::solvePnP(objectPointsMat, imagePointsMat, cameraMatrixMat, distCoeffsMat, rvecMat, tvecMat, useExtrinsicGuess != 0, flags);
     memcpy(rvec, rvecMat.val, sizeof(double) * 3);
     memcpy(tvec, tvecMat.val, sizeof(double) * 3);

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -280,11 +280,13 @@ public class Calib3DTest : TestBase
         Cv2.FishEye.ProjectPoints(objectPoints, imagePoints, rVec, tVec, intrisicMat, distCoeffs, 0, jacobian);
     }
 
-    [Fact]
-    public void SolvePnPTestByArray()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SolvePnPTestByArray(bool useExtrinsicGuess)
     {
-        var rvec = new double[] { 0, 0, 0 };
-        var tvec = new double[] { 0, 0, 0 };
+        var rvec = new double[] { 3, 0, 0 };
+        var tvec = new double[] { 0, 0, -10 };
         var cameraMatrix = new double[,]
         {
             { 1, 0, 0 },
@@ -305,7 +307,7 @@ public class Calib3DTest : TestBase
 
         Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out var jacobian);
 
-        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec);
+        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, useExtrinsicGuess: useExtrinsicGuess);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1556.

I also updated the test to use inputs that reproduce the issue (for many inputs, SolvePnP will still converge when the initial rvec and tvec are wrong). With the updated test and no change to calib3d.h, the `rvec` and `tvec` outputs are clearly wrong. With the fix (or without `useExtrinsicGuess`) they are correct.

SolvePnPRansac has a similar issue, but I didn't fix it here because:
- The API uses `out` parameters for `rvec` and `tvec`, so modifying them would be a breaking change.
- Because these are `out` parameters, it's obvious that `useExtrinsicGuess` won't work, so it's much less likely to confuse users than the normal `solvePnP` version.