### PR TITLE
Add saliency wrapper

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_MotionSaliencyBinWangApr2014.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_MotionSaliencyBinWangApr2014.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_MotionSaliencyBinWangApr2014_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_MotionSaliencyBinWangApr2014_get(
+        IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_create(
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_computeSaliency(
+        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImagesize(
+        IntPtr obj, int W, int H);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_init(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_getImageWidth(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImageWidth(
+        IntPtr obj, int val);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_getImageHeight(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImageHeight(
+        IntPtr obj, int val);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_ObjectnessBING.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_ObjectnessBING.cs
@@ -1,0 +1,57 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_ObjectnessBING_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_ObjectnessBING_get(
+        IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_create(out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_computeSaliency(
+        IntPtr obj, IntPtr image, IntPtr objectnessBoundingBox, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_getobjectnessValues(
+        IntPtr obj, IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_setTrainingPath(
+        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string trainingPath);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_setBBResDir(
+        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string resultsDir);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_getBase(
+        IntPtr obj, out double returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_setBase(IntPtr obj, double val);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_getNSS(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_setNSS(IntPtr obj, int val);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_getW(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_ObjectnessBING_setW(IntPtr obj, int val);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencyFineGrained.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencyFineGrained.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_StaticSaliencyFineGrained_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_StaticSaliencyFineGrained_get(
+        IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencyFineGrained_create(
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencyFineGrained_computeSaliency(
+        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencyFineGrained_computeBinaryMap(
+        IntPtr obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencySpectralResidual.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencySpectralResidual.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_StaticSaliencySpectralResidual_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_Ptr_StaticSaliencySpectralResidual_get(
+        IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_create(
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_computeSaliency(
+        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_computeBinaryMap(
+        IntPtr obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_getImageWidth(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_setImageWidth(
+        IntPtr obj, int val);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_getImageHeight(
+        IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus saliency_StaticSaliencySpectralResidual_setImageHeight(
+        IntPtr obj, int val);
+}

--- a/src/OpenCvSharp/Modules/saliency/MotionSaliencyBinWangApr2014.cs
+++ b/src/OpenCvSharp/Modules/saliency/MotionSaliencyBinWangApr2014.cs
@@ -1,0 +1,125 @@
+﻿using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+
+namespace OpenCvSharp.Saliency;
+
+/// <summary>
+/// A Fast Self-tuning Background Subtraction Algorithm for motion saliency detection.
+/// </summary>
+public class MotionSaliencyBinWangApr2014 : Algorithm
+{
+    private MotionSaliencyBinWangApr2014(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_MotionSaliencyBinWangApr2014_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates a MotionSaliencyBinWangApr2014 instance.
+    /// </summary>
+    public static MotionSaliencyBinWangApr2014 Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_create(out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_MotionSaliencyBinWangApr2014_get(smartPtr, out var rawPtr));
+        return new MotionSaliencyBinWangApr2014(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes the motion saliency map for the given frame.
+    /// </summary>
+    /// <param name="image">Input image frame (grayscale, CV_8UC1).</param>
+    /// <param name="saliencyMap">The computed binary saliency map.</param>
+    /// <returns>true if the saliency map was computed successfully.</returns>
+    public virtual bool ComputeSaliency(InputArray image, OutputArray saliencyMap)
+    {
+        ThrowIfDisposed();
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        if (saliencyMap is null)
+            throw new ArgumentNullException(nameof(saliencyMap));
+        image.ThrowIfDisposed();
+        saliencyMap.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_computeSaliency(
+                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+        saliencyMap.Fix();
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Sets the image dimensions to prepare the algorithm's data structures.
+    /// Must be called before <see cref="Init"/>.
+    /// </summary>
+    /// <param name="width">Width of the input images.</param>
+    /// <param name="height">Height of the input images.</param>
+    public void SetImagesize(int width, int height)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImagesize(RawPtr, width, height));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Initializes all data structures for the algorithm.
+    /// Call after <see cref="SetImagesize"/>.
+    /// </summary>
+    /// <returns>true if initialization succeeded.</returns>
+    public bool Init()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_init(RawPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Gets or sets the image width.
+    /// </summary>
+    public int ImageWidth
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageWidth(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageWidth(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the image height.
+    /// </summary>
+    public int ImageHeight
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageHeight(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageHeight(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
+++ b/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
@@ -1,0 +1,162 @@
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+
+namespace OpenCvSharp.Saliency;
+
+/// <summary>
+/// Objectness saliency using the Binarized Normed Gradients (BING) algorithm.
+/// </summary>
+public class ObjectnessBING : Algorithm
+{
+    private ObjectnessBING(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_ObjectnessBING_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates an ObjectnessBING instance.
+    /// </summary>
+    public static ObjectnessBING Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.saliency_ObjectnessBING_create(out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_ObjectnessBING_get(smartPtr, out var rawPtr));
+        return new ObjectnessBING(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes objectness proposals.
+    /// The model files must be loaded via <see cref="SetTrainingPath"/> before calling this method.
+    /// </summary>
+    /// <param name="image">Input image.</param>
+    /// <param name="objectnessBoundingBox">
+    /// Detected objectness bounding boxes, each as (minX, minY, maxX, maxY).
+    /// Sorted by descending objectness score.
+    /// </param>
+    /// <returns>true if the computation succeeded.</returns>
+    public virtual bool ComputeSaliency(InputArray image, out Vec4i[] objectnessBoundingBox)
+    {
+        ThrowIfDisposed();
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        image.ThrowIfDisposed();
+
+        using var vec = new VectorOfVec4i();
+        NativeMethods.HandleException(
+            NativeMethods.saliency_ObjectnessBING_computeSaliency(
+                RawPtr, image.CvPtr, vec.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+        objectnessBoundingBox = vec.ToArray();
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Returns the objectness score for each bounding box in the order returned by
+    /// <see cref="ComputeSaliency"/>. A larger value indicates a higher likelihood of being an object.
+    /// </summary>
+    public float[] GetObjectnessValues()
+    {
+        ThrowIfDisposed();
+        using var vec = new VectorOfFloat();
+        NativeMethods.HandleException(
+            NativeMethods.saliency_ObjectnessBING_getobjectnessValues(RawPtr, vec.CvPtr));
+        GC.KeepAlive(this);
+        return vec.ToArray();
+    }
+
+    /// <summary>
+    /// Sets the path to the trained model files required by the BING algorithm.
+    /// </summary>
+    public void SetTrainingPath(string trainingPath)
+    {
+        ThrowIfDisposed();
+        if (trainingPath is null)
+            throw new ArgumentNullException(nameof(trainingPath));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_ObjectnessBING_setTrainingPath(RawPtr, trainingPath));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Sets the directory path for writing optional output results.
+    /// </summary>
+    public void SetBBResDir(string resultsDir)
+    {
+        ThrowIfDisposed();
+        if (resultsDir is null)
+            throw new ArgumentNullException(nameof(resultsDir));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_ObjectnessBING_setBBResDir(RawPtr, resultsDir));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Gets or sets the base value used internally by the BING algorithm.
+    /// </summary>
+    public double Base
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_getBase(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_setBase(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the NSS value.
+    /// </summary>
+    public int NSS
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_getNSS(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_setNSS(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the W value.
+    /// </summary>
+    public int W
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_getW(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_ObjectnessBING_setW(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/saliency/StaticSaliencyFineGrained.cs
+++ b/src/OpenCvSharp/Modules/saliency/StaticSaliencyFineGrained.cs
@@ -1,0 +1,78 @@
+﻿using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+
+namespace OpenCvSharp.Saliency;
+
+/// <summary>
+/// The Fine Grained Saliency approach for static saliency detection.
+/// </summary>
+public class StaticSaliencyFineGrained : Algorithm
+{
+    private StaticSaliencyFineGrained(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_StaticSaliencyFineGrained_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates a StaticSaliencyFineGrained instance.
+    /// </summary>
+    public static StaticSaliencyFineGrained Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencyFineGrained_create(out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_StaticSaliencyFineGrained_get(smartPtr, out var rawPtr));
+        return new StaticSaliencyFineGrained(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes the saliency map.
+    /// </summary>
+    /// <param name="image">The input image.</param>
+    /// <param name="saliencyMap">The computed saliency map.</param>
+    /// <returns>true if the saliency map was computed successfully.</returns>
+    public virtual bool ComputeSaliency(InputArray image, OutputArray saliencyMap)
+    {
+        ThrowIfDisposed();
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        if (saliencyMap is null)
+            throw new ArgumentNullException(nameof(saliencyMap));
+        image.ThrowIfDisposed();
+        saliencyMap.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencyFineGrained_computeSaliency(
+                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+        saliencyMap.Fix();
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Computes a binary saliency map from the given saliency map using an adaptive threshold.
+    /// </summary>
+    /// <param name="saliencyMap">The input saliency map.</param>
+    /// <param name="binaryMap">The computed binary map.</param>
+    /// <returns>true if the binary map was computed successfully.</returns>
+    public virtual bool ComputeBinaryMap(InputArray saliencyMap, OutputArray binaryMap)
+    {
+        ThrowIfDisposed();
+        if (saliencyMap is null)
+            throw new ArgumentNullException(nameof(saliencyMap));
+        if (binaryMap is null)
+            throw new ArgumentNullException(nameof(binaryMap));
+        saliencyMap.ThrowIfDisposed();
+        binaryMap.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencyFineGrained_computeBinaryMap(
+                RawPtr, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(saliencyMap);
+        binaryMap.Fix();
+        return ret != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/saliency/StaticSaliencySpectralResidual.cs
+++ b/src/OpenCvSharp/Modules/saliency/StaticSaliencySpectralResidual.cs
@@ -1,0 +1,122 @@
+﻿using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+
+namespace OpenCvSharp.Saliency;
+
+/// <summary>
+/// The Spectral Residual approach for static saliency detection.
+/// </summary>
+public class StaticSaliencySpectralResidual : Algorithm
+{
+    private StaticSaliencySpectralResidual(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_StaticSaliencySpectralResidual_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates a StaticSaliencySpectralResidual instance.
+    /// </summary>
+    public static StaticSaliencySpectralResidual Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencySpectralResidual_create(out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.saliency_Ptr_StaticSaliencySpectralResidual_get(smartPtr, out var rawPtr));
+        return new StaticSaliencySpectralResidual(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes the saliency map.
+    /// </summary>
+    /// <param name="image">The input image.</param>
+    /// <param name="saliencyMap">The computed saliency map (CV_32FC1).</param>
+    /// <returns>true if the saliency map was computed successfully.</returns>
+    public virtual bool ComputeSaliency(InputArray image, OutputArray saliencyMap)
+    {
+        ThrowIfDisposed();
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        if (saliencyMap is null)
+            throw new ArgumentNullException(nameof(saliencyMap));
+        image.ThrowIfDisposed();
+        saliencyMap.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencySpectralResidual_computeSaliency(
+                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+        saliencyMap.Fix();
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Computes a binary saliency map from the given saliency map using an adaptive threshold.
+    /// </summary>
+    /// <param name="saliencyMap">The input saliency map (CV_32FC1).</param>
+    /// <param name="binaryMap">The computed binary map.</param>
+    /// <returns>true if the binary map was computed successfully.</returns>
+    public virtual bool ComputeBinaryMap(InputArray saliencyMap, OutputArray binaryMap)
+    {
+        ThrowIfDisposed();
+        if (saliencyMap is null)
+            throw new ArgumentNullException(nameof(saliencyMap));
+        if (binaryMap is null)
+            throw new ArgumentNullException(nameof(binaryMap));
+        saliencyMap.ThrowIfDisposed();
+        binaryMap.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.saliency_StaticSaliencySpectralResidual_computeBinaryMap(
+                RawPtr, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(saliencyMap);
+        binaryMap.Fix();
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Gets or sets the resize width used during internal computation.
+    /// </summary>
+    public int ImageWidth
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageWidth(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageWidth(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the resize height used during internal computation.
+    /// </summary>
+    public int ImageHeight
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageHeight(RawPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageHeight(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+}

--- a/src/OpenCvSharpExtern/include_opencv.h
+++ b/src/OpenCvSharpExtern/include_opencv.h
@@ -73,6 +73,7 @@
 #include <opencv2/tracking.hpp>
 #include <opencv2/xfeatures2d.hpp>
 #include <opencv2/ximgproc.hpp>
+#include <opencv2/saliency.hpp>
 #include <opencv2/xphoto.hpp>
 #ifndef _WINRT_DLL
 #include <opencv2/wechat_qrcode.hpp>

--- a/src/OpenCvSharpExtern/saliency.cpp
+++ b/src/OpenCvSharpExtern/saliency.cpp
@@ -1,0 +1,5 @@
+﻿// ReSharper disable CppUnusedIncludeDirective
+#include "saliency_StaticSaliencySpectralResidual.h"
+#include "saliency_StaticSaliencyFineGrained.h"
+#include "saliency_MotionSaliencyBinWangApr2014.h"
+#include "saliency_ObjectnessBING.h"

--- a/src/OpenCvSharpExtern/saliency_MotionSaliencyBinWangApr2014.h
+++ b/src/OpenCvSharpExtern/saliency_MotionSaliencyBinWangApr2014.h
@@ -1,0 +1,94 @@
+﻿#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) saliency_Ptr_MotionSaliencyBinWangApr2014_delete(
+    cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_Ptr_MotionSaliencyBinWangApr2014_get(
+    cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> *ptr,
+    cv::saliency::MotionSaliencyBinWangApr2014 **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_create(
+    cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::saliency::MotionSaliencyBinWangApr2014::create();
+    *returnValue = new cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014>(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_computeSaliency(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj,
+    cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImagesize(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int W, int H)
+{
+    BEGIN_WRAP
+    obj->setImagesize(W, H);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_init(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->init() ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_getImageWidth(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getImageWidth();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImageWidth(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setImageWidth(val);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_getImageHeight(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getImageHeight();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImageHeight(
+    cv::saliency::MotionSaliencyBinWangApr2014 *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setImageHeight(val);
+    END_WRAP
+}
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_ObjectnessBING.h
+++ b/src/OpenCvSharpExtern/saliency_ObjectnessBING.h
@@ -1,0 +1,120 @@
+﻿#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) saliency_Ptr_ObjectnessBING_delete(
+    cv::Ptr<cv::saliency::ObjectnessBING> *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_Ptr_ObjectnessBING_get(
+    cv::Ptr<cv::saliency::ObjectnessBING> *ptr,
+    cv::saliency::ObjectnessBING **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_create(
+    cv::Ptr<cv::saliency::ObjectnessBING> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::saliency::ObjectnessBING::create();
+    *returnValue = new cv::Ptr<cv::saliency::ObjectnessBING>(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_computeSaliency(
+    cv::saliency::ObjectnessBING *obj,
+    cv::_InputArray *image,
+    std::vector<cv::Vec4i> *objectnessBoundingBox,
+    int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeSaliency(*image, *objectnessBoundingBox) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_getobjectnessValues(
+    cv::saliency::ObjectnessBING *obj, std::vector<float> *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getobjectnessValues();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_setTrainingPath(
+    cv::saliency::ObjectnessBING *obj, const char *trainingPath)
+{
+    BEGIN_WRAP
+    obj->setTrainingPath(trainingPath);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_setBBResDir(
+    cv::saliency::ObjectnessBING *obj, const char *resultsDir)
+{
+    BEGIN_WRAP
+    obj->setBBResDir(resultsDir);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_getBase(
+    cv::saliency::ObjectnessBING *obj, double *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getBase();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_setBase(
+    cv::saliency::ObjectnessBING *obj, double val)
+{
+    BEGIN_WRAP
+    obj->setBase(val);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_getNSS(
+    cv::saliency::ObjectnessBING *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getNSS();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_setNSS(
+    cv::saliency::ObjectnessBING *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setNSS(val);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_getW(
+    cv::saliency::ObjectnessBING *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getW();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_ObjectnessBING_setW(
+    cv::saliency::ObjectnessBING *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setW(val);
+    END_WRAP
+}
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_StaticSaliencyFineGrained.h
+++ b/src/OpenCvSharpExtern/saliency_StaticSaliencyFineGrained.h
@@ -1,0 +1,55 @@
+﻿#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencyFineGrained_delete(
+    cv::Ptr<cv::saliency::StaticSaliencyFineGrained> *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencyFineGrained_get(
+    cv::Ptr<cv::saliency::StaticSaliencyFineGrained> *ptr,
+    cv::saliency::StaticSaliencyFineGrained **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_create(
+    cv::Ptr<cv::saliency::StaticSaliencyFineGrained> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::saliency::StaticSaliencyFineGrained::create();
+    *returnValue = new cv::Ptr<cv::saliency::StaticSaliencyFineGrained>(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_computeSaliency(
+    cv::saliency::StaticSaliencyFineGrained *obj,
+    cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_computeBinaryMap(
+    cv::saliency::StaticSaliencyFineGrained *obj,
+    cv::_InputArray *saliencyMap, cv::_OutputArray *binaryMap, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeBinaryMap(*saliencyMap, *binaryMap) ? 1 : 0;
+    END_WRAP
+}
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_StaticSaliencySpectralResidual.h
+++ b/src/OpenCvSharpExtern/saliency_StaticSaliencySpectralResidual.h
@@ -1,0 +1,87 @@
+﻿#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencySpectralResidual_delete(
+    cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencySpectralResidual_get(
+    cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> *ptr,
+    cv::saliency::StaticSaliencySpectralResidual **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_create(
+    cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::saliency::StaticSaliencySpectralResidual::create();
+    *returnValue = new cv::Ptr<cv::saliency::StaticSaliencySpectralResidual>(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_computeSaliency(
+    cv::saliency::StaticSaliencySpectralResidual *obj,
+    cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_computeBinaryMap(
+    cv::saliency::StaticSaliencySpectralResidual *obj,
+    cv::_InputArray *saliencyMap, cv::_OutputArray *binaryMap, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->computeBinaryMap(*saliencyMap, *binaryMap) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_getImageWidth(
+    cv::saliency::StaticSaliencySpectralResidual *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getImageWidth();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_setImageWidth(
+    cv::saliency::StaticSaliencySpectralResidual *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setImageWidth(val);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_getImageHeight(
+    cv::saliency::StaticSaliencySpectralResidual *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getImageHeight();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_setImageHeight(
+    cv::saliency::StaticSaliencySpectralResidual *obj, int val)
+{
+    BEGIN_WRAP
+    obj->setImageHeight(val);
+    END_WRAP
+}
+
+#endif // NO_CONTRIB

--- a/test/OpenCvSharp.Tests/saliency/MotionSaliencyTest.cs
+++ b/test/OpenCvSharp.Tests/saliency/MotionSaliencyTest.cs
@@ -1,0 +1,68 @@
+﻿using OpenCvSharp.Saliency;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Saliency;
+
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
+public class MotionSaliencyTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        using var saliency = MotionSaliencyBinWangApr2014.Create();
+        Assert.NotNull(saliency);
+    }
+
+    [Fact]
+    public void SetImagesizeAndInit()
+    {
+        using var saliency = MotionSaliencyBinWangApr2014.Create();
+        saliency.SetImagesize(320, 240);
+
+        Assert.Equal(320, saliency.ImageWidth);
+        Assert.Equal(240, saliency.ImageHeight);
+
+        var initialized = saliency.Init();
+        Assert.True(initialized);
+    }
+
+    [Fact]
+    public void ImageWidthHeightProperty()
+    {
+        using var saliency = MotionSaliencyBinWangApr2014.Create();
+
+        saliency.ImageWidth = 640;
+        saliency.ImageHeight = 480;
+
+        Assert.Equal(640, saliency.ImageWidth);
+        Assert.Equal(480, saliency.ImageHeight);
+    }
+
+    [Fact]
+    public void ComputeSaliency()
+    {
+        const int width = 320;
+        const int height = 240;
+
+        using var saliency = MotionSaliencyBinWangApr2014.Create();
+        saliency.SetImagesize(width, height);
+        saliency.Init();
+
+        using var frame1 = new Mat(height, width, MatType.CV_8UC1, Scalar.All(0));
+        using var frame2 = new Mat(height, width, MatType.CV_8UC1, Scalar.All(128));
+        using var saliencyMap = new Mat();
+
+        // Feed first frame to warm up the background model
+        saliency.ComputeSaliency(frame1, saliencyMap);
+
+        // Second frame should produce a saliency map
+        using var saliencyMap2 = new Mat();
+        var result = saliency.ComputeSaliency(frame2, saliencyMap2);
+
+        Assert.True(result);
+        Assert.False(saliencyMap2.Empty());
+        Assert.Equal(height, saliencyMap2.Rows);
+        Assert.Equal(width, saliencyMap2.Cols);
+    }
+}

--- a/test/OpenCvSharp.Tests/saliency/ObjectnessBINGTest.cs
+++ b/test/OpenCvSharp.Tests/saliency/ObjectnessBINGTest.cs
@@ -1,0 +1,61 @@
+﻿using OpenCvSharp.Saliency;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Saliency;
+
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
+public class ObjectnessBINGTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        using var bing = ObjectnessBING.Create();
+        Assert.NotNull(bing);
+    }
+
+    [Fact]
+    public void DefaultProperties()
+    {
+        using var bing = ObjectnessBING.Create();
+
+        // Verify that property accessors round-trip correctly
+        var originalBase = bing.Base;
+        var originalNSS = bing.NSS;
+        var originalW = bing.W;
+
+        Assert.True(originalBase > 0);
+        Assert.True(originalNSS > 0);
+        Assert.True(originalW > 0);
+    }
+
+    [Fact]
+    public void SetProperties()
+    {
+        using var bing = ObjectnessBING.Create();
+
+        bing.Base = 2.0;
+        bing.NSS = 3;
+        bing.W = 8;
+
+        Assert.Equal(2.0, bing.Base, precision: 10);
+        Assert.Equal(3, bing.NSS);
+        Assert.Equal(8, bing.W);
+    }
+
+    [Fact]
+    public void SetTrainingPath_DoesNotThrow()
+    {
+        using var bing = ObjectnessBING.Create();
+        // Setting a path should not throw even if the directory does not exist;
+        // the error only manifests when ComputeSaliency is called.
+        bing.SetTrainingPath("/nonexistent/path");
+    }
+
+    [Fact]
+    public void SetBBResDir_DoesNotThrow()
+    {
+        using var bing = ObjectnessBING.Create();
+        bing.SetBBResDir("/nonexistent/results");
+    }
+}

--- a/test/OpenCvSharp.Tests/saliency/StaticSaliencyTest.cs
+++ b/test/OpenCvSharp.Tests/saliency/StaticSaliencyTest.cs
@@ -1,0 +1,100 @@
+﻿using OpenCvSharp.Saliency;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Saliency;
+
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
+public class StaticSaliencyTest : TestBase
+{
+    [Fact]
+    public void SpectralResidual_CreateAndDispose()
+    {
+        using var saliency = StaticSaliencySpectralResidual.Create();
+        Assert.NotNull(saliency);
+    }
+
+    [Fact]
+    public void SpectralResidual_ComputeSaliency()
+    {
+        using var saliency = StaticSaliencySpectralResidual.Create();
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var saliencyMap = new Mat();
+
+        var result = saliency.ComputeSaliency(src, saliencyMap);
+
+        Assert.True(result);
+        Assert.False(saliencyMap.Empty());
+        Assert.Equal(MatType.CV_32FC1, saliencyMap.Type());
+        Assert.Equal(src.Rows, saliencyMap.Rows);
+        Assert.Equal(src.Cols, saliencyMap.Cols);
+    }
+
+    [Fact]
+    public void SpectralResidual_ComputeBinaryMap()
+    {
+        using var saliency = StaticSaliencySpectralResidual.Create();
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var saliencyMap = new Mat();
+        using var binaryMap = new Mat();
+
+        saliency.ComputeSaliency(src, saliencyMap);
+        var result = saliency.ComputeBinaryMap(saliencyMap, binaryMap);
+
+        Assert.True(result);
+        Assert.False(binaryMap.Empty());
+        Assert.Equal(src.Rows, binaryMap.Rows);
+        Assert.Equal(src.Cols, binaryMap.Cols);
+    }
+
+    [Fact]
+    public void SpectralResidual_ImageWidthHeight()
+    {
+        using var saliency = StaticSaliencySpectralResidual.Create();
+
+        saliency.ImageWidth = 256;
+        saliency.ImageHeight = 256;
+
+        Assert.Equal(256, saliency.ImageWidth);
+        Assert.Equal(256, saliency.ImageHeight);
+    }
+
+    [Fact]
+    public void FineGrained_CreateAndDispose()
+    {
+        using var saliency = StaticSaliencyFineGrained.Create();
+        Assert.NotNull(saliency);
+    }
+
+    [Fact]
+    public void FineGrained_ComputeSaliency()
+    {
+        using var saliency = StaticSaliencyFineGrained.Create();
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var saliencyMap = new Mat();
+
+        var result = saliency.ComputeSaliency(src, saliencyMap);
+
+        Assert.True(result);
+        Assert.False(saliencyMap.Empty());
+        Assert.Equal(src.Rows, saliencyMap.Rows);
+        Assert.Equal(src.Cols, saliencyMap.Cols);
+    }
+
+    [Fact]
+    public void FineGrained_ComputeBinaryMap()
+    {
+        using var saliency = StaticSaliencyFineGrained.Create();
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var saliencyMap = new Mat();
+        using var binaryMap = new Mat();
+
+        saliency.ComputeSaliency(src, saliencyMap);
+        var result = saliency.ComputeBinaryMap(saliencyMap, binaryMap);
+
+        Assert.True(result);
+        Assert.False(binaryMap.Empty());
+        Assert.Equal(src.Rows, binaryMap.Rows);
+        Assert.Equal(src.Cols, binaryMap.Cols);
+    }
+}


### PR DESCRIPTION
Fix #1826 

This pull request adds C# bindings for the OpenCV Saliency module, enabling .NET users to access various saliency detection algorithms. The changes introduce new wrapper classes and their corresponding native method declarations for four different saliency algorithms, providing object-oriented APIs for creating, configuring, and using these algorithms in managed code.

The most important changes are:

**New Saliency Algorithm Wrappers:**

* Added the `MotionSaliencyBinWangApr2014` class, which wraps the fast self-tuning background subtraction algorithm for motion saliency detection, including methods for initialization, parameter setting, and saliency computation. (`MotionSaliencyBinWangApr2014.cs`, [src/OpenCvSharp/Modules/saliency/MotionSaliencyBinWangApr2014.csR1-R125](diffhunk://#diff-3e224d88d3e54d6f0ee5cca13f930b7e5ccbb7da61b149da12242c5f5cd9be91R1-R125))
* Added the `ObjectnessBING` class, which provides access to the BING objectness saliency algorithm, including model file management, proposal generation, and parameter configuration. (`ObjectnessBING.cs`, [src/OpenCvSharp/Modules/saliency/ObjectnessBING.csR1-R162](diffhunk://#diff-2d371ff3318aac9060cac5851837433775f8b289fcbf29751c2172fd061bbfa8R1-R162))
* Added the `StaticSaliencyFineGrained` class, exposing the fine-grained static saliency detection algorithm with methods for computing saliency and binary maps. (`StaticSaliencyFineGrained.cs`, [src/OpenCvSharp/Modules/saliency/StaticSaliencyFineGrained.csR1-R78](diffhunk://#diff-41793b52d3ac6859be048c92ab946399be587245bdcaa671f34517af177b4d93R1-R78))
* Added the `StaticSaliencySpectralResidual` class, providing the spectral residual static saliency algorithm with support for image size configuration and binary map computation. (`StaticSaliencySpectralResidual.cs`, [src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencySpectralResidual.csR1-R45](diffhunk://#diff-e7313411c7a1421b9a05fb40efbe0c515be067dd0e6fb623152f6e2094d9e5f6R1-R45))

**P/Invoke Declarations:**

* Introduced new P/Invoke native method definitions for each of the above algorithms, enabling interop with the native OpenCV library functions. (`NativeMethods_saliency_MotionSaliencyBinWangApr2014.cs`, [[1]](diffhunk://#diff-8a247733ff1298dd59482aa59d31278c6a111dddf3edbcdc58dfcfd8c70b409eR1-R49); `NativeMethods_saliency_ObjectnessBING.cs`, [[2]](diffhunk://#diff-2080b75fb790a13f1d16499853f5a05f34b623da8ccb1237b7ed4d7338c34b99R1-R57); `NativeMethods_saliency_StaticSaliencyFineGrained.cs`, [[3]](diffhunk://#diff-89f8ff6ec1069711e7880b6c67985354c1b7f6106ca896a1a72cee149132b3b8R1-R29); `NativeMethods_saliency_StaticSaliencySpectralResidual.cs`, [[4]](diffhunk://#diff-e7313411c7a1421b9a05fb40efbe0c515be067dd0e6fb623152f6e2094d9e5f6R1-R45)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four saliency detection algorithms: `MotionSaliencyBinWangApr2014` for motion-based saliency detection, `ObjectnessBING` for objectness detection with bounding boxes, `StaticSaliencySpectralResidual` for spectral residual-based saliency, and `StaticSaliencyFineGrained` for fine-grained static saliency analysis. Each algorithm supports computing saliency maps and configurable parameters.

* **Tests**
  * Added comprehensive test coverage for all new saliency algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->