### PR TITLE
fix: face_detector_yn needs to accept NO_OBJDETECT

### DIFF
--- a/src/OpenCvSharpExtern/face_detector_yn.cpp
+++ b/src/OpenCvSharpExtern/face_detector_yn.cpp
@@ -1,10 +1,9 @@
 #include "face_detector_yn.h"
-#include <opencv2/core/cvstd.hpp>
-#include <opencv2/core/cvstd_wrapper.hpp>
-#include <opencv2/core/mat.hpp>
-#include <opencv2/core/types_c.h>
+
+#ifndef NO_OBJDETECT
+
+#ifdef HAVE_OPENCV_OBJDETECT
 #include <opencv2/objdetect/face.hpp>
-#include <opencv2/opencv_modules.hpp>
 
 cv::FaceDetectorYN* cveFaceDetectorYNCreate(
 	cv::String* model,
@@ -17,7 +16,6 @@ cv::FaceDetectorYN* cveFaceDetectorYNCreate(
 	int targetId,
 	cv::Ptr<cv::FaceDetectorYN>** sharedPtr)
 {
-#ifdef HAVE_OPENCV_OBJDETECT
 	cv::Ptr<cv::FaceDetectorYN> ptr = cv::FaceDetectorYN::create(
 		*model,
 		*config,
@@ -29,26 +27,43 @@ cv::FaceDetectorYN* cveFaceDetectorYNCreate(
 		targetId);
 	*sharedPtr = new cv::Ptr<cv::FaceDetectorYN>(ptr);
 	return (*sharedPtr)->get();
-#else
-	throw_no_objdetect();
-#endif
 }
 
 void cveFaceDetectorYNRelease(cv::Ptr<cv::FaceDetectorYN>** faceDetector)
 {
-#ifdef HAVE_OPENCV_OBJDETECT
 	delete* faceDetector;
 	*faceDetector = 0;
-#else 
-	throw_no_objdetect();
-#endif
 }
 
 int cveFaceDetectorYNDetect(cv::FaceDetectorYN* faceDetector, cv::_InputArray* image, cv::_OutputArray* faces)
 {
-#ifdef HAVE_OPENCV_OBJDETECT
 	return faceDetector->detect(*image, *faces);
-#else 
-	throw_no_objdetect();
-#endif
 }
+
+#else
+
+cv::FaceDetectorYN* cveFaceDetectorYNCreate(
+	cv::String* model,
+	cv::String* config,
+	CvSize* inputSize,
+	float scoreThreshold,
+	float nmsThreshold,
+	int topK,
+	int backendId,
+	int targetId,
+	cv::Ptr<cv::FaceDetectorYN>** sharedPtr)
+{
+	return nullptr;
+}
+
+void cveFaceDetectorYNRelease(cv::Ptr<cv::FaceDetectorYN>** faceDetector)
+{
+}
+
+int cveFaceDetectorYNDetect(cv::FaceDetectorYN* faceDetector, cv::_InputArray* image, cv::_OutputArray* faces)
+{
+	return 0;
+}
+#endif
+
+#endif

--- a/src/OpenCvSharpExtern/face_detector_yn.h
+++ b/src/OpenCvSharpExtern/face_detector_yn.h
@@ -7,13 +7,14 @@
 // ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
 
 #include "my_functions.h"
-#include <opencv2/core/cvstd.hpp>
-#include <opencv2/core/cvstd_wrapper.hpp>
-#include <opencv2/core/types_c.h>
+
+#ifdef HAVE_OPENCV_OBJDETECT
 #include <opencv2/objdetect/face.hpp>
+#endif
 
 #ifndef _WINRT_DLL
 
+#ifdef HAVE_OPENCV_OBJDETECT
 CVAPI(cv::FaceDetectorYN*) cveFaceDetectorYNCreate(
     cv::String* model,
     cv::String* config,
@@ -28,6 +29,7 @@ CVAPI(cv::FaceDetectorYN*) cveFaceDetectorYNCreate(
 CVAPI(void) cveFaceDetectorYNRelease(cv::Ptr<cv::FaceDetectorYN>** faceDetector);
 
 CVAPI(int) cveFaceDetectorYNDetect(cv::FaceDetectorYN* faceDetector, cv::_InputArray* image, cv::_OutputArray* faces);
+#endif
 
 #endif
 


### PR DESCRIPTION
If you're trying to build a slimmed-down version and have NO_OBJDETECT, the new face_detector_yn regressed the build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased robustness of face detection to work with diverse OpenCV configurations. The library now gracefully handles scenarios where optional object detection components may be disabled or unavailable in your OpenCV installation. This prevents build failures and runtime errors, ensuring stable operation across different system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->