### PR TITLE
some obvious submat mistakes

### DIFF
--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -1004,12 +1004,12 @@ public class MatTest : TestBase
 
         using var mat = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(0));
 
-        var rect = new Rect(2, 2, 5, 5);
+        var rect = new Rect(2, 2, 7, 5);
         mat.Rectangle(rect, new Scalar(expectedValue), -1);
 
         using var subMat = mat.SubMat(rect);
-        Assert.Equal(rect.Width, subMat.Rows);
-        Assert.Equal(rect.Height, subMat.Cols);
+        Assert.Equal(rect.Width, subMat.Cols);
+        Assert.Equal(rect.Height, subMat.Rows);
 
         for (int r = 0; r < subMat.Rows; r++)
         {
@@ -1027,12 +1027,12 @@ public class MatTest : TestBase
 
         using var mat = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(0));
 
-        var rect = new Rect(2, 2, 5, 5);
+        var rect = new Rect(2, 2, 7, 5);
         mat.Rectangle(rect, new Scalar(expectedValue), -1);
 
         using var subMat = mat[rect];
-        Assert.Equal(rect.Width, subMat.Rows);
-        Assert.Equal(rect.Height, subMat.Cols);
+        Assert.Equal(rect.Width, subMat.Cols);
+        Assert.Equal(rect.Height, subMat.Rows);
 
         for (int r = 0; r < subMat.Rows; r++)
         {
@@ -1050,12 +1050,12 @@ public class MatTest : TestBase
 
         using var mat = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(0));
 
-        var rect = new Rect(2, 2, 5, 5);
+        var rect = new Rect(2, 2, 7, 5);
         mat[rect].SetTo(expectedValue);
 
-        for (int r = rect.Left; r < rect.Right; r++)
+        for (int r = rect.Top; r < rect.Bottom; r++)
         {
-            for (int c = rect.Top; c < rect.Bottom; c++)
+            for (int c = rect.Left; c < rect.Right; c++)
             {
                 Assert.Equal(expectedValue, mat.Get<byte>(r, c));
             }

--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -264,22 +264,22 @@ public class MatTest : TestBase
     public void SubMatRange()
     {
         var values = new byte[,] {
-            {1, 2, 3},
-            {4, 5, 6},
-            {7, 8, 9}};
+            {1, 2, 3, 4},
+            {5, 6, 7, 8},
+            {9, 10,11,12}};
         using var mat = Mat.FromArray(values);
-        Assert.Equal(new Size(3, 3), mat.Size());
+        Assert.Equal(new Size(4, 3), mat.Size());
 
         // OK
-        using var subMat1 = mat.SubMat(0..2, 1..3);
-        Assert.Equal(new Size(2, 2), subMat1.Size());
+        using var subMat1 = mat.SubMat(0..2, 1..4);
+        Assert.Equal(new Size(3, 2), subMat1.Size());
         Assert.True(subMat1.GetArray(out byte[] subMat1Array));
-        Assert.Equal(new byte[] { 2, 3, 5, 6 }, subMat1Array);
+        Assert.Equal(new byte[] { 2, 3,4, 6,7,8 }, subMat1Array);
 
         using var subMat2 = mat[1..2, ..];
-        Assert.Equal(new Size(3, 1), subMat2.Size());
+        Assert.Equal(new Size(4, 1), subMat2.Size());
         Assert.True(subMat2.GetArray(out byte[] subMat2Array));
-        Assert.Equal(new byte[] { 4, 5, 6 }, subMat2Array);
+        Assert.Equal(new byte[] { 5, 6,7,8 }, subMat2Array);
 
         // out of range 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -515,7 +515,7 @@ public class MatTest : TestBase
     [Fact]
     public void MatOfIntFromRectangularArray()
     {
-        var array = new[,] { { 1, 2 }, { 3, 4 } };
+        var array = new[,] { { 1, 2 }, { 3, 4 },{ 5,6} };
         using var m = Mat.FromArray(array);
 
         var indexer = m.GetIndexer();


### PR DESCRIPTION
Hi opencvsharp team

First of all, thank you for your great work.  We are considering using opencvsharp in our company project and I started to play with opencvsharp a few days ago. I am impressed by your work.

Yesterday I found some obvious mistakes in the test code.

btw, how can i contribute to opencvsharp. I am an experienced CV software engineer for many years. I even have some opencv C# wrapper in my company projects,but we just wrapped a few functions that are actually used.  
I have been working on tracking issues lately and found that lightweight NanoTracker VitTracker are not wrapped by opencvsharp, i have already done some work in my local branch and it seems to work.

Another proposal from me is that: is building the opencvsharp with more option flags on the roadmap, for example, in my case i do not need so many opencv_contrib libraries, i would like to have some opencv wrapper around the core modules only.

best regards
Bin Liu