### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/OpenCvSharp/Modules/features2d/GFTTDetector.cs
+++ b/src/OpenCvSharp/Modules/features2d/GFTTDetector.cs
@@ -35,7 +35,8 @@ public class GFTTDetector : Feature2D
     /// <summary>
     /// Constructor
     /// </summary>
-    /// <param name="p"></param>
+    /// <param name="smartPtr"></param>
+    /// <param name="rawPtr"></param>
     private GFTTDetector(IntPtr smartPtr, IntPtr rawPtr)
         : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features2d_Ptr_GFTTDetector_delete(p)))
     {

--- a/src/OpenCvSharp/Modules/imgproc/GeneralizedHough.cs
+++ b/src/OpenCvSharp/Modules/imgproc/GeneralizedHough.cs
@@ -136,7 +136,6 @@ public abstract class GeneralizedHough : Algorithm
     public void SetTemplate(InputArray templ, Point? templCenter = null)
     {
         ThrowIfDisposed();
-            throw new ObjectDisposedException(GetType().Name);
         if (templ is null)
             throw new ArgumentNullException(nameof(templ));
         templ.ThrowIfDisposed();
@@ -158,7 +157,6 @@ public abstract class GeneralizedHough : Algorithm
     public virtual void SetTemplate(InputArray edges, InputArray dx, InputArray dy, Point? templCenter = null)
     {
         ThrowIfDisposed();
-            throw new ObjectDisposedException(GetType().Name);
         if (edges is null)
             throw new ArgumentNullException(nameof(edges));
         if (dx is null)


### PR DESCRIPTION
This pull request makes minor improvements to code documentation and cleans up redundant exception handling in the `OpenCvSharp` library. The main changes include clarifying parameter names in the `GFTTDetector` constructor and removing unnecessary object disposal checks in the `GeneralizedHough` class.

Code documentation and clarity:

* Updated the parameter names in the private constructor of `GFTTDetector` for better clarity (`GFTTDetector.cs`).

Exception handling cleanup:

* Removed redundant `ObjectDisposedException` throws from the `SetTemplate` methods in `GeneralizedHough` since `ThrowIfDisposed()` already performs this check (`GeneralizedHough.cs`). [[1]](diffhunk://#diff-667b441a6f641bfbecb93339923adae8e9e7131012d647b7448abdff6f97e26bL139) [[2]](diffhunk://#diff-667b441a6f641bfbecb93339923adae8e9e7131012d647b7448abdff6f97e26bL161)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code quality by removing redundant exception handling logic and updating internal documentation identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->