### PR TITLE
Add stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: "Close stale issues and PRs"
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automatically close stale issues and pull requests. The workflow is scheduled to run daily and will mark items as stale after 30 days of inactivity, then close them 5 days later if there is no further activity.

Workflow automation:

* Added a new workflow file `.github/workflows/stale.yml` that uses the `actions/stale` GitHub Action to manage stale issues and PRs, scheduling it to run every day at 1:00 AM UTC.
* Configured the workflow to mark issues and PRs as stale after 30 days of inactivity and to close them 5 days after being marked as stale if there is no further activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage stale issues and pull requests. Inactive items are marked stale after 30 days and automatically closed 5 days later.
  * The cleanup runs daily at 01:00 UTC to keep the issue and pull request list current and reduce noise for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->