### PR TITLE
Align enum naming with native OpenCV

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
@@ -753,7 +753,7 @@ static partial class Cv2
         InputArray distCoeffs,
         OutputArray rvec, OutputArray tvec,
         bool useExtrinsicGuess = false,
-        SolvePnPFlags flags = SolvePnPFlags.Iterative)
+        SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
         if (objectPoints is null)
             throw new ArgumentNullException(nameof(objectPoints));
@@ -812,7 +812,7 @@ static partial class Cv2
         ref double[] rvec, 
         ref double[] tvec,
         bool useExtrinsicGuess = false,
-        SolvePnPFlags flags = SolvePnPFlags.Iterative)
+        SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
         if (objectPoints is null)
             throw new ArgumentNullException(nameof(objectPoints));
@@ -880,7 +880,7 @@ static partial class Cv2
         float reprojectionError = 8.0f,
         double confidence = 0.99,
         OutputArray? inliers = null,
-        SolvePnPFlags flags = SolvePnPFlags.Iterative)
+        SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
         if (objectPoints is null)
             throw new ArgumentNullException(nameof(objectPoints));
@@ -974,7 +974,7 @@ static partial class Cv2
         int iterationsCount = 100,
         float reprojectionError = 8.0f,
         double confidence = 0.99,
-        SolvePnPFlags flags = SolvePnPFlags.Iterative)
+        SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
         if (objectPoints is null)
             throw new ArgumentNullException(nameof(objectPoints));

--- a/src/OpenCvSharp/Cv2/Cv2_photo.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_photo.cs
@@ -13,7 +13,7 @@ static partial class Cv2
     /// <param name="inpaintRadius">Radius of a circular neighborhood of each point inpainted that is considered by the algorithm.</param>
     /// <param name="flags">Inpainting method that could be cv::INPAINT_NS or cv::INPAINT_TELEA</param>
     public static void Inpaint(InputArray src, InputArray inpaintMask,
-        OutputArray dst, double inpaintRadius, InpaintMethod flags)
+        OutputArray dst, double inpaintRadius, InpaintTypes flags)
     {
         if (src is null)
             throw new ArgumentNullException(nameof(src));
@@ -248,7 +248,7 @@ static partial class Cv2
     /// <param name="flags">Cloning method</param>
     public static void SeamlessClone(
         InputArray src, InputArray dst, InputArray? mask, Point p,
-        OutputArray blend, SeamlessCloneMethods flags)
+        OutputArray blend, SeamlessCloneFlags flags)
     {
         if (src is null) 
             throw new ArgumentNullException(nameof(src));

--- a/src/OpenCvSharp/Modules/aruco/CvAruco.cs
+++ b/src/OpenCvSharp/Modules/aruco/CvAruco.cs
@@ -164,7 +164,7 @@ public static class CvAruco
     /// </summary>
     /// <param name="name"></param>
     /// <returns></returns>
-    public static Dictionary GetPredefinedDictionary(PredefinedDictionaryName name)
+    public static Dictionary GetPredefinedDictionary(PredefinedDictionaryType name)
     {
         NativeMethods.HandleException(
             NativeMethods.aruco_getPredefinedDictionary((int) name, out IntPtr p));
@@ -311,7 +311,7 @@ public static class CvAruco
     /// <param name="markerCorners">output list of detected marker corners.</param>
     /// <param name="markerIds">ids of the corners in markerCorners.</param>
     public static void DetectCharucoBoard(InputArray image, int squaresX, int squaresY, float squareLength, float markerLength,
-        PredefinedDictionaryName arucoDictId,
+        PredefinedDictionaryType arucoDictId,
         out Point2f[] charucoCorners, out int[] charucoIds,
         out Point2f[][] markerCorners, out int[] markerIds)
     {
@@ -352,7 +352,7 @@ public static class CvAruco
     /// <param name="charucoCorners">output list of detected charuco corners.</param>
     /// <param name="charucoIds">ids of the charucos in charucoCorners.</param>
     public static void InterpolateCornersCharuco(InputArray image,
-        int squaresX, int squaresY, float squareLength, float markerLength, PredefinedDictionaryName arucoDictId,
+        int squaresX, int squaresY, float squareLength, float markerLength, PredefinedDictionaryType arucoDictId,
         Point2f[][] markerCorners, IEnumerable<int> markerIds,
         out Point2f[] charucoCorners, out int[] charucoIds)
     {

--- a/src/OpenCvSharp/Modules/aruco/Enum/PredefinedDictionaryName.cs
+++ b/src/OpenCvSharp/Modules/aruco/Enum/PredefinedDictionaryName.cs
@@ -2,10 +2,40 @@
 namespace OpenCvSharp.Aruco;
 
 /// <summary>
-/// PredefinedDictionaryName
+/// PredefinedDictionaryType
 /// </summary>
-public enum PredefinedDictionaryName
+public enum PredefinedDictionaryType
 { 
+#pragma warning disable 1591
+    Dict4X4_50 = 0,
+    Dict4X4_100,
+    Dict4X4_250,
+    Dict4X4_1000,
+    Dict5X5_50,
+    Dict5X5_100,
+    Dict5X5_250,
+    Dict5X5_1000,
+    Dict6X6_50,
+    Dict6X6_100,
+    Dict6X6_250,
+    Dict6X6_1000,
+    Dict7X7_50,
+    Dict7X7_100,
+    Dict7X7_250,
+    Dict7X7_1000,
+    DictArucoOriginal,
+    DictAprilTag_16h5,
+    DictAprilTag_25h9,
+    DictAprilTag_36h10,
+    DictAprilTag_36h11
+}
+
+/// <summary>
+/// Obsolete: Use PredefinedDictionaryType instead. This enum is kept for backward compatibility.
+/// </summary>
+[Obsolete("Use PredefinedDictionaryType instead", false)]
+public enum PredefinedDictionaryName
+{
 #pragma warning disable 1591
     Dict4X4_50 = 0,
     Dict4X4_100,

--- a/src/OpenCvSharp/Modules/aruco/Enum/PredefinedDictionaryName.cs
+++ b/src/OpenCvSharp/Modules/aruco/Enum/PredefinedDictionaryName.cs
@@ -33,7 +33,7 @@ public enum PredefinedDictionaryType
 /// <summary>
 /// Obsolete: Use PredefinedDictionaryType instead. This enum is kept for backward compatibility.
 /// </summary>
-[Obsolete("Use PredefinedDictionaryType instead", false)]
+[Obsolete("Use PredefinedDictionaryType instead", true)]
 public enum PredefinedDictionaryName
 {
 #pragma warning disable 1591

--- a/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
+++ b/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
@@ -4,7 +4,7 @@
 /// <summary>
 /// Method for solving a PnP problem:
 /// </summary>
-public enum SolvePnPFlags
+public enum SolvePnPMethod
 {
     /// <summary>
     /// Iterative method is based on Levenberg-Marquardt optimization. 
@@ -29,6 +29,41 @@ public enum SolvePnPFlags
     /// </summary>
     DLS = 3, 
         
+    /// <summary>
+    /// A.Penate-Sanchez, J.Andrade-Cetto, F.Moreno-Noguer. "Exhaustive Linearization for Robust Camera Pose and Focal Length Estimation"
+    /// </summary>
+    UPNP = 4,
+}
+
+/// <summary>
+/// Obsolete: Use SolvePnPMethod instead. This enum is kept for backward compatibility.
+/// </summary>
+[Obsolete("Use SolvePnPMethod instead", false)]
+public enum SolvePnPFlags
+{
+    /// <summary>
+    /// Iterative method is based on Levenberg-Marquardt optimization. 
+    /// In this case the function finds such a pose that minimizes reprojection error, 
+    /// that is the sum of squared distances between the observed projections imagePoints and the projected (using projectPoints() ) objectPoints .
+    /// </summary>
+    Iterative = 0,
+
+    /// <summary>
+    /// Method has been introduced by F.Moreno-Noguer, V.Lepetit and P.Fua in the paper “EPnP: Efficient Perspective-n-Point Camera Pose Estimation”.
+    /// </summary>
+    EPNP = 1,
+
+    /// <summary>
+    /// Method is based on the paper of X.S. Gao, X.-R. Hou, J. Tang, H.-F. Chang“Complete Solution Classification for 
+    /// the Perspective-Three-Point Problem”. In this case the function requires exactly four object and image points.
+    /// </summary>
+    P3P = 2,
+
+    /// <summary>
+    /// Joel A. Hesch and Stergios I. Roumeliotis. "A Direct Least-Squares (DLS) Method for PnP"
+    /// </summary>
+    DLS = 3,
+
     /// <summary>
     /// A.Penate-Sanchez, J.Andrade-Cetto, F.Moreno-Noguer. "Exhaustive Linearization for Robust Camera Pose and Focal Length Estimation"
     /// </summary>

--- a/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
+++ b/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
@@ -38,7 +38,7 @@ public enum SolvePnPMethod
 /// <summary>
 /// Obsolete: Use SolvePnPMethod instead. This enum is kept for backward compatibility.
 /// </summary>
-[Obsolete("Use SolvePnPMethod instead", false)]
+[Obsolete("Use SolvePnPMethod instead", true)]
 public enum SolvePnPFlags
 {
     /// <summary>

--- a/src/OpenCvSharp/Modules/photo/InpaintMethod.cs
+++ b/src/OpenCvSharp/Modules/photo/InpaintMethod.cs
@@ -3,6 +3,24 @@
 /// <summary>
 /// The inpainting method
 /// </summary>
+public enum InpaintTypes
+{
+    /// <summary>
+    /// Navier-Stokes based method.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    NS = 0,
+
+    /// <summary>
+    /// The method by Alexandru Telea
+    /// </summary>
+    Telea = 1,
+}
+
+/// <summary>
+/// Obsolete: Use InpaintTypes instead. This enum is kept for backward compatibility.
+/// </summary>
+[Obsolete("Use InpaintTypes instead", false)]
 public enum InpaintMethod
 {
     /// <summary>

--- a/src/OpenCvSharp/Modules/photo/InpaintMethod.cs
+++ b/src/OpenCvSharp/Modules/photo/InpaintMethod.cs
@@ -20,7 +20,7 @@ public enum InpaintTypes
 /// <summary>
 /// Obsolete: Use InpaintTypes instead. This enum is kept for backward compatibility.
 /// </summary>
-[Obsolete("Use InpaintTypes instead", false)]
+[Obsolete("Use InpaintTypes instead", true)]
 public enum InpaintMethod
 {
     /// <summary>

--- a/src/OpenCvSharp/Modules/photo/SeamlessCloneMethods.cs
+++ b/src/OpenCvSharp/Modules/photo/SeamlessCloneMethods.cs
@@ -31,7 +31,7 @@ public enum SeamlessCloneFlags
 /// <summary>
 /// Obsolete: Use SeamlessCloneFlags instead. This enum is kept for backward compatibility.
 /// </summary>
-[Obsolete("Use SeamlessCloneFlags instead", false)]
+[Obsolete("Use SeamlessCloneFlags instead", true)]
 public enum SeamlessCloneMethods
 {
     /// <summary>

--- a/src/OpenCvSharp/Modules/photo/SeamlessCloneMethods.cs
+++ b/src/OpenCvSharp/Modules/photo/SeamlessCloneMethods.cs
@@ -5,6 +5,33 @@ namespace OpenCvSharp;
 /// <summary>
 /// SeamlessClone method
 /// </summary>
+public enum SeamlessCloneFlags
+{
+    /// <summary>
+    /// The power of the method is fully expressed when inserting objects with 
+    /// complex outlines into a new background.
+    /// </summary>
+    NormalClone = 1,
+
+    /// <summary>
+    /// The classic method, color-based selection and alpha masking might be time 
+    /// consuming and often leaves an undesirable halo. Seamless cloning, even averaged 
+    /// with the original image, is not effective. Mixed seamless cloning based on a 
+    /// loose selection proves effective.
+    /// </summary>
+    MixedClone = 2,
+
+    /// <summary>
+    /// Feature exchange allows the user to easily replace certain features of one 
+    /// object by alternative features.
+    /// </summary>
+    MonochromeTransfer = 3
+}
+
+/// <summary>
+/// Obsolete: Use SeamlessCloneFlags instead. This enum is kept for backward compatibility.
+/// </summary>
+[Obsolete("Use SeamlessCloneFlags instead", false)]
 public enum SeamlessCloneMethods
 {
     /// <summary>

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -49,7 +49,7 @@ public class ArucoTest : TestBase
     public void GetPredefinedDictionary()
     {
 #pragma warning disable CS8605
-        foreach (PredefinedDictionaryName val in Enum.GetValues(typeof(PredefinedDictionaryName)))
+        foreach (PredefinedDictionaryType val in Enum.GetValues(typeof(PredefinedDictionaryType)))
 #pragma warning restore CS8605
         {
             var dict = CvAruco.GetPredefinedDictionary(val);
@@ -61,7 +61,7 @@ public class ArucoTest : TestBase
     public void ReadDictionaryFromFile()
     {
         var dictionaryFile = Path.Combine("_data", "aruco", "Dict6X6_1000.yaml");
-        var toCompareWith = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict6X6_1000);
+        var toCompareWith = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_1000);
         var dict = CvAruco.ReadDictionary(dictionaryFile);
 
         Assert.Equal(toCompareWith.BytesList.Rows, dict.BytesList.Rows);
@@ -83,7 +83,7 @@ public class ArucoTest : TestBase
     public void DetectMarkers()
     {
         using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
-        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict6X6_250);
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
 
         var param = new DetectorParameters();
         CvAruco.DetectMarkers(image, dict, out _, out _, param, out _);
@@ -92,7 +92,7 @@ public class ArucoTest : TestBase
     [Fact]
     public void DictionaryProperties()
     {
-        var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict6X6_250);
+        var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
         Assert.Equal(250, dict.BytesList.Rows);
         Assert.Equal(5, dict.BytesList.Cols); // (6*6 + 7)/8
         Assert.Equal(6, dict.MarkerSize);
@@ -109,7 +109,7 @@ public class ArucoTest : TestBase
     {
         using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
         using var outputImage = image.CvtColor(ColorConversionCodes.GRAY2RGB);
-        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict6X6_250);
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
         var param = new DetectorParameters();
         CvAruco.DetectMarkers(image, dict, out var corners, out var ids, param, out var rejectedImgPoints);
 
@@ -129,7 +129,7 @@ public class ArucoTest : TestBase
     public void EstimatePoseSingleMarkers()
     {
         using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
-        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict6X6_250);
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
         var param = new DetectorParameters();
         CvAruco.DetectMarkers(image, dict, out var corners, out _, param, out _);
 

--- a/test/OpenCvSharp.Tests/photo/PhotoTest.cs
+++ b/test/OpenCvSharp.Tests/photo/PhotoTest.cs
@@ -14,7 +14,7 @@ public class PhotoTest
 
         mask.Rectangle(new Rect(65, 15, 130, 30), Scalar.All(255), -1);
 
-        Cv2.Inpaint(src, mask, dst, 2, InpaintMethod.Telea);
+        Cv2.Inpaint(src, mask, dst, 2, InpaintTypes.Telea);
 
         if (Debugger.IsAttached)
             Window.ShowImages(src, mask, dst);

--- a/test/OpenCvSharp.Tests/system/ExceptionTest.cs
+++ b/test/OpenCvSharp.Tests/system/ExceptionTest.cs
@@ -89,7 +89,7 @@ public class ExceptionTest : TestBase
     public void ArucoDetectMarkers()
     {
         using var image = new Mat();
-        using var dict = OpenCvSharp.Aruco.CvAruco.GetPredefinedDictionary(OpenCvSharp.Aruco.PredefinedDictionaryName.Dict6X6_250);
+        using var dict = OpenCvSharp.Aruco.CvAruco.GetPredefinedDictionary(OpenCvSharp.Aruco.PredefinedDictionaryType.Dict6X6_250);
 
         var param = new OpenCvSharp.Aruco.DetectorParameters();
 

--- a/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
+++ b/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
@@ -78,7 +78,7 @@ public class XPhotoTest : TestBase
         using var src = LoadImage("building.jpg");
         using var mask = LoadImage("building_mask.bmp", ImreadModes.Grayscale);
         using var dst = new Mat(src.Size(), src.Type());
-        CvXPhoto.Inpaint(src, mask, dst, InpaintTypes.SHIFTMAP);
+        CvXPhoto.Inpaint(src, mask, dst, OpenCvSharp.XPhoto.InpaintTypes.SHIFTMAP);
         ShowImagesWhenDebugMode(src);
         ShowImagesWhenDebugMode(dst);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized public API enums and parameter types across pose estimation, inpainting, seamless cloning, and ArUco features; legacy enum names left as deprecated aliases for compatibility.
* **Tests**
  * Updated test calls to use the new enum types and namespace qualifications to match the revised public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->