### PR TITLE
Fix VecXX implementation

### DIFF
--- a/src/OpenCvSharp/Modules/core/Struct/Vec/IVec.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/IVec.cs
@@ -12,7 +12,7 @@ public interface IVec;
 /// </summary>
 /// <typeparam name="TSelf"></typeparam>
 /// <typeparam name="TElem"></typeparam>
-public interface IVec<TSelf, out TElem> : IVec
+public interface IVec<TSelf, TElem> : IVec
     where TSelf : IVec
     where TElem : unmanaged
 {
@@ -49,5 +49,5 @@ public interface IVec<TSelf, out TElem> : IVec
     /// </summary>
     /// <param name="i"></param>
     /// <returns></returns>
-    TElem this[int i] { get; }
+    TElem this[int i] { get; set; }
 }

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2b.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 2-Tuple of byte (System.Byte)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec2b : IVec<Vec2b, byte>, IEquatable<Vec2b>
 {
@@ -130,6 +129,10 @@ public struct Vec2b : IVec<Vec2b, byte>, IEquatable<Vec2b>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2b other) =>
         Item0 == other.Item0 && 
@@ -160,10 +163,10 @@ public struct Vec2b : IVec<Vec2b, byte>, IEquatable<Vec2b>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
-            }
+        unchecked
+        {
+            return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
+        }
 #else
         return HashCode.Combine(Item0, Item1);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2b.cs
@@ -130,6 +130,7 @@ public struct Vec2b : IVec<Vec2b, byte>, IEquatable<Vec2b>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2d.cs
@@ -112,6 +112,7 @@ public struct Vec2d : IVec<Vec2d, double>, IEquatable<Vec2d>
     #endregion
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2d.cs
@@ -7,7 +7,6 @@ namespace OpenCvSharp;
 /// <summary>
 /// 2-Tuple of double (System.Double)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
 public struct Vec2d : IVec<Vec2d, double>, IEquatable<Vec2d>
 {
@@ -82,6 +81,7 @@ public struct Vec2d : IVec<Vec2d, double>, IEquatable<Vec2d>
     public static Vec2d operator -(Vec2d a, Vec2d b) => a.Subtract(b);
     public static Vec2d operator *(Vec2d a, double alpha) => a.Multiply(alpha);
     public static Vec2d operator /(Vec2d a, double alpha) => a.Divide(alpha);
+    public static Vec2d operator -(Vec2d a) => new(-a.Item0, -a.Item1);
 #pragma warning restore 1591
 
     /// <summary>
@@ -111,6 +111,10 @@ public struct Vec2d : IVec<Vec2d, double>, IEquatable<Vec2d>
 
     #endregion
 
+#if !NETSTANDARD2_0
+    public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2d other) => Item0.Equals(other.Item0) && Item1.Equals(other.Item1);
 
@@ -130,23 +134,23 @@ public struct Vec2d : IVec<Vec2d, double>, IEquatable<Vec2d>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec2d a, Vec2d b) => a.Equals(b);
+    public static bool operator ==(Vec2d a, Vec2d b) => a.Item0 == b.Item0 && a.Item1 == b.Item1;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec2d a, Vec2d b) => !(a == b);
+    public static bool operator !=(Vec2d a, Vec2d b) => a.Item0 != b.Item0 || a.Item1 != b.Item1;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
-            }
+        unchecked
+        {
+            return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
+        }
 #else
         return HashCode.Combine(Item0, Item1);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2f.cs
@@ -120,6 +120,7 @@ public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2f.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 2-Tuple of float (System.Single)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
 {
@@ -83,6 +82,7 @@ public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
     public static Vec2f operator -(Vec2f a, Vec2f b) => a.Subtract(b);
     public static Vec2f operator *(Vec2f a, double alpha) => a.Multiply(alpha);
     public static Vec2f operator /(Vec2f a, double alpha) => a.Divide(alpha);
+    public static Vec2f operator -(Vec2f a) => new(-a.Item0, -a.Item1);
 #pragma warning restore 1591
 
     /// <summary>
@@ -119,6 +119,10 @@ public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2f other) => Item0.Equals(other.Item0) && Item1.Equals(other.Item1);
 
@@ -134,14 +138,14 @@ public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec2f a, Vec2f b) => a.Equals(b);
+    public static bool operator ==(Vec2f a, Vec2f b) => a.Item0 == b.Item0 && a.Item1 == b.Item1;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec2f a, Vec2f b) => !(a == b);
+    public static bool operator !=(Vec2f a, Vec2f b) => a.Item0 != b.Item0 || a.Item1 != b.Item1;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
@@ -152,7 +156,7 @@ public struct Vec2f : IVec<Vec2f, float>, IEquatable<Vec2f>
             return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
         }
 #else
-            return HashCode.Combine(Item0, Item1);
+        return HashCode.Combine(Item0, Item1);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2i.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 2-Tuple of int (System.Int32)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec2i : IVec<Vec2i, int>, IEquatable<Vec2i>
 {
@@ -84,6 +83,7 @@ public struct Vec2i : IVec<Vec2i, int>, IEquatable<Vec2i>
     public static Vec2i operator -(Vec2i a, Vec2i b) => a.Subtract(b);
     public static Vec2i operator *(Vec2i a, double alpha) => a.Multiply(alpha);
     public static Vec2i operator /(Vec2i a, double alpha) => a.Divide(alpha);
+    public static Vec2i operator -(Vec2i a) => new(SaturateCast.ToInt32(-(long)a.Item0), SaturateCast.ToInt32(-(long)a.Item1));
 #pragma warning restore 1591
 
     /// <summary>
@@ -120,6 +120,10 @@ public struct Vec2i : IVec<Vec2i, int>, IEquatable<Vec2i>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2i other) =>
         Item0 == other.Item0 &&
@@ -150,10 +154,10 @@ public struct Vec2i : IVec<Vec2i, int>, IEquatable<Vec2i>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                return (Item0 * 397) ^ Item1;
-            }
+        unchecked
+        {
+            return (Item0 * 397) ^ Item1;
+        }
 #else
         return HashCode.Combine(Item0, Item1);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2i.cs
@@ -121,6 +121,7 @@ public struct Vec2i : IVec<Vec2i, int>, IEquatable<Vec2i>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2s.cs
@@ -8,7 +8,6 @@ namespace OpenCvSharp;
 /// <summary>
 /// 2-Tuple of short (System.Int16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
 // ReSharper disable once InconsistentNaming
 public struct Vec2s : IVec<Vec2s, short>, IEquatable<Vec2s>
@@ -84,6 +83,7 @@ public struct Vec2s : IVec<Vec2s, short>, IEquatable<Vec2s>
     public static Vec2s operator -(Vec2s a, Vec2s b) => a.Subtract(b);
     public static Vec2s operator *(Vec2s a, double alpha) => a.Multiply(alpha);
     public static Vec2s operator /(Vec2s a, double alpha) => a.Divide(alpha);
+    public static Vec2s operator -(Vec2s a) => new(SaturateCast.ToInt16(-a.Item0), SaturateCast.ToInt16(-a.Item1));
 #pragma warning restore 1591
 
     /// <summary>
@@ -122,6 +122,10 @@ public struct Vec2s : IVec<Vec2s, short>, IEquatable<Vec2s>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2s other) => Item0 == other.Item0 && Item1 == other.Item1;
 
@@ -155,7 +159,7 @@ public struct Vec2s : IVec<Vec2s, short>, IEquatable<Vec2s>
             return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
         }
 #else
-            return HashCode.Combine(Item0, Item1);
+        return HashCode.Combine(Item0, Item1);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2s.cs
@@ -123,6 +123,7 @@ public struct Vec2s : IVec<Vec2s, short>, IEquatable<Vec2s>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2w.cs
@@ -123,6 +123,7 @@ public struct Vec2w : IVec<Vec2w, ushort>, IEquatable<Vec2w>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 2 elements of this vector.</summary>
     public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec2w.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 2-Tuple of ushort (System.UInt16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec2w : IVec<Vec2w, ushort>, IEquatable<Vec2w>
 {
@@ -123,6 +122,10 @@ public struct Vec2w : IVec<Vec2w, ushort>, IEquatable<Vec2w>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 2);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec2w other) => Item0 == other.Item0 && Item1 == other.Item1;
 
@@ -156,7 +159,7 @@ public struct Vec2w : IVec<Vec2w, ushort>, IEquatable<Vec2w>
             return (Item0.GetHashCode() * 397) ^ Item1.GetHashCode();
         }
 #else
-            return HashCode.Combine(Item0, Item1);
+        return HashCode.Combine(Item0, Item1);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3b.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 3-Tuple of byte (System.Byte)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec3b : IVec<Vec3b, byte>, IEquatable<Vec3b>
 {
@@ -137,6 +136,10 @@ public struct Vec3b : IVec<Vec3b, byte>, IEquatable<Vec3b>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3b other) =>
         Item0 == other.Item0 &&
@@ -176,7 +179,7 @@ public struct Vec3b : IVec<Vec3b, byte>, IEquatable<Vec3b>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2);
+        return HashCode.Combine(Item0, Item1, Item2);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3b.cs
@@ -137,6 +137,7 @@ public struct Vec3b : IVec<Vec3b, byte>, IEquatable<Vec3b>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3d.cs
@@ -7,7 +7,6 @@ namespace OpenCvSharp;
 /// <summary>
 /// 3-Tuple of double (System.Double)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
 public struct Vec3d : IVec<Vec3d, double>, IEquatable<Vec3d>
 {
@@ -95,6 +94,7 @@ public struct Vec3d : IVec<Vec3d, double>, IEquatable<Vec3d>
     public static Vec3d operator -(Vec3d a, Vec3d b) => a.Subtract(b);
     public static Vec3d operator *(Vec3d a, double alpha) => a.Multiply(alpha);
     public static Vec3d operator /(Vec3d a, double alpha) => a.Divide(alpha);
+    public static Vec3d operator -(Vec3d a) => new(-a.Item0, -a.Item1, -a.Item2);
 #pragma warning restore 1591
 
     /// <summary>
@@ -126,6 +126,10 @@ public struct Vec3d : IVec<Vec3d, double>, IEquatable<Vec3d>
 
     #endregion
 
+#if !NETSTANDARD2_0
+    public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3d other) => Item0.Equals(other.Item0) && Item1.Equals(other.Item1) && Item2.Equals(other.Item2);
 
@@ -141,26 +145,26 @@ public struct Vec3d : IVec<Vec3d, double>, IEquatable<Vec3d>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec3d a, Vec3d b) => a.Equals(b);
+    public static bool operator ==(Vec3d a, Vec3d b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec3d a, Vec3d b) => !(a == b);
+    public static bool operator !=(Vec3d a, Vec3d b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3d.cs
@@ -127,6 +127,7 @@ public struct Vec3d : IVec<Vec3d, double>, IEquatable<Vec3d>
     #endregion
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3f.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 3-Tuple of float (System.Single)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
 {
@@ -95,6 +94,7 @@ public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
     public static Vec3f operator -(Vec3f a, Vec3f b) => a.Subtract(b);
     public static Vec3f operator *(Vec3f a, double alpha) => a.Multiply(alpha);
     public static Vec3f operator /(Vec3f a, double alpha) => a.Divide(alpha);
+    public static Vec3f operator -(Vec3f a) => new(-a.Item0, -a.Item1, -a.Item2);
 #pragma warning restore 1591
 
     /// <summary>
@@ -133,6 +133,10 @@ public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3f other) => Item0.Equals(other.Item0) && Item1.Equals(other.Item1) && Item2.Equals(other.Item2);
 
@@ -148,14 +152,14 @@ public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec3f a, Vec3f b) => a.Equals(b);
+    public static bool operator ==(Vec3f a, Vec3f b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec3f a, Vec3f b) => !(a == b);
+    public static bool operator !=(Vec3f a, Vec3f b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
@@ -169,7 +173,7 @@ public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2);
+        return HashCode.Combine(Item0, Item1, Item2);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3f.cs
@@ -134,6 +134,7 @@ public struct Vec3f : IVec<Vec3f, float>, IEquatable<Vec3f>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3i.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 3-Tuple of int (System.Int32)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec3i : IVec<Vec3i, int>, IEquatable<Vec3i>
 {
@@ -97,6 +96,7 @@ public struct Vec3i : IVec<Vec3i, int>, IEquatable<Vec3i>
     public static Vec3i operator -(Vec3i a, Vec3i b) => a.Subtract(b);
     public static Vec3i operator *(Vec3i a, double alpha) => a.Multiply(alpha);
     public static Vec3i operator /(Vec3i a, double alpha) => a.Divide(alpha);
+    public static Vec3i operator -(Vec3i a) => new(SaturateCast.ToInt32(-(long)a.Item0), SaturateCast.ToInt32(-(long)a.Item1), SaturateCast.ToInt32(-(long)a.Item2));
 #pragma warning restore 1591
 
     /// <summary>
@@ -135,6 +135,10 @@ public struct Vec3i : IVec<Vec3i, int>, IEquatable<Vec3i>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3i other) =>
         Item0 == other.Item0 &&
@@ -166,13 +170,13 @@ public struct Vec3i : IVec<Vec3i, int>, IEquatable<Vec3i>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0;
-                hashCode = (hashCode * 397) ^ Item1;
-                hashCode = (hashCode * 397) ^ Item2;
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0;
+            hashCode = (hashCode * 397) ^ Item1;
+            hashCode = (hashCode * 397) ^ Item2;
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3i.cs
@@ -136,6 +136,7 @@ public struct Vec3i : IVec<Vec3i, int>, IEquatable<Vec3i>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3s.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 3-Tuple of short (System.Int16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec3s : IVec<Vec3s, short>, IEquatable<Vec3s>
 {
@@ -96,6 +95,7 @@ public struct Vec3s : IVec<Vec3s, short>, IEquatable<Vec3s>
     public static Vec3s operator -(Vec3s a, Vec3s b) => a.Subtract(b);
     public static Vec3s operator *(Vec3s a, double alpha) => a.Multiply(alpha);
     public static Vec3s operator /(Vec3s a, double alpha) => a.Divide(alpha);
+    public static Vec3s operator -(Vec3s a) => new(SaturateCast.ToInt16(-a.Item0), SaturateCast.ToInt16(-a.Item1), SaturateCast.ToInt16(-a.Item2));
 #pragma warning restore 1591
 
     /// <summary>
@@ -137,6 +137,10 @@ public struct Vec3s : IVec<Vec3s, short>, IEquatable<Vec3s>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3s other) =>
         Item0 == other.Item0 &&
@@ -176,7 +180,7 @@ public struct Vec3s : IVec<Vec3s, short>, IEquatable<Vec3s>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2);
+        return HashCode.Combine(Item0, Item1, Item2);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3s.cs
@@ -138,6 +138,7 @@ public struct Vec3s : IVec<Vec3s, short>, IEquatable<Vec3s>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3w.cs
@@ -138,6 +138,7 @@ public struct Vec3w : IVec<Vec3w, ushort>, IEquatable<Vec3w>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 3 elements of this vector.</summary>
     public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec3w.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 3-Tuple of ushort (System.UInt16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec3w : IVec<Vec3w, ushort>, IEquatable<Vec3w>
 {
@@ -138,6 +137,10 @@ public struct Vec3w : IVec<Vec3w, ushort>, IEquatable<Vec3w>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 3);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec3w other) =>
         Item0 == other.Item0 &&
@@ -169,13 +172,13 @@ public struct Vec3w : IVec<Vec3w, ushort>, IEquatable<Vec3w>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4b.cs
@@ -151,6 +151,7 @@ public struct Vec4b : IVec<Vec4b, byte>, IEquatable<Vec4b>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4b.cs
@@ -8,7 +8,6 @@ namespace OpenCvSharp;
 /// <summary>
 /// 4-Tuple of byte (System.Byte)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
 // ReSharper disable once InconsistentNaming
 public struct Vec4b : IVec<Vec4b, byte>, IEquatable<Vec4b>
@@ -151,6 +150,10 @@ public struct Vec4b : IVec<Vec4b, byte>, IEquatable<Vec4b>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4b other) =>
         Item0 == other.Item0 &&
@@ -192,7 +195,7 @@ public struct Vec4b : IVec<Vec4b, byte>, IEquatable<Vec4b>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3);
+        return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4d.cs
@@ -141,6 +141,7 @@ public struct Vec4d : IVec<Vec4d, double>, IEquatable<Vec4d>
     #endregion
         
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4d.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 4-Tuple of double (System.Double)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 public struct Vec4d : IVec<Vec4d, double>, IEquatable<Vec4d>
 {
     /// <summary>
@@ -107,6 +106,7 @@ public struct Vec4d : IVec<Vec4d, double>, IEquatable<Vec4d>
     public static Vec4d operator -(Vec4d a, Vec4d b) => a.Subtract(b);
     public static Vec4d operator *(Vec4d a, double alpha) => a.Multiply(alpha);
     public static Vec4d operator /(Vec4d a, double alpha) => a.Divide(alpha);
+    public static Vec4d operator -(Vec4d a) => new(-a.Item0, -a.Item1, -a.Item2, -a.Item3);
 #pragma warning restore 1591
 
     /// <summary>
@@ -140,6 +140,10 @@ public struct Vec4d : IVec<Vec4d, double>, IEquatable<Vec4d>
 
     #endregion
         
+#if !NETSTANDARD2_0
+    public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4d other) =>
         Item0.Equals(other.Item0) &&
@@ -159,27 +163,27 @@ public struct Vec4d : IVec<Vec4d, double>, IEquatable<Vec4d>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec4d a, Vec4d b) => a.Equals(b);
+    public static bool operator ==(Vec4d a, Vec4d b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2 && a.Item3 == b.Item3;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec4d a, Vec4d b) => !(a == b);
+    public static bool operator !=(Vec4d a, Vec4d b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2 || a.Item3 != b.Item3;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item3.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item3.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4f.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 4-Tuple of float (System.Single)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
 {
@@ -108,6 +107,7 @@ public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
     public static Vec4f operator -(Vec4f a, Vec4f b) => a.Subtract(b);
     public static Vec4f operator *(Vec4f a, double alpha) => a.Multiply(alpha);
     public static Vec4f operator /(Vec4f a, double alpha) => a.Divide(alpha);
+    public static Vec4f operator -(Vec4f a) => new(-a.Item0, -a.Item1, -a.Item2, -a.Item3);
 #pragma warning restore 1591
 
     /// <summary>
@@ -148,6 +148,10 @@ public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4f other) =>
         Item0.Equals(other.Item0) &&
@@ -167,14 +171,14 @@ public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec4f a, Vec4f b) => a.Equals(b);
+    public static bool operator ==(Vec4f a, Vec4f b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2 && a.Item3 == b.Item3;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec4f a, Vec4f b) => !(a == b);
+    public static bool operator !=(Vec4f a, Vec4f b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2 || a.Item3 != b.Item3;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
@@ -189,7 +193,7 @@ public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3);
+        return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4f.cs
@@ -149,6 +149,7 @@ public struct Vec4f : IVec<Vec4f, float>, IEquatable<Vec4f>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4i.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 4-Tuple of int (System.Int32)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec4i : IVec<Vec4i, int>, IEquatable<Vec4i>
 {
@@ -109,6 +108,7 @@ public struct Vec4i : IVec<Vec4i, int>, IEquatable<Vec4i>
     public static Vec4i operator -(Vec4i a, Vec4i b) => a.Subtract(b);
     public static Vec4i operator *(Vec4i a, double alpha) => a.Multiply(alpha);
     public static Vec4i operator /(Vec4i a, double alpha) => a.Divide(alpha);
+    public static Vec4i operator -(Vec4i a) => new(SaturateCast.ToInt32(-(long)a.Item0), SaturateCast.ToInt32(-(long)a.Item1), SaturateCast.ToInt32(-(long)a.Item2), SaturateCast.ToInt32(-(long)a.Item3));
 #pragma warning restore 1591
 
     /// <summary>
@@ -149,6 +149,10 @@ public struct Vec4i : IVec<Vec4i, int>, IEquatable<Vec4i>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4i other) =>
         Item0 == other.Item0 &&
@@ -181,14 +185,14 @@ public struct Vec4i : IVec<Vec4i, int>, IEquatable<Vec4i>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0;
-                hashCode = (hashCode * 397) ^ Item1;
-                hashCode = (hashCode * 397) ^ Item2;
-                hashCode = (hashCode * 397) ^ Item3;
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0;
+            hashCode = (hashCode * 397) ^ Item1;
+            hashCode = (hashCode * 397) ^ Item2;
+            hashCode = (hashCode * 397) ^ Item3;
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4i.cs
@@ -150,6 +150,7 @@ public struct Vec4i : IVec<Vec4i, int>, IEquatable<Vec4i>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4s.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 4-Tuple of short (System.Int16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec4s : IVec<Vec4s, short>, IEquatable<Vec4s>
 {
@@ -109,6 +108,7 @@ public struct Vec4s : IVec<Vec4s, short>, IEquatable<Vec4s>
     public static Vec4s operator -(Vec4s a, Vec4s b) => a.Subtract(b);
     public static Vec4s operator *(Vec4s a, double alpha) => a.Multiply(alpha);
     public static Vec4s operator /(Vec4s a, double alpha) => a.Divide(alpha);
+    public static Vec4s operator -(Vec4s a) => new(SaturateCast.ToInt16(-a.Item0), SaturateCast.ToInt16(-a.Item1), SaturateCast.ToInt16(-a.Item2), SaturateCast.ToInt16(-a.Item3));
 #pragma warning restore 1591
 
     /// <summary>
@@ -153,6 +153,10 @@ public struct Vec4s : IVec<Vec4s, short>, IEquatable<Vec4s>
 #pragma warning restore 1591
 
 
+#if !NETSTANDARD2_0
+    public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4s other) =>
         Item0 == other.Item0 &&
@@ -194,7 +198,7 @@ public struct Vec4s : IVec<Vec4s, short>, IEquatable<Vec4s>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3);
+        return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4s.cs
@@ -154,6 +154,7 @@ public struct Vec4s : IVec<Vec4s, short>, IEquatable<Vec4s>
 
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4w.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 4-Tuple of ushort (System.UInt16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec4w : IVec<Vec4w, ushort>, IEquatable<Vec4w>
 {
@@ -152,6 +151,10 @@ public struct Vec4w : IVec<Vec4w, ushort>, IEquatable<Vec4w>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec4w other) =>
         Item0 == other.Item0 &&
@@ -193,7 +196,7 @@ public struct Vec4w : IVec<Vec4w, ushort>, IEquatable<Vec4w>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3);
+        return HashCode.Combine(Item0, Item1, Item2, Item3);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec4w.cs
@@ -152,6 +152,7 @@ public struct Vec4w : IVec<Vec4w, ushort>, IEquatable<Vec4w>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 4 elements of this vector.</summary>
     public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 4);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6b.cs
@@ -179,6 +179,7 @@ public struct Vec6b : IVec<Vec6b, byte>, IEquatable<Vec6b>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6b.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6b.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 6-Tuple of byte (System.Byte)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec6b : IVec<Vec6b, byte>, IEquatable<Vec6b>
 {
@@ -179,6 +178,10 @@ public struct Vec6b : IVec<Vec6b, byte>, IEquatable<Vec6b>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec6b other) =>
         Item0 == other.Item0 &&
@@ -213,16 +216,16 @@ public struct Vec6b : IVec<Vec6b, byte>, IEquatable<Vec6b>
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item3.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item4.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item5.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item3.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item4.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item5.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
@@ -193,14 +193,14 @@ public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec6d a, Vec6d b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2 && a.Item3 == b.Item3 && a.Item4 == b.Item4 && a.Item5 == b.Item5;
+    public static bool operator ==(Vec6d a, Vec6d b) => a.Item0.Equals(b.Item0) && a.Item1.Equals(b.Item1) && a.Item2.Equals(b.Item2) && a.Item3.Equals(b.Item3) && a.Item4.Equals(b.Item4) && a.Item5.Equals(b.Item5);
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec6d a, Vec6d b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2 || a.Item3 != b.Item3 || a.Item4 != b.Item4 || a.Item5 != b.Item5;
+    public static bool operator !=(Vec6d a, Vec6d b) => !a.Item0.Equals(b.Item0) || !a.Item1.Equals(b.Item1) || !a.Item2.Equals(b.Item2) || !a.Item3.Equals(b.Item3) || !a.Item4.Equals(b.Item4) || !a.Item5.Equals(b.Item5);
 
     /// <inheritdoc />
     public readonly override int GetHashCode()

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 6-Tuple of double (System.Double)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
 {
     /// <summary>
@@ -131,6 +130,7 @@ public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
     public static Vec6d operator -(Vec6d a, Vec6d b) => a.Subtract(b);
     public static Vec6d operator *(Vec6d a, double alpha) => a.Multiply(alpha);
     public static Vec6d operator /(Vec6d a, double alpha) => a.Divide(alpha);
+    public static Vec6d operator -(Vec6d a) => new(-a.Item0, -a.Item1, -a.Item2, -a.Item3, -a.Item4, -a.Item5);
 #pragma warning restore 1591
 
     /// <summary>
@@ -168,6 +168,10 @@ public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
 
     #endregion
 
+#if !NETSTANDARD2_0
+    public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec6d other) =>
         Item0.Equals(other.Item0) && 
@@ -189,29 +193,29 @@ public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec6d a, Vec6d b) => a.Equals(b);
+    public static bool operator ==(Vec6d a, Vec6d b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2 && a.Item3 == b.Item3 && a.Item4 == b.Item4 && a.Item5 == b.Item5;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec6d a, Vec6d b) => !(a == b);
+    public static bool operator !=(Vec6d a, Vec6d b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2 || a.Item3 != b.Item3 || a.Item4 != b.Item4 || a.Item5 != b.Item5;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item3.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item4.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item5.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item3.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item4.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item5.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6d.cs
@@ -169,6 +169,7 @@ public struct Vec6d : IVec<Vec6d, double>, IEquatable<Vec6d>
     #endregion
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<double> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6f.cs
@@ -177,6 +177,7 @@ public struct Vec6f : IVec<Vec6f, float>, IEquatable<Vec6f>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6f.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6f.cs
@@ -1,14 +1,13 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 6-Tuple of float (System.Single)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec6f : IVec<Vec6f, float>, IEquatable<Vec6f>
 {
@@ -132,6 +131,7 @@ public struct Vec6f : IVec<Vec6f, float>, IEquatable<Vec6f>
     public static Vec6f operator -(Vec6f a, Vec6f b) => a.Subtract(b);
     public static Vec6f operator *(Vec6f a, double alpha) => a.Multiply(alpha);
     public static Vec6f operator /(Vec6f a, double alpha) => a.Divide(alpha);
+    public static Vec6f operator -(Vec6f a) => new(-a.Item0, -a.Item1, -a.Item2, -a.Item3, -a.Item4, -a.Item5);
 #pragma warning restore 1591
 
     /// <summary>
@@ -176,6 +176,10 @@ public struct Vec6f : IVec<Vec6f, float>, IEquatable<Vec6f>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<float> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec6f other) =>
         Item0.Equals(other.Item0) && 
@@ -197,29 +201,29 @@ public struct Vec6f : IVec<Vec6f, float>, IEquatable<Vec6f>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator ==(Vec6f a, Vec6f b) => a.Equals(b);
+    public static bool operator ==(Vec6f a, Vec6f b) => a.Item0 == b.Item0 && a.Item1 == b.Item1 && a.Item2 == b.Item2 && a.Item3 == b.Item3 && a.Item4 == b.Item4 && a.Item5 == b.Item5;
 
     /// <summary> 
     /// </summary>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool operator !=(Vec6f a, Vec6f b) => !a.Equals(b);
+    public static bool operator !=(Vec6f a, Vec6f b) => a.Item0 != b.Item0 || a.Item1 != b.Item1 || a.Item2 != b.Item2 || a.Item3 != b.Item3 || a.Item4 != b.Item4 || a.Item5 != b.Item5;
 
     /// <inheritdoc />
     public readonly override int GetHashCode()
     {
 #if NETSTANDARD2_0
-            unchecked
-            {
-                var hashCode = Item0.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item1.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item2.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item3.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item4.GetHashCode();
-                hashCode = (hashCode * 397) ^ Item5.GetHashCode();
-                return hashCode;
-            }
+        unchecked
+        {
+            var hashCode = Item0.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item1.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item2.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item3.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item4.GetHashCode();
+            hashCode = (hashCode * 397) ^ Item5.GetHashCode();
+            return hashCode;
+        }
 #else
         return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6i.cs
@@ -178,6 +178,7 @@ public struct Vec6i : IVec<Vec6i, int>, IEquatable<Vec6i>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6i.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6i.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 6-Tuple of int (System.Int32)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec6i : IVec<Vec6i, int>, IEquatable<Vec6i>
 {
@@ -133,6 +132,7 @@ public struct Vec6i : IVec<Vec6i, int>, IEquatable<Vec6i>
     public static Vec6i operator -(Vec6i a, Vec6i b) => a.Subtract(b);
     public static Vec6i operator *(Vec6i a, double alpha) => a.Multiply(alpha);
     public static Vec6i operator /(Vec6i a, double alpha) => a.Divide(alpha);
+    public static Vec6i operator -(Vec6i a) => new(SaturateCast.ToInt32(-(long)a.Item0), SaturateCast.ToInt32(-(long)a.Item1), SaturateCast.ToInt32(-(long)a.Item2), SaturateCast.ToInt32(-(long)a.Item3), SaturateCast.ToInt32(-(long)a.Item4), SaturateCast.ToInt32(-(long)a.Item5));
 #pragma warning restore 1591
 
     /// <summary>
@@ -176,6 +176,10 @@ public struct Vec6i : IVec<Vec6i, int>, IEquatable<Vec6i>
     public Vec6d ToVec6d() => new(Item0, Item1, Item2, Item3, Item4, Item5);
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
+
+#if !NETSTANDARD2_0
+    public Span<int> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
 
     /// <inheritdoc />
     public readonly bool Equals(Vec6i other) =>
@@ -222,7 +226,7 @@ public struct Vec6i : IVec<Vec6i, int>, IEquatable<Vec6i>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
+        return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6s.cs
@@ -181,6 +181,7 @@ public struct Vec6s : IVec<Vec6s, short>, IEquatable<Vec6s>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6s.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6s.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
 /// 6-Tuple of short (System.Int16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec6s : IVec<Vec6s, short>, IEquatable<Vec6s>
 {
@@ -133,6 +132,7 @@ public struct Vec6s : IVec<Vec6s, short>, IEquatable<Vec6s>
     public static Vec6s operator -(Vec6s a, Vec6s b) => a.Subtract(b);
     public static Vec6s operator *(Vec6s a, double alpha) => a.Multiply(alpha);
     public static Vec6s operator /(Vec6s a, double alpha) => a.Divide(alpha);
+    public static Vec6s operator -(Vec6s a) => new(SaturateCast.ToInt16(-a.Item0), SaturateCast.ToInt16(-a.Item1), SaturateCast.ToInt16(-a.Item2), SaturateCast.ToInt16(-a.Item3), SaturateCast.ToInt16(-a.Item4), SaturateCast.ToInt16(-a.Item5));
 #pragma warning restore 1591
 
     /// <summary>
@@ -180,6 +180,10 @@ public struct Vec6s : IVec<Vec6s, short>, IEquatable<Vec6s>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<short> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec6s other) =>
         Item0 == other.Item0 &&
@@ -225,7 +229,7 @@ public struct Vec6s : IVec<Vec6s, short>, IEquatable<Vec6s>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
+        return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6w.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCvSharp.Internal.Util;
+
+#pragma warning disable CA1051
 
 namespace OpenCvSharp;
 
 /// <summary>
-/// 4-Tuple of ushort (System.UInt16)
+/// 6-Tuple of ushort (System.UInt16)
 /// </summary>
-[Serializable]
 [StructLayout(LayoutKind.Sequential)]
-[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
 // ReSharper disable once InconsistentNaming
 public struct Vec6w : IVec<Vec6w, ushort>, IEquatable<Vec6w>
 {
@@ -180,6 +179,10 @@ public struct Vec6w : IVec<Vec6w, ushort>, IEquatable<Vec6w>
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+#if !NETSTANDARD2_0
+    public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
+#endif
+
     /// <inheritdoc />
     public readonly bool Equals(Vec6w other) =>
         Item0 == other.Item0 && 
@@ -225,7 +228,7 @@ public struct Vec6w : IVec<Vec6w, ushort>, IEquatable<Vec6w>
             return hashCode;
         }
 #else
-            return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
+        return HashCode.Combine(Item0, Item1, Item2, Item3, Item4, Item5);
 #endif
     }
 

--- a/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6w.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Vec/Vec6w.cs
@@ -180,6 +180,7 @@ public struct Vec6w : IVec<Vec6w, ushort>, IEquatable<Vec6w>
 #pragma warning restore 1591
 
 #if !NETSTANDARD2_0
+    /// <summary>Returns a <see cref="Span{T}"/> over the 6 elements of this vector.</summary>
     public Span<ushort> AsSpan() => MemoryMarshal.CreateSpan(ref Item0, 6);
 #endif
 

--- a/test/OpenCvSharp.Tests/core/VecTest.cs
+++ b/test/OpenCvSharp.Tests/core/VecTest.cs
@@ -239,12 +239,12 @@ public class VecTest
     [Fact]
     public void ToStringFormat()
     {
-        Assert.Contains("Vec2b", new Vec2b(1, 2).ToString());
-        Assert.Contains("1", new Vec2b(1, 2).ToString());
+        Assert.Contains("Vec2b", new Vec2b(1, 2).ToString(), StringComparison.Ordinal);
+        Assert.Contains("1", new Vec2b(1, 2).ToString(), StringComparison.Ordinal);
 
-        Assert.Contains("Vec3f", new Vec3f(1f, 2f, 3f).ToString());
-        Assert.Contains("Vec6i", new Vec6i(1, 2, 3, 4, 5, 6).ToString());
-        Assert.Contains("Vec4d", new Vec4d(1.0, 2.0, 3.0, 4.0).ToString());
+        Assert.Contains("Vec3f", new Vec3f(1f, 2f, 3f).ToString(), StringComparison.Ordinal);
+        Assert.Contains("Vec6i", new Vec6i(1, 2, 3, 4, 5, 6).ToString(), StringComparison.Ordinal);
+        Assert.Contains("Vec4d", new Vec4d(1.0, 2.0, 3.0, 4.0).ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -305,13 +305,12 @@ public class VecTest
     [Fact]
     public void FloatingPointNaNEquality()
     {
+#pragma warning disable CS1718 // Comparison made to same variable — intentional: testing IEEE 754 NaN behaviour
         // float
         var vfNaN = new Vec2f(float.NaN, 1f);
         Assert.True(vfNaN.Equals(vfNaN));   // IEquatable contract: reflexive
-#pragma warning disable CS1718 // Comparison made to same variable — intentional: testing IEEE 754 NaN behaviour
         Assert.False(vfNaN == vfNaN);        // IEEE 754: NaN != NaN
         Assert.True(vfNaN != vfNaN);
-#pragma warning restore CS1718
 
         var vfNormal = new Vec2f(1f, 2f);
         Assert.True(vfNormal == vfNormal);
@@ -320,14 +319,13 @@ public class VecTest
         // double
         var vdNaN = new Vec3d(double.NaN, 1.0, 2.0);
         Assert.True(vdNaN.Equals(vdNaN));
-#pragma warning disable CS1718
         Assert.False(vdNaN == vdNaN);
         Assert.True(vdNaN != vdNaN);
-#pragma warning restore CS1718
 
         var vdNormal = new Vec3d(1.0, 2.0, 3.0);
         Assert.True(vdNormal == vdNormal);
         Assert.False(vdNormal != vdNormal);
+#pragma warning restore CS1718
     }
 
 #if !NETFRAMEWORK

--- a/test/OpenCvSharp.Tests/core/VecTest.cs
+++ b/test/OpenCvSharp.Tests/core/VecTest.cs
@@ -308,8 +308,10 @@ public class VecTest
         // float
         var vfNaN = new Vec2f(float.NaN, 1f);
         Assert.True(vfNaN.Equals(vfNaN));   // IEquatable contract: reflexive
+#pragma warning disable CS1718 // Comparison made to same variable — intentional: testing IEEE 754 NaN behaviour
         Assert.False(vfNaN == vfNaN);        // IEEE 754: NaN != NaN
         Assert.True(vfNaN != vfNaN);
+#pragma warning restore CS1718
 
         var vfNormal = new Vec2f(1f, 2f);
         Assert.True(vfNormal == vfNormal);
@@ -318,8 +320,10 @@ public class VecTest
         // double
         var vdNaN = new Vec3d(double.NaN, 1.0, 2.0);
         Assert.True(vdNaN.Equals(vdNaN));
+#pragma warning disable CS1718
         Assert.False(vdNaN == vdNaN);
         Assert.True(vdNaN != vdNaN);
+#pragma warning restore CS1718
 
         var vdNormal = new Vec3d(1.0, 2.0, 3.0);
         Assert.True(vdNormal == vdNormal);

--- a/test/OpenCvSharp.Tests/core/VecTest.cs
+++ b/test/OpenCvSharp.Tests/core/VecTest.cs
@@ -123,6 +123,241 @@ public class VecTest
 
 
     [Fact]
+    public void Vec4b()
+    {
+        Assert.Equal(new Vec4b(4, 6, 8, 10), new Vec4b(1, 2, 3, 4) + new Vec4b(3, 4, 5, 6));
+        Assert.Equal(new Vec4b(255, 255, 255, 255), new Vec4b(200, 200, 200, 200) + new Vec4b(100, 100, 100, 100));
+        Assert.Equal(new Vec4b(0, 0, 0, 0), new Vec4b(1, 2, 3, 4) - new Vec4b(10, 20, 30, 40));
+        Assert.Equal(new Vec4b(2, 4, 6, 8), new Vec4b(1, 2, 3, 4) * 2);
+        Assert.Equal(new Vec4b(0, 1, 1, 2), new Vec4b(1, 2, 3, 4) / 2);
+    }
+
+    [Fact]
+    public void Vec6b()
+    {
+        Assert.Equal(new Vec6b(2, 4, 6, 8, 10, 12), new Vec6b(1, 2, 3, 4, 5, 6) * 2);
+        Assert.Equal(new Vec6b(255, 255, 255, 255, 255, 255), new Vec6b(200, 200, 200, 200, 200, 200) + new Vec6b(100, 100, 100, 100, 100, 100));
+        Assert.Equal(new Vec6b(0, 0, 0, 0, 0, 0), new Vec6b(1, 2, 3, 4, 5, 6) - new Vec6b(10, 10, 10, 10, 10, 10));
+    }
+
+    [Fact]
+    public void ArithmeticSaturatingInt()
+    {
+        // short: saturation on overflow
+        Assert.Equal(new Vec2s(4, 6), new Vec2s(1, 2) + new Vec2s(3, 4));
+        Assert.Equal(new Vec2s(short.MaxValue, 0), new Vec2s(30000, 0) + new Vec2s(10000, 0));
+        Assert.Equal(new Vec2s(short.MinValue, 0), new Vec2s(-30000, 0) - new Vec2s(10000, 0));
+        Assert.Equal(new Vec2s(2, 4), new Vec2s(1, 2) * 2);
+        Assert.Equal(new Vec2s(1, 2), new Vec2s(2, 4) / 2);
+
+        // ushort: clamp to 0 on underflow
+        Assert.Equal(new Vec2w(4, 6), new Vec2w(1, 2) + new Vec2w(3, 4));
+        Assert.Equal(new Vec2w(ushort.MaxValue, ushort.MaxValue), new Vec2w(60000, 1) + new Vec2w(10000, ushort.MaxValue));
+        Assert.Equal(new Vec2w(0, 0), new Vec2w(5, 3) - new Vec2w(10, 5));
+        Assert.Equal(new Vec2w(2, 4), new Vec2w(1, 2) * 2);
+
+        // int
+        Assert.Equal(new Vec3i(4, 6, 8), new Vec3i(1, 2, 3) + new Vec3i(3, 4, 5));
+        Assert.Equal(new Vec3i(-2, -2, -2), new Vec3i(1, 2, 3) - new Vec3i(3, 4, 5));
+        Assert.Equal(new Vec3i(2, 4, 6), new Vec3i(1, 2, 3) * 2);
+        Assert.Equal(new Vec3i(1, 2, 3), new Vec3i(2, 4, 6) / 2);
+    }
+
+    [Fact]
+    public void ArithmeticFloating()
+    {
+        Assert.Equal(new Vec2f(4f, 6f), new Vec2f(1f, 2f) + new Vec2f(3f, 4f));
+        Assert.Equal(new Vec2f(-2f, -2f), new Vec2f(1f, 2f) - new Vec2f(3f, 4f));
+        Assert.Equal(new Vec2f(2f, 4f), new Vec2f(1f, 2f) * 2);
+        Assert.Equal(new Vec2f(0.5f, 1f), new Vec2f(1f, 2f) / 2);
+
+        Assert.Equal(new Vec4f(2f, 4f, 6f, 8f), new Vec4f(1f, 2f, 3f, 4f) * 2);
+
+        Assert.Equal(new Vec2d(4.0, 6.0), new Vec2d(1.0, 2.0) + new Vec2d(3.0, 4.0));
+        Assert.Equal(new Vec2d(-2.0, -2.0), new Vec2d(1.0, 2.0) - new Vec2d(3.0, 4.0));
+        Assert.Equal(new Vec2d(2.0, 4.0), new Vec2d(1.0, 2.0) * 2);
+        Assert.Equal(new Vec2d(0.5, 1.0), new Vec2d(1.0, 2.0) / 2);
+
+        Assert.Equal(new Vec6d(2.0, 4.0, 6.0, 8.0, 10.0, 12.0), new Vec6d(1.0, 2.0, 3.0, 4.0, 5.0, 6.0) * 2);
+    }
+
+    [Fact]
+    public void EqualityAndHashCode()
+    {
+        var a = new Vec3i(1, 2, 3);
+        var b = new Vec3i(1, 2, 3);
+        var c = new Vec3i(1, 2, 4);
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+        Assert.False(a == c);
+        Assert.True(a != c);
+        Assert.False(a.Equals(c));
+
+        Assert.True(new Vec4b(1, 2, 3, 4) == new Vec4b(1, 2, 3, 4));
+        Assert.True(new Vec4b(1, 2, 3, 4) != new Vec4b(1, 2, 3, 5));
+
+        Assert.True(new Vec2f(1f, 2f) == new Vec2f(1f, 2f));
+        Assert.False(new Vec2f(1f, 2f) != new Vec2f(1f, 2f));
+
+        Assert.True(new Vec4d(1.0, 2.0, 3.0, 4.0) == new Vec4d(1.0, 2.0, 3.0, 4.0));
+        Assert.True(new Vec4d(1.0, 2.0, 3.0, 4.0) != new Vec4d(1.0, 2.0, 3.0, 5.0));
+    }
+
+    [Fact]
+    public void Deconstruct()
+    {
+        var (x, y) = new Vec2d(1.0, 2.0);
+        Assert.Equal(1.0, x);
+        Assert.Equal(2.0, y);
+
+        var (xi, yi, zi) = new Vec3i(3, 4, 5);
+        Assert.Equal(3, xi);
+        Assert.Equal(5, zi);
+
+        var (a, b, c, d) = new Vec4f(1f, 2f, 3f, 4f);
+        Assert.Equal(4f, d);
+
+        var (p, q, r, s, t, u) = new Vec6b(10, 20, 30, 40, 50, 60);
+        Assert.Equal(10, p);
+        Assert.Equal(60, u);
+    }
+
+    [Fact]
+    public void IndexerOutOfRange()
+    {
+        var v = new Vec3d(1.0, 2.0, 3.0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = v[-1]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = v[3]);
+
+        var w = new Vec4i(1, 2, 3, 4);
+        Assert.Throws<ArgumentOutOfRangeException>(() => w[4] = 0);
+    }
+
+    [Fact]
+    public void ToStringFormat()
+    {
+        Assert.Contains("Vec2b", new Vec2b(1, 2).ToString());
+        Assert.Contains("1", new Vec2b(1, 2).ToString());
+
+        Assert.Contains("Vec3f", new Vec3f(1f, 2f, 3f).ToString());
+        Assert.Contains("Vec6i", new Vec6i(1, 2, 3, 4, 5, 6).ToString());
+        Assert.Contains("Vec4d", new Vec4d(1.0, 2.0, 3.0, 4.0).ToString());
+    }
+
+    [Fact]
+    public void ConversionNonByte()
+    {
+        // short
+        var vs = new Vec3s(10, 20, 30);
+        Assert.Equal(new Vec3w(10, 20, 30), vs.ToVec3w());
+        Assert.Equal(new Vec3i(10, 20, 30), vs.ToVec3i());
+        Assert.Equal(new Vec3f(10f, 20f, 30f), vs.ToVec3f());
+        Assert.Equal(new Vec3d(10.0, 20.0, 30.0), vs.ToVec3d());
+
+        // int
+        var vi = new Vec3i(1, 2, 3);
+        Assert.Equal(new Vec3f(1f, 2f, 3f), vi.ToVec3f());
+        Assert.Equal(new Vec3d(1.0, 2.0, 3.0), vi.ToVec3d());
+
+        // float
+        var vf = new Vec2f(1.5f, 2.5f);
+        Assert.Equal(new Vec2i(2, 2), vf.ToVec2i()); // rounds
+        Assert.Equal(new Vec2d(1.5, 2.5), vf.ToVec2d());
+    }
+
+    [Fact]
+    public void UnaryMinus()
+    {
+        // short (with saturation: -short.MinValue clamps to short.MaxValue)
+        Assert.Equal(new Vec2s(-1, -2), -new Vec2s(1, 2));
+        Assert.Equal(new Vec2s(short.MaxValue, 0), -new Vec2s(short.MinValue, 0));
+        Assert.Equal(new Vec3s(-1, -2, -3), -new Vec3s(1, 2, 3));
+        Assert.Equal(new Vec4s(-1, -2, -3, -4), -new Vec4s(1, 2, 3, 4));
+        Assert.Equal(new Vec6s(-1, -2, -3, -4, -5, -6), -new Vec6s(1, 2, 3, 4, 5, 6));
+
+        // int (with saturation: -int.MinValue clamps to int.MaxValue)
+        Assert.Equal(new Vec2i(-1, -2), -new Vec2i(1, 2));
+        Assert.Equal(new Vec2i(int.MaxValue, 0), -new Vec2i(int.MinValue, 0));
+        Assert.Equal(new Vec3i(-1, -2, -3), -new Vec3i(1, 2, 3));
+        Assert.Equal(new Vec4i(-1, -2, -3, -4), -new Vec4i(1, 2, 3, 4));
+        Assert.Equal(new Vec6i(-1, -2, -3, -4, -5, -6), -new Vec6i(1, 2, 3, 4, 5, 6));
+
+        // float
+        Assert.Equal(new Vec2f(-1f, -2f), -new Vec2f(1f, 2f));
+        Assert.Equal(new Vec3f(-1f, -2f, -3f), -new Vec3f(1f, 2f, 3f));
+        Assert.Equal(new Vec4f(-1f, -2f, -3f, -4f), -new Vec4f(1f, 2f, 3f, 4f));
+        Assert.Equal(new Vec6f(-1f, -2f, -3f, -4f, -5f, -6f), -new Vec6f(1f, 2f, 3f, 4f, 5f, 6f));
+
+        // double
+        Assert.Equal(new Vec2d(-1.0, -2.0), -new Vec2d(1.0, 2.0));
+        Assert.Equal(new Vec3d(-1.0, -2.0, -3.0), -new Vec3d(1.0, 2.0, 3.0));
+        Assert.Equal(new Vec4d(-1.0, -2.0, -3.0, -4.0), -new Vec4d(1.0, 2.0, 3.0, 4.0));
+        Assert.Equal(new Vec6d(-1.0, -2.0, -3.0, -4.0, -5.0, -6.0), -new Vec6d(1.0, 2.0, 3.0, 4.0, 5.0, 6.0));
+    }
+
+    /// <summary>
+    /// Equals() follows .NET contract (NaN.Equals(NaN) == true, required for collections).
+    /// operator == follows IEEE 754 (NaN == NaN is false, same as double/float).
+    /// </summary>
+    [Fact]
+    public void FloatingPointNaNEquality()
+    {
+        // float
+        var vfNaN = new Vec2f(float.NaN, 1f);
+        Assert.True(vfNaN.Equals(vfNaN));   // IEquatable contract: reflexive
+        Assert.False(vfNaN == vfNaN);        // IEEE 754: NaN != NaN
+        Assert.True(vfNaN != vfNaN);
+
+        var vfNormal = new Vec2f(1f, 2f);
+        Assert.True(vfNormal == vfNormal);
+        Assert.False(vfNormal != vfNormal);
+
+        // double
+        var vdNaN = new Vec3d(double.NaN, 1.0, 2.0);
+        Assert.True(vdNaN.Equals(vdNaN));
+        Assert.False(vdNaN == vdNaN);
+        Assert.True(vdNaN != vdNaN);
+
+        var vdNormal = new Vec3d(1.0, 2.0, 3.0);
+        Assert.True(vdNormal == vdNormal);
+        Assert.False(vdNormal != vdNormal);
+    }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void AsSpan()
+    {
+        var v2b = new Vec2b(1, 2);
+        var s2b = v2b.AsSpan();
+        Assert.Equal(2, s2b.Length);
+        Assert.Equal(1, s2b[0]);
+        Assert.Equal(2, s2b[1]);
+        // mutation via Span reflects back in the struct
+        s2b[0] = 99;
+        Assert.Equal(99, v2b.Item0);
+
+        var v3d = new Vec3d(1.0, 2.0, 3.0);
+        var s3d = v3d.AsSpan();
+        Assert.Equal(3, s3d.Length);
+        Assert.Equal(1.0, s3d[0]);
+        Assert.Equal(3.0, s3d[2]);
+
+        var v4f = new Vec4f(10f, 20f, 30f, 40f);
+        var s4f = v4f.AsSpan();
+        Assert.Equal(4, s4f.Length);
+        Assert.Equal(40f, s4f[3]);
+
+        var v6i = new Vec6i(1, 2, 3, 4, 5, 6);
+        var s6i = v6i.AsSpan();
+        Assert.Equal(6, s6i.Length);
+        Assert.Equal(6, s6i[5]);
+    }
+#endif
+
+    [Fact]
     public void ReflectionCheck()
     {
         foreach (var channels in new[] {2, 3, 4, 6})

--- a/test/OpenCvSharp.Tests/core/VecTest.cs
+++ b/test/OpenCvSharp.Tests/core/VecTest.cs
@@ -129,7 +129,7 @@ public class VecTest
         Assert.Equal(new Vec4b(255, 255, 255, 255), new Vec4b(200, 200, 200, 200) + new Vec4b(100, 100, 100, 100));
         Assert.Equal(new Vec4b(0, 0, 0, 0), new Vec4b(1, 2, 3, 4) - new Vec4b(10, 20, 30, 40));
         Assert.Equal(new Vec4b(2, 4, 6, 8), new Vec4b(1, 2, 3, 4) * 2);
-        Assert.Equal(new Vec4b(0, 1, 1, 2), new Vec4b(1, 2, 3, 4) / 2);
+        Assert.Equal(new Vec4b(0, 1, 2, 2), new Vec4b(1, 2, 3, 4) / 2);
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class VecTest
 
         // float
         var vf = new Vec2f(1.5f, 2.5f);
-        Assert.Equal(new Vec2i(2, 2), vf.ToVec2i()); // rounds
+        Assert.Equal(new Vec2i(1, 2), vf.ToVec2i()); // (int) cast truncates, not rounds
         Assert.Equal(new Vec2d(1.5, 2.5), vf.ToVec2d());
     }
 


### PR DESCRIPTION
This pull request introduces several improvements and API changes to the `Vec` struct family in OpenCvSharp, focusing on interface consistency, new utility methods, and operator enhancements. The changes make the `Vec` types more flexible and efficient, especially for modern .NET versions, and improve clarity and maintainability.

Key changes include:

**Interface and API Consistency:**
- Removed the `out` variance from the `TElem` type parameter in `IVec<TSelf, TElem>`, and made the indexer read-write instead of read-only, allowing both getting and setting elements. [[1]](diffhunk://#diff-97c9a32cf4b73bd55233a5cb8ce5b093ba65abd028750e42a68a22e3ccacd91bL15-R15) [[2]](diffhunk://#diff-97c9a32cf4b73bd55233a5cb8ce5b093ba65abd028750e42a68a22e3ccacd91bL52-R52)

**.NET API Enhancements:**
- Added `AsSpan()` methods to all `Vec` structs (e.g., `Vec2b`, `Vec2d`, `Vec2f`, `Vec2i`, `Vec2s`, `Vec2w`, `Vec3b`, `Vec3d`, `Vec3f`) for .NET Standard 2.1+ to enable efficient, allocation-free access to the underlying data. [[1]](diffhunk://#diff-d689c647a8835da7eb3ed79db081df90f153b85eb482ca829454986f06727d4fR132-R135) [[2]](diffhunk://#diff-2a62ff05bc5d3407a4c8d2b49c7989f957f95e5009d718910609150f65c56ee9R114-R117) [[3]](diffhunk://#diff-56433da47154443ddee34b11bb91dd64ad912df2beb4eaa4086121cc97c738adR122-R125) [[4]](diffhunk://#diff-09561e7af156fec7bf121296ac9627d52d823ef74f1d5a41c554df2b29005853R123-R126) [[5]](diffhunk://#diff-e462fe1914d910d8b2bd8a138649d1acad3be99e11d7ba7598db48efea123c38R125-R128) [[6]](diffhunk://#diff-2809278f0270aa199d7bebadc1cf194865413345b948ecb58cbb4cef6a0475adR125-R128) [[7]](diffhunk://#diff-1ac8c4ad43eb17dfcb2c67de04fb9e56ba9ca0de005887d7d37897b96cd22b5eR139-R142) [[8]](diffhunk://#diff-3b26bc0573232630e6961470cb0fb2d54cfea285a23231b0a50d36ed89f18bcbR129-R132) [[9]](diffhunk://#diff-47e4724e1a2a1b6ecb74af618e7fd86e309bfc8d47ce7761431f2affa020b50aR136-R139)

**Operator Improvements:**
- Added unary negation operators (e.g., `-a`) to all 2- and 3-element `Vec` structs, enabling concise element-wise negation. [[1]](diffhunk://#diff-2a62ff05bc5d3407a4c8d2b49c7989f957f95e5009d718910609150f65c56ee9R84) [[2]](diffhunk://#diff-56433da47154443ddee34b11bb91dd64ad912df2beb4eaa4086121cc97c738adR85) [[3]](diffhunk://#diff-09561e7af156fec7bf121296ac9627d52d823ef74f1d5a41c554df2b29005853R86) [[4]](diffhunk://#diff-e462fe1914d910d8b2bd8a138649d1acad3be99e11d7ba7598db48efea123c38R86) [[5]](diffhunk://#diff-3b26bc0573232630e6961470cb0fb2d54cfea285a23231b0a50d36ed89f18bcbR97) [[6]](diffhunk://#diff-47e4724e1a2a1b6ecb74af618e7fd86e309bfc8d47ce7761431f2affa020b50aR97)
- Updated equality (`==`) and inequality (`!=`) operators for `Vec2d`, `Vec2f`, `Vec3d`, and `Vec3f` to compare elements directly instead of relying on `Equals`, ensuring more predictable behavior. [[1]](diffhunk://#diff-2a62ff05bc5d3407a4c8d2b49c7989f957f95e5009d718910609150f65c56ee9L133-R144) [[2]](diffhunk://#diff-56433da47154443ddee34b11bb91dd64ad912df2beb4eaa4086121cc97c738adL137-R148) [[3]](diffhunk://#diff-3b26bc0573232630e6961470cb0fb2d54cfea285a23231b0a50d36ed89f18bcbL144-R155) [[4]](diffhunk://#diff-47e4724e1a2a1b6ecb74af618e7fd86e309bfc8d47ce7761431f2affa020b50aL151-R162)

**Code Cleanup:**
- Removed unnecessary `[Serializable]` and `[SuppressMessage]` attributes, and suppressed CA1051 warnings via pragmas, simplifying the codebase and reducing clutter. [[1]](diffhunk://#diff-d689c647a8835da7eb3ed79db081df90f153b85eb482ca829454986f06727d4fL1-L12) [[2]](diffhunk://#diff-56433da47154443ddee34b11bb91dd64ad912df2beb4eaa4086121cc97c738adL1-L11) [[3]](diffhunk://#diff-09561e7af156fec7bf121296ac9627d52d823ef74f1d5a41c554df2b29005853L1-L12) [[4]](diffhunk://#diff-2809278f0270aa199d7bebadc1cf194865413345b948ecb58cbb4cef6a0475adL1-L12) [[5]](diffhunk://#diff-1ac8c4ad43eb17dfcb2c67de04fb9e56ba9ca0de005887d7d37897b96cd22b5eL1-L12) [[6]](diffhunk://#diff-47e4724e1a2a1b6ecb74af618e7fd86e309bfc8d47ce7761431f2affa020b50aL1-L11) [[7]](diffhunk://#diff-2fc4196641f89c38a13b377e3cf54fd79fdb5ab238b3da808e80a0ac72be182fL1-L12) [[8]](diffhunk://#diff-2a62ff05bc5d3407a4c8d2b49c7989f957f95e5009d718910609150f65c56ee9L10) [[9]](diffhunk://#diff-e462fe1914d910d8b2bd8a138649d1acad3be99e11d7ba7598db48efea123c38L11) [[10]](diffhunk://#diff-3b26bc0573232630e6961470cb0fb2d54cfea285a23231b0a50d36ed89f18bcbL10)

These changes modernize the `Vec` types, improve their usability in high-performance scenarios, and bring the codebase in line with current .NET best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AsSpan() on many vector types (span-based access on supported targets)
  * Added unary negation operator for many vector types

* **Refactor**
  * Vector indexers now support assignment (mutable indexer)
  * Equality/inequality operators use component-wise semantics
  * Serialization metadata attributes removed from vector types; analyzer suppression consolidated

* **Tests**
  * Expanded vector tests (arithmetic, equality, indexer bounds, ToString, AsSpan, conversions, unary minus)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->