### PR TITLE
Enable libjpeg-turbo jpeg7 feature to fix IMWRITE_JPEG_LUMA/CHROMA_QUALITY (fixes #1869)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,10 @@
     "tesseract",
     "zlib",
     "libpng",
-    "libjpeg-turbo",
+    {
+      "name": "libjpeg-turbo",
+      "features": ["jpeg7"]
+    },
     "tiff",
     "libwebp"
   ],


### PR DESCRIPTION
## Summary

- Adds the `jpeg7` feature to the `libjpeg-turbo` vcpkg dependency so that `JPEG_LIB_VERSION` is 70 on Windows and manylinux-full builds
- Resolves the warning `IMWRITE_JPEG_LUMA/CHROMA_QUALITY are not supported because JPEG_LIB_VERSION < 70`
- `ImwriteFlags.JpegLumaQuality` and `ImwriteFlags.JpegChromaQuality` now work as expected on all platforms

## Root cause

OpenCV's JPEG support comes from two different sources depending on platform:

| Platform | JPEG source | `JPEG_LIB_VERSION` before | after |
|---|---|---|---|
| Windows x64, manylinux-full | vcpkg `libjpeg-turbo` | **62** (6b compat default) | **70** |
| Linux Docker, ARM, manylinux-slim | OpenCV bundled `libjpeg-turbo` | 70 (hardcoded in `3rdparty/libjpeg-turbo/CMakeLists.txt:137`) | unchanged |
| WASM | `WITH_JPEG=OFF` | N/A | N/A |

The vcpkg port for `libjpeg-turbo` already exposes a `jpeg7` feature (`-DWITH_JPEG7=ON`). This PR opts in to that feature.

## Notes

- The `jpeg7` feature changes the libjpeg ABI (incompatible with libjpeg 6b). Since all libraries are statically linked here, this has no impact on end users.
- The vcpkg CI cache will be invalidated once and rebuilt automatically.
- No source code changes — only `vcpkg.json`.

Fixes #1869