### PR TITLE
Fix bug in NativeMethods implementation

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
@@ -28,7 +28,7 @@ public static partial class NativeMethods
 
     private const UnmanagedType StringUnmanagedTypeNotWindows =
 #if NETSTANDARD2_0
-            UnmanagedType.LPStr;
+        UnmanagedType.LPStr;
 #else
         UnmanagedType.LPUTF8Str;
 #endif
@@ -169,8 +169,8 @@ public static partial class NativeMethods
                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || 
                RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
 #else
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+               RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 #endif
     }
 
@@ -189,10 +189,10 @@ public static partial class NativeMethods
     /// <returns></returns>
     public static bool IsWasm()
     {
-#if NET6_0
+#if NET5_0_OR_GREATER
         return RuntimeInformation.OSArchitecture == Architecture.Wasm;
 #else
-            return false;
+        return false;
 #endif
     }
 


### PR DESCRIPTION
This pull request updates the platform detection logic in the `IsWasm()` method to improve compatibility with newer .NET versions.

Platform detection update:

* Updated the preprocessor directive in the `IsWasm()` method of `NativeMethods.cs` from `#if NET6_0` to `#if NET5_0_OR_GREATER`, ensuring that the WebAssembly architecture check works correctly on .NET 5.0 and later versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted conditional compilation targets in platform detection logic to expand support for additional .NET target frameworks, including improved WebAssembly architecture detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->