### PR TITLE
4.9.0

### DIFF
--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  OPENCV_VERSION: 4.8.0
+  OPENCV_VERSION: 4.9.0
 
 jobs:
   build:

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  OPENCV_VERSION: 4.8.0
+  OPENCV_VERSION: 4.9.0
   OPENCV_CACHE_VERSION: 1
 
 jobs:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  OPENCV_VERSION: 4.8.0
+  OPENCV_VERSION: 4.9.0
   EM_VERSION: 3.1.32
   EM_CACHE_FOLDER: 'emsdk-cache'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true
@@ -67,7 +67,7 @@ jobs:
           . ".\download_tesseract_windows.ps1"
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1.3.1
 
       - name: Build x64
         shell: cmd
@@ -77,15 +77,15 @@ jobs:
         shell: cmd
         run: msbuild OpenCvSharp.sln /t:build /p:configuration=Release /p:platform=x86 -maxcpucount
 
-      - name: Build ARM
-        shell: cmd
-        run: msbuild OpenCvSharp.sln /t:build /p:configuration=Release /p:platform=ARM -maxcpucount
+      #- name: Build ARM
+      #  shell: cmd
+      #  run: msbuild OpenCvSharp.sln /t:build /p:configuration=Release /p:platform=ARM -maxcpucount
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
 
       - name: Build net6.0
         shell: cmd
@@ -156,7 +156,7 @@ jobs:
           dotnet run -c Release --runtime win-x64 -- "${env:GITHUB_WORKSPACE}" "${env:GITHUB_WORKSPACE}\artifacts" ${{env.OPENCV_VERSION}}
 
       - name: Upload NuGet packages and Release packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages_windows
           path: ${{ github.workspace }}\artifacts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -135,7 +135,6 @@ jobs:
           nuget pack nuget/OpenCvSharp4.Extensions.nuspec -OutputDirectory artifacts -Symbols -SymbolPackageFormat snupkg
           nuget pack nuget/OpenCvSharp4.WpfExtensions.nuspec -OutputDirectory artifacts -Symbols -SymbolPackageFormat snupkg
           nuget pack nuget/OpenCvSharp4.runtime.win.nuspec -OutputDirectory artifacts
-          nuget pack nuget/OpenCvSharp4.runtime.uwp.nuspec -OutputDirectory artifacts
 
       - name: Test
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  OPENCV_VERSION: 4.8.0
+  OPENCV_VERSION: 4.9.0
 
 jobs:
   build:

--- a/OpenCvSharp.sln
+++ b/OpenCvSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29503.13
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E048D213-B3B9-453F-9A41-29FDEB0D496B}"
 EndProject
@@ -24,8 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tool", "tool", "{A6E578C0-A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCvSharp.NupkgBetaRemover", "tool\OpenCvSharp.NupkgBetaRemover\OpenCvSharp.NupkgBetaRemover.csproj", "{CC19F9A5-01A7-4BDF-B34C-CF56F46A474A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "uwpOpenCvSharpExtern", "src\uwpOpenCvSharpExtern\uwpOpenCvSharpExtern.vcxproj", "{BD5471E5-7B55-5192-8DA4-042B66AF71AE}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCvSharp.WpfExtensions", "src\OpenCvSharp.WpfExtensions\OpenCvSharp.WpfExtensions.csproj", "{01FD66CE-F81A-4641-BE30-3CF9DE84D6D5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCvSharp.ReleaseMaker", "tool\OpenCvSharp.ReleaseMaker\OpenCvSharp.ReleaseMaker.csproj", "{1C399497-5240-439A-879A-4ACB34C409AE}"
@@ -37,7 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenCvSharp.DebuggerVisualizers.Tester", "test\OpenCvSharp.DebuggerVisualizers.Tester\OpenCvSharp.DebuggerVisualizers.Tester.csproj", "{FFD602AA-0A08-40DD-8ACD-7F5A3BA51DEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenCvSharp.Tests.Windows", "test\OpenCvSharp.Tests.Windows\OpenCvSharp.Tests.Windows.csproj", "{36F6A125-3633-441E-9794-97EB91E50F20}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenCvSharp.Tests.Windows", "test\OpenCvSharp.Tests.Windows\OpenCvSharp.Tests.Windows.csproj", "{36F6A125-3633-441E-9794-97EB91E50F20}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -144,19 +142,6 @@ Global
 		{CC19F9A5-01A7-4BDF-B34C-CF56F46A474A}.Release|x64.Build.0 = Release|Any CPU
 		{CC19F9A5-01A7-4BDF-B34C-CF56F46A474A}.Release|x86.ActiveCfg = Release|Any CPU
 		{CC19F9A5-01A7-4BDF-B34C-CF56F46A474A}.Release|x86.Build.0 = Release|Any CPU
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|ARM.ActiveCfg = Debug|ARM
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|x64.ActiveCfg = Release|x64
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|x64.Build.0 = Release|x64
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|x86.ActiveCfg = Release|Win32
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Debug|x86.Build.0 = Release|Win32
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|Any CPU.ActiveCfg = Release|Win32
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|ARM.ActiveCfg = Release|ARM
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|ARM.Build.0 = Release|ARM
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|x64.ActiveCfg = Release|x64
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|x64.Build.0 = Release|x64
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|x86.ActiveCfg = Release|Win32
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE}.Release|x86.Build.0 = Release|Win32
 		{01FD66CE-F81A-4641-BE30-3CF9DE84D6D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01FD66CE-F81A-4641-BE30-3CF9DE84D6D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01FD66CE-F81A-4641-BE30-3CF9DE84D6D5}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -232,7 +217,6 @@ Global
 		{8E7279F8-F801-4672-B42F-1ED2C68B16A4} = {E048D213-B3B9-453F-9A41-29FDEB0D496B}
 		{4232CB4A-DFE3-46CA-9503-C5F1798BAED3} = {E048D213-B3B9-453F-9A41-29FDEB0D496B}
 		{CC19F9A5-01A7-4BDF-B34C-CF56F46A474A} = {A6E578C0-A34A-4CCF-A808-CBAC81CB48C0}
-		{BD5471E5-7B55-5192-8DA4-042B66AF71AE} = {E048D213-B3B9-453F-9A41-29FDEB0D496B}
 		{01FD66CE-F81A-4641-BE30-3CF9DE84D6D5} = {E048D213-B3B9-453F-9A41-29FDEB0D496B}
 		{1C399497-5240-439A-879A-4ACB34C409AE} = {A6E578C0-A34A-4CCF-A808-CBAC81CB48C0}
 		{FFD602AA-0A08-40DD-8ACD-7F5A3BA51DEC} = {1F113DD0-E292-47A5-8EFF-3FB5D0869BF3}

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ dotnet run
 If you do not use NuGet, get DLL files from the [release page](https://github.com/shimat/opencvsharp/releases).
 
 ## Target OpenCV
-* [OpenCV 4.7](http://opencv.org/) with [opencv_contrib](https://github.com/opencv/opencv_contrib)
+* [OpenCV 4.9.0](http://opencv.org/) with [opencv_contrib](https://github.com/opencv/opencv_contrib)
 
 ## Requirements
-* [.NET Framework 4.8](http://www.microsoft.com/ja-jp/download/details.aspx?id=1639) / [.NET Core 2.0](https://www.microsoft.com/net/download) / [Mono](http://www.mono-project.com/Main_Page)
+* [.NET Framework 4.8](http://www.microsoft.com/ja-jp/download/details.aspx?id=1639) / [.NET 6](https://www.microsoft.com/net/download) / .NET Standard 2.0 / [Mono](http://www.mono-project.com/Main_Page)
 * (Windows) [Visual C++ 2022 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 * (Windows Server) Media Foundation
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you do not use NuGet, get DLL files from the [release page](https://github.co
 * [OpenCV 4.9.0](http://opencv.org/) with [opencv_contrib](https://github.com/opencv/opencv_contrib)
 
 ## Requirements
-* [.NET Framework 4.8](http://www.microsoft.com/ja-jp/download/details.aspx?id=1639) / [.NET 6](https://www.microsoft.com/net/download) / .NET Standard 2.0 / [Mono](http://www.mono-project.com/Main_Page)
+* [.NET Framework 4.8](http://www.microsoft.com/ja-jp/download/details.aspx?id=1639) / [.NET 6](https://www.microsoft.com/net/download) / .NET Standard 2.0
 * (Windows) [Visual C++ 2022 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 * (Windows Server) Media Foundation
 ```

--- a/download_opencv_windows.ps1
+++ b/download_opencv_windows.ps1
@@ -1,5 +1,5 @@
-$tag = "4.8.0.20230705"
-$version = "480"
+$tag = "4.9.0.20231231-beta"
+$version = "490"
 $uriArray = @(
     "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_win_x64.zip"
     "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_win_x86.zip" 

--- a/download_opencv_windows.ps1
+++ b/download_opencv_windows.ps1
@@ -2,10 +2,7 @@ $tag = "4.9.0.20231231-beta"
 $version = "490"
 $uriArray = @(
     "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_win_x64.zip"
-    "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_win_x86.zip" 
-    "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_uwp_x64.zip" 
-    "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_uwp_x86.zip"
-    "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_uwp_ARM.zip"
+    "https://github.com/shimat/opencv_files/releases/download/${tag}/opencv${version}_win_x86.zip"
 )
 
 function Download($uri, $outFile) {

--- a/nuget/OpenCvSharp4.runtime.uwp.nuspec
+++ b/nuget/OpenCvSharp4.runtime.uwp.nuspec
@@ -26,11 +26,11 @@
         <file src="..\src\Release\uwpOpenCvSharpExtern\x64\OpenCvSharpExtern.dll"   target="runtimes\win-x64\native" />
         <file src="..\src\Release\uwpOpenCvSharpExtern\Win32\OpenCvSharpExtern.dll" target="runtimes\win-x86\native" />
         <file src="..\src\Release\uwpOpenCvSharpExtern\ARM\OpenCvSharpExtern.dll" target="runtimes\win-arm\native" />
-        <file src="..\opencv_files\opencv480_uwp_x64\x64\vc17\bin\opencv_world480.dll" target="runtimes\win-x64\native" />
-        <file src="..\opencv_files\opencv480_uwp_x86\x86\vc17\bin\opencv_world480.dll" target="runtimes\win-x86\native" />
-        <file src="..\opencv_files\opencv480_uwp_arm\x86\vc17\bin\opencv_world480.dll" target="runtimes\win-arm\native" />
-        <file src="..\opencv_files\opencv480_uwp_x64\x64\vc17\bin\opencv_img_hash480.dll" target="runtimes\win-x64\native" />
-        <file src="..\opencv_files\opencv480_uwp_x86\x86\vc17\bin\opencv_img_hash480.dll" target="runtimes\win-x86\native" />
-        <file src="..\opencv_files\opencv480_uwp_arm\x86\vc17\bin\opencv_img_hash480.dll" target="runtimes\win-arm\native" />
+        <file src="..\opencv_files\opencv490_uwp_x64\x64\vc17\bin\opencv_world490.dll" target="runtimes\win-x64\native" />
+        <file src="..\opencv_files\opencv490_uwp_x86\x86\vc17\bin\opencv_world490.dll" target="runtimes\win-x86\native" />
+        <file src="..\opencv_files\opencv490_uwp_arm\x86\vc17\bin\opencv_world490.dll" target="runtimes\win-arm\native" />
+        <file src="..\opencv_files\opencv490_uwp_x64\x64\vc17\bin\opencv_img_hash490.dll" target="runtimes\win-x64\native" />
+        <file src="..\opencv_files\opencv490_uwp_x86\x86\vc17\bin\opencv_img_hash490.dll" target="runtimes\win-x86\native" />
+        <file src="..\opencv_files\opencv490_uwp_arm\x86\vc17\bin\opencv_img_hash490.dll" target="runtimes\win-arm\native" />
     </files>
 </package>

--- a/nuget/OpenCvSharp4.runtime.win.nuspec
+++ b/nuget/OpenCvSharp4.runtime.win.nuspec
@@ -27,8 +27,8 @@
     <files>
         <file src="..\src\Release\x64\OpenCvSharpExtern.dll"   target="runtimes\win-x64\native" />
         <file src="..\src\Release\Win32\OpenCvSharpExtern.dll" target="runtimes\win-x86\native" />
-        <file src="..\opencv_files\opencv480_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg480_64.dll" target="runtimes\win-x64\native" />
-        <file src="..\opencv_files\opencv480_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg480.dll"    target="runtimes\win-x86\native" />
+        <file src="..\opencv_files\opencv490_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg490_64.dll" target="runtimes\win-x64\native" />
+        <file src="..\opencv_files\opencv490_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg490.dll"    target="runtimes\win-x86\native" />
         <file src="OpenCvSharp4.runtime.win.props" target="build\net48\OpenCvSharp4.runtime.win.props" />
         <file src="OpenCvSharp4.runtime.win.props" target="build\netstandard\OpenCvSharp4.runtime.win.props" />
         <file src="OpenCvSharp4.runtime.win.props" target="build\netcoreapp\OpenCvSharp4.runtime.win.props" />

--- a/nuget/OpenCvSharp4.runtime.win.props
+++ b/nuget/OpenCvSharp4.runtime.win.props
@@ -7,8 +7,8 @@
 			<Link>dll\x86\OpenCvSharpExtern.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-x86\native\opencv_videoio_ffmpeg480.dll">
-			<Link>dll\x86\opencv_videoio_ffmpeg480.dll</Link>
+		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-x86\native\opencv_videoio_ffmpeg490.dll">
+			<Link>dll\x86\opencv_videoio_ffmpeg490.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
@@ -17,8 +17,8 @@
 			<Link>dll\x64\OpenCvSharpExtern.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-x64\native\opencv_videoio_ffmpeg480_64.dll">
-			<Link>dll\x64\opencv_videoio_ffmpeg480_64.dll</Link>
+		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-x64\native\opencv_videoio_ffmpeg490_64.dll">
+			<Link>dll\x64\opencv_videoio_ffmpeg490_64.dll</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>

--- a/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
@@ -52,7 +52,7 @@ static partial class Cv2
         if (vector is null)
             throw new ArgumentNullException(nameof(vector));
         if (vector.Length != 3)
-            throw new ArgumentException("vector.Length != 3");
+            throw new ArgumentException("Length != 3", nameof(vector));
 
         using var vectorM = new Mat(3, 1, MatType.CV_64FC1, vector);
         using var matrixM = new Mat<double>();

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -912,7 +912,7 @@ static partial class Cv2
         if (mv is null)
             throw new ArgumentNullException(nameof(mv));
         if (mv.Length == 0)
-            throw new ArgumentException("mv.Length == 0");
+            throw new ArgumentException("mv is empty", nameof(mv));
         if (dst is null)
             throw new ArgumentNullException(nameof(dst));
         foreach (var m in mv)
@@ -985,11 +985,11 @@ static partial class Cv2
         if (fromTo is null)
             throw new ArgumentNullException(nameof(fromTo));
         if (src.Length == 0)
-            throw new ArgumentException("src.Length == 0");
+            throw new ArgumentException("Length == 0", nameof(src));
         if (dst.Length == 0)
-            throw new ArgumentException("dst.Length == 0");
+            throw new ArgumentException("Length == 0", nameof(dst));
         if (fromTo.Length == 0 || fromTo.Length % 2 != 0)
-            throw new ArgumentException("fromTo.Length == 0");
+            throw new ArgumentException("Invalid length", nameof(fromTo));
         var srcPtr = new IntPtr[src.Length];
         var dstPtr = new IntPtr[dst.Length];
         for (var i = 0; i < src.Length; i++)
@@ -1165,7 +1165,7 @@ static partial class Cv2
 
         var srcArray = src as Mat[] ?? src.ToArray();
         if (srcArray.Length == 0)
-            throw new ArgumentException("src.Count == 0", nameof(src));
+            throw new ArgumentException("src is empty", nameof(src));
         var srcPtr = new IntPtr[srcArray.Length];
         for (var i = 0; i < srcArray.Length; i++)
         {

--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -569,7 +569,7 @@ public class InputArray : DisposableCvObject
         if (t == typeof(Point3f))
             return MatType.CV_32FC3;
         if (t == typeof(Point3d))
-            return MatType.CV_32FC3;
+            return MatType.CV_64FC3;
         if (t == typeof(Range))
             return MatType.CV_32SC2;
         if (t == typeof(Rangef))

--- a/src/OpenCvSharp/Modules/imgproc/Enum/ColormapTypes.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Enum/ColormapTypes.cs
@@ -30,4 +30,3 @@ public enum ColormapTypes
     Turbo = 20,
     DeepGreen = 21
 }
-}

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
@@ -144,7 +144,7 @@ public class SelectiveSearchSegmentation : Algorithm
         g.ThrowIfDisposed();
 
         if (g.PtrObj is null)
-            throw new ArgumentException("g.PtrObj = null");
+            throw new ArgumentException($"PtrObj = null", nameof(g));
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(ptr, g.PtrObj.CvPtr));

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Configurations>Debug;Release;Release-JP</Configurations>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
@@ -79,14 +79,14 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)src\$(Configuration)\$(PlatformName)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">src\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\opencv_files\opencv480_win_x64\include;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\opencv_files\opencv480_win_x64\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\opencv_files\opencv480_win_x64\x64\vc16\staticlib;$(LibraryPath)</LibraryPath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\opencv_files\opencv480_win_x64\x64\vc17\staticlib;$(SolutionDir)\tesseract_files\tesseract_vcpkg\x64-windows-static\lib;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\opencv_files\opencv480_win_x86\include;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\opencv_files\opencv480_win_x86\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\opencv_files\opencv480_win_x86\x86\vc17\staticlib;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Lib;$(SolutionDir)\tesseract_files\tesseract_vcpkg\x86-windows-static\lib;$(LibraryPath)</LibraryPath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\opencv_files\opencv480_win_x86\x86\vc16\staticlib;$(LibraryPath)</LibraryPath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\opencv_files\opencv490_win_x64\include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\opencv_files\opencv490_win_x64\include;$(IncludePath)</IncludePath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\opencv_files\opencv490_win_x64\x64\vc16\staticlib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\opencv_files\opencv490_win_x64\x64\vc17\staticlib;$(SolutionDir)\tesseract_files\tesseract_vcpkg\x64-windows-static\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\opencv_files\opencv490_win_x86\include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\opencv_files\opencv490_win_x86\include;$(IncludePath)</IncludePath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\opencv_files\opencv490_win_x86\x86\vc17\staticlib;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Lib;$(SolutionDir)\tesseract_files\tesseract_vcpkg\x86-windows-static\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\opencv_files\opencv490_win_x86\x86\vc16\staticlib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -164,7 +164,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>IlmImf.lib;ippicvmt.lib;ippiw.lib;ittnotify.lib;libjpeg-turbo.lib;libopenjp2.lib;libpng.lib;libprotobuf.lib;libtiff.lib;libwebp.lib;opencv_aruco480.lib;opencv_bgsegm480.lib;opencv_bioinspired480.lib;opencv_calib3d480.lib;opencv_ccalib480.lib;opencv_core480.lib;opencv_dnn480.lib;opencv_dnn_superres480.lib;opencv_dnn_objdetect480.lib;opencv_dpm480.lib;opencv_face480.lib;opencv_features2d480.lib;opencv_flann480.lib;opencv_fuzzy480.lib;opencv_hfs480.lib;opencv_highgui480.lib;opencv_imgcodecs480.lib;opencv_imgproc480.lib;opencv_img_hash480.lib;opencv_line_descriptor480.lib;opencv_ml480.lib;opencv_objdetect480.lib;opencv_optflow480.lib;opencv_phase_unwrapping480.lib;opencv_photo480.lib;opencv_plot480.lib;opencv_quality480.lib;opencv_reg480.lib;opencv_rgbd480.lib;opencv_saliency480.lib;opencv_shape480.lib;opencv_stereo480.lib;opencv_stitching480.lib;opencv_structured_light480.lib;opencv_superres480.lib;opencv_surface_matching480.lib;opencv_text480.lib;opencv_tracking480.lib;opencv_video480.lib;opencv_videoio480.lib;opencv_videostab480.lib;opencv_wechat_qrcode480.lib;opencv_xfeatures2d480.lib;opencv_ximgproc480.lib;opencv_xobjdetect480.lib;opencv_xphoto480.lib;quirc.lib;zlib.lib;ws2_32.lib;tesseract53.lib;leptonica-1.83.1.lib;archive.lib;bz2.lib;charset.lib;gif.lib;iconv.lib;jpeg.lib;libcrypto.lib;libcurl.lib;libpng16.lib;libsharpyuv.lib;libssl.lib;libxml2.lib;lz4.lib;lzma.lib;tiff.lib;turbojpeg.lib;zstd.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>IlmImf.lib;ippicvmt.lib;ippiw.lib;ittnotify.lib;libjpeg-turbo.lib;libopenjp2.lib;libpng.lib;libprotobuf.lib;libtiff.lib;libwebp.lib;opencv_aruco490.lib;opencv_bgsegm490.lib;opencv_bioinspired490.lib;opencv_calib3d490.lib;opencv_ccalib490.lib;opencv_core490.lib;opencv_dnn490.lib;opencv_dnn_objdetect490.lib;opencv_dnn_superres490.lib;opencv_dpm490.lib;opencv_face490.lib;opencv_features2d490.lib;opencv_flann490.lib;opencv_fuzzy490.lib;opencv_hfs490.lib;opencv_highgui490.lib;opencv_imgcodecs490.lib;opencv_imgproc490.lib;opencv_img_hash490.lib;opencv_intensity_transform490.lib;opencv_line_descriptor490.lib;opencv_mcc490.lib;opencv_ml490.lib;opencv_objdetect490.lib;opencv_optflow490.lib;opencv_phase_unwrapping490.lib;opencv_photo490.lib;opencv_plot490.lib;opencv_quality490.lib;opencv_rapid490.lib;opencv_reg490.lib;opencv_rgbd490.lib;opencv_saliency490.lib;opencv_shape490.lib;opencv_stereo490.lib;opencv_stitching490.lib;opencv_structured_light490.lib;opencv_superres490.lib;opencv_surface_matching490.lib;opencv_text490.lib;opencv_tracking490.lib;opencv_video490.lib;opencv_videoio490.lib;opencv_videostab490.lib;opencv_wechat_qrcode490.lib;opencv_xfeatures2d490.lib;opencv_ximgproc490.lib;opencv_xobjdetect490.lib;opencv_xphoto490.lib;zlib.lib;ws2_32.lib;tesseract53.lib;leptonica-1.83.1.lib;archive.lib;bz2.lib;charset.lib;gif.lib;iconv.lib;jpeg.lib;libcrypto.lib;libcurl.lib;libpng16.lib;libsharpyuv.lib;libssl.lib;libxml2.lib;lz4.lib;lzma.lib;tiff.lib;turbojpeg.lib;zstd.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
@@ -179,8 +179,8 @@
     <PostBuildEvent>
       <Command>copy "$(LocalDebuggerCommand)" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x86\$(TargetFileName)"
 copy "$(LocalDebuggerCommand)" "$(SolutionDir)test\OpenCvSharp.Tests\$(TargetFileName)"
-copy "$(SolutionDir)opencv_files\opencv480_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg480.dll" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x86\opencv_videoio_ffmpeg480.dll"
-copy "$(SolutionDir)opencv_files\opencv480_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg480.dll" "$(SolutionDir)test\OpenCvSharp.Tests\opencv_videoio_ffmpeg480.dll"
+copy "$(SolutionDir)opencv_files\opencv490_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg490.dll" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x86\opencv_videoio_ffmpeg490.dll"
+copy "$(SolutionDir)opencv_files\opencv490_win_x86\x86\vc17\bin\opencv_videoio_ffmpeg490.dll" "$(SolutionDir)test\OpenCvSharp.Tests\opencv_videoio_ffmpeg490.dll"
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -207,7 +207,7 @@ copy "$(SolutionDir)opencv_files\opencv480_win_x86\x86\vc17\bin\opencv_videoio_f
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>IlmImf.lib;ippicvmt.lib;ippiw.lib;ittnotify.lib;libopenjp2.lib;libjpeg-turbo.lib;libpng.lib;libprotobuf.lib;libtiff.lib;libwebp.lib;opencv_aruco480.lib;opencv_bgsegm480.lib;opencv_bioinspired480.lib;opencv_calib3d480.lib;opencv_ccalib480.lib;opencv_core480.lib;opencv_dnn480.lib;opencv_dnn_superres480.lib;opencv_dnn_objdetect480.lib;opencv_dpm480.lib;opencv_face480.lib;opencv_features2d480.lib;opencv_flann480.lib;opencv_fuzzy480.lib;opencv_hfs480.lib;opencv_highgui480.lib;opencv_imgcodecs480.lib;opencv_imgproc480.lib;opencv_img_hash480.lib;opencv_line_descriptor480.lib;opencv_ml480.lib;opencv_objdetect480.lib;opencv_optflow480.lib;opencv_phase_unwrapping480.lib;opencv_photo480.lib;opencv_plot480.lib;opencv_quality480.lib;opencv_reg480.lib;opencv_rgbd480.lib;opencv_saliency480.lib;opencv_shape480.lib;opencv_stereo480.lib;opencv_stitching480.lib;opencv_structured_light480.lib;opencv_superres480.lib;opencv_surface_matching480.lib;opencv_text480.lib;opencv_tracking480.lib;opencv_video480.lib;opencv_videoio480.lib;opencv_videostab480.lib;opencv_wechat_qrcode480.lib;opencv_xfeatures2d480.lib;opencv_ximgproc480.lib;opencv_xobjdetect480.lib;opencv_xphoto480.lib;quirc.lib;zlib.lib;ws2_32.lib;tesseract53.lib;leptonica-1.83.1.lib;archive.lib;bz2.lib;charset.lib;gif.lib;iconv.lib;jpeg.lib;libcrypto.lib;libcurl.lib;libpng16.lib;libsharpyuv.lib;libssl.lib;libxml2.lib;lz4.lib;lzma.lib;tiff.lib;turbojpeg.lib;zstd.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>IlmImf.lib;ippicvmt.lib;ippiw.lib;ittnotify.lib;libopenjp2.lib;libjpeg-turbo.lib;libpng.lib;libprotobuf.lib;libtiff.lib;libwebp.lib;opencv_aruco490.lib;opencv_bgsegm490.lib;opencv_bioinspired490.lib;opencv_calib3d490.lib;opencv_ccalib490.lib;opencv_core490.lib;opencv_dnn490.lib;opencv_dnn_objdetect490.lib;opencv_dnn_superres490.lib;opencv_dpm490.lib;opencv_face490.lib;opencv_features2d490.lib;opencv_flann490.lib;opencv_fuzzy490.lib;opencv_hfs490.lib;opencv_highgui490.lib;opencv_imgcodecs490.lib;opencv_imgproc490.lib;opencv_img_hash490.lib;opencv_intensity_transform490.lib;opencv_line_descriptor490.lib;opencv_mcc490.lib;opencv_ml490.lib;opencv_objdetect490.lib;opencv_optflow490.lib;opencv_phase_unwrapping490.lib;opencv_photo490.lib;opencv_plot490.lib;opencv_quality490.lib;opencv_rapid490.lib;opencv_reg490.lib;opencv_rgbd490.lib;opencv_saliency490.lib;opencv_shape490.lib;opencv_stereo490.lib;opencv_stitching490.lib;opencv_structured_light490.lib;opencv_superres490.lib;opencv_surface_matching490.lib;opencv_text490.lib;opencv_tracking490.lib;opencv_video490.lib;opencv_videoio490.lib;opencv_videostab490.lib;opencv_wechat_qrcode490.lib;opencv_xfeatures2d490.lib;opencv_ximgproc490.lib;opencv_xobjdetect490.lib;opencv_xphoto490.lib;zlib.lib;ws2_32.lib;tesseract53.lib;leptonica-1.83.1.lib;archive.lib;bz2.lib;charset.lib;gif.lib;iconv.lib;jpeg.lib;libcrypto.lib;libcurl.lib;libpng16.lib;libsharpyuv.lib;libssl.lib;libxml2.lib;lz4.lib;lzma.lib;tiff.lib;turbojpeg.lib;zstd.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
@@ -222,8 +222,8 @@ copy "$(SolutionDir)opencv_files\opencv480_win_x86\x86\vc17\bin\opencv_videoio_f
     <PostBuildEvent>
       <Command>copy "$(LocalDebuggerCommand)" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x64\$(TargetFileName)"
 copy "$(LocalDebuggerCommand)" "$(SolutionDir)test\OpenCvSharp.Tests\$(TargetFileName)"
-copy "$(SolutionDir)opencv_files\opencv480_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg480_64.dll" "$(SolutionDir)test\OpenCvSharp.Tests\opencv_videoio_ffmpeg480_64.dll"
-copy "$(SolutionDir)opencv_files\opencv480_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg480_64.dll" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x64\opencv_videoio_ffmpeg480_64.dll"</Command>
+copy "$(SolutionDir)opencv_files\opencv490_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg490_64.dll" "$(SolutionDir)test\OpenCvSharp.Tests\opencv_videoio_ffmpeg490_64.dll"
+copy "$(SolutionDir)opencv_files\opencv490_win_x64\x64\vc17\bin\opencv_videoio_ffmpeg490_64.dll" "$(SolutionDir)test\OpenCvSharp.Tests\dll\x64\opencv_videoio_ffmpeg490_64.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tool/OpenCvSharp.ReleaseMaker/Packer.cs
+++ b/tool/OpenCvSharp.ReleaseMaker/Packer.cs
@@ -59,7 +59,7 @@ public static class Packer
     private static readonly IReadOnlyDictionary<string, string[]> architectures = new Dictionary<string, string[]>
     {
         ["win"] = new[] { "x86", "x64" },
-        ["uwp"] = new[] { "x86", "x64", "ARM" },
+        //["uwp"] = new[] { "x86", "x64", "ARM" },
     };
 
     private static readonly IReadOnlySet<string> ignoredExt = new[]{


### PR DESCRIPTION
- Fix #1630
- The wrapper for UWP has been deprecated, as OpenCV CMake does not succeed when targeting WindowsStore.