### PR TITLE
Fix Cv2.StereoCalibrate functionality

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib3d.FishEye.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib3d.FishEye.cs
@@ -1,0 +1,499 @@
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp;
+
+static partial class Cv2
+{
+    /// <summary>
+    /// The methods in this class use a so-called fisheye camera model.
+    /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible
+    public static class FishEye
+#pragma warning restore CA1034
+    {
+        /// <summary>
+        /// Projects points using fisheye model.
+        /// 
+        /// The function computes projections of 3D points to the image plane given intrinsic and extrinsic 
+        /// camera parameters.Optionally, the function computes Jacobians - matrices of partial derivatives of 
+        /// image points coordinates(as functions of all the input parameters) with respect to the particular 
+        /// parameters, intrinsic and/or extrinsic.
+        /// </summary>
+        /// <param name="objectPoints">Array of object points, 1xN/Nx1 3-channel (or vector&lt;Point3f&gt; ), 
+        /// where N is the number of points in the view.</param>
+        /// <param name="imagePoints">Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, 
+        /// or vector&lt;Point2f&gt;.</param>
+        /// <param name="rvec"></param>
+        /// <param name="tvec"></param>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients</param>
+        /// <param name="alpha">The skew coefficient.</param>
+        /// <param name="jacobian">Optional output 2Nx15 jacobian matrix of derivatives of image points with respect 
+        /// to components of the focal lengths, coordinates of the principal point, distortion coefficients, 
+        /// rotation vector, translation vector, and the skew.In the old interface different components of 
+        /// the jacobian are returned via different output parameters.</param>
+        public static void ProjectPoints(
+            InputArray objectPoints, OutputArray imagePoints, InputArray rvec, InputArray tvec,
+            InputArray k, InputArray d, double alpha = 0, OutputArray? jacobian = null)
+        {
+            if (objectPoints is null)
+                throw new ArgumentNullException(nameof(objectPoints));
+            if (imagePoints is null)
+                throw new ArgumentNullException(nameof(imagePoints));
+            if (rvec is null)
+                throw new ArgumentNullException(nameof(rvec));
+            if (tvec is null)
+                throw new ArgumentNullException(nameof(tvec));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            objectPoints.ThrowIfDisposed();
+            rvec.ThrowIfDisposed();
+            tvec.ThrowIfDisposed();
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+            jacobian?.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_projectPoints2(
+                    objectPoints.CvPtr,
+                    imagePoints.CvPtr,
+                    rvec.CvPtr, tvec.CvPtr,
+                    k.CvPtr, d.CvPtr,
+                    alpha, ToPtr(jacobian)));
+
+            GC.KeepAlive(objectPoints);
+            GC.KeepAlive(rvec);
+            GC.KeepAlive(tvec);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+            GC.KeepAlive(imagePoints);
+            GC.KeepAlive(jacobian);
+        }
+
+        /// <summary>
+        /// Distorts 2D points using fisheye model.
+        /// </summary>
+        /// <param name="undistorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt; ), 
+        /// where N is the number of points in the view.</param>
+        /// <param name="distorted">Output array of image points, 1xN/Nx1 2-channel, or vector&lt;Point2f&gt; .</param>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients</param>
+        /// <param name="alpha">The skew coefficient.</param>
+        public static void DistortPoints(
+            InputArray undistorted, OutputArray distorted, InputArray k, InputArray d, double alpha = 0)
+        {
+            if (undistorted is null)
+                throw new ArgumentNullException(nameof(undistorted));
+            if (distorted is null)
+                throw new ArgumentNullException(nameof(distorted));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            undistorted.ThrowIfDisposed();
+            distorted.ThrowIfNotReady();
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_distortPoints(
+                    undistorted.CvPtr, distorted.CvPtr, k.CvPtr, d.CvPtr, alpha));
+
+            GC.KeepAlive(undistorted);
+            GC.KeepAlive(distorted);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+        }
+
+        /// <summary>
+        /// Undistorts 2D points using fisheye model
+        /// </summary>
+        /// <param name="distorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt; ), 
+        /// where N is the number of points in the view.</param>
+        /// <param name="undistorted">Output array of image points, 1xN/Nx1 2-channel, or vector&gt;Point2f&gt; .</param>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
+        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3 1-channel or 1x1 3-channel</param>
+        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
+        // ReSharper disable once MemberHidesStaticFromOuterClass
+        public static void UndistortPoints(
+            InputArray distorted, OutputArray undistorted,
+            InputArray k, InputArray d, InputArray? r = null, InputArray? p = null)
+        {
+            if (distorted is null)
+                throw new ArgumentNullException(nameof(distorted));
+            if (undistorted is null)
+                throw new ArgumentNullException(nameof(undistorted));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            distorted.ThrowIfDisposed();
+            undistorted.ThrowIfNotReady();
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+            r?.ThrowIfDisposed();
+            p?.ThrowIfDisposed();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_undistortPoints(
+                    distorted.CvPtr, undistorted.CvPtr, k.CvPtr, d.CvPtr, ToPtr(r), ToPtr(p)));
+
+            GC.KeepAlive(distorted);
+            GC.KeepAlive(undistorted);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+            GC.KeepAlive(r);
+            GC.KeepAlive(p);
+        }
+
+        /// <summary>
+        /// Computes undistortion and rectification maps for image transform by cv::remap(). 
+        /// If D is empty zero distortion is used, if R or P is empty identity matrixes are used.
+        /// </summary>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
+        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3 1-channel or 1x1 3-channel</param>
+        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
+        /// <param name="size">Undistorted image size.</param>
+        /// <param name="m1type">Type of the first output map that can be CV_32FC1 or CV_16SC2 . See convertMaps() for details.</param>
+        /// <param name="map1">The first output map.</param>
+        /// <param name="map2">The second output map.</param>
+        public static void InitUndistortRectifyMap(
+            InputArray k, InputArray d, InputArray r, InputArray p,
+            Size size, int m1type, OutputArray map1, OutputArray map2)
+        {
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            if (r is null)
+                throw new ArgumentNullException(nameof(r));
+            if (p is null)
+                throw new ArgumentNullException(nameof(p));
+            if (map1 is null)
+                throw new ArgumentNullException(nameof(map1));
+            if (map2 is null)
+                throw new ArgumentNullException(nameof(map2));
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+            r.ThrowIfDisposed();
+            p.ThrowIfDisposed();
+            map1.ThrowIfNotReady();
+            map2.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_initUndistortRectifyMap(
+                    k.CvPtr, d.CvPtr, r.CvPtr, p.CvPtr, size, m1type, map1.CvPtr, map2.CvPtr));
+                
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+            GC.KeepAlive(r);
+            GC.KeepAlive(p);
+            GC.KeepAlive(map1);
+            GC.KeepAlive(map2);
+        }
+
+        /// <summary>
+        /// Transforms an image to compensate for fisheye lens distortion.
+        /// </summary>
+        /// <param name="distorted">image with fisheye lens distortion.</param>
+        /// <param name="undistorted">Output image with compensated fisheye lens distortion.</param>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
+        /// <param name="knew">Camera matrix of the distorted image. By default, it is the identity matrix but you
+        /// may additionally scale and shift the result by using a different matrix.</param>
+        /// <param name="newSize"></param>
+        public static void UndistortImage(
+            InputArray distorted, OutputArray undistorted,
+            InputArray k, InputArray d, InputArray? knew = null, Size newSize = default)
+        {
+            if (distorted is null)
+                throw new ArgumentNullException(nameof(distorted));
+            if (undistorted is null)
+                throw new ArgumentNullException(nameof(undistorted));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            distorted.ThrowIfDisposed();
+            undistorted.ThrowIfNotReady();
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+            knew?.ThrowIfDisposed();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_undistortImage(
+                    distorted.CvPtr, undistorted.CvPtr, k.CvPtr, d.CvPtr, ToPtr(knew), newSize));
+
+            GC.KeepAlive(distorted);
+            GC.KeepAlive(undistorted);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+            GC.KeepAlive(knew);
+        }
+
+        /// <summary>
+        /// Estimates new camera matrix for undistortion or rectification.
+        /// </summary>
+        /// <param name="k">Camera matrix</param>
+        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
+        /// <param name="imageSize"></param>
+        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3
+        /// 1-channel or 1x1 3-channel</param>
+        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
+        /// <param name="balance">Sets the new focal length in range between the min focal length and the max focal 
+        /// length.Balance is in range of[0, 1].</param>
+        /// <param name="newSize"></param>
+        /// <param name="fovScale">Divisor for new focal length.</param>
+        public static void EstimateNewCameraMatrixForUndistortRectify(
+            InputArray k, InputArray d, Size imageSize, InputArray r,
+            OutputArray p, double balance = 0.0, Size newSize = default, double fovScale = 1.0)
+        {
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            if (r is null)
+                throw new ArgumentNullException(nameof(r));
+            if (p is null)
+                throw new ArgumentNullException(nameof(p));
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+            r.ThrowIfDisposed();
+            p.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_estimateNewCameraMatrixForUndistortRectify(
+                    k.CvPtr, d.CvPtr, imageSize, r.CvPtr, p.CvPtr, balance, newSize, fovScale));
+
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+            GC.KeepAlive(r);
+            GC.KeepAlive(p);
+        }
+
+        /// <summary>
+        /// Performs camera calibaration
+        /// </summary>
+        /// <param name="objectPoints">vector of vectors of calibration pattern points in the calibration pattern coordinate space.</param>
+        /// <param name="imagePoints">vector of vectors of the projections of calibration pattern points. 
+        /// imagePoints.size() and objectPoints.size() and imagePoints[i].size() must be equal to 
+        /// objectPoints[i].size() for each i.</param>
+        /// <param name="imageSize">Size of the image used only to initialize the intrinsic camera matrix.</param>
+        /// <param name="k">Output 3x3 floating-point camera matrix</param>
+        /// <param name="d">Output vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
+        /// <param name="rvecs">Output vector of rotation vectors (see Rodrigues ) estimated for each pattern view. 
+        /// That is, each k-th rotation vector together with the corresponding k-th translation vector(see 
+        /// the next output parameter description) brings the calibration pattern from the model coordinate 
+        /// space(in which object points are specified) to the world coordinate space, that is, a real 
+        /// position of the calibration pattern in the k-th pattern view(k= 0.. * M * -1).</param>
+        /// <param name="tvecs">Output vector of translation vectors estimated for each pattern view.</param>
+        /// <param name="flags">Different flags that may be zero or a combination of flag values</param>
+        /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+        /// <returns></returns>
+        public static double Calibrate(
+            IEnumerable<Mat> objectPoints, IEnumerable<Mat> imagePoints,
+            Size imageSize, InputOutputArray k, InputOutputArray d,
+            out IEnumerable<Mat> rvecs, out IEnumerable<Mat> tvecs,
+            FishEyeCalibrationFlags flags = 0, TermCriteria? criteria = null)
+        {
+            if (objectPoints is null)
+                throw new ArgumentNullException(nameof(objectPoints));
+            if (imagePoints is null)
+                throw new ArgumentNullException(nameof(imagePoints));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+
+            var criteriaVal = criteria.GetValueOrDefault(
+                new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
+
+            using var objectPointsVec = new VectorOfMat(objectPoints);
+            using var imagePointsVec = new VectorOfMat(imagePoints);
+            using var rvecsVec = new VectorOfMat();
+            using var tvecsVec = new VectorOfMat();
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_calibrate(
+                    objectPointsVec.CvPtr, imagePointsVec.CvPtr, imageSize,
+                    k.CvPtr, d.CvPtr, rvecsVec.CvPtr, tvecsVec.CvPtr, (int) flags, criteriaVal, out var result));
+
+            rvecs = rvecsVec.ToArray();
+            tvecs = tvecsVec.ToArray();
+
+            GC.KeepAlive(objectPoints);
+            GC.KeepAlive(imagePoints);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Stereo rectification for fisheye camera model
+        /// </summary>
+        /// <param name="k1">First camera matrix.</param>
+        /// <param name="d1">First camera distortion parameters.</param>
+        /// <param name="k2">Second camera matrix.</param>
+        /// <param name="d2">Second camera distortion parameters.</param>
+        /// <param name="imageSize">Size of the image used for stereo calibration.</param>
+        /// <param name="r">Rotation matrix between the coordinate systems of the first and the second cameras.</param>
+        /// <param name="tvec">Translation vector between coordinate systems of the cameras.</param>
+        /// <param name="r1">Output 3x3 rectification transform (rotation matrix) for the first camera.</param>
+        /// <param name="r2">Output 3x3 rectification transform (rotation matrix) for the second camera.</param>
+        /// <param name="p1">Output 3x4 projection matrix in the new (rectified) coordinate systems for the first camera.</param>
+        /// <param name="p2">Output 3x4 projection matrix in the new (rectified) coordinate systems for the second camera.</param>
+        /// <param name="q">Output 4x4 disparity-to-depth mapping matrix (see reprojectImageTo3D ).</param>
+        /// <param name="flags">Operation flags that may be zero or CALIB_ZERO_DISPARITY . If the flag is set, 
+        /// the function makes the principal points of each camera have the same pixel coordinates in the 
+        /// rectified views.And if the flag is not set, the function may still shift the images in the 
+        /// horizontal or vertical direction(depending on the orientation of epipolar lines) to maximize the 
+        /// useful image area.</param>
+        /// <param name="newImageSize">New image resolution after rectification. The same size should be passed to 
+        /// initUndistortRectifyMap(see the stereo_calib.cpp sample in OpenCV samples directory). When(0,0) 
+        /// is passed(default), it is set to the original imageSize.Setting it to larger value can help you 
+        /// preserve details in the original image, especially when there is a big radial distortion.</param>
+        /// <param name="balance">Sets the new focal length in range between the min focal length and the max focal
+        /// length.Balance is in range of[0, 1].</param>
+        /// <param name="fovScale">Divisor for new focal length.</param>
+        public static void StereoRectify(
+            InputArray k1, InputArray d1, InputArray k2, InputArray d2, 
+            Size imageSize, InputArray r, InputArray tvec, OutputArray r1, OutputArray r2, 
+            OutputArray p1, OutputArray p2, OutputArray q, FishEyeCalibrationFlags flags, Size newImageSize = default,
+            double balance = 0.0, double fovScale = 1.0)
+        {
+            if (k1 is null)
+                throw new ArgumentNullException(nameof(k1));
+            if (d1 is null)
+                throw new ArgumentNullException(nameof(d1));
+            if (k2 is null)
+                throw new ArgumentNullException(nameof(k2));
+            if (d2 is null)
+                throw new ArgumentNullException(nameof(d2));
+            if (r is null)
+                throw new ArgumentNullException(nameof(r));
+            if (tvec is null)
+                throw new ArgumentNullException(nameof(tvec));
+            if (r1 is null)
+                throw new ArgumentNullException(nameof(r1));
+            if (r2 is null)
+                throw new ArgumentNullException(nameof(r2));
+            if (p1 is null)
+                throw new ArgumentNullException(nameof(p1));
+            if (p2 is null)
+                throw new ArgumentNullException(nameof(p2));
+            if (q is null)
+                throw new ArgumentNullException(nameof(q));
+            k1.ThrowIfDisposed();
+            d1.ThrowIfDisposed();
+            k2.ThrowIfDisposed();
+            d2.ThrowIfDisposed();
+            r.ThrowIfDisposed();
+            tvec.ThrowIfDisposed();
+            r1.ThrowIfNotReady();
+            r2.ThrowIfNotReady();
+            p1.ThrowIfNotReady();
+            p2.ThrowIfNotReady();
+            q.ThrowIfNotReady();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_stereoRectify(
+                    k1.CvPtr, d1.CvPtr, k2.CvPtr, d2.CvPtr,
+                    imageSize, r.CvPtr, tvec.CvPtr, r1.CvPtr, r2.CvPtr,
+                    p1.CvPtr, p2.CvPtr, q.CvPtr, (int) flags, newImageSize, balance, fovScale));
+
+            GC.KeepAlive(k1);
+            GC.KeepAlive(d1);
+            GC.KeepAlive(k2);
+            GC.KeepAlive(d2);
+            GC.KeepAlive(r);
+            GC.KeepAlive(tvec);
+            GC.KeepAlive(r1);
+            GC.KeepAlive(r2);
+            GC.KeepAlive(p1);
+            GC.KeepAlive(p2);
+            GC.KeepAlive(q);
+        }
+
+        /// <summary>
+        /// Performs stereo calibration
+        /// </summary>
+        /// <param name="objectPoints">Vector of vectors of the calibration pattern points.</param>
+        /// <param name="imagePoints1">Vector of vectors of the projections of the calibration pattern points, 
+        /// observed by the first camera.</param>
+        /// <param name="imagePoints2">Vector of vectors of the projections of the calibration pattern points, 
+        /// observed by the second camera.</param>
+        /// <param name="k1">Input/output first camera matrix</param>
+        /// <param name="d1">Input/output vector of distortion coefficients (k_1, k_2, k_3, k_4) of 4 elements.</param>
+        /// <param name="k2">Input/output second camera matrix. The parameter is similar to K1 .</param>
+        /// <param name="d2">Input/output lens distortion coefficients for the second camera. The parameter is 
+        /// similar to D1.</param>
+        /// <param name="imageSize">Size of the image used only to initialize intrinsic camera matrix.</param>
+        /// <param name="r">Output rotation matrix between the 1st and the 2nd camera coordinate systems.</param>
+        /// <param name="t">Output translation vector between the coordinate systems of the cameras.</param>
+        /// <param name="flags">Different flags that may be zero or a combination of the FishEyeCalibrationFlags values</param>
+        /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+        /// <returns></returns>
+        public static double StereoCalibrate(
+            IEnumerable<Mat> objectPoints, IEnumerable<Mat> imagePoints1, IEnumerable<Mat> imagePoints2,
+            InputOutputArray k1, InputOutputArray d1, InputOutputArray k2, InputOutputArray d2, Size imageSize,
+            OutputArray r, OutputArray t, FishEyeCalibrationFlags flags = FishEyeCalibrationFlags.FixIntrinsic,
+            TermCriteria? criteria = null)
+        {
+            if (objectPoints is null)
+                throw new ArgumentNullException(nameof(objectPoints));
+            if (imagePoints1 is null)
+                throw new ArgumentNullException(nameof(imagePoints1));
+            if (imagePoints2 is null)
+                throw new ArgumentNullException(nameof(imagePoints2));
+            if (k1 is null)
+                throw new ArgumentNullException(nameof(k1));
+            if (d1 is null)
+                throw new ArgumentNullException(nameof(d1));
+            if (k2 is null)
+                throw new ArgumentNullException(nameof(k2));
+            if (d2 is null)
+                throw new ArgumentNullException(nameof(d2));
+            if (r is null)
+                throw new ArgumentNullException(nameof(r));
+            if (t is null)
+                throw new ArgumentNullException(nameof(t));
+            k1.ThrowIfNotReady();
+            d1.ThrowIfNotReady();
+            k2.ThrowIfNotReady();
+            d2.ThrowIfNotReady();
+            r.ThrowIfNotReady();
+            t.ThrowIfNotReady();
+
+            var criteriaVal = criteria.GetValueOrDefault(
+                new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
+
+            using var objectPointsVec = new VectorOfMat(objectPoints);
+            using var imagePoints1Vec = new VectorOfMat(imagePoints1); 
+            using var imagePoints2Vec = new VectorOfMat(imagePoints2);
+            NativeMethods.HandleException(
+                NativeMethods.calib3d_fisheye_stereoCalibrate(
+                    objectPointsVec.CvPtr, imagePoints1Vec.CvPtr, imagePoints2Vec.CvPtr,
+                    k1.CvPtr, d1.CvPtr, k2.CvPtr, d2.CvPtr, imageSize,
+                    r.CvPtr, t.CvPtr, (int) flags, criteriaVal, out var result));
+
+            GC.KeepAlive(objectPoints);
+            GC.KeepAlive(imagePoints1);
+            GC.KeepAlive(imagePoints2);
+            GC.KeepAlive(k1);
+            GC.KeepAlive(d1);
+            GC.KeepAlive(k2);
+            GC.KeepAlive(d2);
+            GC.KeepAlive(r);
+            GC.KeepAlive(t);
+
+            return result;
+        }
+    }
+}

--- a/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib3d.cs
@@ -1729,6 +1729,90 @@ static partial class Cv2
     /// <param name="flags">Different flags that may be zero or a combination of the CalibrationFlag values</param>
     /// <returns></returns>
     public static double StereoCalibrate(
+        IEnumerable<Mat> objectPoints,
+        IEnumerable<Mat> imagePoints1,
+        IEnumerable<Mat> imagePoints2,
+        Mat cameraMatrix1, Mat distCoeffs1,
+        Mat cameraMatrix2, Mat distCoeffs2,
+        Size imageSize, Mat R, Mat T, Mat E, Mat F,
+        CalibrationFlags flags = CalibrationFlags.FixIntrinsic,
+        TermCriteria? criteria = null)
+    {
+        if (objectPoints is null)
+            throw new ArgumentNullException(nameof(objectPoints));
+        if (imagePoints1 is null)
+            throw new ArgumentNullException(nameof(imagePoints1));
+        if (imagePoints2 is null)
+            throw new ArgumentNullException(nameof(imagePoints2));
+        if (cameraMatrix1 is null)
+            throw new ArgumentNullException(nameof(cameraMatrix1));
+        if (distCoeffs1 is null)
+            throw new ArgumentNullException(nameof(distCoeffs1));
+        if (cameraMatrix2 is null)
+            throw new ArgumentNullException(nameof(cameraMatrix2));
+        if (distCoeffs2 is null)
+            throw new ArgumentNullException(nameof(distCoeffs2));
+        if (R is null)
+            throw new ArgumentNullException(nameof(R));
+        if (T is null)
+            throw new ArgumentNullException(nameof(T));
+        if (E is null)
+            throw new ArgumentNullException(nameof(E));
+        if (F is null)
+            throw new ArgumentNullException(nameof(F));
+
+        var opPtrs = objectPoints.Select(x => x.CvPtr).ToArray();
+        var ip1Ptrs = imagePoints1.Select(x => x.CvPtr).ToArray();
+        var ip2Ptrs = imagePoints2.Select(x => x.CvPtr).ToArray();
+
+        var criteria0 = criteria.GetValueOrDefault(
+            new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, 1e-6));
+
+        NativeMethods.HandleException(
+            NativeMethods.calib3d_stereoCalibrate_Mat(
+                opPtrs, opPtrs.Length,
+                ip1Ptrs, ip1Ptrs.Length,
+                ip2Ptrs, ip2Ptrs.Length,
+                cameraMatrix1.CvPtr, distCoeffs1.CvPtr,
+                cameraMatrix2.CvPtr, distCoeffs2.CvPtr,
+                imageSize, R.CvPtr, T.CvPtr, E.CvPtr, F.CvPtr,
+                (int)flags, criteria0, out var ret));
+
+        GC.KeepAlive(objectPoints);
+        GC.KeepAlive(imagePoints1);
+        GC.KeepAlive(imagePoints2);
+        GC.KeepAlive(cameraMatrix1);
+        GC.KeepAlive(distCoeffs1);
+        GC.KeepAlive(cameraMatrix2);
+        GC.KeepAlive(distCoeffs2);
+        GC.KeepAlive(R);
+        GC.KeepAlive(T);
+        GC.KeepAlive(E);
+        GC.KeepAlive(F);
+
+        return ret;
+    }
+
+    /// <summary>
+    /// finds intrinsic and extrinsic parameters of a stereo camera
+    /// </summary>
+    /// <param name="objectPoints">Vector of vectors of the calibration pattern points.</param>
+    /// <param name="imagePoints1">Vector of vectors of the projections of the calibration pattern points, observed by the first camera.</param>
+    /// <param name="imagePoints2">Vector of vectors of the projections of the calibration pattern points, observed by the second camera.</param>
+    /// <param name="cameraMatrix1">Input/output first camera matrix</param>
+    /// <param name="distCoeffs1">Input/output vector of distortion coefficients (k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6]]) of 4, 5, or 8 elements. 
+    /// The output vector length depends on the flags.</param>
+    /// <param name="cameraMatrix2"> Input/output second camera matrix. The parameter is similar to cameraMatrix1 .</param>
+    /// <param name="distCoeffs2">Input/output lens distortion coefficients for the second camera. The parameter is similar to distCoeffs1 .</param>
+    /// <param name="imageSize">Size of the image used only to initialize intrinsic camera matrix.</param>
+    /// <param name="R">Output rotation matrix between the 1st and the 2nd camera coordinate systems.</param>
+    /// <param name="T">Output translation vector between the coordinate systems of the cameras.</param>
+    /// <param name="E">Output essential matrix.</param>
+    /// <param name="F">Output fundamental matrix.</param>
+    /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+    /// <param name="flags">Different flags that may be zero or a combination of the CalibrationFlag values</param>
+    /// <returns></returns>
+    public static double StereoCalibrate(
         IEnumerable<IEnumerable<Point3f>> objectPoints,
         IEnumerable<IEnumerable<Point2f>> imagePoints1,
         IEnumerable<IEnumerable<Point2f>> imagePoints2,
@@ -4056,497 +4140,5 @@ static partial class Cv2
         GC.KeepAlive(r);
         GC.KeepAlive(p);
         dst.Fix();
-    }
-
-    /// <summary>
-    /// The methods in this class use a so-called fisheye camera model.
-    /// </summary>
-#pragma warning disable CA1034 // Nested types should not be visible
-    public static class FishEye
-#pragma warning restore CA1034
-    {
-        /// <summary>
-        /// Projects points using fisheye model.
-        /// 
-        /// The function computes projections of 3D points to the image plane given intrinsic and extrinsic 
-        /// camera parameters.Optionally, the function computes Jacobians - matrices of partial derivatives of 
-        /// image points coordinates(as functions of all the input parameters) with respect to the particular 
-        /// parameters, intrinsic and/or extrinsic.
-        /// </summary>
-        /// <param name="objectPoints">Array of object points, 1xN/Nx1 3-channel (or vector&lt;Point3f&gt; ), 
-        /// where N is the number of points in the view.</param>
-        /// <param name="imagePoints">Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, 
-        /// or vector&lt;Point2f&gt;.</param>
-        /// <param name="rvec"></param>
-        /// <param name="tvec"></param>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients</param>
-        /// <param name="alpha">The skew coefficient.</param>
-        /// <param name="jacobian">Optional output 2Nx15 jacobian matrix of derivatives of image points with respect 
-        /// to components of the focal lengths, coordinates of the principal point, distortion coefficients, 
-        /// rotation vector, translation vector, and the skew.In the old interface different components of 
-        /// the jacobian are returned via different output parameters.</param>
-        public static void ProjectPoints(
-            InputArray objectPoints, OutputArray imagePoints, InputArray rvec, InputArray tvec,
-            InputArray k, InputArray d, double alpha = 0, OutputArray? jacobian = null)
-        {
-            if (objectPoints is null)
-                throw new ArgumentNullException(nameof(objectPoints));
-            if (imagePoints is null)
-                throw new ArgumentNullException(nameof(imagePoints));
-            if (rvec is null)
-                throw new ArgumentNullException(nameof(rvec));
-            if (tvec is null)
-                throw new ArgumentNullException(nameof(tvec));
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            objectPoints.ThrowIfDisposed();
-            rvec.ThrowIfDisposed();
-            tvec.ThrowIfDisposed();
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-            jacobian?.ThrowIfNotReady();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_projectPoints2(
-                    objectPoints.CvPtr,
-                    imagePoints.CvPtr,
-                    rvec.CvPtr, tvec.CvPtr,
-                    k.CvPtr, d.CvPtr,
-                    alpha, ToPtr(jacobian)));
-
-            GC.KeepAlive(objectPoints);
-            GC.KeepAlive(rvec);
-            GC.KeepAlive(tvec);
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-            GC.KeepAlive(imagePoints);
-            GC.KeepAlive(jacobian);
-        }
-
-        /// <summary>
-        /// Distorts 2D points using fisheye model.
-        /// </summary>
-        /// <param name="undistorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt; ), 
-        /// where N is the number of points in the view.</param>
-        /// <param name="distorted">Output array of image points, 1xN/Nx1 2-channel, or vector&lt;Point2f&gt; .</param>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients</param>
-        /// <param name="alpha">The skew coefficient.</param>
-        public static void DistortPoints(
-            InputArray undistorted, OutputArray distorted, InputArray k, InputArray d, double alpha = 0)
-        {
-            if (undistorted is null)
-                throw new ArgumentNullException(nameof(undistorted));
-            if (distorted is null)
-                throw new ArgumentNullException(nameof(distorted));
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            undistorted.ThrowIfDisposed();
-            distorted.ThrowIfNotReady();
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_distortPoints(
-                    undistorted.CvPtr, distorted.CvPtr, k.CvPtr, d.CvPtr, alpha));
-
-            GC.KeepAlive(undistorted);
-            GC.KeepAlive(distorted);
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-        }
-
-        /// <summary>
-        /// Undistorts 2D points using fisheye model
-        /// </summary>
-        /// <param name="distorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt; ), 
-        /// where N is the number of points in the view.</param>
-        /// <param name="undistorted">Output array of image points, 1xN/Nx1 2-channel, or vector&gt;Point2f&gt; .</param>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
-        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3 1-channel or 1x1 3-channel</param>
-        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
-        // ReSharper disable once MemberHidesStaticFromOuterClass
-        public static void UndistortPoints(
-            InputArray distorted, OutputArray undistorted,
-            InputArray k, InputArray d, InputArray? r = null, InputArray? p = null)
-        {
-            if (distorted is null)
-                throw new ArgumentNullException(nameof(distorted));
-            if (undistorted is null)
-                throw new ArgumentNullException(nameof(undistorted));
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            distorted.ThrowIfDisposed();
-            undistorted.ThrowIfNotReady();
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-            r?.ThrowIfDisposed();
-            p?.ThrowIfDisposed();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_undistortPoints(
-                    distorted.CvPtr, undistorted.CvPtr, k.CvPtr, d.CvPtr, ToPtr(r), ToPtr(p)));
-
-            GC.KeepAlive(distorted);
-            GC.KeepAlive(undistorted);
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-            GC.KeepAlive(r);
-            GC.KeepAlive(p);
-        }
-
-        /// <summary>
-        /// Computes undistortion and rectification maps for image transform by cv::remap(). 
-        /// If D is empty zero distortion is used, if R or P is empty identity matrixes are used.
-        /// </summary>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
-        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3 1-channel or 1x1 3-channel</param>
-        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
-        /// <param name="size">Undistorted image size.</param>
-        /// <param name="m1type">Type of the first output map that can be CV_32FC1 or CV_16SC2 . See convertMaps() for details.</param>
-        /// <param name="map1">The first output map.</param>
-        /// <param name="map2">The second output map.</param>
-        public static void InitUndistortRectifyMap(
-            InputArray k, InputArray d, InputArray r, InputArray p,
-            Size size, int m1type, OutputArray map1, OutputArray map2)
-        {
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            if (r is null)
-                throw new ArgumentNullException(nameof(r));
-            if (p is null)
-                throw new ArgumentNullException(nameof(p));
-            if (map1 is null)
-                throw new ArgumentNullException(nameof(map1));
-            if (map2 is null)
-                throw new ArgumentNullException(nameof(map2));
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-            r.ThrowIfDisposed();
-            p.ThrowIfDisposed();
-            map1.ThrowIfNotReady();
-            map2.ThrowIfNotReady();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_initUndistortRectifyMap(
-                    k.CvPtr, d.CvPtr, r.CvPtr, p.CvPtr, size, m1type, map1.CvPtr, map2.CvPtr));
-                
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-            GC.KeepAlive(r);
-            GC.KeepAlive(p);
-            GC.KeepAlive(map1);
-            GC.KeepAlive(map2);
-        }
-
-        /// <summary>
-        /// Transforms an image to compensate for fisheye lens distortion.
-        /// </summary>
-        /// <param name="distorted">image with fisheye lens distortion.</param>
-        /// <param name="undistorted">Output image with compensated fisheye lens distortion.</param>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
-        /// <param name="knew">Camera matrix of the distorted image. By default, it is the identity matrix but you
-        /// may additionally scale and shift the result by using a different matrix.</param>
-        /// <param name="newSize"></param>
-        public static void UndistortImage(
-            InputArray distorted, OutputArray undistorted,
-            InputArray k, InputArray d, InputArray? knew = null, Size newSize = default)
-        {
-            if (distorted is null)
-                throw new ArgumentNullException(nameof(distorted));
-            if (undistorted is null)
-                throw new ArgumentNullException(nameof(undistorted));
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            distorted.ThrowIfDisposed();
-            undistorted.ThrowIfNotReady();
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-            knew?.ThrowIfDisposed();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_undistortImage(
-                    distorted.CvPtr, undistorted.CvPtr, k.CvPtr, d.CvPtr, ToPtr(knew), newSize));
-
-            GC.KeepAlive(distorted);
-            GC.KeepAlive(undistorted);
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-            GC.KeepAlive(knew);
-        }
-
-        /// <summary>
-        /// Estimates new camera matrix for undistortion or rectification.
-        /// </summary>
-        /// <param name="k">Camera matrix</param>
-        /// <param name="d">Input vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
-        /// <param name="imageSize"></param>
-        /// <param name="r">Rectification transformation in the object space: 3x3 1-channel, or vector: 3x1/1x3
-        /// 1-channel or 1x1 3-channel</param>
-        /// <param name="p">New camera matrix (3x3) or new projection matrix (3x4)</param>
-        /// <param name="balance">Sets the new focal length in range between the min focal length and the max focal 
-        /// length.Balance is in range of[0, 1].</param>
-        /// <param name="newSize"></param>
-        /// <param name="fovScale">Divisor for new focal length.</param>
-        public static void EstimateNewCameraMatrixForUndistortRectify(
-            InputArray k, InputArray d, Size imageSize, InputArray r,
-            OutputArray p, double balance = 0.0, Size newSize = default, double fovScale = 1.0)
-        {
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            if (r is null)
-                throw new ArgumentNullException(nameof(r));
-            if (p is null)
-                throw new ArgumentNullException(nameof(p));
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-            r.ThrowIfDisposed();
-            p.ThrowIfNotReady();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_estimateNewCameraMatrixForUndistortRectify(
-                    k.CvPtr, d.CvPtr, imageSize, r.CvPtr, p.CvPtr, balance, newSize, fovScale));
-
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-            GC.KeepAlive(r);
-            GC.KeepAlive(p);
-        }
-
-        /// <summary>
-        /// Performs camera calibaration
-        /// </summary>
-        /// <param name="objectPoints">vector of vectors of calibration pattern points in the calibration pattern coordinate space.</param>
-        /// <param name="imagePoints">vector of vectors of the projections of calibration pattern points. 
-        /// imagePoints.size() and objectPoints.size() and imagePoints[i].size() must be equal to 
-        /// objectPoints[i].size() for each i.</param>
-        /// <param name="imageSize">Size of the image used only to initialize the intrinsic camera matrix.</param>
-        /// <param name="k">Output 3x3 floating-point camera matrix</param>
-        /// <param name="d">Output vector of distortion coefficients (k_1, k_2, k_3, k_4).</param>
-        /// <param name="rvecs">Output vector of rotation vectors (see Rodrigues ) estimated for each pattern view. 
-        /// That is, each k-th rotation vector together with the corresponding k-th translation vector(see 
-        /// the next output parameter description) brings the calibration pattern from the model coordinate 
-        /// space(in which object points are specified) to the world coordinate space, that is, a real 
-        /// position of the calibration pattern in the k-th pattern view(k= 0.. * M * -1).</param>
-        /// <param name="tvecs">Output vector of translation vectors estimated for each pattern view.</param>
-        /// <param name="flags">Different flags that may be zero or a combination of flag values</param>
-        /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
-        /// <returns></returns>
-        public static double Calibrate(
-            IEnumerable<Mat> objectPoints, IEnumerable<Mat> imagePoints,
-            Size imageSize, InputOutputArray k, InputOutputArray d,
-            out IEnumerable<Mat> rvecs, out IEnumerable<Mat> tvecs,
-            FishEyeCalibrationFlags flags = 0, TermCriteria? criteria = null)
-        {
-            if (objectPoints is null)
-                throw new ArgumentNullException(nameof(objectPoints));
-            if (imagePoints is null)
-                throw new ArgumentNullException(nameof(imagePoints));
-            if (k is null)
-                throw new ArgumentNullException(nameof(k));
-            if (d is null)
-                throw new ArgumentNullException(nameof(d));
-            k.ThrowIfDisposed();
-            d.ThrowIfDisposed();
-
-            var criteriaVal = criteria.GetValueOrDefault(
-                new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
-
-            using var objectPointsVec = new VectorOfMat(objectPoints);
-            using var imagePointsVec = new VectorOfMat(imagePoints);
-            using var rvecsVec = new VectorOfMat();
-            using var tvecsVec = new VectorOfMat();
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_calibrate(
-                    objectPointsVec.CvPtr, imagePointsVec.CvPtr, imageSize,
-                    k.CvPtr, d.CvPtr, rvecsVec.CvPtr, tvecsVec.CvPtr, (int) flags, criteriaVal, out var result));
-
-            rvecs = rvecsVec.ToArray();
-            tvecs = tvecsVec.ToArray();
-
-            GC.KeepAlive(objectPoints);
-            GC.KeepAlive(imagePoints);
-            GC.KeepAlive(k);
-            GC.KeepAlive(d);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Stereo rectification for fisheye camera model
-        /// </summary>
-        /// <param name="k1">First camera matrix.</param>
-        /// <param name="d1">First camera distortion parameters.</param>
-        /// <param name="k2">Second camera matrix.</param>
-        /// <param name="d2">Second camera distortion parameters.</param>
-        /// <param name="imageSize">Size of the image used for stereo calibration.</param>
-        /// <param name="r">Rotation matrix between the coordinate systems of the first and the second cameras.</param>
-        /// <param name="tvec">Translation vector between coordinate systems of the cameras.</param>
-        /// <param name="r1">Output 3x3 rectification transform (rotation matrix) for the first camera.</param>
-        /// <param name="r2">Output 3x3 rectification transform (rotation matrix) for the second camera.</param>
-        /// <param name="p1">Output 3x4 projection matrix in the new (rectified) coordinate systems for the first camera.</param>
-        /// <param name="p2">Output 3x4 projection matrix in the new (rectified) coordinate systems for the second camera.</param>
-        /// <param name="q">Output 4x4 disparity-to-depth mapping matrix (see reprojectImageTo3D ).</param>
-        /// <param name="flags">Operation flags that may be zero or CALIB_ZERO_DISPARITY . If the flag is set, 
-        /// the function makes the principal points of each camera have the same pixel coordinates in the 
-        /// rectified views.And if the flag is not set, the function may still shift the images in the 
-        /// horizontal or vertical direction(depending on the orientation of epipolar lines) to maximize the 
-        /// useful image area.</param>
-        /// <param name="newImageSize">New image resolution after rectification. The same size should be passed to 
-        /// initUndistortRectifyMap(see the stereo_calib.cpp sample in OpenCV samples directory). When(0,0) 
-        /// is passed(default), it is set to the original imageSize.Setting it to larger value can help you 
-        /// preserve details in the original image, especially when there is a big radial distortion.</param>
-        /// <param name="balance">Sets the new focal length in range between the min focal length and the max focal
-        /// length.Balance is in range of[0, 1].</param>
-        /// <param name="fovScale">Divisor for new focal length.</param>
-        public static void StereoRectify(
-            InputArray k1, InputArray d1, InputArray k2, InputArray d2, 
-            Size imageSize, InputArray r, InputArray tvec, OutputArray r1, OutputArray r2, 
-            OutputArray p1, OutputArray p2, OutputArray q, FishEyeCalibrationFlags flags, Size newImageSize = default,
-            double balance = 0.0, double fovScale = 1.0)
-        {
-            if (k1 is null)
-                throw new ArgumentNullException(nameof(k1));
-            if (d1 is null)
-                throw new ArgumentNullException(nameof(d1));
-            if (k2 is null)
-                throw new ArgumentNullException(nameof(k2));
-            if (d2 is null)
-                throw new ArgumentNullException(nameof(d2));
-            if (r is null)
-                throw new ArgumentNullException(nameof(r));
-            if (tvec is null)
-                throw new ArgumentNullException(nameof(tvec));
-            if (r1 is null)
-                throw new ArgumentNullException(nameof(r1));
-            if (r2 is null)
-                throw new ArgumentNullException(nameof(r2));
-            if (p1 is null)
-                throw new ArgumentNullException(nameof(p1));
-            if (p2 is null)
-                throw new ArgumentNullException(nameof(p2));
-            if (q is null)
-                throw new ArgumentNullException(nameof(q));
-            k1.ThrowIfDisposed();
-            d1.ThrowIfDisposed();
-            k2.ThrowIfDisposed();
-            d2.ThrowIfDisposed();
-            r.ThrowIfDisposed();
-            tvec.ThrowIfDisposed();
-            r1.ThrowIfNotReady();
-            r2.ThrowIfNotReady();
-            p1.ThrowIfNotReady();
-            p2.ThrowIfNotReady();
-            q.ThrowIfNotReady();
-
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_stereoRectify(
-                    k1.CvPtr, d1.CvPtr, k2.CvPtr, d2.CvPtr,
-                    imageSize, r.CvPtr, tvec.CvPtr, r1.CvPtr, r2.CvPtr,
-                    p1.CvPtr, p2.CvPtr, q.CvPtr, (int) flags, newImageSize, balance, fovScale));
-
-            GC.KeepAlive(k1);
-            GC.KeepAlive(d1);
-            GC.KeepAlive(k2);
-            GC.KeepAlive(d2);
-            GC.KeepAlive(r);
-            GC.KeepAlive(tvec);
-            GC.KeepAlive(r1);
-            GC.KeepAlive(r2);
-            GC.KeepAlive(p1);
-            GC.KeepAlive(p2);
-            GC.KeepAlive(q);
-        }
-
-        /// <summary>
-        /// Performs stereo calibration
-        /// </summary>
-        /// <param name="objectPoints">Vector of vectors of the calibration pattern points.</param>
-        /// <param name="imagePoints1">Vector of vectors of the projections of the calibration pattern points, 
-        /// observed by the first camera.</param>
-        /// <param name="imagePoints2">Vector of vectors of the projections of the calibration pattern points, 
-        /// observed by the second camera.</param>
-        /// <param name="k1">Input/output first camera matrix</param>
-        /// <param name="d1">Input/output vector of distortion coefficients (k_1, k_2, k_3, k_4) of 4 elements.</param>
-        /// <param name="k2">Input/output second camera matrix. The parameter is similar to K1 .</param>
-        /// <param name="d2">Input/output lens distortion coefficients for the second camera. The parameter is 
-        /// similar to D1.</param>
-        /// <param name="imageSize">Size of the image used only to initialize intrinsic camera matrix.</param>
-        /// <param name="r">Output rotation matrix between the 1st and the 2nd camera coordinate systems.</param>
-        /// <param name="t">Output translation vector between the coordinate systems of the cameras.</param>
-        /// <param name="flags">Different flags that may be zero or a combination of the FishEyeCalibrationFlags values</param>
-        /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
-        /// <returns></returns>
-        public static double StereoCalibrate(
-            IEnumerable<Mat> objectPoints, IEnumerable<Mat> imagePoints1, IEnumerable<Mat> imagePoints2,
-            InputOutputArray k1, InputOutputArray d1, InputOutputArray k2, InputOutputArray d2, Size imageSize,
-            OutputArray r, OutputArray t, FishEyeCalibrationFlags flags = FishEyeCalibrationFlags.FixIntrinsic,
-            TermCriteria? criteria = null)
-        {
-            if (objectPoints is null)
-                throw new ArgumentNullException(nameof(objectPoints));
-            if (imagePoints1 is null)
-                throw new ArgumentNullException(nameof(imagePoints1));
-            if (imagePoints2 is null)
-                throw new ArgumentNullException(nameof(imagePoints2));
-            if (k1 is null)
-                throw new ArgumentNullException(nameof(k1));
-            if (d1 is null)
-                throw new ArgumentNullException(nameof(d1));
-            if (k2 is null)
-                throw new ArgumentNullException(nameof(k2));
-            if (d2 is null)
-                throw new ArgumentNullException(nameof(d2));
-            if (r is null)
-                throw new ArgumentNullException(nameof(r));
-            if (t is null)
-                throw new ArgumentNullException(nameof(t));
-            k1.ThrowIfNotReady();
-            d1.ThrowIfNotReady();
-            k2.ThrowIfNotReady();
-            d2.ThrowIfNotReady();
-            r.ThrowIfNotReady();
-            t.ThrowIfNotReady();
-
-            var criteriaVal = criteria.GetValueOrDefault(
-                new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
-
-            using var objectPointsVec = new VectorOfMat(objectPoints);
-            using var imagePoints1Vec = new VectorOfMat(imagePoints1); 
-            using var imagePoints2Vec = new VectorOfMat(imagePoints2);
-            NativeMethods.HandleException(
-                NativeMethods.calib3d_fisheye_stereoCalibrate(
-                    objectPointsVec.CvPtr, imagePoints1Vec.CvPtr, imagePoints2Vec.CvPtr,
-                    k1.CvPtr, d1.CvPtr, k2.CvPtr, d2.CvPtr, imageSize,
-                    r.CvPtr, t.CvPtr, (int) flags, criteriaVal, out var result));
-
-            GC.KeepAlive(objectPoints);
-            GC.KeepAlive(imagePoints1);
-            GC.KeepAlive(imagePoints2);
-            GC.KeepAlive(k1);
-            GC.KeepAlive(d1);
-            GC.KeepAlive(k2);
-            GC.KeepAlive(d2);
-            GC.KeepAlive(r);
-            GC.KeepAlive(t);
-
-            return result;
-        }
     }
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib3d/NativeMethods_calib3d.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib3d/NativeMethods_calib3d.cs
@@ -203,6 +203,21 @@ static partial class NativeMethods
         out double returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus calib3d_stereoCalibrate_Mat(
+        IntPtr[] objectPoints, int opSize,
+        IntPtr[] imagePoints1, int ip1Size,
+        IntPtr[] imagePoints2, int ip2Size,
+        IntPtr cameraMatrix1,
+        IntPtr distCoeffs1,
+        IntPtr cameraMatrix2,
+        IntPtr distCoeffs2,
+        Size imageSize,
+        IntPtr R, IntPtr T,
+        IntPtr E, IntPtr F,
+        int flags, TermCriteria criteria,
+        out double returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern unsafe ExceptionStatus calib3d_stereoCalibrate_array(
         IntPtr[] objectPoints, int opSize1, int[] opSizes2,
         IntPtr[] imagePoints1, int ip1Size1, int[] ip1Sizes2,

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -695,6 +695,84 @@ public partial class Mat : CvObject
         return retVal;
     }
 
+    /// <summary>
+    /// Returns a zero array of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Zeros(int,int,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="rows">Number of rows.</param>
+    /// <param name="cols">Number of columns.</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat ZerosMat(int rows, int cols, MatType type)
+    {
+        using var expr = Zeros(rows, cols, type);
+        return (Mat)expr;
+    }
+
+    /// <summary>
+    /// Returns a zero array of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Zeros(Size,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="size">Alternative to the matrix size specification Size(cols, rows).</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat ZerosMat(Size size, MatType type)
+        => ZerosMat(size.Height, size.Width, type);
+
+    /// <summary>
+    /// Returns an array of all 1's of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Ones(int,int,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="rows">Number of rows.</param>
+    /// <param name="cols">Number of columns.</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat OnesMat(int rows, int cols, MatType type)
+    {
+        using var expr = Ones(rows, cols, type);
+        return (Mat)expr;
+    }
+
+    /// <summary>
+    /// Returns an array of all 1's of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Ones(Size,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="size">Alternative to the matrix size specification Size(cols, rows).</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat OnesMat(Size size, MatType type)
+        => OnesMat(size.Height, size.Width, type);
+
+    /// <summary>
+    /// Returns an identity matrix of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Eye(int,int,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="rows">Number of rows.</param>
+    /// <param name="cols">Number of columns.</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat EyeMat(int rows, int cols, MatType type)
+    {
+        using var expr = Eye(rows, cols, type);
+        return (Mat)expr;
+    }
+
+    /// <summary>
+    /// Returns an identity matrix of the specified size and type as <see cref="Mat"/>.
+    /// Unlike <see cref="Eye(Size,MatType)"/>, this method returns a <see cref="Mat"/> directly,
+    /// so a single <c>using</c> statement is sufficient to manage its lifetime.
+    /// </summary>
+    /// <param name="size">Alternative to the matrix size specification Size(cols, rows).</param>
+    /// <param name="type">Created matrix type.</param>
+    /// <returns></returns>
+    public static Mat EyeMat(Size size, MatType type)
+        => EyeMat(size.Height, size.Width, type);
+
     #region FromArray
 
     /// <summary>

--- a/src/OpenCvSharpExtern/calib3d.h
+++ b/src/OpenCvSharpExtern/calib3d.h
@@ -279,9 +279,9 @@ CVAPI(ExceptionStatus) calib3d_initCameraMatrix2D_array(
     std::vector<std::vector<cv::Point3f> > objectPointsVec(opSize1);
     for (auto i = 0; i < opSize1; i++)
         objectPointsVec[i] = std::vector<cv::Point3f>(objectPoints[i], objectPoints[i] + opSize2[i]);
-    std::vector<std::vector<cv::Point3f> > imagePointsVec(ipSize1);
+    std::vector<std::vector<cv::Point2f> > imagePointsVec(ipSize1);
     for (auto i = 0; i < ipSize1; i++)
-        imagePointsVec[i] = std::vector<cv::Point3f>(imagePoints[i], imagePoints[i] + ipSize2[i]);
+        imagePointsVec[i] = std::vector<cv::Point2f>(imagePoints[i], imagePoints[i] + ipSize2[i]);
 
     const auto ret = cv::initCameraMatrix2D(objectPointsVec, imagePointsVec, cpp(imageSize), aspectRatio);
     *returnValue = new cv::Mat(ret);
@@ -509,9 +509,41 @@ CVAPI(ExceptionStatus) calib3d_stereoCalibrate_InputArray(
     double *returnValue)
 {
     BEGIN_WRAP
-    std::vector<cv::_InputArray> objectPointsVec(opSize);
-    std::vector<cv::_InputArray> imagePoints1Vec(ip1Size);
-    std::vector<cv::_InputArray> imagePoints2Vec(ip2Size);
+    std::vector<cv::Mat> objectPointsVec(opSize);
+    std::vector<cv::Mat> imagePoints1Vec(ip1Size);
+    std::vector<cv::Mat> imagePoints2Vec(ip2Size);
+    for (auto i = 0; i < opSize; i++)
+        objectPointsVec[i] = objectPoints[i]->getMat();
+    for (auto i = 0; i < ip1Size; i++)
+        imagePoints1Vec[i] = imagePoints1[i]->getMat();
+    for (auto i = 0; i < ip2Size; i++)
+        imagePoints2Vec[i] = imagePoints2[i]->getMat();
+
+    *returnValue = cv::stereoCalibrate(objectPointsVec, imagePoints1Vec, imagePoints2Vec,
+        *cameraMatrix1, *distCoeffs1,
+        *cameraMatrix2, *distCoeffs2,
+        cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
+    END_WRAP
+}
+CVAPI(ExceptionStatus) calib3d_stereoCalibrate_Mat(
+    cv::Mat **objectPoints, int opSize,
+    cv::Mat **imagePoints1, int ip1Size,
+    cv::Mat **imagePoints2, int ip2Size,
+    cv::Mat *cameraMatrix1,
+    cv::Mat *distCoeffs1,
+    cv::Mat *cameraMatrix2,
+    cv::Mat *distCoeffs2,
+    MyCvSize imageSize,
+    cv::Mat *R, cv::Mat *T,
+    cv::Mat *E, cv::Mat *F,
+    int flags,
+    MyCvTermCriteria criteria,
+    double *returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::Mat> objectPointsVec(opSize);
+    std::vector<cv::Mat> imagePoints1Vec(ip1Size);
+    std::vector<cv::Mat> imagePoints2Vec(ip2Size);
     for (auto i = 0; i < opSize; i++)
         objectPointsVec[i] = *objectPoints[i];
     for (auto i = 0; i < ip1Size; i++)
@@ -522,7 +554,7 @@ CVAPI(ExceptionStatus) calib3d_stereoCalibrate_InputArray(
     *returnValue = cv::stereoCalibrate(objectPointsVec, imagePoints1Vec, imagePoints2Vec,
         *cameraMatrix1, *distCoeffs1,
         *cameraMatrix2, *distCoeffs2,
-        cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
+        cpp(imageSize), *R, *T, *E, *F, flags, cpp(criteria));
     END_WRAP
 }
 CVAPI(ExceptionStatus) calib3d_stereoCalibrate_array(
@@ -659,12 +691,12 @@ CVAPI(ExceptionStatus) calib3d_rectify3Collinear_InputArray(
     float *returnValue)
 {
     BEGIN_WRAP
-    std::vector<cv::_InputArray> imgpt1Vec(imgpt1Size);
-    std::vector<cv::_InputArray> imgpt3Vec(imgpt3Size);
+    std::vector<cv::Mat> imgpt1Vec(imgpt1Size);
+    std::vector<cv::Mat> imgpt3Vec(imgpt3Size);
     for (auto i = 0; i < imgpt1Size; i++)
-        imgpt1Vec[i] = *(imgpt1[i]);
-    for (auto i = 0; i < imgpt1Size; i++)
-        imgpt3Vec[i] = *(imgpt3[i]);
+        imgpt1Vec[i] = imgpt1[i]->getMat();
+    for (auto i = 0; i < imgpt3Size; i++)
+        imgpt3Vec[i] = imgpt3[i]->getMat();
     cv::Rect _roi1, _roi2;
 
     const auto ret = cv::rectify3Collinear(*cameraMatrix1, *distCoeffs1,

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -575,6 +575,72 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         });*/
     }
 
+    [Fact]
+    public void StereoCalibrateByInputArray()
+    {
+        var patternSize = new Size(10, 7);
+
+        using var image = LoadImage("calibration/00.jpg");
+        Cv2.FindChessboardCorners(image, patternSize, out var cornerPoints);
+
+        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
+
+        using var opIA = InputArray.Create(objectPointsArray);
+        using var ip1IA = InputArray.Create(cornerPoints);
+        using var ip2IA = InputArray.Create(cornerPoints);
+
+        using var cameraMatrix1 = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var distCoeffs1 = new Mat<double>();
+        using var cameraMatrix2 = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var distCoeffs2 = new Mat<double>();
+        using var R = new Mat();
+        using var T = new Mat();
+        using var E = new Mat();
+        using var F = new Mat();
+
+        var rms = Cv2.StereoCalibrate(
+            new[] { opIA }, new[] { ip1IA }, new[] { ip2IA },
+            cameraMatrix1, distCoeffs1,
+            cameraMatrix2, distCoeffs2,
+            image.Size(), R, T, E, F,
+            CalibrationFlags.UseIntrinsicGuess);
+
+        Assert.False(double.IsNaN(rms));
+        Assert.False(double.IsInfinity(rms));
+    }
+
+    [Fact]
+    public void StereoCalibrateByMat()
+    {
+        var patternSize = new Size(10, 7);
+
+        using var image = LoadImage("calibration/00.jpg");
+        Cv2.FindChessboardCorners(image, patternSize, out var cornerPoints);
+
+        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
+
+        using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
+        using var imagePoints = Mat<Point2f>.FromArray(cornerPoints);
+        using var cameraMatrix1 = new Mat(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var distCoeffs1 = new Mat();
+        using var cameraMatrix2 = new Mat(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var distCoeffs2 = new Mat();
+        using var R = new Mat();
+        using var T = new Mat();
+        using var E = new Mat();
+        using var F = new Mat();
+
+        var rms = Cv2.StereoCalibrate(
+            new[] { objectPoints }, new[] { imagePoints }, new[] { imagePoints },
+            cameraMatrix1, distCoeffs1,
+            cameraMatrix2, distCoeffs2,
+            image.Size(), R, T, E, F,
+            CalibrationFlags.UseIntrinsicGuess);
+
+        Assert.False(double.IsNaN(rms));
+        Assert.False(double.IsInfinity(rms));
+    }
+
     private static IEnumerable<Point3f> Create3DChessboardCorners(Size boardSize, float squareSize)
     {
         for (var y = 0; y < boardSize.Height; y++)

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -140,7 +140,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
         using var imagePoints = Mat<Point2f>.FromArray(imagePointsArray);
-        using var cameraMatrix = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs = new Mat<double>();
         var rms = Cv2.CalibrateCamera([objectPoints], [imagePoints], image.Size(), cameraMatrix,
             distCoeffs, out var rotationVectors, out var translationVectors,
@@ -165,7 +165,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
         using var imagePoints = Mat<Point2f>.FromArray(imagePointsArray);
-        using var cameraMatrix = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs = new Mat<double>();
         var rms = Cv2.FishEye.Calibrate([objectPoints], [imagePoints], image.Size(), cameraMatrix,
             distCoeffs, out var rotationVectors, out var translationVectors);
@@ -327,8 +327,8 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         using var objPtsMat = Mat.FromPixelData(objPts.Length, 1, MatType.CV_32FC3, objPts);
         using var imgPtsMat = Mat.FromPixelData(imgPts.Length, 1, MatType.CV_32FC2, imgPts);
-        using var cameraMatrixMat = Mat.Eye(3, 3, MatType.CV_64FC1);
-        using var distMat = Mat.Zeros(5, 0, MatType.CV_64FC1);
+        using var cameraMatrixMat = Mat.EyeMat(3, 3, MatType.CV_64FC1);
+        using var distMat = Mat.ZerosMat(5, 0, MatType.CV_64FC1);
         using var rvecMat = new Mat();
         using var tvecMat = new Mat();
         Cv2.SolvePnP(objPtsMat, imgPtsMat, cameraMatrixMat, distMat, rvecMat, tvecMat);
@@ -496,7 +496,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         using var points1m = Mat<double>.FromArray(points1);
         using var points2m = Mat<double>.FromArray(points2);
-        using var K = Mat.Eye(3, 3, MatType.CV_64F);
+        using var K = Mat.EyeMat(3, 3, MatType.CV_64F);
         using var inliers = new Mat();
         using var E = Cv2.FindEssentialMat(points1m, points2m, K, EssentialMatMethod.LMedS, 0.99, 1.0, inliers);
 
@@ -589,9 +589,9 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         using var ip1IA = InputArray.Create(cornerPoints);
         using var ip2IA = InputArray.Create(cornerPoints);
 
-        using var cameraMatrix1 = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix1 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs1 = new Mat<double>();
-        using var cameraMatrix2 = new Mat<double>(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix2 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs2 = new Mat<double>();
         using var R = new Mat();
         using var T = new Mat();
@@ -621,9 +621,9 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
         using var imagePoints = Mat<Point2f>.FromArray(cornerPoints);
-        using var cameraMatrix1 = new Mat(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix1 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs1 = new Mat();
-        using var cameraMatrix2 = new Mat(Mat.Eye(3, 3, MatType.CV_64FC1));
+        using var cameraMatrix2 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
         using var distCoeffs2 = new Mat();
         using var R = new Mat();
         using var T = new Mat();

--- a/test/OpenCvSharp.Tests/shape/HistogramCostExtractorTest.cs
+++ b/test/OpenCvSharp.Tests/shape/HistogramCostExtractorTest.cs
@@ -63,8 +63,8 @@ public class HistogramCostExtractorTest : TestBase
     public void Norm_BuildCostMatrix()
     {
         using var ext = NormHistogramCostExtractor.Create();
-        using var hist1 = Mat.FromArray(new float[] { 0.5f, 0.3f, 0.2f });
-        using var hist2 = Mat.FromArray(new float[] { 0.4f, 0.4f, 0.2f });
+        using var hist1 = Mat.FromArray([0.5f, 0.3f, 0.2f]);
+        using var hist2 = Mat.FromArray([0.4f, 0.4f, 0.2f]);
         using var costMat = new Mat();
 
         ext.BuildCostMatrix(hist1, hist2, costMat);


### PR DESCRIPTION
Fix #1842 

---

This pull request adds new overloads and improves support for stereo calibration in OpenCvSharp, with changes across the native C++ layer, C# P/Invoke bindings, and test coverage. The main focus is on supporting both `InputArray` and `Mat` types for the `StereoCalibrate` function, ensuring better type safety and usability. Additionally, it fixes a minor type issue in camera matrix initialization and updates a test for array initialization syntax.

**Stereo calibration improvements:**

* Added a new native C++ function `calib3d_stereoCalibrate_Mat` to support stereo calibration directly with `cv::Mat` arrays, along with corresponding P/Invoke binding in `NativeMethods_calib3d.cs`. This enables more flexible and type-safe usage from C#. [[1]](diffhunk://#diff-c486668e28206c8ad9f95e0d5f78bdb72d4bb6a8ca94c38cef0f4c3155c88b09L512-R546) [[2]](diffhunk://#diff-b355d9c724ae0eed17a7cb76a8ec2a4c989fe9d10f916bb5cfa207e576a49364R205-R219)
* Refactored the implementation of `calib3d_stereoCalibrate_InputArray` and related functions to use `cv::Mat` instead of `cv::_InputArray` internally, improving compatibility and reducing potential errors. [[1]](diffhunk://#diff-c486668e28206c8ad9f95e0d5f78bdb72d4bb6a8ca94c38cef0f4c3155c88b09L512-R546) [[2]](diffhunk://#diff-c486668e28206c8ad9f95e0d5f78bdb72d4bb6a8ca94c38cef0f4c3155c88b09L662-R699)
* Fixed the usage of output matrix references in the `calib3d_stereoCalibrate_InputArray` function, ensuring correct assignment of results.

**Test coverage:**

* Added two new unit tests, `StereoCalibrateByInputArray` and `StereoCalibrateByMat`, to verify the new overloads and ensure correct behavior for both `InputArray` and `Mat` inputs.

**Other improvements:**

* Fixed a type error in the initialization of `imagePointsVec` in the camera matrix initialization function, changing from `Point3f` to `Point2f`.
* Updated a test to use C# array initializer syntax for `Mat.FromArray` calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fisheye camera model API supporting 3D point projection, point distortion/undistortion, image correction, and single/stereo camera calibration.
  * Added Mat factory methods: `ZerosMat`, `OnesMat`, and `EyeMat` with both row/column and Size-based overloads.
  * Added new `StereoCalibrate` overload accepting Mat-based input collections.

* **Tests**
  * Added stereo calibration test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->