### PR TITLE
Fixed the System.Drawing.Common version mismatch mentioned in #1688.

### DIFF
--- a/nuget/OpenCvSharp4.Extensions.nuspec
+++ b/nuget/OpenCvSharp4.Extensions.nuspec
@@ -18,19 +18,19 @@
         <dependencies>
             <group targetFramework="net48">
                 <dependency id="OpenCvSharp4" version="4.5.3.20211226" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
             <group targetFramework="netstandard2.0">
                 <dependency id="OpenCvSharp4" version="4.3.0.20190901" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
             <group targetFramework="netstandard2.1">
                 <dependency id="OpenCvSharp4" version="4.5.3.20211226" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
             <group targetFramework="net6.0">
                 <dependency id="OpenCvSharp4" version="4.5.3.20211226" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
         </dependencies>
         <frameworkAssemblies>

--- a/nuget/OpenCvSharp4.WpfExtensions.nuspec
+++ b/nuget/OpenCvSharp4.WpfExtensions.nuspec
@@ -18,11 +18,11 @@
         <dependencies>
             <group targetFramework="net48">
                 <dependency id="OpenCvSharp4" version="4.3.0.20190901" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
             <group targetFramework="net6.0">
                 <dependency id="OpenCvSharp4" version="4.3.0.20190901" />
-                <dependency id="System.Drawing.Common" version="7.0.0" />
+                <dependency id="System.Drawing.Common" version="8.0.0" />
             </group>
         </dependencies>
         <frameworkAssemblies>


### PR DESCRIPTION
The version of ```System.Drawing.Common``` was set to ```8.0.6``` in the ```OpenCvSharp.Extensions``` and ```OpenCvSharp.WpfExtension``` projects. However, it was not updated in the **nuspec** file in time, where version ```7.0.0``` was still being used, leading to a dependency error from the compiler.
Related issue: #1688
