### PR TITLE
Fix linux-arm RID: rename NuGet package to linux-arm64, keep shim for compatibility

### DIFF
--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -1,4 +1,4 @@
-﻿name: Linux ARM
+﻿name: Linux ARM64
 
 on:
   pull_request:
@@ -57,7 +57,7 @@ jobs:
           path: |
             ${{ github.workspace }}/opencv_artifacts/include
             ${{ github.workspace }}/opencv_artifacts/lib
-          key: opencv-arm-v${{ env.CACHE_VERSION }}-${{ env.OPENCV_VERSION }}-${{ hashFiles('cmake/opencv_build_options.cmake', '.github/workflows/linux-arm.yml') }}
+          key: opencv-arm-v${{ env.CACHE_VERSION }}-${{ env.OPENCV_VERSION }}-${{ hashFiles('cmake/opencv_build_options.cmake', '.github/workflows/linux-arm64.yml') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -103,8 +103,8 @@ jobs:
           path: |
             ${{ github.workspace }}/opencv_artifacts/include
             ${{ github.workspace }}/opencv_artifacts/lib
-          key: opencv-arm-v${{ env.CACHE_VERSION }}-${{ env.OPENCV_VERSION }}-${{ hashFiles('cmake/opencv_build_options.cmake', '.github/workflows/linux-arm.yml') }}
-      
+          key: opencv-arm-v${{ env.CACHE_VERSION }}-${{ env.OPENCV_VERSION }}-${{ hashFiles('cmake/opencv_build_options.cmake', '.github/workflows/linux-arm64.yml') }}
+
       - name: Build OpenCvSharpExtern
         run: |
           cmake \
@@ -132,23 +132,24 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Create NuGet package
-        env: 
+        env:
           BETA: "-beta"
         run: |
           yyyymmdd=`date '+%Y%m%d'`
           echo $yyyymmdd
           version="${OPENCV_VERSION}.${yyyymmdd}${BETA}"
           echo "Package version: $version"
-          
+
           cd ${GITHUB_WORKSPACE}
-          dotnet pack nuget/OpenCvSharp4.runtime.linux-arm.csproj -o ${GITHUB_WORKSPACE}/artifacts_arm -p:Version=$version
-          
-          ls ${GITHUB_WORKSPACE}/artifacts_arm
+          dotnet pack nuget/OpenCvSharp4.runtime.linux-arm64.csproj -o ${GITHUB_WORKSPACE}/artifacts_arm64 -p:Version=$version
+          dotnet pack nuget/OpenCvSharp4.runtime.linux-arm.csproj  -o ${GITHUB_WORKSPACE}/artifacts_arm64 -p:Version=$version
+
+          ls ${GITHUB_WORKSPACE}/artifacts_arm64
 
       - uses: actions/upload-artifact@v6
         with:
-          name: artifacts_linux_arm
-          path: artifacts_arm
+          name: artifacts_linux_arm64
+          path: artifacts_arm64
         
       - name: Test
         run: |

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -142,7 +142,7 @@ jobs:
 
           cd ${GITHUB_WORKSPACE}
           dotnet pack nuget/OpenCvSharp4.runtime.linux-arm64.csproj -o ${GITHUB_WORKSPACE}/artifacts_arm64 -p:Version=$version
-          dotnet pack nuget/OpenCvSharp4.runtime.linux-arm.csproj  -o ${GITHUB_WORKSPACE}/artifacts_arm64 -p:Version=$version
+          dotnet pack nuget/OpenCvSharp4.runtime.linux-arm.csproj  -o ${GITHUB_WORKSPACE}/artifacts_arm64 -p:Version=$version --no-restore
 
           ls ${GITHUB_WORKSPACE}/artifacts_arm64
 

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -18,12 +18,12 @@ jobs:
           name: packages_windows
           branch: ${{ github.ref_name }}
 
-      - name: Download ubuntu arm artifact
+      - name: Download ubuntu arm64 artifact
         uses: dawidd6/action-download-artifact@v19
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: linux-arm.yml
-          name: artifacts_linux_arm
+          workflow: linux-arm64.yml
+          name: artifacts_linux_arm64
           branch: ${{ github.ref_name }}
 
       #- name: Download macos artifact

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ http://shimat.github.io/opencvsharp/api/OpenCvSharp.html
 |**[OpenCvSharp4.runtime.win.slim](https://www.nuget.org/packages/OpenCvSharp4.runtime.win.slim/)**| Slim native bindings for Windows x64 (except UWP), with `core,imgproc,imgcodecs,calib3d,features2d,flann,objdetect,photo,ml,video,stitching,barcode` enabled |
 |**[OpenCvSharp4.official.runtime.linux-x64](https://www.nuget.org/packages/OpenCvSharp4.official.runtime.linux-x64/)**| Native bindings for Linux x64 (portable RID, recommended). Built on manylinux_2_28. Includes FFmpeg and Tesseract statically linked. Requires GTK3 runtime (`libgtk-3.so.0`) for highgui (`Cv2.ImShow` etc.). |
 |**[OpenCvSharp4.official.runtime.linux-x64.slim](https://www.nuget.org/packages/OpenCvSharp4.official.runtime.linux-x64.slim/)**| Slim native bindings for Linux x64 (portable RID), with `core,imgproc,imgcodecs,calib3d,features2d,flann,objdetect,photo,ml,video,stitching,barcode` enabled. No external runtime dependencies. |
-|**[OpenCvSharp4.runtime.linux-arm](https://www.nuget.org/packages/OpenCvSharp4.runtime.linux-arm/)**| Native bindings for Linux Arm |
+|**[OpenCvSharp4.runtime.linux-arm64](https://www.nuget.org/packages/OpenCvSharp4.runtime.linux-arm64/)**| Native bindings for Linux ARM64 (AArch64) |
+|**[OpenCvSharp4.runtime.linux-arm](https://www.nuget.org/packages/OpenCvSharp4.runtime.linux-arm/)**| **Deprecated.** Compatibility shim for `OpenCvSharp4.runtime.linux-arm64`. |
 |**[OpenCvSharp4.runtime.wasm](https://www.nuget.org/packages/OpenCvSharp4.runtime.wasm/)**| Native bindings for WebAssembly |
 
 > **Note:** Windows x86 (32-bit) support has been dropped as of the OpenCV 4.13.0 release series.

--- a/nuget/OpenCvSharp4.runtime.linux-arm64.csproj
+++ b/nuget/OpenCvSharp4.runtime.linux-arm64.csproj
@@ -5,14 +5,14 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <!-- NuGet Package Metadata -->
-    <PackageId>OpenCvSharp4.runtime.linux-arm</PackageId>
-    <Title>OpenCvSharp native bindings for linux-arm (deprecated shim)</Title>
+    <PackageId>OpenCvSharp4.runtime.linux-arm64</PackageId>
+    <Title>OpenCvSharp native bindings for linux-arm64</Title>
     <Authors>shimat</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/shimat/opencvsharp</PackageProjectUrl>
     <PackageIcon>opencvsharp.png</PackageIcon>
-    <Description>This package has been renamed to OpenCvSharp4.runtime.linux-arm64. This is a compatibility shim that automatically pulls in the renamed package.</Description>
-    <PackageTags>Image Processing OpenCV Wrapper FFI opencvsharp linux arm arm64</PackageTags>
+    <Description>Internal implementation package for OpenCvSharp to work on Linux ARM64 (AArch64)</Description>
+    <PackageTags>Image Processing OpenCV Wrapper FFI opencvsharp linux arm64 aarch64</PackageTags>
     <Copyright>Copyright 2008-2026</Copyright>
     <PackageReleaseNotes></PackageReleaseNotes>
     <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
@@ -22,12 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="libOpenCvSharpExtern.so" Pack="true" PackagePath="runtimes/linux-arm64/native/" />
     <None Include="icon/opencvsharp.png" Pack="true" PackagePath="" />
     <None Include="README.runtime.md" Pack="true" PackagePath="" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Shim: depends on the renamed package so existing references continue to work -->
-    <PackageReference Include="OpenCvSharp4.runtime.linux-arm64" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/nuget/README.runtime.md
+++ b/nuget/README.runtime.md
@@ -27,7 +27,6 @@ The Linux `linux-x64` packages are built on **manylinux_2_28** (glibc 2.28) and 
 | `OpenCvSharp4.runtime.osx.10.15-x64` | macOS 10.15+ x64 |
 
 > **Note:** `OpenCvSharp4.official.runtime.ubuntu.22.04-x64`, `ubuntu.22.04-x64.slim`, `ubuntu.24.04-x64`, and `ubuntu.24.04-x64.slim` are **deprecated**. Migrate to the portable `linux-x64` packages.
-
 > **Note:** `OpenCvSharp4.runtime.linux-arm` has been renamed to `OpenCvSharp4.runtime.linux-arm64` to correctly reflect the ARM64 (AArch64) RID. The old package is kept as a compatibility shim that automatically pulls in the renamed package, but new projects should reference `OpenCvSharp4.runtime.linux-arm64` directly.
 
 ## Slim Profile

--- a/nuget/README.runtime.md
+++ b/nuget/README.runtime.md
@@ -22,10 +22,13 @@ The Linux `linux-x64` packages are built on **manylinux_2_28** (glibc 2.28) and 
 | `OpenCvSharp4.runtime.win.slim` | Windows x64 (slim) |
 | `OpenCvSharp4.official.runtime.linux-x64` | Linux x64 (portable, manylinux_2_28) |
 | `OpenCvSharp4.official.runtime.linux-x64.slim` | Linux x64 (portable, manylinux_2_28, slim) |
-| `OpenCvSharp4.runtime.linux-arm` | Linux ARM |
+| `OpenCvSharp4.runtime.linux-arm64` | Linux ARM64 (AArch64) |
+| `OpenCvSharp4.runtime.linux-arm` | Linux ARM64 — **deprecated**, use `linux-arm64` |
 | `OpenCvSharp4.runtime.osx.10.15-x64` | macOS 10.15+ x64 |
 
 > **Note:** `OpenCvSharp4.official.runtime.ubuntu.22.04-x64`, `ubuntu.22.04-x64.slim`, `ubuntu.24.04-x64`, and `ubuntu.24.04-x64.slim` are **deprecated**. Migrate to the portable `linux-x64` packages.
+
+> **Note:** `OpenCvSharp4.runtime.linux-arm` has been renamed to `OpenCvSharp4.runtime.linux-arm64` to correctly reflect the ARM64 (AArch64) RID. The old package is kept as a compatibility shim that automatically pulls in the renamed package, but new projects should reference `OpenCvSharp4.runtime.linux-arm64` directly.
 
 ## Slim Profile
 


### PR DESCRIPTION
## Summary

Fixes #1870.

The `OpenCvSharp4.runtime.linux-arm` NuGet package placed native binaries under
`runtimes/linux-arm/native/`, but the CI has always built on ARM64 hardware
(`ubuntu-24.04-arm`) and tested with `--runtime linux-arm64`. In the .NET RID graph,
`linux-arm` (32-bit ARMv7) and `linux-arm64` (64-bit AArch64) are **siblings, not
parent/child**, so .NET never automatically resolves `runtimes/linux-arm/native/` when
running on `linux-arm64` targets — the native library was silently not copied.

## Changes

- **`nuget/OpenCvSharp4.runtime.linux-arm64.csproj`** — New package with the correct `runtimes/linux-arm64/native/` path.
- **`nuget/OpenCvSharp4.runtime.linux-arm.csproj`** — Converted to a compatibility shim: native `.so` removed, replaced with a `PackageReference` dependency on `linux-arm64`. Existing users who reference the old package name will automatically get the real library.
- **`.github/workflows/linux-arm.yml` → `linux-arm64.yml`** — Renamed and updated to pack both the new `linux-arm64` package and the shim. Artifact name changed to `artifacts_linux_arm64`.
- **`.github/workflows/publish_nuget.yml`** — Updated workflow and artifact references.
- **`nuget/README.runtime.md`** / **`README.md`** — Package table updated; deprecation note added for `linux-arm`.

## Reviewer notes

- The shim package carries a minimum-version dependency on `linux-arm64` at the same version, so existing projects require no code changes — NuGet will resolve the correct native library automatically.
- The OpenCV cache key in the workflow now hashes `linux-arm64.yml` instead of `linux-arm.yml`; the existing cache will be invalidated once on the first run after merge, which is expected and harmless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native runtime support for Linux ARM64 (AArch64).

* **Documentation**
  * Announced the new Linux ARM64 runtime package and clarified that the prior Linux ARM package is retained as a deprecated compatibility shim redirecting to the ARM64 package; guidance updated to reference the ARM64 package for new projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->