### PR TITLE
Fix NupkgBetaRemover for Ubuntu packages and add approval gate to publish workflow

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Publish:
+  Prepare:
     runs-on: ubuntu-24.04
 
     steps:
@@ -103,6 +103,54 @@ jobs:
           for f in $(find $PWD -maxdepth 1 -regex ".+\.s?nupkg"); do
             dotnet run --project tool/OpenCvSharp.NupkgBetaRemover --configuration Release -- "$f"
           done
+
+      - name: Verify no beta versions remain
+        run: |
+          if find . -maxdepth 1 -name "*-beta*" -type f | grep -q .; then
+            echo "ERROR: beta packages still exist after rename"
+            find . -maxdepth 1 -name "*-beta*" -type f
+            exit 1
+          fi
+
+      - name: List packages to publish
+        run: |
+          echo "=== Packages ready for publishing ==="
+          ls -lh *.nupkg *.snupkg 2>/dev/null || true
+
+          echo "## NuGet Packages to Publish" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Package | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|------|" >> $GITHUB_STEP_SUMMARY
+          for f in *.nupkg; do
+            [ -f "$f" ] || continue
+            size=$(du -h "$f" | cut -f1)
+            echo "| \`${f}\` | ${size} |" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total:** $(find . -maxdepth 1 -name '*.nupkg' | wc -l) nupkg, $(find . -maxdepth 1 -name '*.snupkg' | wc -l) snupkg" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload release packages
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-packages
+          path: |
+            *.nupkg
+            *.snupkg
+          retention-days: 7
+
+  Publish:
+    needs: Prepare
+    runs-on: ubuntu-24.04
+    environment: nuget-production
+
+    steps:
+      - name: Download release packages
+        uses: actions/download-artifact@v6
+        with:
+          name: release-packages
+
+      - name: List packages
+        run: ls -lh *.nupkg *.snupkg 2>/dev/null || true
 
       - name: Push to nuget.org
         run: |

--- a/tool/OpenCvSharp.NupkgBetaRemover/Program.cs
+++ b/tool/OpenCvSharp.NupkgBetaRemover/Program.cs
@@ -34,13 +34,9 @@ foreach (var nupkgFile in args)
             nuspecContent = nuspecContentStreamReader.ReadToEnd();
         }
 
-        if (nupkgFile.Contains("ubuntu"))
+        nuspecContent = Regex.Replace(nuspecContent, @"-beta-?\d*</version>", "</version>");
+        if (!nupkgFile.Contains("ubuntu"))
         {
-            nuspecContent = Regex.Replace(nuspecContent, @"-\d+</version>", $".{date:yyyyMMdd}</version>");
-        }
-        else
-        {
-            nuspecContent = Regex.Replace(nuspecContent, @"-beta-?\d*</version>", "</version>");
             nuspecContent = Regex.Replace(nuspecContent, @"(?<=<dependency.*version="")(?<version>\d{1,2}\.\d{1,2}\.\d{1,2}\.\d{8})(?<betaVersion>-beta-?\d*)",
                 match => match.Groups["version"].Value);
         }


### PR DESCRIPTION
### Problem

Ubuntu 22.04/24.04 NuGet packages (both full and slim variants) were published to nuget.org with `-beta` still in the version. The root cause is a regex bug in `NupkgBetaRemover`:

The Ubuntu-specific code path used the pattern `-\d+</version>`, which was designed for an older version format (e.g. `4.13.0-20260226`). The current format is `4.13.0.20260226-beta`, where the suffix `-beta` contains letters, not digits — so the regex never matched. The nuspec `<version>` inside the `.nupkg` was left untouched while only the **filename** was renamed (via a separate, correctly working regex). Since NuGet reads the version from the nuspec, the packages appeared as prerelease.

### Changes

**1. `tool/OpenCvSharp.NupkgBetaRemover/Program.cs`**

Removed the separate ubuntu/non-ubuntu branching. The `-beta` removal regex (`-beta-?\d*</version>` → `</version>`) is now applied uniformly to all packages. The dependency version cleanup (non-ubuntu only) is preserved since ubuntu packages have no dependency references.

**2. `.github/workflows/publish_nuget.yml`**

- **Split into two jobs: `Prepare` → `Publish`** with a manual approval gate via the `nuget-production` environment. This prevents accidental publishes and allows reviewers to inspect packages before they go out.
- **Added a "Verify no beta versions remain" step** after the Rename step. The workflow fails immediately if any `-beta` files are still present.
- **Added a "List packages to publish" step** that writes a package table to `$GITHUB_STEP_SUMMARY`, so reviewers can see exactly which packages (and their sizes) are about to be published — directly on the workflow Summary tab without digging into logs.

### Required setup

A GitHub Environment named `nuget-production` with **Required reviewers** enabled must exist in the repository settings (already created).

### How to republish the affected packages

1. Unlist the 4 incorrectly published `-beta` packages on nuget.org (via the web UI or `dotnet nuget delete`).
2. Re-run the `ubuntu.yml` and `ubuntu-slim.yml` workflows to produce fresh artifacts.
3. Trigger `publish_nuget.yml` — the corrected `NupkgBetaRemover` will produce proper stable versions, and the approval gate will let you verify before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process Improvements**
  * Enhanced release validation to ensure no beta packages are accidentally published.
  * Introduced artifact retention management with configurable retention policy.
  * Extended NuGet publishing to include all package formats.
  * Added detailed package listing in the release pipeline for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->