### PR TITLE
Fix: add lib prefix to NativeFileReference in wasm.props

### DIFF
--- a/nuget/OpenCvSharp4.runtime.wasm.props
+++ b/nuget/OpenCvSharp4.runtime.wasm.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"  encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\browser-wasm\4.0.23\OpenCvSharpExtern.a" />
+    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\browser-wasm\4.0.23\libOpenCvSharpExtern.a" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Close #1838 

## Problem

`OpenCvSharp4.runtime.wasm.props` referenced the WASM static library as `OpenCvSharpExtern.a` (without the `lib` prefix), but the actual filename produced by the CMake/Emscripten build is `libOpenCvSharpExtern.a`.

CMake on Unix-like platforms (including Emscripten) automatically prepends `lib` to the target name when creating a static library via `add_library(OpenCvSharpExtern STATIC ...)`. This is consistent with how the Linux (`.so`) and macOS (`.dylib`) libraries are already named in this repository.

The mismatch caused a `NativeFileReference` resolution failure at build time when consuming the NuGet package.

## Root cause analysis of PR #1838

PR #1838 proposed the opposite approach - removing the `lib` prefix from `wasm.yml` and `OpenCvSharp4.runtime.wasm.csproj`. However, that would break the CI workflow because `cmake --build` produces `libOpenCvSharpExtern.a`; changing the copy command to reference `OpenCvSharpExtern.a` would make the copy step fail.

The correct fix is to align `wasm.props` with the actual filename (`libOpenCvSharpExtern.a`), keeping all other references consistent with the `lib`-prefixed convention used throughout the repository.

## Change

- `nuget/OpenCvSharp4.runtime.wasm.props`: `OpenCvSharpExtern.a` to `libOpenCvSharpExtern.a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected native library reference for WebAssembly runtime to ensure proper bundling of the correct native artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->