### PR TITLE
fix crash in FastNlMeansDenoisingMulti

### DIFF
--- a/src/OpenCvSharpExtern/photo.h
+++ b/src/OpenCvSharpExtern/photo.h
@@ -37,7 +37,7 @@ CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(cv::Mat **srcImgs, int sr
 {
     BEGIN_WRAP
 
-    std::vector<cv::Mat> srcImgsVec;
+    std::vector<cv::Mat> srcImgsVec(srcImgsLength);
     for (int i = 0; i < srcImgsLength; i++)
         srcImgsVec[i] = *srcImgs[i];
 

--- a/test/OpenCvSharp.Tests/photo/PhotoTest.cs
+++ b/test/OpenCvSharp.Tests/photo/PhotoTest.cs
@@ -32,7 +32,6 @@ public class PhotoTest
             Window.ShowImages(src, dst);
     }
 
-    /*
     [Fact]
     public void FastNlMeansDenoisingMulti()
     {
@@ -45,5 +44,5 @@ public class PhotoTest
 
         if (Debugger.IsAttached)
             Window.ShowImages(src1, src2, dst);
-    }*/
+    }
 }


### PR DESCRIPTION
issue is caused by improper std::vector allocation
fixes #1402 