### PR TITLE
Changed NuGet package name for Linux [2]

### DIFF
--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -151,9 +151,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/opencvsharp
           sed -E --in-place=.bak \
             "s/<version>[0-9]\.[0-9]{1,2}\.[0-9]{1,2}.[0-9]{8}(-beta[0-9]*)?<\/version>/<version>${OPENCV_VERSION}.${yyyymmdd}${BETA}<\/version>/" \
-            nuget/OpenCvSharp4_.runtime.linux-x64.nuspec
-          cat nuget/OpenCvSharp4_.runtime.linux-x64.nuspec
-          dotnet pack nuget/OpenCvSharp4_.runtime.linux-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
+            nuget/OpenCvSharp4.official.runtime.linux-x64.nuspec
+          cat nuget/OpenCvSharp4.official.runtime.linux-x64.nuspec
+          dotnet pack nuget/OpenCvSharp4.official.runtime.linux-x64.csproj -o ${GITHUB_WORKSPACE}/artifacts_ubuntu
           ls ${GITHUB_WORKSPACE}/artifacts_ubuntu
 
       - uses: actions/upload-artifact@v4

--- a/nuget/OpenCvSharp4.official.runtime.linux-x64.csproj
+++ b/nuget/OpenCvSharp4.official.runtime.linux-x64.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;</TargetFrameworks>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <NuspecFile>OpenCvSharp4_.runtime.linux-x64.nuspec</NuspecFile>
+    <NuspecFile>OpenCvSharp4.official.runtime.linux-x64.nuspec</NuspecFile>
     <NuspecProperties></NuspecProperties>
     <NuspecBasePath></NuspecBasePath>
     <!--<IncludeSymbols>true</IncludeSymbols>

--- a/nuget/OpenCvSharp4.official.runtime.linux-x64.nuspec
+++ b/nuget/OpenCvSharp4.official.runtime.linux-x64.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>OpenCvSharp4_.runtime.linux-x64</id>
+        <id>OpenCvSharp4.official.runtime.linux-x64</id>
         <version>4.6.0.20220608</version>
         <title>OpenCvSharp native bindings for Linux-x64</title>
         <authors>shimat</authors>


### PR DESCRIPTION
> Pushing OpenCvSharp4_.runtime.linux-x64.4.10.0.20241107.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  BadRequest https://www.nuget.org/api/v2/package/ 5299ms
error: Response status code does not indicate success: 400 (The uploaded package's id is too similar to the already existing packages: OpenCvSharp4.runtime.linux-x64 ).