### PR TITLE
Migrate ArUco API to OpenCV 4.7+ detector-class design

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_aruco.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_aruco.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using OpenCvSharp.Aruco;
 
 #pragma warning disable 1591
@@ -10,24 +10,14 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus aruco_detectMarkers(
-        IntPtr image, IntPtr dictionary, IntPtr corners, IntPtr ids, ref DetectorParameters detectParameters, IntPtr outrejectedImgPoints);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_drawDetectedMarkers(
-        IntPtr image, 
-        [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2, 
+        IntPtr image,
+        [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2,
         [MarshalAs(UnmanagedType.LPArray)] int[] ids, int idxLength, Scalar borderColor);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_drawDetectedMarkers(
         IntPtr image, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2, IntPtr ids, int idxLength, Scalar borderColor);
-    
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus aruco_estimatePoseSingleMarkers(
-        [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornersLength1, 
-        int[] cornersLengths2, float markerLength, 
-        IntPtr cameraMatrix, IntPtr distCoeffs, IntPtr rvecs, IntPtr tvecs, IntPtr objPoints);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_getPredefinedDictionary(int name, out IntPtr returnValue);
@@ -36,40 +26,104 @@ static partial class NativeMethods
     public static extern ExceptionStatus aruco_readDictionary(string dictionaryFile, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus aruco_detectCharucoDiamond(
-        IntPtr image, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] markerCorners, int markerCornersSize1, int[] markerCornersSize2,
-        IntPtr markerIds, float squareMarkerLengthRate,
-        IntPtr diamondCorners, IntPtr diamondIds, IntPtr cameraMatrix, IntPtr distCoeffs);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_drawDetectedDiamonds(
         IntPtr image,
         [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2,
         IntPtr ids, Scalar borderColor);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus aruco_detectCharucoBoard(
-        IntPtr image,
-        int squaresX, int squaresY, float squareLength, float markerLength, int arucoDictId,
-        IntPtr charucoCorners, IntPtr charucoIds, IntPtr markerCorners, IntPtr markerIds);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus aruco_interpolateCornersCharuco(
-        IntPtr image,
-        int squaresX, int squaresY, float squareLength, float markerLength, int arucoDictId,
-        [MarshalAs(UnmanagedType.LPArray)] IntPtr[] markerCorners, int markerCornersSize1, int[] markerCornersSize2, IntPtr markerIds,
-        IntPtr charucoCorners, IntPtr charucoIds);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_drawDetectedCornersCharuco(
         IntPtr image,
         IntPtr corners, IntPtr ids, Scalar cornerColor);
+
+    #region ArucoDetector
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_ArucoDetector_create(
+        IntPtr dictionary, ref DetectorParameters detectorParams, ref RefineParameters refineParams, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_ArucoDetector_delete(IntPtr ptr);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_ArucoDetector_detectMarkers(
+        IntPtr detector, IntPtr image, IntPtr corners, IntPtr ids, IntPtr rejectedImgPoints);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_ArucoDetector_refineDetectedMarkers(
+        IntPtr detector, IntPtr image, IntPtr board,
+        IntPtr detectedCorners, IntPtr detectedIds, IntPtr rejectedCorners,
+        IntPtr cameraMatrix, IntPtr distCoeffs, IntPtr recoveredIdxs);
+
+    #endregion
+
+    #region CharucoBoard
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_create(
+        int squaresX, int squaresY, float squareLength, float markerLength, IntPtr dictionary, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_delete(IntPtr ptr);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_getChessboardSize(IntPtr ptr, out Size returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_getSquareLength(IntPtr ptr, out float returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_getMarkerLength(IntPtr ptr, out float returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_setLegacyPattern(IntPtr ptr, int value);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_getLegacyPattern(IntPtr ptr, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_generateImage(
+        IntPtr ptr, Size outSize, IntPtr img, int marginSize, int borderBits);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoBoard_checkCharucoCornersCollinear(
+        IntPtr ptr, IntPtr charucoIds, out int returnValue);
+
+    #endregion
+
+    #region CharucoDetector
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoDetector_create(
+        IntPtr board, IntPtr cameraMatrix, IntPtr distCoeffs,
+        int minMarkers,
+        [MarshalAs(UnmanagedType.U1)] bool tryRefineMarkers,
+        [MarshalAs(UnmanagedType.U1)] bool checkMarkers,
+        ref DetectorParameters detectorParams, ref RefineParameters refineParams,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoDetector_delete(IntPtr ptr);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoDetector_detectBoard(
+        IntPtr detector, IntPtr image,
+        IntPtr charucoCorners, IntPtr charucoIds,
+        IntPtr markerCorners, IntPtr markerIds);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus aruco_CharucoDetector_detectDiamonds(
+        IntPtr detector, IntPtr image,
+        IntPtr diamondCorners, IntPtr diamondIds,
+        IntPtr markerCorners, IntPtr markerIds);
+
+    #endregion
 
     #region Dictionary
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_Dictionary_delete(IntPtr ptr);
-    
+
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus aruco_Dictionary_setMarkerSize(IntPtr obj, int value);
 

--- a/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
@@ -1,0 +1,63 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Aruco;
+
+/// <summary>
+/// The main functionality of ArucoDetector class is detection of markers in an image with detectMarkers() method.
+/// </summary>
+public class ArucoDetector : CvObject
+{
+    /// <summary>
+    /// Creates ArucoDetector with default parameters.
+    /// </summary>
+    public ArucoDetector(Dictionary dictionary)
+        : this(dictionary, new DetectorParameters(), new RefineParameters())
+    {
+    }
+
+    /// <summary>
+    /// Creates ArucoDetector.
+    /// </summary>
+    public ArucoDetector(Dictionary dictionary, DetectorParameters detectorParams, RefineParameters refineParams)
+    {
+        if (dictionary is null)
+            throw new ArgumentNullException(nameof(dictionary));
+        dictionary.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_ArucoDetector_create(dictionary.CvPtr, ref detectorParams, ref refineParams, out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static h => NativeMethods.HandleException(NativeMethods.aruco_ArucoDetector_delete(h))));
+        GC.KeepAlive(dictionary);
+    }
+
+    /// <summary>
+    /// Basic marker detection.
+    /// </summary>
+    public void DetectMarkers(
+        InputArray image,
+        out Point2f[][] corners,
+        out int[] ids,
+        out Point2f[][] rejectedImgPoints)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        ThrowIfDisposed();
+
+        using var cornersVec = new VectorOfVectorPoint2f();
+        using var idsVec = new VectorOfInt32();
+        using var rejectedVec = new VectorOfVectorPoint2f();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_ArucoDetector_detectMarkers(
+                CvPtr, image.CvPtr, cornersVec.CvPtr, idsVec.CvPtr, rejectedVec.CvPtr));
+
+        corners = cornersVec.ToArray();
+        ids = idsVec.ToArray();
+        rejectedImgPoints = rejectedVec.ToArray();
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+    }
+}

--- a/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
@@ -1,0 +1,136 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Aruco;
+
+/// <summary>
+/// ChArUco board — a planar chessboard where the markers are placed inside the white squares.
+/// </summary>
+public class CharucoBoard : CvObject
+{
+    /// <summary>
+    /// Creates a CharucoBoard.
+    /// </summary>
+    /// <param name="squaresX">number of chessboard squares in x direction</param>
+    /// <param name="squaresY">number of chessboard squares in y direction</param>
+    /// <param name="squareLength">chessboard square side length (normally in meters)</param>
+    /// <param name="markerLength">marker side length (same unit as squareLength)</param>
+    /// <param name="dictionary">dictionary of markers</param>
+    public CharucoBoard(int squaresX, int squaresY, float squareLength, float markerLength, Dictionary dictionary)
+    {
+        if (dictionary is null)
+            throw new ArgumentNullException(nameof(dictionary));
+        dictionary.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoBoard_create(squaresX, squaresY, squareLength, markerLength, dictionary.CvPtr, out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static h => NativeMethods.HandleException(NativeMethods.aruco_CharucoBoard_delete(h))));
+        GC.KeepAlive(dictionary);
+    }
+
+    internal CharucoBoard(IntPtr ptr)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static h => NativeMethods.HandleException(NativeMethods.aruco_CharucoBoard_delete(h))));
+    }
+
+    /// <summary>
+    /// Gets the number of chessboard squares in x and y directions.
+    /// </summary>
+    public Size ChessboardSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.aruco_CharucoBoard_getChessboardSize(CvPtr, out var size));
+            GC.KeepAlive(this);
+            return size;
+        }
+    }
+
+    /// <summary>
+    /// Gets the chessboard square side length.
+    /// </summary>
+    public float SquareLength
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.aruco_CharucoBoard_getSquareLength(CvPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+    }
+
+    /// <summary>
+    /// Gets the marker side length.
+    /// </summary>
+    public float MarkerLength
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.aruco_CharucoBoard_getMarkerLength(CvPtr, out var val));
+            GC.KeepAlive(this);
+            return val;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the legacy pattern mode for compatibility with patterns created before OpenCV 4.6.
+    /// </summary>
+    public bool LegacyPattern
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.aruco_CharucoBoard_getLegacyPattern(CvPtr, out var val));
+            GC.KeepAlive(this);
+            return val != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.aruco_CharucoBoard_setLegacyPattern(CvPtr, value ? 1 : 0));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Generate the board image.
+    /// </summary>
+    public void GenerateImage(Size outSize, OutputArray img, int marginSize = 0, int borderBits = 1)
+    {
+        if (img is null)
+            throw new ArgumentNullException(nameof(img));
+        img.ThrowIfNotReady();
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoBoard_generateImage(CvPtr, outSize, img.CvPtr, marginSize, borderBits));
+        img.Fix();
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Check whether the ChArUco markers are collinear.
+    /// </summary>
+    public bool CheckCharucoCornersCollinear(InputArray charucoIds)
+    {
+        if (charucoIds is null)
+            throw new ArgumentNullException(nameof(charucoIds));
+        charucoIds.ThrowIfDisposed();
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoBoard_checkCharucoCornersCollinear(CvPtr, charucoIds.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        GC.KeepAlive(charucoIds);
+        return ret != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
@@ -1,0 +1,125 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Aruco;
+
+/// <summary>
+/// CharucoDetector detects ChArUco board corners and diamond markers.
+/// </summary>
+public class CharucoDetector : CvObject
+{
+    /// <summary>
+    /// Creates CharucoDetector with default parameters.
+    /// </summary>
+    public CharucoDetector(CharucoBoard board)
+        : this(board, null, null, 2, false, true, new DetectorParameters(), new RefineParameters())
+    {
+    }
+
+    /// <summary>
+    /// Creates CharucoDetector.
+    /// </summary>
+    public CharucoDetector(
+        CharucoBoard board,
+        InputArray? cameraMatrix,
+        InputArray? distCoeffs,
+        int minMarkers = 2,
+        bool tryRefineMarkers = false,
+        bool checkMarkers = true,
+        DetectorParameters? detectorParams = null,
+        RefineParameters? refineParams = null)
+    {
+        if (board is null)
+            throw new ArgumentNullException(nameof(board));
+        board.ThrowIfDisposed();
+        if (cameraMatrix is null != distCoeffs is null)
+            throw new ArgumentException("cameraMatrix and distCoeffs must both be null or both non-null.");
+
+        var dp = detectorParams ?? new DetectorParameters();
+        var rp = refineParams ?? new RefineParameters();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoDetector_create(
+                board.CvPtr,
+                cameraMatrix?.CvPtr ?? IntPtr.Zero,
+                distCoeffs?.CvPtr ?? IntPtr.Zero,
+                minMarkers, tryRefineMarkers, checkMarkers,
+                ref dp, ref rp,
+                out var ptr));
+
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static h => NativeMethods.HandleException(NativeMethods.aruco_CharucoDetector_delete(h))));
+
+        GC.KeepAlive(board);
+        GC.KeepAlive(cameraMatrix);
+        GC.KeepAlive(distCoeffs);
+    }
+
+    /// <summary>
+    /// Detect aruco markers and interpolate position of ChArUco board corners.
+    /// </summary>
+    public void DetectBoard(
+        InputArray image,
+        out Point2f[] charucoCorners,
+        out int[] charucoIds,
+        out Point2f[][] markerCorners,
+        out int[] markerIds)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        ThrowIfDisposed();
+
+        using var charucoCornersVec = new VectorOfPoint2f();
+        using var charucoIdsVec = new VectorOfInt32();
+        using var markerCornersVec = new VectorOfVectorPoint2f();
+        using var markerIdsVec = new VectorOfInt32();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoDetector_detectBoard(
+                CvPtr, image.CvPtr,
+                charucoCornersVec.CvPtr, charucoIdsVec.CvPtr,
+                markerCornersVec.CvPtr, markerIdsVec.CvPtr));
+
+        charucoCorners = charucoCornersVec.ToArray();
+        charucoIds = charucoIdsVec.ToArray();
+        markerCorners = markerCornersVec.ToArray();
+        markerIds = markerIdsVec.ToArray();
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+    }
+
+    /// <summary>
+    /// Detect ChArUco Diamond markers.
+    /// </summary>
+    public void DetectDiamonds(
+        InputArray image,
+        out Point2f[][] diamondCorners,
+        out Vec4i[] diamondIds,
+        out Point2f[][] markerCorners,
+        out int[] markerIds)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        ThrowIfDisposed();
+
+        using var diamondCornersVec = new VectorOfVectorPoint2f();
+        using var diamondIdsVec = new VectorOfVec4i();
+        using var markerCornersVec = new VectorOfVectorPoint2f();
+        using var markerIdsVec = new VectorOfInt32();
+
+        NativeMethods.HandleException(
+            NativeMethods.aruco_CharucoDetector_detectDiamonds(
+                CvPtr, image.CvPtr,
+                diamondCornersVec.CvPtr, diamondIdsVec.CvPtr,
+                markerCornersVec.CvPtr, markerIdsVec.CvPtr));
+
+        diamondCorners = diamondCornersVec.ToArray();
+        diamondIds = diamondIdsVec.ToArray();
+        markerCorners = markerCornersVec.ToArray();
+        markerIds = markerIdsVec.ToArray();
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(image);
+    }
+}

--- a/src/OpenCvSharp/Modules/aruco/CvAruco.cs
+++ b/src/OpenCvSharp/Modules/aruco/CvAruco.cs
@@ -1,4 +1,4 @@
-﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Util;
 using OpenCvSharp.Internal.Vectors;
 
@@ -10,113 +10,10 @@ namespace OpenCvSharp.Aruco;
 public static class CvAruco
 {
     /// <summary>
-    /// Basic marker detection
-    /// </summary>
-    /// <param name="image">input image</param>
-    /// <param name="dictionary">indicates the type of markers that will be searched</param>
-    /// <param name="corners">vector of detected marker corners. 
-    /// For each marker, its four corners are provided. For N detected markers,
-    ///  the dimensions of this array is Nx4.The order of the corners is clockwise.</param>
-    /// <param name="ids">vector of identifiers of the detected markers. The identifier is of type int. 
-    /// For N detected markers, the size of ids is also N. The identifiers have the same order than the markers in the imgPoints array.</param>
-    /// <param name="parameters">marker detection parameters</param>
-    /// <param name="rejectedImgPoints">contains the imgPoints of those squares whose inner code has not a 
-    /// correct codification.Useful for debugging purposes.</param>
-    public static void DetectMarkers(
-        InputArray image,
-        Dictionary dictionary, 
-        out Point2f[][] corners,
-        out int[] ids, 
-        DetectorParameters parameters, 
-        out Point2f[][] rejectedImgPoints)
-    {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-        if (dictionary is null)
-            throw new ArgumentNullException(nameof(dictionary));
-        dictionary.ThrowIfDisposed();
-
-        using var cornersVec = new VectorOfVectorPoint2f();
-        using var idsVec = new VectorOfInt32();
-        using var rejectedImgPointsVec = new VectorOfVectorPoint2f();
-
-        NativeMethods.HandleException(
-            NativeMethods.aruco_detectMarkers(
-                image.CvPtr, dictionary.CvPtr, cornersVec.CvPtr, idsVec.CvPtr, ref parameters,
-                rejectedImgPointsVec.CvPtr));
-
-        corners = cornersVec.ToArray();
-        ids = idsVec.ToArray();
-        rejectedImgPoints = rejectedImgPointsVec.ToArray();
-
-        GC.KeepAlive(image);
-        GC.KeepAlive(dictionary);
-        GC.KeepAlive(parameters);
-    }
-
-    /// <summary>
-    /// Pose estimation for single markers
-    /// </summary>
-    /// <param name="corners">corners vector of already detected markers corners. 
-    /// For each marker, its four corners are provided, (e.g std::vector&lt;std::vector&lt;cv::Point2f&gt;&gt; ). 
-    /// For N detected markers, the dimensions of this array should be Nx4. The order of the corners should be clockwise.</param>
-    /// <param name="markerLength">the length of the markers' side. The returning translation vectors will 
-    /// be in the same unit.Normally, unit is meters.</param>
-    /// <param name="cameraMatrix">input 3x3 floating-point camera matrix 
-    /// \f$A = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$</param>
-    /// <param name="distortionCoefficients">vector of distortion coefficients 
-    /// \f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements</param>
-    /// <param name="rvec">array of output rotation vectors (@sa Rodrigues) (e.g. std::vector&lt;cv::Vec3d&gt;). 
-    /// Each element in rvecs corresponds to the specific marker in imgPoints.</param>
-    /// <param name="tvec">array of output translation vectors (e.g. std::vector&lt;cv::Vec3d&gt;).
-    /// Each element in tvecs corresponds to the specific marker in imgPoints.</param>
-    /// <param name="objPoints">array of object points of all the marker corners</param>
-    public static void EstimatePoseSingleMarkers(
-        Point2f[][] corners,
-        float markerLength, 
-        InputArray cameraMatrix,
-        InputArray distortionCoefficients,
-        OutputArray rvec, 
-        OutputArray tvec,
-        OutputArray? objPoints = null)
-    {
-        if (corners is null)
-            throw new ArgumentNullException(nameof(corners));
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
-        if (distortionCoefficients is null)
-            throw new ArgumentNullException(nameof(distortionCoefficients));
-        if (rvec is null)
-            throw new ArgumentNullException(nameof(rvec));
-        if (tvec is null)
-            throw new ArgumentNullException(nameof(tvec));
-
-        cameraMatrix.ThrowIfDisposed();
-        distortionCoefficients.ThrowIfDisposed();
-        rvec.ThrowIfNotReady();
-        tvec.ThrowIfNotReady();
-        objPoints?.ThrowIfNotReady();
-
-        using var cornersAddress = new ArrayAddress2<Point2f>(corners);
-
-        NativeMethods.HandleException(
-            NativeMethods.aruco_estimatePoseSingleMarkers(
-                cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
-                markerLength, cameraMatrix.CvPtr, distortionCoefficients.CvPtr, rvec.CvPtr, tvec.CvPtr,
-                objPoints?.CvPtr ?? IntPtr.Zero));
-
-        GC.KeepAlive(cameraMatrix);
-        GC.KeepAlive(distortionCoefficients);
-        rvec.Fix();
-        tvec.Fix();
-        objPoints?.Fix();
-    }
-
-    /// <summary>
     /// Draw detected markers in image
     /// </summary>
     /// <param name="image">input/output image. It must have 1 or 3 channels. The number of channels is not altered.</param>
-    /// <param name="corners">positions of marker corners on input image. 
+    /// <param name="corners">positions of marker corners on input image.
     /// For N detected markers, the dimensions of this array should be Nx4.The order of the corners should be clockwise.</param>
     /// <param name="ids">vector of identifiers for markers in markersCorners. Optional, if not provided, ids are not painted.</param>
     public static void DrawDetectedMarkers(InputArray image, Point2f[][] corners, IEnumerable<int> ids)
@@ -128,7 +25,7 @@ public static class CvAruco
     /// Draw detected markers in image
     /// </summary>
     /// <param name="image">input/output image. It must have 1 or 3 channels. The number of channels is not altered.</param>
-    /// <param name="corners">positions of marker corners on input image. 
+    /// <param name="corners">positions of marker corners on input image.
     /// For N detected markers, the dimensions of this array should be Nx4.The order of the corners should be clockwise.</param>
     /// <param name="ids">vector of identifiers for markers in markersCorners. Optional, if not provided, ids are not painted.</param>
     /// <param name="borderColor">color of marker borders. Rest of colors (text color and first corner color)
@@ -158,7 +55,7 @@ public static class CvAruco
         }
         GC.KeepAlive(image);
     }
-    
+
     /// <summary>
     /// Returns one of the predefined dictionaries defined in PREDEFINED_DICTIONARY_NAME
     /// </summary>
@@ -192,61 +89,6 @@ public static class CvAruco
         NativeMethods.HandleException(
             NativeMethods.aruco_readDictionary(dictionaryFile, out IntPtr p));
         return new Dictionary(p);
-    }
-
-    /// <summary>
-    /// Detect ChArUco Diamond markers.
-    /// </summary>
-    /// <param name="image">input image necessary for corner subpixel.</param>
-    /// <param name="markerCorners">list of detected marker corners from detectMarkers function.</param>
-    /// <param name="markerIds">list of marker ids in markerCorners.</param>
-    /// <param name="squareMarkerLengthRate">rate between square and marker length: squareMarkerLengthRate = squareLength/markerLength. The real units are not necessary.</param>
-    /// <param name="diamondCorners">output list of detected diamond corners (4 corners per diamond). The order is the same than in marker corners: top left, top right, bottom right and bottom left. Similar format than the corners returned by detectMarkers (e.g std::vector&lt;std::vector&lt;cv::Point2f&gt;&gt;).</param>
-    /// <param name="diamondIds">ids of the diamonds in diamondCorners. The id of each diamond is in fact of type Vec4i, so each diamond has 4 ids, which are the ids of the aruco markers composing the diamond.</param>
-    /// <param name="cameraMatrix">Optional camera calibration matrix.</param>
-    /// <param name="distCoeffs">Optional camera distortion coefficients.</param>
-    public static void DetectCharucoDiamond(InputArray image, Point2f[][] markerCorners, IEnumerable<int> markerIds,
-        float squareMarkerLengthRate, out Point2f[][] diamondCorners, out Vec4i[] diamondIds,
-        InputArray? cameraMatrix = null, InputArray? distCoeffs = null)
-    {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-        if (markerCorners is null)
-            throw new ArgumentNullException(nameof(markerCorners));
-        if (markerIds is null)
-            throw new ArgumentNullException(nameof(markerIds));
-
-        if (cameraMatrix is null && distCoeffs is not null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
-        if (cameraMatrix is not null && distCoeffs is null)
-            throw new ArgumentNullException(nameof(distCoeffs));
-
-        image.ThrowIfDisposed();
-
-        cameraMatrix?.ThrowIfDisposed();
-        distCoeffs?.ThrowIfDisposed();
-
-        using var markerCornersAddress = new ArrayAddress2<Point2f>(markerCorners);
-        using var markerIdsVec = new VectorOfInt32(markerIds);
-
-        using var diamondCornersVec = new VectorOfVectorPoint2f();
-        using var diamondIdsVec = new VectorOfVec4i();
-
-        NativeMethods.HandleException(
-            NativeMethods.aruco_detectCharucoDiamond(
-                image.CvPtr, markerCornersAddress.GetPointer(), markerCornersAddress.GetDim1Length(), markerCornersAddress.GetDim2Lengths(),
-                markerIdsVec.CvPtr, squareMarkerLengthRate,
-                diamondCornersVec.CvPtr, diamondIdsVec.CvPtr,
-                cameraMatrix?.CvPtr ?? IntPtr.Zero, distCoeffs?.CvPtr ?? IntPtr.Zero));
-
-        diamondCorners = diamondCornersVec.ToArray();
-        diamondIds = diamondIdsVec.ToArray();
-
-        GC.KeepAlive(image);
-        if (cameraMatrix is not null)
-            GC.KeepAlive(cameraMatrix);
-        if (distCoeffs is not null)
-            GC.KeepAlive(distCoeffs);
     }
 
     /// <summary>
@@ -293,93 +135,6 @@ public static class CvAruco
                     cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
                     ids.CvPtr, borderColor));
         }
-
-        GC.KeepAlive(image);
-    }
-
-    /// <summary>
-    /// Detect ChArUco Board.
-    /// </summary>
-    /// <param name="image">input image necessary for corner refinement.</param>
-    /// <param name="squaresX">number of chessboard squares in x directions.</param>
-    /// <param name="squaresY">number of chessboard squares in y directions.</param>
-    /// <param name="squareLength">chessboard square side length (normally in meters).</param>
-    /// <param name="markerLength">marker side length (same unit than squareLength).</param>
-    /// <param name="arucoDictId">dictionary of markers indicating the type of markers.</param>
-    /// <param name="charucoCorners">output list of detected charuco corners.</param>
-    /// <param name="charucoIds">ids of the charucos in charucoCorners.</param>
-    /// <param name="markerCorners">output list of detected marker corners.</param>
-    /// <param name="markerIds">ids of the corners in markerCorners.</param>
-    public static void DetectCharucoBoard(InputArray image, int squaresX, int squaresY, float squareLength, float markerLength,
-        PredefinedDictionaryType arucoDictId,
-        out Point2f[] charucoCorners, out int[] charucoIds,
-        out Point2f[][] markerCorners, out int[] markerIds)
-    {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-
-        image.ThrowIfDisposed();
-
-        using var charucoCornersVec = new VectorOfPoint2f();
-        using var charucoIdsVec = new VectorOfInt32();
-        using var markerCornersVec = new VectorOfVectorPoint2f();
-        using var markerIdsVec = new VectorOfInt32();
-
-        NativeMethods.HandleException(
-            NativeMethods.aruco_detectCharucoBoard(
-                image.CvPtr,
-                squaresX, squaresY, squareLength, markerLength, (int)arucoDictId,
-                charucoCornersVec.CvPtr, charucoIdsVec.CvPtr,
-                markerCornersVec.CvPtr, markerIdsVec.CvPtr
-                ));
-
-        charucoCorners = charucoCornersVec.ToArray();
-        charucoIds = charucoIdsVec.ToArray();
-        markerCorners = markerCornersVec.ToArray();
-        markerIds = markerIdsVec.ToArray();
-
-        GC.KeepAlive(image);
-    }
-
-    /// <param name="image">input image necessary for corner refinement.</param>
-    /// <param name="squaresX">number of chessboard squares in x directions.</param>
-    /// <param name="squaresY">number of chessboard squares in y directions.</param>
-    /// <param name="squareLength">chessboard square side length (normally in meters).</param>
-    /// <param name="markerLength">marker side length (same unit than squareLength).</param>
-    /// <param name="arucoDictId">dictionary of markers indicating the type of markers.</param>
-    /// <param name="markerCorners">list of detected marker corners.</param>
-    /// <param name="markerIds">ids of the corners in markerCorners.</param>
-    /// <param name="charucoCorners">output list of detected charuco corners.</param>
-    /// <param name="charucoIds">ids of the charucos in charucoCorners.</param>
-    public static void InterpolateCornersCharuco(InputArray image,
-        int squaresX, int squaresY, float squareLength, float markerLength, PredefinedDictionaryType arucoDictId,
-        Point2f[][] markerCorners, IEnumerable<int> markerIds,
-        out Point2f[] charucoCorners, out int[] charucoIds)
-    {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-        if (markerCorners is null)
-            throw new ArgumentNullException(nameof(markerCorners));
-        if (markerIds is null)
-            throw new ArgumentNullException(nameof(markerIds));
-
-        image.ThrowIfDisposed();
-
-        using var markerCornersAddress = new ArrayAddress2<Point2f>(markerCorners);
-        using var markerIdsVec = new VectorOfInt32(markerIds);
-        using var charucoCornersVec = new VectorOfPoint2f();
-        using var charucoIdsVec = new VectorOfInt32();
-
-        NativeMethods.HandleException(
-            NativeMethods.aruco_interpolateCornersCharuco(
-                image.CvPtr,
-                squaresX, squaresY, squareLength, markerLength, (int)arucoDictId,
-                markerCornersAddress.GetPointer(), markerCornersAddress.GetDim1Length(), markerCornersAddress.GetDim2Lengths(), markerIdsVec.CvPtr,
-                charucoCornersVec.CvPtr, charucoIdsVec.CvPtr)
-        );
-
-        charucoCorners = charucoCornersVec.ToArray();
-        charucoIds = charucoIdsVec.ToArray();
 
         GC.KeepAlive(image);
     }

--- a/src/OpenCvSharp/Modules/aruco/DetectorParameters.cs
+++ b/src/OpenCvSharp/Modules/aruco/DetectorParameters.cs
@@ -60,10 +60,15 @@ public struct DetectorParameters
     public int MinDistanceToBorder = 3;
 
     /// <summary>
-    /// minimum mean distance between two marker corners to be considered similar, 
+    /// minimum mean distance between two marker corners to be considered similar,
     /// so that the smaller one is removed.The rate is relative to the smaller perimeter of the two markers(default 0.05).
     /// </summary>
     public double MinMarkerDistanceRate = 0.05;
+
+    /// <summary>
+    /// minimum average distance between the corners of the two markers in group to add them to the list of candidates (default 0.21).
+    /// </summary>
+    public float MinGroupDistance = 0.21f;
 
     /// <summary>
     /// corner refinement method.
@@ -76,6 +81,11 @@ public struct DetectorParameters
     /// window size for the corner refinement process (in pixels) (default 5).
     /// </summary>
     public int CornerRefinementWinSize = 5;
+
+    /// <summary>
+    /// Dynamic window size for corner refinement relative to Aruco module size (default 0.3).
+    /// </summary>
+    public float RelativeCornerRefinmentWinSize = 0.3f;
 
     /// <summary>
     /// maximum number of iterations for stop criteria of the corner refinement process(default 30).

--- a/src/OpenCvSharp/Modules/aruco/RefineParameters.cs
+++ b/src/OpenCvSharp/Modules/aruco/RefineParameters.cs
@@ -1,0 +1,47 @@
+using System.Runtime.InteropServices;
+
+namespace OpenCvSharp.Aruco;
+
+#pragma warning disable CA1815
+
+/// <summary>
+/// struct RefineParameters is used by ArucoDetector
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct RefineParameters
+{
+    /// <summary>
+    /// Minimum distance between the corners of the rejected candidate and the reprojected marker
+    /// in order to consider it as a correspondence (default 10).
+    /// </summary>
+    public float MinRepDistance = 10f;
+
+    /// <summary>
+    /// Rate of allowed erroneous bits respect to the error correction capability of the used dictionary.
+    /// -1 ignores the error correction step (default 3).
+    /// </summary>
+    public float ErrorCorrectionRate = 3f;
+
+    /// <summary>
+    /// Consider the four possible corner orders in the rejectedCorners array (default true).
+    /// </summary>
+    [MarshalAs(UnmanagedType.U1)]
+    public bool CheckAllOrders = true;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RefineParameters()
+    {
+    }
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RefineParameters(float minRepDistance, float errorCorrectionRate, bool checkAllOrders)
+    {
+        MinRepDistance = minRepDistance;
+        ErrorCorrectionRate = errorCorrectionRate;
+        CheckAllOrders = checkAllOrders;
+    }
+}

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -266,7 +266,8 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	MyCvScalar cornerColor)
 {
 	BEGIN_WRAP
-	const cv::_InputArray idArray = (ids != nullptr) ? cv::_InputArray(*ids) : cv::noArray();
+	cv::_InputArray idArray = cv::noArray();
+	if (ids != nullptr) idArray = *ids;
 	cv::aruco::drawDetectedCornersCharuco(*image, *corners, idArray, cpp(cornerColor));
 	END_WRAP
 }
@@ -317,8 +318,10 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
 	std::vector<int>* recoveredIdxs)
 {
 	BEGIN_WRAP
+	cv::_OutputArray recoveredIdxsArr = cv::noArray();
+	if (recoveredIdxs != nullptr) recoveredIdxsArr = *recoveredIdxs;
 	detector->refineDetectedMarkers(*image, *board, *detectedCorners, *detectedIds, *rejectedCorners,
-		entity(cameraMatrix), entity(distCoeffs), entity(recoveredIdxs));
+		entity(cameraMatrix), entity(distCoeffs), recoveredIdxsArr);
 	END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -266,7 +266,8 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	MyCvScalar cornerColor)
 {
 	BEGIN_WRAP
-	cv::aruco::drawDetectedCornersCharuco(*image, *corners, *ids, cpp(cornerColor));
+	const cv::_InputArray idArray = (ids != nullptr) ? cv::_InputArray(*ids) : cv::noArray();
+	cv::aruco::drawDetectedCornersCharuco(*image, *corners, idArray, cpp(cornerColor));
 	END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -15,15 +15,17 @@ extern "C"
 		int adaptiveThreshWinSizeMin;
 		int adaptiveThreshWinSizeMax;
 		int adaptiveThreshWinSizeStep;
-		double adaptiveThreshConstant;		
+		double adaptiveThreshConstant;
 		double minMarkerPerimeterRate;
 		double maxMarkerPerimeterRate;
 		double polygonalApproxAccuracyRate;
 		double minCornerDistanceRate;
-		int minDistanceToBorder;		
+		int minDistanceToBorder;
 		double minMarkerDistanceRate;
+		float minGroupDistance;
 		int cornerRefinementMethod;
 		int cornerRefinementWinSize;
+		float relativeCornerRefinmentWinSize;
 		int cornerRefinementMaxIterations;
 		double cornerRefinementMinAccuracy;
 		int markerBorderBits;
@@ -45,6 +47,13 @@ extern "C"
 		int minSideLengthCanonicalImg;
 		float minMarkerLengthRatioOriginalImg;
 	};
+
+	struct aruco_RefineParameters
+	{
+		float minRepDistance;
+		float errorCorrectionRate;
+		bool checkAllOrders;
+	};
 }
 
 static cv::aruco::DetectorParameters cpp(const aruco_DetectorParameters& p)
@@ -60,8 +69,10 @@ static cv::aruco::DetectorParameters cpp(const aruco_DetectorParameters& p)
 	pp.minCornerDistanceRate = p.minCornerDistanceRate;
 	pp.minDistanceToBorder = p.minDistanceToBorder;
 	pp.minMarkerDistanceRate = p.minMarkerDistanceRate;
+	pp.minGroupDistance = p.minGroupDistance;
 	pp.cornerRefinementMethod = static_cast<cv::aruco::CornerRefineMethod>(p.cornerRefinementMethod);
 	pp.cornerRefinementWinSize = p.cornerRefinementWinSize;
+	pp.relativeCornerRefinmentWinSize = p.relativeCornerRefinmentWinSize;
 	pp.cornerRefinementMaxIterations = p.cornerRefinementMaxIterations;
 	pp.cornerRefinementMinAccuracy = p.cornerRefinementMinAccuracy;
 	pp.markerBorderBits = p.markerBorderBits;
@@ -78,7 +89,7 @@ static cv::aruco::DetectorParameters cpp(const aruco_DetectorParameters& p)
 	pp.aprilTagMaxLineFitMse = p.aprilTagMaxLineFitMse;
 	pp.aprilTagDeglitch = p.aprilTagDeglitch;
 	pp.aprilTagMinWhiteBlackDiff = p.aprilTagMinWhiteBlackDiff;
-	pp.detectInvertedMarker = p.detectInvertedMarker;	
+	pp.detectInvertedMarker = p.detectInvertedMarker;
 	pp.useAruco3Detection = p.useAruco3Detection;
 	pp.minSideLengthCanonicalImg = p.minSideLengthCanonicalImg;
 	pp.minMarkerLengthRatioOriginalImg = p.minMarkerLengthRatioOriginalImg;
@@ -90,7 +101,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 	cv::Point2f** corners,
 	int cornerSize1,
 	int* cornerSize2,
-	int* idx, int idxCount, 
+	int* idx, int idxCount,
 	MyCvScalar borderColor)
 {
 	BEGIN_WRAP
@@ -103,40 +114,6 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 		idxVec = std::vector<int>(idx, idx + idxCount);
 
 	cv::aruco::drawDetectedMarkers(*image, cornerVec, idxVec, cpp(borderColor));
-	END_WRAP
-}
-
-CVAPI(ExceptionStatus) aruco_detectMarkers(
-	cv::_InputArray* image,
-	cv::aruco::Dictionary* dictionary,
-	std::vector< std::vector<cv::Point2f> >* corners,
-	std::vector<int>* ids,
-	aruco_DetectorParameters* parameters,
-	std::vector< std::vector<cv::Point2f> >* rejectedImgPoints)
-{
-	BEGIN_WRAP
-	const auto p = cpp(*parameters);
-	const auto pp = cv::makePtr<cv::aruco::DetectorParameters>(p);
-	const auto d = cv::makePtr<cv::aruco::Dictionary>(*dictionary);
-	cv::aruco::detectMarkers(*image, d, *corners, *ids, pp, *rejectedImgPoints);
-	END_WRAP
-}
-
-CVAPI(ExceptionStatus) aruco_estimatePoseSingleMarkers(
-	cv::Point2f** corners, int cornersLength1,
-	int* cornersLengths2, float markerLength,
-	cv::_InputArray* cameraMatrix,
-	cv::_InputArray* distCoeffs,
-	cv::_OutputArray* rvecs,
-	cv::_OutputArray* tvecs,
-	cv::_OutputArray* objPoints)
-{
-	BEGIN_WRAP
-	std::vector<std::vector<cv::Point2f> > cornersVec(cornersLength1);
-	for (int i = 0; i < cornersLength1; i++)
-		cornersVec[i] = std::vector<cv::Point2f>(corners[i], corners[i] + cornersLengths2[i]);
-
-	cv::aruco::estimatePoseSingleMarkers(cornersVec, markerLength, *cameraMatrix, *distCoeffs, *rvecs, *tvecs, entity(objPoints));
 	END_WRAP
 }
 
@@ -162,7 +139,7 @@ CVAPI(ExceptionStatus) aruco_readDictionary(const char* dictionaryFile, cv::aruc
 	storeage.release();
 
 	*returnValue = new cv::aruco::Dictionary(dictionary);
-	
+
 	END_WRAP
 }
 
@@ -205,7 +182,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getMaxCorrectionBits(cv::aruco::Dictiona
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_identify(
-	cv::aruco::Dictionary* obj, 
+	cv::aruco::Dictionary* obj,
 	cv::Mat *onlyBits,
 	int *idx,
 	int *rotation,
@@ -218,7 +195,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_identify(
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_getDistanceToId(
-	cv::aruco::Dictionary* obj, 
+	cv::aruco::Dictionary* obj,
 	cv::_InputArray *bits,
 	int id,
 	int allRotations,
@@ -262,28 +239,6 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getBitsFromByteList(
 	END_WRAP
 }
 
-
-CVAPI(ExceptionStatus) aruco_detectCharucoDiamond(
-	cv::_InputArray* image,
-	cv::Point2f** markerCorners,
-	int markerCornersSize1,
-	int* markerCornersSize2,
-	std::vector<int>* markerIds,
-	float squareMarkerLengthRate,
-	std::vector< std::vector<cv::Point2f> >* diamondCorners,
-	std::vector<cv::Vec4i>* diamondIds,
-	cv::_InputArray* cameraMatrix, cv::_InputArray* distCoeffs)
-{
-	BEGIN_WRAP
-		std::vector< std::vector<cv::Point2f> > markerCornerVec(markerCornersSize1);
-	for (int i = 0; i < markerCornersSize1; i++)
-		markerCornerVec[i] = std::vector<cv::Point2f>(markerCorners[i], markerCorners[i] + markerCornersSize2[i]);
-
-	cv::aruco::detectCharucoDiamond(*image, markerCornerVec, *markerIds, squareMarkerLengthRate,
-		*diamondCorners, *diamondIds, entity(cameraMatrix), entity(distCoeffs));
-	END_WRAP
-}
-
 CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 	cv::_InputOutputArray* image,
 	cv::Point2f** corners,
@@ -304,66 +259,6 @@ CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 	END_WRAP
 }
 
-CVAPI(ExceptionStatus) aruco_detectCharucoBoard(
-	cv::_InputArray* image,
-	int squaresX,
-	int squaresY,
-	float squareLength,
-	float markerLength,
-	int arucoDictId,
-	std::vector<cv::Point2f>* charucoCorners,
-	std::vector<int>* charucoIds,
-	std::vector< std::vector<cv::Point2f> >* markerCorners,
-	std::vector<int>* markerIds
-	)
-{
-	BEGIN_WRAP
-	cv::aruco::Dictionary dictionary = cv::aruco::getPredefinedDictionary(arucoDictId);
-    cv::aruco::CharucoBoard charucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, dictionary);
-	cv::aruco::CharucoDetector detector(charucoBoard);
-	cv::Mat charucoCorners_mat, charucoIds_mat;
-	//detector.detectBoard(*image, *charucoCorners, *charucoIds, *markerCorners, *markerIds);
-	detector.detectBoard(*image, charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
-	for (int i = 0; i < charucoCorners_mat.rows; ++i)
-	{
-		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
-		charucoIds->push_back(charucoIds_mat.at<int>(i, 0));
-	}
-	END_WRAP
-}
-
-CVAPI(ExceptionStatus) aruco_interpolateCornersCharuco(
-	cv::_InputArray* image,
-	int squaresX,
-	int squaresY,
-	float squareLength,
-	float markerLength,
-	int arucoDictId,
-	cv::Point2f** markerCorners,
-	int markerCornersSize1,
-	int* markerCornersSize2,
-	std::vector<int>* markerIds,
-	std::vector<cv::Point2f>* charucoCorners,
-	std::vector<int>* charucoIds
-	)
-{
-	BEGIN_WRAP
-	std::vector< std::vector<cv::Point2f> > markerCornerVec(markerCornersSize1);
-	for (int i = 0; i < markerCornersSize1; i++)
-		markerCornerVec[i] = std::vector<cv::Point2f>(markerCorners[i], markerCorners[i] + markerCornersSize2[i]);
-
-	cv::aruco::Dictionary dictionary = cv::aruco::getPredefinedDictionary(arucoDictId);
-	cv::Ptr<cv::aruco::CharucoBoard> ptr_charucoBoard = new cv::aruco::CharucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, dictionary);
-	cv::Mat charucoCorners_mat, charucoIds_mat;
-	cv::aruco::interpolateCornersCharuco(markerCornerVec, *markerIds, *image, ptr_charucoBoard, charucoCorners_mat, charucoIds_mat);
-	for (int i = 0; i < charucoCorners_mat.rows; ++i)
-	{
-		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
-		charucoIds->push_back(charucoIds_mat.at<int>(i, 0));
-	}
-	END_WRAP
-}
-
 CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	cv::_InputOutputArray* image,
 	std::vector<cv::Point2f>* corners,
@@ -372,6 +267,203 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 {
 	BEGIN_WRAP
 	cv::aruco::drawDetectedCornersCharuco(*image, *corners, *ids, cpp(cornerColor));
+	END_WRAP
+}
+
+// ==================== ArucoDetector ====================
+
+CVAPI(ExceptionStatus) aruco_ArucoDetector_create(
+	cv::aruco::Dictionary* dictionary,
+	aruco_DetectorParameters* detectorParams,
+	aruco_RefineParameters* refineParams,
+	cv::aruco::ArucoDetector** returnValue)
+{
+	BEGIN_WRAP
+	const auto dp = cpp(*detectorParams);
+	const auto rp = cv::aruco::RefineParameters(refineParams->minRepDistance, refineParams->errorCorrectionRate, refineParams->checkAllOrders);
+	*returnValue = new cv::aruco::ArucoDetector(*dictionary, dp, rp);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_ArucoDetector_delete(cv::aruco::ArucoDetector* ptr)
+{
+	BEGIN_WRAP
+	delete ptr;
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkers(
+	cv::aruco::ArucoDetector* detector,
+	cv::_InputArray* image,
+	std::vector<std::vector<cv::Point2f>>* corners,
+	std::vector<int>* ids,
+	std::vector<std::vector<cv::Point2f>>* rejectedImgPoints)
+{
+	BEGIN_WRAP
+	detector->detectMarkers(*image, *corners, *ids, *rejectedImgPoints);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
+	cv::aruco::ArucoDetector* detector,
+	cv::_InputArray* image,
+	cv::aruco::Board* board,
+	std::vector<std::vector<cv::Point2f>>* detectedCorners,
+	std::vector<int>* detectedIds,
+	std::vector<std::vector<cv::Point2f>>* rejectedCorners,
+	cv::_InputArray* cameraMatrix,
+	cv::_InputArray* distCoeffs,
+	std::vector<int>* recoveredIdxs)
+{
+	BEGIN_WRAP
+	detector->refineDetectedMarkers(*image, *board, *detectedCorners, *detectedIds, *rejectedCorners,
+		entity(cameraMatrix), entity(distCoeffs), entity(recoveredIdxs));
+	END_WRAP
+}
+
+// ==================== CharucoBoard ====================
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_create(
+	int squaresX, int squaresY,
+	float squareLength, float markerLength,
+	cv::aruco::Dictionary* dictionary,
+	cv::aruco::CharucoBoard** returnValue)
+{
+	BEGIN_WRAP
+	*returnValue = new cv::aruco::CharucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, *dictionary);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_delete(cv::aruco::CharucoBoard* ptr)
+{
+	BEGIN_WRAP
+	delete ptr;
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_getChessboardSize(cv::aruco::CharucoBoard* ptr, MyCvSize* returnValue)
+{
+	BEGIN_WRAP
+	const auto s = ptr->getChessboardSize();
+	returnValue->width = s.width;
+	returnValue->height = s.height;
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_getSquareLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
+{
+	BEGIN_WRAP
+	*returnValue = ptr->getSquareLength();
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_getMarkerLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
+{
+	BEGIN_WRAP
+	*returnValue = ptr->getMarkerLength();
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_setLegacyPattern(cv::aruco::CharucoBoard* ptr, int value)
+{
+	BEGIN_WRAP
+	ptr->setLegacyPattern(value != 0);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_getLegacyPattern(cv::aruco::CharucoBoard* ptr, int* returnValue)
+{
+	BEGIN_WRAP
+	*returnValue = ptr->getLegacyPattern() ? 1 : 0;
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_generateImage(
+	cv::aruco::CharucoBoard* ptr,
+	MyCvSize outSize,
+	cv::_OutputArray* img,
+	int marginSize,
+	int borderBits)
+{
+	BEGIN_WRAP
+	ptr->generateImage(cpp(outSize), *img, marginSize, borderBits);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
+	cv::aruco::CharucoBoard* ptr,
+	cv::_InputArray* charucoIds,
+	int* returnValue)
+{
+	BEGIN_WRAP
+	*returnValue = ptr->checkCharucoCornersCollinear(*charucoIds) ? 1 : 0;
+	END_WRAP
+}
+
+// ==================== CharucoDetector ====================
+
+CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
+	cv::aruco::CharucoBoard* board,
+	cv::_InputArray* cameraMatrix,
+	cv::_InputArray* distCoeffs,
+	int minMarkers,
+	bool tryRefineMarkers,
+	bool checkMarkers,
+	aruco_DetectorParameters* detectorParams,
+	aruco_RefineParameters* refineParams,
+	cv::aruco::CharucoDetector** returnValue)
+{
+	BEGIN_WRAP
+	cv::aruco::CharucoParameters cp;
+	if (cameraMatrix != nullptr)
+		cp.cameraMatrix = cameraMatrix->getMat();
+	if (distCoeffs != nullptr)
+		cp.distCoeffs = distCoeffs->getMat();
+	cp.minMarkers = minMarkers;
+	cp.tryRefineMarkers = tryRefineMarkers;
+	cp.checkMarkers = checkMarkers;
+	const auto dp = cpp(*detectorParams);
+	const auto rp = cv::aruco::RefineParameters(refineParams->minRepDistance, refineParams->errorCorrectionRate, refineParams->checkAllOrders);
+	*returnValue = new cv::aruco::CharucoDetector(*board, cp, dp, rp);
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoDetector_delete(cv::aruco::CharucoDetector* ptr)
+{
+	BEGIN_WRAP
+	delete ptr;
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
+	cv::aruco::CharucoDetector* detector,
+	cv::_InputArray* image,
+	std::vector<cv::Point2f>* charucoCorners,
+	std::vector<int>* charucoIds,
+	std::vector<std::vector<cv::Point2f>>* markerCorners,
+	std::vector<int>* markerIds)
+{
+	BEGIN_WRAP
+	cv::Mat charucoCorners_mat, charucoIds_mat;
+	detector->detectBoard(*image, charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
+	for (int i = 0; i < charucoCorners_mat.rows; ++i)
+	{
+		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
+		charucoIds->push_back(charucoIds_mat.at<int>(i, 0));
+	}
+	END_WRAP
+}
+
+CVAPI(ExceptionStatus) aruco_CharucoDetector_detectDiamonds(
+	cv::aruco::CharucoDetector* detector,
+	cv::_InputArray* image,
+	std::vector<std::vector<cv::Point2f>>* diamondCorners,
+	std::vector<cv::Vec4i>* diamondIds,
+	std::vector<std::vector<cv::Point2f>>* markerCorners,
+	std::vector<int>* markerIds)
+{
+	BEGIN_WRAP
+	detector->detectDiamonds(*image, *diamondCorners, *diamondIds, *markerCorners, *markerIds);
 	END_WRAP
 }
 

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using OpenCvSharp.Aruco;
 using Xunit;
 
@@ -21,8 +21,10 @@ public class ArucoTest : TestBase
         Assert.Equal(0.05, param.MinCornerDistanceRate, 3);
         Assert.Equal(3, param.MinDistanceToBorder);
         Assert.Equal(0.05, param.MinMarkerDistanceRate, 3);
+        Assert.Equal(0.21f, param.MinGroupDistance, 1e-3f);
         Assert.Equal(CornerRefineMethod.None, param.CornerRefinementMethod);
         Assert.Equal(5, param.CornerRefinementWinSize);
+        Assert.Equal(0.3f, param.RelativeCornerRefinmentWinSize, 1e-3f);
         Assert.Equal(30, param.CornerRefinementMaxIterations);
         Assert.Equal(0.1, param.CornerRefinementMinAccuracy, 3);
         Assert.Equal(1, param.MarkerBorderBits);
@@ -44,7 +46,7 @@ public class ArucoTest : TestBase
         Assert.Equal(32, param.MinSideLengthCanonicalImg);
         Assert.Equal(0, param.MinMarkerLengthRatioOriginalImg);
     }
-    
+
     [Fact]
     public void GetPredefinedDictionary()
     {
@@ -79,7 +81,7 @@ public class ArucoTest : TestBase
 
         for (int idx = 0; idx < dictData.Length; idx++)
             Assert.Equal(refData[idx], dictData[idx]);
-        
+
         toCompareWith.Dispose();
         dict.Dispose();
     }
@@ -89,9 +91,9 @@ public class ArucoTest : TestBase
     {
         using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
         using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        using var detector = new ArucoDetector(dict);
 
-        var param = new DetectorParameters();
-        CvAruco.DetectMarkers(image, dict, out _, out _, param, out _);
+        detector.DetectMarkers(image, out _, out _, out _);
     }
 
     [Fact]
@@ -108,15 +110,15 @@ public class ArucoTest : TestBase
         Assert.Equal(4, dict.MarkerSize);
         Assert.Equal(50, dict.MaxCorrectionBits);
     }
-    
+
     [Fact]
     public void DrawDetectedMarker()
     {
         using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
         using var outputImage = image.CvtColor(ColorConversionCodes.GRAY2RGB);
         using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
-        var param = new DetectorParameters();
-        CvAruco.DetectMarkers(image, dict, out var corners, out var ids, param, out var rejectedImgPoints);
+        using var detector = new ArucoDetector(dict);
+        detector.DetectMarkers(image, out var corners, out var ids, out var rejectedImgPoints);
 
         CvAruco.DrawDetectedMarkers(outputImage, corners, ids, new Scalar(255, 0, 0));
         CvAruco.DrawDetectedMarkers(outputImage, rejectedImgPoints, null, new Scalar(0, 0, 255));
@@ -128,25 +130,5 @@ public class ArucoTest : TestBase
             Cv2.ImWrite(path, outputImage);
             Process.Start(path);
         }
-    }
-
-    [Fact]
-    public void EstimatePoseSingleMarkers()
-    {
-        using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
-        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
-        var param = new DetectorParameters();
-        CvAruco.DetectMarkers(image, dict, out var corners, out _, param, out _);
-
-        using var cameraMatrix = Mat.Eye(3, 3, MatType.CV_64FC1);
-        using var distCoeffs = Mat.Zeros(4, 1, MatType.CV_64FC1);
-        using var rvec = new Mat();
-        using var tvec = new Mat();
-        using var objPoints = new Mat();
-        CvAruco.EstimatePoseSingleMarkers(corners, 6, cameraMatrix, distCoeffs, rvec, tvec, objPoints);
-
-        Assert.Equal(20, rvec.Total());
-        Assert.Equal(20, tvec.Total());
-        Assert.Equal(4, objPoints.Total());
     }
 }

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -7,6 +7,8 @@ namespace OpenCvSharp.Tests.Aruco;
 // ReSharper disable once InconsistentNaming
 public class ArucoTest : TestBase
 {
+    // ==================== DetectorParameters ====================
+
     [Fact]
     public void CreateDetectorParameters()
     {
@@ -46,6 +48,28 @@ public class ArucoTest : TestBase
         Assert.Equal(32, param.MinSideLengthCanonicalImg);
         Assert.Equal(0, param.MinMarkerLengthRatioOriginalImg);
     }
+
+    // ==================== RefineParameters ====================
+
+    [Fact]
+    public void CreateRefineParametersDefaults()
+    {
+        var param = new RefineParameters();
+        Assert.Equal(10f, param.MinRepDistance, 1e-3f);
+        Assert.Equal(3f, param.ErrorCorrectionRate, 1e-3f);
+        Assert.True(param.CheckAllOrders);
+    }
+
+    [Fact]
+    public void CreateRefineParametersCustom()
+    {
+        var param = new RefineParameters(5f, 2f, false);
+        Assert.Equal(5f, param.MinRepDistance, 1e-3f);
+        Assert.Equal(2f, param.ErrorCorrectionRate, 1e-3f);
+        Assert.False(param.CheckAllOrders);
+    }
+
+    // ==================== Dictionary ====================
 
     [Fact]
     public void GetPredefinedDictionary()
@@ -87,16 +111,6 @@ public class ArucoTest : TestBase
     }
 
     [Fact]
-    public void DetectMarkers()
-    {
-        using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
-        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
-        using var detector = new ArucoDetector(dict);
-
-        detector.DetectMarkers(image, out _, out _, out _);
-    }
-
-    [Fact]
     public void DictionaryProperties()
     {
         var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
@@ -111,6 +125,69 @@ public class ArucoTest : TestBase
         Assert.Equal(50, dict.MaxCorrectionBits);
     }
 
+    // ==================== ArucoDetector ====================
+
+    [Fact]
+    public void ArucoDetector_CreateDefault()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        using var detector = new ArucoDetector(dict);
+        Assert.NotNull(detector);
+    }
+
+    [Fact]
+    public void ArucoDetector_CreateWithCustomParams()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        var dp = new DetectorParameters { CornerRefinementMethod = CornerRefineMethod.Subpix };
+        var rp = new RefineParameters(5f, 2f, false);
+        using var detector = new ArucoDetector(dict, dp, rp);
+        Assert.NotNull(detector);
+    }
+
+    [Fact]
+    public void ArucoDetector_DetectMarkers()
+    {
+        using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        using var detector = new ArucoDetector(dict);
+
+        detector.DetectMarkers(image, out var corners, out var ids, out var rejectedImgPoints);
+
+        Assert.NotNull(corners);
+        Assert.NotNull(ids);
+        Assert.NotNull(rejectedImgPoints);
+        Assert.True(ids.Length > 0, "Expected at least one marker to be detected");
+        Assert.Equal(ids.Length, corners.Length);
+        foreach (var markerCorners in corners)
+            Assert.Equal(4, markerCorners.Length);
+    }
+
+    [Fact]
+    public void ArucoDetector_DetectMarkersWithCustomParams()
+    {
+        using var image = LoadImage("markers_6x6_250.png", ImreadModes.Grayscale);
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        var dp = new DetectorParameters { CornerRefinementMethod = CornerRefineMethod.Subpix };
+        using var detector = new ArucoDetector(dict, dp, new RefineParameters());
+
+        detector.DetectMarkers(image, out var corners, out var ids, out _);
+
+        Assert.True(ids.Length > 0);
+        Assert.Equal(ids.Length, corners.Length);
+    }
+
+    [Fact]
+    public void ArucoDetector_Dispose()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        var detector = new ArucoDetector(dict);
+        detector.Dispose();
+        Assert.True(detector.IsDisposed);
+    }
+
+    // ==================== DrawDetected* ====================
+
     [Fact]
     public void DrawDetectedMarker()
     {
@@ -121,14 +198,173 @@ public class ArucoTest : TestBase
         detector.DetectMarkers(image, out var corners, out var ids, out var rejectedImgPoints);
 
         CvAruco.DrawDetectedMarkers(outputImage, corners, ids, new Scalar(255, 0, 0));
+        // ids=null path
         CvAruco.DrawDetectedMarkers(outputImage, rejectedImgPoints, null, new Scalar(0, 0, 255));
 
         if (Debugger.IsAttached)
         {
-            // If you want to save markers image, you must change the following values.
             const string path = "C:\\detected_markers_6x6_250.png";
             Cv2.ImWrite(path, outputImage);
             Process.Start(path);
         }
+    }
+
+    // ==================== CharucoBoard ====================
+
+    [Fact]
+    public void CharucoBoard_Create()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        Assert.NotNull(board);
+    }
+
+    [Fact]
+    public void CharucoBoard_Properties()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+
+        Assert.Equal(new Size(5, 7), board.ChessboardSize);
+        Assert.Equal(0.04f, board.SquareLength, 1e-5f);
+        Assert.Equal(0.02f, board.MarkerLength, 1e-5f);
+    }
+
+    [Fact]
+    public void CharucoBoard_LegacyPattern()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+
+        Assert.False(board.LegacyPattern);
+        board.LegacyPattern = true;
+        Assert.True(board.LegacyPattern);
+        board.LegacyPattern = false;
+        Assert.False(board.LegacyPattern);
+    }
+
+    [Fact]
+    public void CharucoBoard_GenerateImage()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var img = new Mat();
+
+        board.GenerateImage(new Size(500, 700), img);
+
+        Assert.False(img.Empty());
+        Assert.Equal(700, img.Rows);
+        Assert.Equal(500, img.Cols);
+    }
+
+    [Fact]
+    public void CharucoBoard_CheckCharucoCornersCollinear_Collinear()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+
+        // IDs on the same row are collinear
+        var collinearIds = new[] { 0, 1, 2, 3 };
+        using var idsMat = Mat.FromArray(collinearIds);
+        Assert.True(board.CheckCharucoCornersCollinear(idsMat));
+    }
+
+    [Fact]
+    public void CharucoBoard_Dispose()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        board.Dispose();
+        Assert.True(board.IsDisposed);
+    }
+
+    // ==================== CharucoDetector ====================
+
+    [Fact]
+    public void CharucoDetector_Create()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var detector = new CharucoDetector(board);
+        Assert.NotNull(detector);
+    }
+
+    [Fact]
+    public void CharucoDetector_CreateWithAllParams()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        var dp = new DetectorParameters();
+        var rp = new RefineParameters();
+        using var detector = new CharucoDetector(board, null, null, 2, false, true, dp, rp);
+        Assert.NotNull(detector);
+    }
+
+    [Fact]
+    public void CharucoDetector_DetectBoard()
+    {
+        // Generate a synthetic charuco board image and detect from it
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var boardImage = new Mat();
+        board.GenerateImage(new Size(600, 800), boardImage, 10, 1);
+
+        using var detector = new CharucoDetector(board);
+        detector.DetectBoard(boardImage, out var charucoCorners, out var charucoIds,
+            out var markerCorners, out var markerIds);
+
+        Assert.NotNull(charucoCorners);
+        Assert.NotNull(charucoIds);
+        Assert.NotNull(markerCorners);
+        Assert.NotNull(markerIds);
+        Assert.True(charucoIds.Length > 0, "Expected at least one charuco corner detected");
+        Assert.Equal(charucoCorners.Length, charucoIds.Length);
+        Assert.Equal(markerCorners.Length, markerIds.Length);
+    }
+
+    [Fact]
+    public void CharucoDetector_DetectBoard_EmptyImage()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var emptyImage = Mat.Zeros(300, 300, MatType.CV_8UC1);
+
+        using var detector = new CharucoDetector(board);
+        detector.DetectBoard(emptyImage, out var charucoCorners, out var charucoIds,
+            out var markerCorners, out var markerIds);
+
+        // No markers or corners should be detected in a blank image
+        Assert.Equal(0, charucoIds.Length);
+        Assert.Equal(0, markerIds.Length);
+    }
+
+    [Fact]
+    public void CharucoDetector_Dispose()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        var detector = new CharucoDetector(board);
+        detector.Dispose();
+        Assert.True(detector.IsDisposed);
+    }
+
+    // ==================== DrawDetectedCornersCharuco / DrawDetectedDiamonds ====================
+
+    [Fact]
+    public void DrawDetectedCornersCharuco()
+    {
+        using var dict = CvAruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var boardImage = new Mat();
+        board.GenerateImage(new Size(600, 800), boardImage, 10, 1);
+        using var outputImage = boardImage.CvtColor(ColorConversionCodes.GRAY2RGB);
+
+        using var detector = new CharucoDetector(board);
+        detector.DetectBoard(boardImage, out var charucoCorners, out var charucoIds, out _, out _);
+
+        // With ids
+        CvAruco.DrawDetectedCornersCharuco(outputImage, charucoCorners, charucoIds, new Scalar(0, 255, 0));
+        // Without ids (null path)
+        CvAruco.DrawDetectedCornersCharuco(outputImage, charucoCorners, null);
     }
 }

--- a/test/OpenCvSharp.Tests/system/ExceptionTest.cs
+++ b/test/OpenCvSharp.Tests/system/ExceptionTest.cs
@@ -90,11 +90,10 @@ public class ExceptionTest : TestBase
     {
         using var image = new Mat();
         using var dict = OpenCvSharp.Aruco.CvAruco.GetPredefinedDictionary(OpenCvSharp.Aruco.PredefinedDictionaryType.Dict6X6_250);
-
-        var param = new OpenCvSharp.Aruco.DetectorParameters();
+        using var detector = new OpenCvSharp.Aruco.ArucoDetector(dict);
 
         var ex = Assert.Throws<OpenCVException>(
-            () => { OpenCvSharp.Aruco.CvAruco.DetectMarkers(image, dict, out _, out _, param, out _); });
+            () => { detector.DetectMarkers(image, out _, out _, out _); });
 
         Assert.StartsWith("!_image.empty()", ex.ErrMsg, StringComparison.Ordinal);
         Assert.NotEmpty(ex.FileName);


### PR DESCRIPTION
## Summary

- Remove deprecated free-function wrappers (`detectMarkers`, `estimatePoseSingleMarkers`, `detectCharucoDiamond`, `detectCharucoBoard`, `interpolateCornersCharuco`) that no longer exist as non-deprecated API since OpenCV 4.7
- Add `ArucoDetector` class wrapping `cv::aruco::ArucoDetector`
- Add `CharucoBoard` class wrapping `cv::aruco::CharucoBoard`
- Add `CharucoDetector` class wrapping `cv::aruco::CharucoDetector`
- Add `RefineParameters` struct wrapping `cv::aruco::RefineParameters`
- Update `DetectorParameters` with two new fields: `MinGroupDistance` and `RelativeCornerRefinmentWinSize`
- Fix null-pointer dereference in `aruco_drawDetectedCornersCharuco` when `ids` is null

## Breaking changes

This PR intentionally breaks the existing C# API to align with OpenCV's own breaking change introduced in 4.7.

| Removed | Replacement |
|---|---|
| `CvAruco.DetectMarkers(...)` | `new ArucoDetector(dict).DetectMarkers(...)` |
| `CvAruco.EstimatePoseSingleMarkers(...)` | Removed — use `Board.MatchImagePoints` + `Cv2.SolvePnP` |
| `CvAruco.DetectCharucoDiamond(...)` | `new CharucoDetector(board).DetectDiamonds(...)` |
| `CvAruco.DetectCharucoBoard(...)` | `new CharucoDetector(board).DetectBoard(...)` |
| `CvAruco.InterpolateCornersCharuco(...)` | `new CharucoDetector(board).DetectBoard(...)` |

## Test plan

- [ ] `ArucoDetector`: create (default / custom params), `DetectMarkers` on real image, dispose
- [ ] `CharucoBoard`: create, properties, `LegacyPattern`, `GenerateImage`, `CheckCharucoCornersCollinear`, dispose
- [ ] `CharucoDetector`: create, `DetectBoard` on generated image, empty image, dispose
- [ ] `RefineParameters`: default and custom constructors
- [ ] `DetectorParameters`: new fields verified
- [ ] Draw helpers: `DrawDetectedCornersCharuco` with and without ids

Closes #1796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ArucoDetector for marker detection with customizable parameters
  * CharucoBoard for creating/managing ChArUco boards and generating board images
  * CharucoDetector for ChArUco board and diamond detection
  * RefineParameters struct to control detection refinement

* **Improvements**
  * Extended DetectorParameters with new tuning options for improved detection accuracy

* **Tests**
  * Expanded ArUco/ChArUco test coverage and updated detection tests to use the new detector classes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->