### PR TITLE
Revert "Fix NuGet package name"

### DIFF
--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -152,9 +152,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/opencvsharp
           sed -E --in-place=.bak \
             "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" \
-            nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
-          cat nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec
-          dotnet pack nuget/OpenCvSharp4.runtime.ubuntu.20.04-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
+            nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.nuspec
+          cat nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.nuspec
+          dotnet pack nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
           ls ${GITHUB_WORKSPACE}/artifacts_ubuntu
 
       - uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Old versions of OpenCvSharp are stored in [opencvsharp_2410](https://github.com/
 |---------|-------------|------|
 |**OpenCvSharp4.runtime.win**| Native bindings for Windows x64/x86 (except UWP) | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4.runtime.win.svg)](https://badge.fury.io/nu/OpenCvSharp4.runtime.win) |
 |**OpenCvSharp4.runtime.uwp**| Native bindings for UWP (Universal Windows Platform) x64/x86/ARM | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4.runtime.uwp.svg)](https://badge.fury.io/nu/OpenCvSharp4.runtime.uwp) |
-|**OpenCvSharp4.runtime.ubuntu.20.04-x64**| Native bindings for Ubuntu 20.04 x64 | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4.runtime.ubuntu.20.04-x64.svg)](https://badge.fury.io/nu/OpenCvSharp4.runtime.ubuntu.20.04-x64) |
+|**OpenCvSharp4.runtime.ubuntu.20.04-x64**| Native bindings for Ubuntu 20.04 x64 | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4_.runtime.ubuntu.20.04-x64.svg)](https://badge.fury.io/nu/OpenCvSharp4_.runtime.ubuntu.20.04-x64) |
 |**OpenCvSharp4.runtime.linux-arm**| Native bindings for Linux Arm | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4.runtime.linux-arm.svg)](https://www.nuget.org/packages/OpenCvSharp4.runtime.linux-arm/) |
 |**OpenCvSharp4.runtime.wasm**| Native bindings for WebAssembly | [![NuGet version](https://badge.fury.io/nu/OpenCvSharp4.runtime.wasm.svg)](https://www.nuget.org/packages/OpenCvSharp4.runtime.wasm/) |
 

--- a/nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.csproj
+++ b/nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;</TargetFrameworks>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <NuspecFile>OpenCvSharp4.runtime.ubuntu.20.04-x64.nuspec</NuspecFile>
+    <NuspecFile>OpenCvSharp4_.runtime.ubuntu.20.04-x64.nuspec</NuspecFile>
     <NuspecProperties></NuspecProperties>
     <NuspecBasePath></NuspecBasePath>
     <!--<IncludeSymbols>true</IncludeSymbols>

--- a/nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.nuspec
+++ b/nuget/OpenCvSharp4_.runtime.ubuntu.20.04-x64.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>OpenCvSharp4.runtime.ubuntu.20.04-x64</id>
+        <id>OpenCvSharp4_.runtime.ubuntu.20.04-x64</id>
         <version>4.6.0.20220608</version>
         <title>OpenCvSharp native bindings for ubuntu.20.04-x64</title>
         <authors>shimat</authors>


### PR DESCRIPTION
Reverts shimat/opencvsharp#1623

Because I can't push new packages to https://www.nuget.org/packages/OpenCvSharp4.runtime.ubuntu.20.04-x64/ which was created by someone who is not me
https://github.com/shimat/opencvsharp/actions/runs/7395702669/job/20119375752