### PR TITLE
Fix: Correct WASM library filename from libOpenCvSharpExtern.a to OpenCvSharpExtern.a

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,4 +1,4 @@
-name: Wasm
+﻿name: Wasm
 
 on:
   pull_request:
@@ -153,7 +153,7 @@ jobs:
           emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv4 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o
           cmake --build src/build --parallel $(nproc)
           ls src/build/OpenCvSharpExtern
-          cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.a ${GITHUB_WORKSPACE}/nuget/
+          cp src/build/OpenCvSharpExtern/OpenCvSharpExtern.a ${GITHUB_WORKSPACE}/nuget/
 
       - name: Check OpenCvSharpExtern
         run: |

--- a/nuget/OpenCvSharp4.runtime.wasm.csproj
+++ b/nuget/OpenCvSharp4.runtime.wasm.csproj
@@ -23,7 +23,7 @@
   
   <ItemGroup>
     <None Include="OpenCvSharp4.runtime.wasm.props" Pack="true" PackagePath="build/net8.0" />
-    <None Include="libOpenCvSharpExtern.a" Pack="true" PackagePath="runtimes/browser-wasm/4.0.23" />
+    <None Include="OpenCvSharpExtern.a" Pack="true" PackagePath="runtimes/browser-wasm/4.0.23" />
     <None Include="icon/opencvsharp.png" Pack="true" PackagePath="" />
     <None Include="README.runtime.md" Pack="true" PackagePath="" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Fixes the NativeFileReference error in the WASM runtime package build caused by a filename mismatch.

## Problem
The emcmake/cmake build outputs `OpenCvSharpExtern.a` (without 'lib' prefix), but the project configuration was referencing `libOpenCvSharpExtern.a`, causing:

```
Error: Could not find NativeFileReference C:\Users\...\runtimes\browser-wasm\4.0.23\OpenCvSharpExtern.a
```

## Changes
- **`.github/workflows/wasm.yml`**: Updated copy command from `libOpenCvSharpExtern.a` → `OpenCvSharpExtern.a`
- **`nuget/OpenCvSharp4.runtime.wasm.csproj`**: Updated NativeFileReference path from `libOpenCvSharpExtern.a` → `OpenCvSharpExtern.a`
- Ensured all files comply with UTF-8 with BOM encoding per contributing guidelines

## Testing
This fix resolves the WASM runtime package build error where the NativeFileReference could not locate the compiled library file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebAssembly runtime package artifact naming and distribution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->