### PR TITLE
Fix SNUPKG push process

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -133,6 +133,7 @@ jobs:
           set -euo pipefail
 
           pushed=0
+          skipped=0
           failed=0
 
           push_package() {
@@ -141,11 +142,19 @@ jobs:
             name=$(basename "$file")
             local output
             if output=$(dotnet nuget push "$file" \
+                --skip-duplicate \
                 -k ${{secrets.NUGET_ORG_API_KEY}} \
                 -s https://api.nuget.org/v3/index.json 2>&1); then
-              echo "PUSHED: $name"
-              echo "| \`$name\` | ✅ Pushed |" >> $GITHUB_STEP_SUMMARY
-              pushed=$((pushed + 1))
+              echo "$output"
+              if echo "$output" | grep -qi "already exists"; then
+                echo "SKIPPED (already exists): $name"
+                echo "| \`$name\` | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
+                skipped=$((skipped + 1))
+              else
+                echo "PUSHED: $name"
+                echo "| \`$name\` | ✅ Pushed |" >> $GITHUB_STEP_SUMMARY
+                pushed=$((pushed + 1))
+              fi
             else
               echo "FAILED: $name"
               echo "$output"
@@ -158,13 +167,17 @@ jobs:
           echo "| Package | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          for f in *.nupkg *.snupkg; do
+          # dotnet nuget push automatically uploads the matching .snupkg when pushing a .nupkg
+          # if the file exists in the same directory (nupkg is pushed first, then snupkg).
+          # See: https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package
+          echo "--- Pushing .nupkg (and corresponding .snupkg automatically) ---"
+          for f in *.nupkg; do
             [ -f "$f" ] || continue
             push_package "$f"
           done
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pushed:** $pushed  **Failed:** $failed" >> $GITHUB_STEP_SUMMARY
+          echo "**Pushed:** $pushed  **Skipped:** $skipped  **Failed:** $failed" >> $GITHUB_STEP_SUMMARY
 
           if [ "$failed" -gt 0 ]; then
             echo "ERROR: $failed package(s) failed to push."

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -142,7 +142,8 @@ jobs:
             name=$(basename "$file")
             local output
             if output=$(dotnet nuget push "$file" \
-                --skip-duplicate \
+                --skip-duplicate \                
+                --force-english-output \
                 -k ${{secrets.NUGET_ORG_API_KEY}} \
                 -s https://api.nuget.org/v3/index.json 2>&1); then
               echo "$output"


### PR DESCRIPTION
This pull request improves the NuGet package publishing workflow by making the push process more robust and user-friendly. The main changes are focused on handling duplicate package uploads more gracefully, providing clearer output, and ensuring that symbol packages (`.snupkg`) are handled correctly.

**Enhancements to NuGet publishing workflow:**

* Added logic to detect and count skipped packages when a duplicate is encountered, incrementing a new `skipped` counter and updating the summary output accordingly. [[1]](diffhunk://#diff-8e6049acd0c7d6b3ec8068d3944c11d3b9219168de911b8d43adb01e5692f1cfR136) [[2]](diffhunk://#diff-8e6049acd0c7d6b3ec8068d3944c11d3b9219168de911b8d43adb01e5692f1cfR145-R157) [[3]](diffhunk://#diff-8e6049acd0c7d6b3ec8068d3944c11d3b9219168de911b8d43adb01e5692f1cfL161-R180)
* Improved output in the workflow summary to clearly indicate which packages were pushed, skipped (because they already exist), or failed. The summary now includes a "Skipped" count. [[1]](diffhunk://#diff-8e6049acd0c7d6b3ec8068d3944c11d3b9219168de911b8d43adb01e5692f1cfR145-R157) [[2]](diffhunk://#diff-8e6049acd0c7d6b3ec8068d3944c11d3b9219168de911b8d43adb01e5692f1cfL161-R180)
* Updated the loop to only push `.nupkg` files, relying on `dotnet nuget push` to automatically handle the corresponding `.snupkg` symbol packages, as per NuGet best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved NuGet publishing workflow to detect and gracefully skip duplicate package uploads, reducing redundant uploads and build time.
  * Publishing now only targets main package files; symbol packages are uploaded automatically when the main package is pushed.
  * Release summary enhanced to show "Skipped" alongside "Pushed" and "Failed" for clearer publish results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->