### PR TITLE
Fix multiple disposal issue

### DIFF
--- a/src/OpenCvSharp/Fundamentals/CvObject.cs
+++ b/src/OpenCvSharp/Fundamentals/CvObject.cs
@@ -13,7 +13,7 @@ public abstract class CvObject : DisposableObject
     /// The SafeHandle that wraps (and optionally owns) the native pointer.
     /// This is the single source of truth for the native handle value.
     /// </summary>
-    private OpenCvSafeHandle? safeHandle;
+    private volatile OpenCvSafeHandle? safeHandle;
 
     /// <summary>
     /// Native data pointer, derived from <see cref="safeHandle"/>.
@@ -94,10 +94,6 @@ public abstract class CvObject : DisposableObject
     }
 
     /// <summary>
-    /// releases unmanaged resources
-    /// </summary>
-
-    /// <summary>
     /// Releases managed resources, including the SafeHandle if present.
     /// </summary>
     protected override void DisposeManaged()
@@ -107,6 +103,18 @@ public abstract class CvObject : DisposableObject
             safeHandle.Dispose();
         }
         base.DisposeManaged();
+    }
+
+    /// <summary>
+    /// Releases unmanaged resources.
+    /// Nulls out the SafeHandle so that <see cref="ptr"/> returns <see cref="IntPtr.Zero"/>
+    /// after disposal, matching the behaviour of the former <c>ptr = IntPtr.Zero</c> pattern
+    /// and providing defence-in-depth against use-after-dispose.
+    /// </summary>
+    protected override void DisposeUnmanaged()
+    {
+        safeHandle = null;
+        base.DisposeUnmanaged();
     }
         
     /// <summary>

--- a/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
+++ b/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
@@ -49,11 +49,6 @@ public abstract class CvPtrObject : DisposableObject
     }
 
     /// <summary>
-    /// Alias for <see cref="RawPtr"/>. Kept for source compatibility with existing subclass code.
-    /// </summary>
-    //public IntPtr CvPtr => RawPtr;
-
-    /// <summary>
     /// Returns the cv::Ptr&lt;T&gt;* smart pointer for P/Invoke calls that require it
     /// (e.g. functions that take ownership of the pointer).
     /// </summary>

--- a/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
+++ b/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
@@ -8,7 +8,7 @@
 /// </summary>
 public abstract class CvPtrObject : DisposableObject
 {
-    private OpenCvSafeHandle? lifecycleHandle;
+    private volatile OpenCvSafeHandle? lifecycleHandle;
     private readonly IntPtr rawPtr;
 
     /// <summary>
@@ -70,6 +70,12 @@ public abstract class CvPtrObject : DisposableObject
     protected override void DisposeManaged()
     {
         lifecycleHandle?.Dispose();
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeUnmanaged()
+    {
         lifecycleHandle = null;
+        base.DisposeUnmanaged();
     }
 }


### PR DESCRIPTION
This pull request improves thread safety and resource management for OpenCV object wrappers by making handle fields volatile and ensuring handles are properly nulled out during disposal. The changes help prevent use-after-dispose bugs and make the disposal process more robust.

**Thread safety improvements:**
* Made the `safeHandle` field in `CvObject` and the `lifecycleHandle` field in `CvPtrObject` `volatile` to ensure correct visibility of changes across threads. [[1]](diffhunk://#diff-0ba9481b71a9c57ee83ca39f667de7a4d5b57eae911be922933a0ed849903f59L16-R16) [[2]](diffhunk://#diff-9a083bf024caee96256d126347a6fdde97a98987b35babf47cb5241570424384L11-R11)

**Resource management enhancements:**
* Added an override of `DisposeUnmanaged` in both `CvObject` and `CvPtrObject` to null out the handle fields after disposal, preventing access to invalid pointers and providing defense-in-depth against use-after-dispose errors. [[1]](diffhunk://#diff-0ba9481b71a9c57ee83ca39f667de7a4d5b57eae911be922933a0ed849903f59R108-R119) [[2]](diffhunk://#diff-9a083bf024caee96256d126347a6fdde97a98987b35babf47cb5241570424384R73-R79)
* Removed a redundant summary comment about releasing unmanaged resources in `CvObject` for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disposal to ensure objects report a cleared state after being disposed, reducing risk of use-after-dispose.
  * Strengthened thread-safety for resource management so concurrent operations observe consistent disposal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->