### PR TITLE
Fix Row()/At<T> misuse and add Span-based pixel access APIs (fixes #1775)

### DIFF
--- a/src/OpenCvSharp.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/OpenCvSharp.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,8 +2,8 @@
 
 ### New Rules
 
-Rule ID | Category    | Severity | Notes
---------|-------------|----------|-------
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
 OCVS001 | Correctness | Warning  | At&lt;T&gt;(int) called on a Mat row submatrix
 OCVS002 | Performance | Warning  | Mat property (Rows/Cols/Dims/Width/Height) in loop condition
 OCVS003 | Performance | Warning  | Mat.Row() / Mat.Col() called inside a loop body

--- a/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,6 +2,10 @@
 
 ### New Rules
 
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-OCVS001 | Correctness | Warning | At&lt;T&gt;(int) called on a Mat row submatrix
+Rule ID | Category    | Severity | Notes
+--------|-------------|----------|-------
+OCVS001 | Correctness | Warning  | At&lt;T&gt;(int) called on a Mat row submatrix
+OCVS002 | Performance | Warning  | Mat property (Rows/Cols/Dims/Width/Height) in loop condition
+OCVS003 | Performance | Warning  | Mat.Row() / Mat.Col() called inside a loop body
+OCVS004 | Reliability | Warning  | Mat submatrix (Row/Col/RowRange/ColRange) not disposed
+OCVS005 | Reliability | Warning  | Intermediate MatExpr not disposed in chained Mat arithmetic

--- a/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/OpenCvSharp.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OCVS001 | Correctness | Warning | At&lt;T&gt;(int) called on a Mat row submatrix

--- a/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenCvSharp.Analyzers;
+
+/// <summary>
+/// Detects chained arithmetic on <c>Mat</c> (e.g. <c>a + b + c</c>) where intermediate
+/// <c>MatExpr</c> objects are never disposed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Mat</c> arithmetic operators return <c>MatExpr</c> (an <see cref="IDisposable"/> wrapper
+/// around a native lazy-evaluation expression). In a chain such as <c>a + b + c</c>, the
+/// <c>MatExpr</c> produced by <c>a + b</c> is consumed by the second <c>+</c> and never disposed,
+/// leaving the native object to the GC finalizer.
+/// </para>
+/// <para>
+/// Prefer <c>Cv2.Add</c> / <c>Cv2.Subtract</c> etc., or assign each step to a <c>using</c>
+/// variable.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MatExprChainAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCVS005";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Intermediate MatExpr not disposed in chained Mat arithmetic",
+        messageFormat: "The intermediate MatExpr from '{0}' is never disposed. " +
+                       "Use Cv2.Add/Subtract/Multiply/Divide, or assign each step to a 'using' variable.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Mat arithmetic operators return MatExpr, an IDisposable wrapping a native " +
+                     "lazy-evaluation object. In a chain like a + b + c, the MatExpr for a + b " +
+                     "is consumed without being disposed, leaking the native resource until " +
+                     "the GC finalizer runs.",
+        helpLinkUri: "https://github.com/shimat/opencvsharp/issues/1775");
+
+    private const string MatExprFullName = "OpenCvSharp.MatExpr";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeBinaryExpression, SyntaxKind.AddExpression,
+            SyntaxKind.SubtractExpression, SyntaxKind.MultiplyExpression, SyntaxKind.DivideExpression);
+    }
+
+    private static void AnalyzeBinaryExpression(SyntaxNodeAnalysisContext context)
+    {
+        var binary = (BinaryExpressionSyntax)context.Node;
+
+        // The result of this expression must be MatExpr
+        var resultType = context.SemanticModel.GetTypeInfo(binary).Type;
+        if (resultType?.ToDisplayString() != MatExprFullName)
+            return;
+
+        // Flag only when this MatExpr is consumed immediately by another binary expression
+        // without being assigned to a variable — that's the intermediate-temporary case.
+        var parent = binary.Parent;
+        if (parent is BinaryExpressionSyntax or AssignmentExpressionSyntax { Left: not IdentifierNameSyntax })
+        {
+            var operatorToken = binary.OperatorToken.ToString();
+            context.ReportDiagnostic(Diagnostic.Create(Rule, binary.GetLocation(), operatorToken));
+        }
+    }
+}

--- a/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
@@ -12,7 +12,7 @@ namespace OpenCvSharp.Analyzers;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>Mat</c> arithmetic operators return <c>MatExpr</c> (an <see cref="IDisposable"/> wrapper
+/// <c>Mat</c> arithmetic operators return <c>MatExpr</c> (an <see cref="System.IDisposable"/> wrapper
 /// around a native lazy-evaluation expression). In a chain such as <c>a + b + c</c>, the
 /// <c>MatExpr</c> produced by <c>a + b</c> is consumed by the second <c>+</c> and never disposed,
 /// leaving the native object to the GC finalizer.

--- a/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/MatExprChainAnalyzer.cs
@@ -65,7 +65,11 @@ public sealed class MatExprChainAnalyzer : DiagnosticAnalyzer
 
         // Flag only when this MatExpr is consumed immediately by another binary expression
         // without being assigned to a variable — that's the intermediate-temporary case.
+        // Unwrap any parentheses: (a + b) + c has a ParenthesizedExpressionSyntax between the
+        // inner binary and the outer one, but the semantics are identical.
         var parent = binary.Parent;
+        while (parent is ParenthesizedExpressionSyntax)
+            parent = parent.Parent;
         if (parent is BinaryExpressionSyntax or AssignmentExpressionSyntax { Left: not IdentifierNameSyntax })
         {
             var operatorToken = binary.OperatorToken.ToString();

--- a/src/OpenCvSharp.Analyzers/MatPropertyInLoopConditionAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/MatPropertyInLoopConditionAnalyzer.cs
@@ -19,7 +19,7 @@ public sealed class MatPropertyInLoopConditionAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticId,
         title: "Mat property accessed in loop condition",
-        messageFormat: "'{0}' is a P/Invoke call evaluated on every iteration. Cache the value before the loop: 'int {1} = mat.{0};'",
+        messageFormat: "'{0}' is a P/Invoke call on every iteration; cache it before the loop as 'int {1} = mat.{0};'",
         category: "Performance",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/OpenCvSharp.Analyzers/MatPropertyInLoopConditionAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/MatPropertyInLoopConditionAnalyzer.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenCvSharp.Analyzers;
+
+/// <summary>
+/// Detects <c>mat.Rows</c>, <c>mat.Cols</c>, <c>mat.Dims</c>, <c>mat.Width</c>, or <c>mat.Height</c>
+/// used in loop conditions, where each access is a P/Invoke call evaluated on every iteration.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MatPropertyInLoopConditionAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCVS002";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Mat property accessed in loop condition",
+        messageFormat: "'{0}' is a P/Invoke call evaluated on every iteration. Cache the value before the loop: 'int {1} = mat.{0};'",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Mat.Rows, Mat.Cols, Mat.Dims, Mat.Width, and Mat.Height each invoke a native " +
+                     "P/Invoke call. Placing them in a loop condition causes one P/Invoke call per " +
+                     "iteration. Cache the value in a local variable before the loop.",
+        helpLinkUri: "https://github.com/shimat/opencvsharp/issues/1775");
+
+    // Properties on OpenCvSharp.Mat that are P/Invoke calls
+    private static readonly ImmutableHashSet<string> ExpensiveProperties =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "Rows", "Cols", "Dims", "Width", "Height");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeFor,     SyntaxKind.ForStatement);
+        context.RegisterSyntaxNodeAction(AnalyzeWhile,   SyntaxKind.WhileStatement);
+        context.RegisterSyntaxNodeAction(AnalyzeDo,      SyntaxKind.DoStatement);
+    }
+
+    private static void AnalyzeFor(SyntaxNodeAnalysisContext context)
+    {
+        var forLoop = (ForStatementSyntax)context.Node;
+        if (forLoop.Condition is not null)
+            CheckExpression(forLoop.Condition, context);
+    }
+
+    private static void AnalyzeWhile(SyntaxNodeAnalysisContext context)
+    {
+        var whileLoop = (WhileStatementSyntax)context.Node;
+        CheckExpression(whileLoop.Condition, context);
+    }
+
+    private static void AnalyzeDo(SyntaxNodeAnalysisContext context)
+    {
+        var doLoop = (DoStatementSyntax)context.Node;
+        CheckExpression(doLoop.Condition, context);
+    }
+
+    private static void CheckExpression(ExpressionSyntax condition, SyntaxNodeAnalysisContext context)
+    {
+        foreach (var node in condition.DescendantNodesAndSelf())
+        {
+            if (node is not MemberAccessExpressionSyntax ma)
+                continue;
+
+            var propName = ma.Name.Identifier.ValueText;
+            if (!ExpensiveProperties.Contains(propName))
+                continue;
+
+            var symbol = context.SemanticModel.GetSymbolInfo(ma).Symbol as IPropertySymbol;
+            if (symbol?.ContainingType?.ToDisplayString() != "OpenCvSharp.Mat")
+                continue;
+
+            var suggestedName = char.ToLowerInvariant(propName[0]) + propName.Substring(1);
+            context.ReportDiagnostic(Diagnostic.Create(Rule, ma.GetLocation(), propName, suggestedName));
+        }
+    }
+}

--- a/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
+++ b/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
+++ b/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
@@ -6,6 +6,11 @@
     <Nullable>enable</Nullable>
     <RootNamespace>OpenCvSharp.Analyzers</RootNamespace>
     <AssemblyName>OpenCvSharp.Analyzers</AssemblyName>
+    <!-- AssemblyVersion must be a valid major.minor.build.revision (each ≤ 65535).
+         The repo uses date-based Version (e.g. 4.13.0.20260524) which exceeds that limit,
+         so we pin the assembly version independently. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
     <IsRoslynComponent>true</IsRoslynComponent>
     <!-- EnforceExtendedAnalyzerRules ensures the analyzer follows Roslyn analyzer best practices -->
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
+++ b/src/OpenCvSharp.Analyzers/OpenCvSharp.Analyzers.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <RootNamespace>OpenCvSharp.Analyzers</RootNamespace>
+    <AssemblyName>OpenCvSharp.Analyzers</AssemblyName>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <!-- EnforceExtendedAnalyzerRules ensures the analyzer follows Roslyn analyzer best practices -->
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Suppress build output from the package; it goes into analyzers/ folder only -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- DiagnosticId, SupportedDiagnostics, Initialize are required overrides; XML comments not needed -->
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenCvSharp.Analyzers/RowAtAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowAtAnalyzer.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/OpenCvSharp.Analyzers/RowAtAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowAtAnalyzer.cs
@@ -1,0 +1,128 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenCvSharp.Analyzers;
+
+/// <summary>
+/// Detects the misuse pattern <c>mat.Row(i).At&lt;T&gt;(col)</c> where the column index is
+/// silently interpreted as a row index, causing out-of-bounds memory access.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Mat.Row(i)</c> returns a 1×N submatrix. <c>At&lt;T&gt;(int i0)</c> on a 2D matrix
+/// treats <c>i0</c> as the row index (dimension 0), not a column index. The resulting
+/// address is <c>data + step * col</c> — jumping entire rows past the end of the submatrix.
+/// </para>
+/// <para>
+/// Use <c>mat.At&lt;T&gt;(row, col)</c> or <c>mat.AsRows&lt;T&gt;()</c> instead.
+/// See https://github.com/shimat/opencvsharp/issues/1775
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RowAtAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCVS001";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "At<T>(int) called on a Mat row submatrix",
+        messageFormat: "At<T>(int) on the 1-row Mat returned by Row() treats the argument as a row index, " +
+                       "not a column index, silently producing wrong results or out-of-bounds access. " +
+                       "Use mat.At<T>(row, col) or mat.AsRows<T>() instead.",
+        category: "Correctness",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Mat.Row(i) returns a 2D 1×N submatrix. At<T>(int i0) interprets i0 as a row " +
+                     "index (dimension 0), not a column index. Access the parent matrix directly: " +
+                     "mat.At<T>(row, col), or use mat.AsRows<T>() for high-performance loops.",
+        helpLinkUri: "https://github.com/shimat/opencvsharp/issues/1775");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var atInvocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsMatAtIntCall(atInvocation, context.SemanticModel))
+            return;
+
+        if (atInvocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        var receiver = memberAccess.Expression;
+
+        // Case 1: direct chain — mat.Row(i).At<T>(c)
+        if (IsMatRowCall(receiver, context.SemanticModel))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, atInvocation.GetLocation()));
+            return;
+        }
+
+        // Case 2: local variable — var row = mat.Row(i); row.At<T>(c)
+        if (receiver is IdentifierNameSyntax identifier &&
+            context.SemanticModel.GetSymbolInfo(identifier).Symbol is ILocalSymbol local &&
+            IsLocalDeclaredFromRowCall(local, context.SemanticModel))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, atInvocation.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="expr"/> is a call to <c>OpenCvSharp.Mat.At&lt;T&gt;(int)</c>.
+    /// </summary>
+    private static bool IsMatAtIntCall(InvocationExpressionSyntax expr, SemanticModel model)
+    {
+        if (expr.Expression is not MemberAccessExpressionSyntax ma)
+            return false;
+        if (ma.Name.Identifier.ValueText != "At")
+            return false;
+        if (expr.ArgumentList.Arguments.Count != 1)
+            return false;
+
+        var sym = model.GetSymbolInfo(expr).Symbol as IMethodSymbol;
+        return sym is { Parameters.Length: 1 } &&
+               sym.ContainingType?.ToDisplayString() == "OpenCvSharp.Mat" &&
+               sym.Parameters[0].Type.SpecialType == SpecialType.System_Int32;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="expr"/> is a call to <c>OpenCvSharp.Mat.Row(int)</c>.
+    /// </summary>
+    private static bool IsMatRowCall(ExpressionSyntax expr, SemanticModel model)
+    {
+        if (expr is not InvocationExpressionSyntax inv)
+            return false;
+        if (inv.Expression is not MemberAccessExpressionSyntax ma)
+            return false;
+        if (ma.Name.Identifier.ValueText != "Row")
+            return false;
+
+        var sym = model.GetSymbolInfo(inv).Symbol as IMethodSymbol;
+        return sym?.ContainingType?.ToDisplayString() == "OpenCvSharp.Mat";
+    }
+
+    /// <summary>
+    /// Returns true when the local variable's declaration initializer is a call to <c>Mat.Row(int)</c>.
+    /// Covers: <c>var row = mat.Row(i);</c>
+    /// </summary>
+    private static bool IsLocalDeclaredFromRowCall(ILocalSymbol local, SemanticModel model)
+    {
+        var syntaxRef = local.DeclaringSyntaxReferences.FirstOrDefault();
+        if (syntaxRef?.GetSyntax() is not VariableDeclaratorSyntax { Initializer.Value: { } initializer })
+            return false;
+
+        return IsMatRowCall(initializer, model);
+    }
+}

--- a/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenCvSharp.Analyzers;
+
+/// <summary>
+/// Detects <c>mat.Row()</c> or <c>mat.Col()</c> called inside a loop body,
+/// suggesting <see cref="Mat.AsRows{T}"/> or <c>AsCols&lt;T&gt;</c> as a zero-allocation alternative.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RowColInLoopBodyAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCVS003";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Mat.Row() / Mat.Col() called inside a loop",
+        messageFormat: "Mat.{0}() allocates a new submatrix object on every iteration. " +
+                       "Use mat.AsRows<T>() (or AsCols<T>()) outside the loop for zero-allocation row access.",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Calling Mat.Row() or Mat.Col() inside a loop allocates a native Mat " +
+                     "submatrix object on every iteration, creating GC pressure. " +
+                     "Obtain a MatRowAccessor<T> via AsRows<T>() before the loop; " +
+                     "each row is then a Span<T> with no allocation.",
+        helpLinkUri: "https://github.com/shimat/opencvsharp/issues/1775");
+
+    private static readonly ImmutableHashSet<string> RowColMethods =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "Row", "Col");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax ma)
+            return;
+
+        var methodName = ma.Name.Identifier.ValueText;
+        if (!RowColMethods.Contains(methodName))
+            return;
+
+        var symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+        if (symbol?.ContainingType?.ToDisplayString() != "OpenCvSharp.Mat")
+            return;
+
+        if (IsInsideLoopBody(invocation))
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+    }
+
+    private static bool IsInsideLoopBody(SyntaxNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            // Function boundaries: stop searching upward
+            if (current is MethodDeclarationSyntax
+                         or LocalFunctionStatementSyntax
+                         or LambdaExpressionSyntax
+                         or AnonymousMethodExpressionSyntax)
+                return false;
+
+            // Loop constructs
+            if (current is ForStatementSyntax
+                         or WhileStatementSyntax
+                         or DoStatementSyntax
+                         or ForEachStatementSyntax)
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
@@ -73,12 +73,18 @@ public sealed class RowColInLoopBodyAnalyzer : DiagnosticAnalyzer
                          or AnonymousMethodExpressionSyntax)
                 return false;
 
-            // Loop constructs
-            if (current is ForStatementSyntax
-                         or WhileStatementSyntax
-                         or DoStatementSyntax
-                         or ForEachStatementSyntax)
-                return true;
+            // Loop constructs: only flag when node is inside the loop body (Statement),
+            // not in the initializer, condition, or iterator of a for/foreach.
+            StatementSyntax? loopBody = current switch
+            {
+                ForStatementSyntax f       => f.Statement,
+                WhileStatementSyntax w     => w.Statement,
+                DoStatementSyntax d        => d.Statement,
+                ForEachStatementSyntax fe  => fe.Statement,
+                _                          => null,
+            };
+            if (loopBody is not null)
+                return loopBody.FullSpan.Contains(node.FullSpan);
         }
         return false;
     }

--- a/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColInLoopBodyAnalyzer.cs
@@ -9,7 +9,7 @@ namespace OpenCvSharp.Analyzers;
 
 /// <summary>
 /// Detects <c>mat.Row()</c> or <c>mat.Col()</c> called inside a loop body,
-/// suggesting <see cref="Mat.AsRows{T}"/> or <c>AsCols&lt;T&gt;</c> as a zero-allocation alternative.
+/// suggesting <c>AsRows&lt;T&gt;()</c> or <c>AsCols&lt;T&gt;()</c> as a zero-allocation alternative.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class RowColInLoopBodyAnalyzer : DiagnosticAnalyzer

--- a/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace OpenCvSharp.Analyzers;
+
+/// <summary>
+/// Detects <c>Mat.Row()</c>, <c>Mat.Col()</c>, <c>Mat.RowRange()</c>, or <c>Mat.ColRange()</c>
+/// whose return value is not wrapped in a <c>using</c> statement or declaration.
+/// </summary>
+/// <remarks>
+/// These methods allocate a native submatrix object. Unlike <c>new Mat()</c> (which CA2000 flags),
+/// these look like simple accessors and are easy to overlook. The recommended alternative for
+/// iteration is <see cref="Mat.AsRows{T}"/> which avoids allocation entirely.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RowColNotDisposedAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCVS004";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Mat submatrix not disposed",
+        messageFormat: "Mat.{0}() returns a Mat submatrix that must be disposed. " +
+                       "Wrap in 'using', or use AsRows<T>() / AsCols<T>() to avoid allocation entirely.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Mat.Row(), Mat.Col(), Mat.RowRange(), and Mat.ColRange() each allocate a " +
+                     "native Mat header. If not disposed, the native object lives until the GC " +
+                     "finalizer runs, causing uncontrolled native memory pressure.",
+        helpLinkUri: "https://github.com/shimat/opencvsharp/issues/1775");
+
+    private static readonly ImmutableHashSet<string> SubmatrixMethods =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "Row", "Col", "RowRange", "ColRange");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax ma)
+            return;
+
+        var methodName = ma.Name.Identifier.ValueText;
+        if (!SubmatrixMethods.Contains(methodName))
+            return;
+
+        var symbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+        if (symbol?.ContainingType?.ToDisplayString() != "OpenCvSharp.Mat")
+            return;
+
+        if (!IsDisposed(invocation))
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+    }
+
+    private static bool IsDisposed(InvocationExpressionSyntax invocation)
+    {
+        var parent = invocation.Parent;
+
+        // using var row = mat.Row(i);
+        if (parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: LocalDeclarationStatementSyntax localDecl } } }
+            && localDecl.UsingKeyword.IsKind(SyntaxKind.UsingKeyword))
+            return true;
+
+        // using (var row = mat.Row(i)) { ... }
+        if (parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: UsingStatementSyntax } } })
+            return true;
+
+        // using (mat.Row(i)) { ... }  — expression form
+        if (parent is UsingStatementSyntax)
+            return true;
+
+        // mat.Row(i).SomeMethod() — member access chain; OCVS001 handles the At<T> case,
+        // and a chained call generally means the caller is using the result.
+        // Skip to avoid double-warning.
+        if (parent is MemberAccessExpressionSyntax)
+            return true;
+
+        // Passed as argument — caller is responsible
+        if (parent is ArgumentSyntax)
+            return true;
+
+        // Return statement — caller is responsible
+        if (parent is ReturnStatementSyntax)
+            return true;
+
+        return false;
+    }
+}

--- a/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
@@ -84,10 +84,12 @@ public sealed class RowColNotDisposedAnalyzer : DiagnosticAnalyzer
         if (parent is UsingStatementSyntax)
             return true;
 
-        // mat.Row(i).SomeMethod() — member access chain; OCVS001 handles the At<T> case,
-        // and a chained call generally means the caller is using the result.
-        // Skip to avoid double-warning.
-        if (parent is MemberAccessExpressionSyntax)
+        // mat.Row(i).At<T>(col) — OCVS001 already flags this exact pattern; skip here
+        // to avoid a double warning. Only At<T> is exempted; other chains like .Clone()
+        // still leak the submatrix and should be reported.
+        if (parent is MemberAccessExpressionSyntax chainedMa
+            && chainedMa.Parent is InvocationExpressionSyntax
+            && chainedMa.Name.Identifier.Text == "At")
             return true;
 
         // Passed as argument — caller is responsible

--- a/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
+++ b/src/OpenCvSharp.Analyzers/RowColNotDisposedAnalyzer.cs
@@ -15,7 +15,7 @@ namespace OpenCvSharp.Analyzers;
 /// <remarks>
 /// These methods allocate a native submatrix object. Unlike <c>new Mat()</c> (which CA2000 flags),
 /// these look like simple accessors and are easy to overlook. The recommended alternative for
-/// iteration is <see cref="Mat.AsRows{T}"/> which avoids allocation entirely.
+/// iteration is <c>AsRows&lt;T&gt;()</c> which avoids allocation entirely.
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class RowColNotDisposedAnalyzer : DiagnosticAnalyzer

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -1552,6 +1552,7 @@ public partial class Mat : CvObject
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_Mat_row(CvPtr, y, out var matPtr));
+        GC.KeepAlive(this);
         return new Mat(matPtr);
     }
 
@@ -3118,6 +3119,8 @@ public partial class Mat : CvObject
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
+    [Obsolete("Use At<T>(row, col) for occasional access, or AsRows<T>() for high-performance loops. " +
+              "GetGenericIndexer uses Marshal.PtrToStructure which is slower than both alternatives.")]
     public Indexer<T> GetGenericIndexer<T>() where T : struct
     {
         return new Indexer<T>(this);
@@ -3136,6 +3139,8 @@ public partial class Mat : CvObject
     /// Mat Indexer
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [Obsolete("Use At<T>(row, col) for occasional access, or AsRows<T>() for high-performance loops. " +
+              "This class uses Marshal.PtrToStructure which is slower than both alternatives.")]
     public sealed class Indexer<T> : MatIndexer<T> where T : struct
     {
         private readonly long ptrVal;
@@ -3401,13 +3406,23 @@ public partial class Mat : CvObject
     }
 
     /// <summary>
-    /// Returns a value to the specified array element.
+    /// Returns a reference to the specified array element.
+    /// For 2D matrices, <paramref name="i0"/> is the row index (dimension 0).
+    /// Do NOT call this with a column index on a row-submatrix obtained from <see cref="Row"/>;
+    /// use <see cref="At{T}(int, int)"/> or <see cref="RowSpan{T}"/> instead.
+    /// For performance-sensitive pixel loops, prefer <see cref="AsRows{T}"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="i0">Index along the dimension 0</param>
-    /// <returns>A value to the specified array element.</returns>
+    /// <returns>A reference to the specified array element.</returns>
     public unsafe ref T At<T>(int i0) where T : unmanaged
     {
+#if DEBUG
+        if (Dims == 2 && Rows == 1 && Cols > 1)
+            throw new InvalidOperationException(
+                "At<T>(int) on a 1-row 2D matrix treats i0 as a row index, not a column index. " +
+                "Use At<T>(0, col) or RowSpan<T>(0) instead.");
+#endif
         var p = Ptr(i0);
         return ref Unsafe.AsRef<T>(p.ToPointer());
     }
@@ -4242,11 +4257,48 @@ public partial class Mat : CvObject
     #endregion
 
     /// <summary>
+    /// Returns a <see cref="Span{T}"/> over a single row of this matrix without allocating a submatrix object.
+    /// Padding bytes between rows are excluded from the span.
+    /// For iterating all rows in a loop, prefer <see cref="AsRows{T}"/> which captures the step once.
+    /// </summary>
+    /// <typeparam name="T">Element type. Must match the matrix element type.</typeparam>
+    /// <param name="row">Zero-based row index.</param>
+    /// <returns>A span covering the <paramref name="row"/>-th row.</returns>
+    public unsafe Span<T> RowSpan<T>(int row) where T : unmanaged
+    {
+        ThrowIfDisposed();
+        if (Dims != 2)
+            throw new InvalidOperationException("RowSpan is only supported for 2D matrices.");
+        if ((uint)row >= (uint)Rows)
+            throw new ArgumentOutOfRangeException(nameof(row));
+        var rowPtr = DataPointer + (nint)Step(0) * row;
+        return new Span<T>(rowPtr, Cols * ElemSize() / sizeof(T));
+    }
+
+    /// <summary>
+    /// Returns a <see cref="MatRowAccessor{T}"/> that provides efficient row-by-row access
+    /// with no P/Invoke per row or per element.
+    /// The data pointer, step, and dimensions are captured once; all indexing is pure pointer arithmetic.
+    /// </summary>
+    /// <typeparam name="T">Element type. Must match the matrix element type (e.g. <see cref="Vec3b"/> for CV_8UC3).</typeparam>
+    /// <returns>A <see cref="MatRowAccessor{T}"/> over this matrix.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the matrix is not 2-dimensional.</exception>
+    public unsafe MatRowAccessor<T> AsRows<T>() where T : unmanaged
+    {
+        ThrowIfDisposed();
+        if (Dims != 2)
+            throw new InvalidOperationException("AsRows is only supported for 2D matrices.");
+        var elemCount = Cols * ElemSize() / sizeof(T);
+        return new MatRowAccessor<T>((nint)DataPointer, (nint)Step(0), Rows, elemCount);
+    }
+
+    /// <summary>
     /// Creates a new span over the Mat.
+    /// The matrix must be continuous (<see cref="IsContinuous"/>); returns an empty span otherwise.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public unsafe Span<T> AsSpan<T>() where T : unmanaged  
+    public unsafe Span<T> AsSpan<T>() where T : unmanaged
         => IsContinuous() ? new Span<T>(DataPointer, (int)Total() * ElemSize() / sizeof(T)) : [];
 
     #endregion

--- a/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
@@ -1,0 +1,63 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Provides zero-allocation, zero-P/Invoke-per-element row access to a 2D <see cref="Mat"/>.
+/// Obtain via <see cref="Mat.AsRows{T}"/>. The data pointer, step, and dimensions are captured
+/// once at construction time, so all subsequent row indexing is pure pointer arithmetic.
+/// </summary>
+/// <typeparam name="T">Unmanaged element type matching the matrix element type (e.g. <see cref="Vec3b"/> for CV_8UC3).</typeparam>
+/// <remarks>
+/// <para>
+/// Typical usage for per-pixel iteration:
+/// <code>
+/// var rows = mat.AsRows&lt;Vec3b&gt;();
+/// for (int r = 0; r &lt; rows.Count; r++)
+/// {
+///     Span&lt;Vec3b&gt; row = rows[r];
+///     for (int c = 0; c &lt; row.Length; c++)
+///     {
+///         Vec3b pixel = row[c];
+///     }
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// This is a <c>ref struct</c> and therefore cannot be stored in fields, boxed, or used as a
+/// generic type argument.
+/// </para>
+/// </remarks>
+public readonly ref struct MatRowAccessor<T> where T : unmanaged
+{
+    private readonly nint _data;
+    private readonly nint _step;
+    private readonly int _cols;
+
+    /// <summary>Number of rows in the matrix.</summary>
+    public int Count { get; }
+
+    internal MatRowAccessor(nint data, nint step, int rows, int cols)
+    {
+        _data = data;
+        _step = step;
+        Count = rows;
+        _cols = cols;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Span{T}"/> over the specified row.
+    /// No P/Invoke is performed; this is pure pointer arithmetic.
+    /// Bounds are checked in DEBUG builds only.
+    /// </summary>
+    /// <param name="row">Zero-based row index.</param>
+    public unsafe Span<T> this[int row]
+    {
+        get
+        {
+#if DEBUG
+            if ((uint)row >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(row));
+#endif
+            return new Span<T>((void*)(_data + _step * row), _cols);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
@@ -1,4 +1,4 @@
-namespace OpenCvSharp;
+﻿namespace OpenCvSharp;
 
 /// <summary>
 /// Provides zero-allocation, zero-P/Invoke-per-element row access to a 2D <see cref="Mat"/>.

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -44,6 +44,14 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Include the analyzer in this package under analyzers/dotnet/cs/ -->
+    <ProjectReference Include="..\OpenCvSharp.Analyzers\OpenCvSharp.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>

--- a/test/OpenCvSharp.Analyzers.Tests/MatExprChainAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/MatExprChainAnalyzerTests.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using OpenCvSharp.Analyzers;
+using Xunit;
+
+namespace OpenCvSharp.Analyzers.Tests;
+
+public class MatExprChainAnalyzerTests
+{
+    private const string MatStub = """
+        namespace OpenCvSharp
+        {
+            public class Mat : System.IDisposable
+            {
+                public static MatExpr operator +(Mat a, Mat b) => new MatExpr();
+                public static MatExpr operator -(Mat a, Mat b) => new MatExpr();
+                public static MatExpr operator *(Mat a, double s) => new MatExpr();
+                public void Dispose() { }
+            }
+            public class MatExpr : System.IDisposable
+            {
+                public static MatExpr operator +(MatExpr a, Mat b) => new MatExpr();
+                public static implicit operator Mat(MatExpr e) => new Mat();
+                public void Dispose() { }
+            }
+        }
+        """;
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<MatExprChainAnalyzer, XUnitVerifier>
+        {
+            TestCode = MatStub + source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task TripleChain_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat a, OpenCvSharp.Mat b, OpenCvSharp.Mat c)
+            {
+                OpenCvSharp.Mat result = {|#0:a + b|} + c;
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(MatExprChainAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("+"));
+
+    [Fact]
+    public Task SimpleAdd_AssignedToVar_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat a, OpenCvSharp.Mat b)
+            {
+                OpenCvSharp.Mat result = a + b;
+            }
+        }
+        """);
+
+    [Fact]
+    public Task UsingMatExprVariable_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat a, OpenCvSharp.Mat b, OpenCvSharp.Mat c)
+            {
+                using var ab = a + b;
+                OpenCvSharp.Mat result = ab + c;
+            }
+        }
+        """);
+}

--- a/test/OpenCvSharp.Analyzers.Tests/MatExprChainAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/MatExprChainAnalyzerTests.cs
@@ -64,6 +64,20 @@ public class MatExprChainAnalyzerTests
         """);
 
     [Fact]
+    public Task ParenthesizedChain_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat a, OpenCvSharp.Mat b, OpenCvSharp.Mat c)
+            {
+                OpenCvSharp.Mat result = ({|#0:a + b|}) + c;
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(MatExprChainAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("+"));
+
+    [Fact]
     public Task UsingMatExprVariable_NoWarning() => Verify(
         """
         class Test

--- a/test/OpenCvSharp.Analyzers.Tests/MatPropertyInLoopConditionAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/MatPropertyInLoopConditionAnalyzerTests.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using OpenCvSharp.Analyzers;
+using Xunit;
+
+namespace OpenCvSharp.Analyzers.Tests;
+
+public class MatPropertyInLoopConditionAnalyzerTests
+{
+    private const string MatStub = """
+        namespace OpenCvSharp
+        {
+            public class Mat
+            {
+                public int Rows { get; }
+                public int Cols { get; }
+                public int Dims { get; }
+                public int Width { get; }
+                public int Height { get; }
+            }
+        }
+        """;
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<MatPropertyInLoopConditionAnalyzer, XUnitVerifier>
+        {
+            TestCode = MatStub + source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task ForLoop_Rows_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                for (int i = 0; i < {|#0:mat.Rows|}; i++) { }
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(MatPropertyInLoopConditionAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Rows", "rows"));
+
+    [Fact]
+    public Task ForLoop_Cols_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                for (int j = 0; j < {|#0:mat.Cols|}; j++) { }
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(MatPropertyInLoopConditionAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Cols", "cols"));
+
+    [Fact]
+    public Task WhileLoop_Rows_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat, int i)
+            {
+                while (i < {|#0:mat.Rows|}) { i++; }
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(MatPropertyInLoopConditionAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Rows", "rows"));
+
+    [Fact]
+    public Task CachedLocal_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                int rows = mat.Rows;
+                for (int i = 0; i < rows; i++) { }
+            }
+        }
+        """);
+
+    [Fact]
+    public Task RowsUsedOutsideLoop_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                int n = mat.Rows;
+            }
+        }
+        """);
+}

--- a/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
+++ b/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <!-- Override the old CodeAnalysis pulled in transitively by the testing framework -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenCvSharp.Analyzers\OpenCvSharp.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
+++ b/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <!-- Override the old CodeAnalysis pulled in transitively by the testing framework -->

--- a/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis.CSharp.Testing;
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using OpenCvSharp.Analyzers;

--- a/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using OpenCvSharp.Analyzers;
+using Xunit;
+
+namespace OpenCvSharp.Analyzers.Tests;
+
+public class RowAtAnalyzerTests
+{
+    // Minimal stub of OpenCvSharp.Mat — lets the analyzer resolve types
+    // without requiring the actual OpenCvSharp assembly.
+    private const string MatStub = """
+        namespace OpenCvSharp
+        {
+            public class Mat
+            {
+                public Mat Row(int y) => this;
+                public ref T At<T>(int i0) where T : unmanaged => throw null!;
+                public ref T At<T>(int i0, int i1) where T : unmanaged => throw null!;
+            }
+            public struct Vec3b { }
+        }
+        """;
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<RowAtAnalyzer, XUnitVerifier>
+        {
+            TestCode = MatStub + source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task DirectChain_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var _ = {|#0:mat.Row(1).At<OpenCvSharp.Vec3b>(2)|};
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowAtAnalyzer.DiagnosticId).WithLocation(0));
+
+    [Fact]
+    public Task LocalVariable_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var row = mat.Row(1);
+                var _ = {|#0:row.At<OpenCvSharp.Vec3b>(2)|};
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowAtAnalyzer.DiagnosticId).WithLocation(0));
+
+    [Fact]
+    public Task TwoArgAt_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var _ = mat.At<OpenCvSharp.Vec3b>(1, 2);
+            }
+        }
+        """);
+
+    [Fact]
+    public Task AtOnFullMatrix_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var _ = mat.At<OpenCvSharp.Vec3b>(1);
+            }
+        }
+        """);
+
+    [Fact]
+    public Task LocalAssignedFromNonRowMethod_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat, OpenCvSharp.Mat other)
+            {
+                var row = other;
+                var _ = row.At<OpenCvSharp.Vec3b>(2);
+            }
+        }
+        """);
+}

--- a/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using OpenCvSharp.Analyzers;
+using Xunit;
+
+namespace OpenCvSharp.Analyzers.Tests;
+
+public class RowColInLoopBodyAnalyzerTests
+{
+    private const string MatStub = """
+        namespace OpenCvSharp
+        {
+            public class Mat
+            {
+                public int Rows { get; }
+                public Mat Row(int y) => this;
+                public Mat Col(int x) => this;
+            }
+        }
+        """;
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<RowColInLoopBodyAnalyzer, XUnitVerifier>
+        {
+            TestCode = MatStub + source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task RowInForLoop_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                int rows = mat.Rows;
+                for (int i = 0; i < rows; i++)
+                {
+                    var row = {|#0:mat.Row(i)|};
+                }
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowColInLoopBodyAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Row"));
+
+    [Fact]
+    public Task ColInWhileLoop_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat, int i)
+            {
+                while (i < 10)
+                {
+                    var col = {|#0:mat.Col(i)|};
+                    i++;
+                }
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowColInLoopBodyAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Col"));
+
+    [Fact]
+    public Task RowOutsideLoop_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var row = mat.Row(0);
+            }
+        }
+        """);
+
+    [Fact]
+    public Task RowInNestedLambda_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    System.Action a = () => mat.Row(0);  // lambda boundary — not flagged
+                }
+            }
+        }
+        """);
+}

--- a/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
@@ -79,6 +79,30 @@ public class RowColInLoopBodyAnalyzerTests
         """);
 
     [Fact]
+    public Task RowInForLoopCondition_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                for (int i = 0; i < mat.Row(0).Rows; i++) { }
+            }
+        }
+        """);
+
+    [Fact]
+    public Task RowInForLoopInitializer_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                for (var r = mat.Row(0); ; ) { }
+            }
+        }
+        """);
+
+    [Fact]
     public Task RowInNestedLambda_NoWarning() => Verify(
         """
         class Test

--- a/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using OpenCvSharp.Analyzers;
+using Xunit;
+
+namespace OpenCvSharp.Analyzers.Tests;
+
+public class RowColNotDisposedAnalyzerTests
+{
+    private const string MatStub = """
+        namespace OpenCvSharp
+        {
+            public class Mat : System.IDisposable
+            {
+                public Mat Row(int y) => this;
+                public Mat Col(int x) => this;
+                public Mat RowRange(int start, int end) => this;
+                public Mat ColRange(int start, int end) => this;
+                public void Dispose() { }
+            }
+        }
+        """;
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<RowColNotDisposedAnalyzer, XUnitVerifier>
+        {
+            TestCode = MatStub + source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    [Fact]
+    public Task VarWithoutUsing_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var row = {|#0:mat.Row(0)|};
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowColNotDisposedAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Row"));
+
+    [Fact]
+    public Task UsingVar_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                using var row = mat.Row(0);
+            }
+        }
+        """);
+
+    [Fact]
+    public Task UsingStatement_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                using (var row = mat.RowRange(0, 2)) { }
+            }
+        }
+        """);
+
+    [Fact]
+    public Task PassedAsArgument_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void Use(OpenCvSharp.Mat m) { }
+            void M(OpenCvSharp.Mat mat)
+            {
+                Use(mat.Row(0));
+            }
+        }
+        """);
+
+    [Fact]
+    public Task ColRangeWithoutUsing_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var c = {|#0:mat.ColRange(0, 3)|};
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowColNotDisposedAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("ColRange"));
+}

--- a/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
@@ -17,6 +17,8 @@ public class RowColNotDisposedAnalyzerTests
                 public Mat Col(int x) => this;
                 public Mat RowRange(int start, int end) => this;
                 public Mat ColRange(int start, int end) => this;
+                public T At<T>(int i0) where T : struct => default;
+                public Mat Clone() => new Mat();
                 public void Dispose() { }
             }
         }
@@ -82,6 +84,32 @@ public class RowColNotDisposedAnalyzerTests
             }
         }
         """);
+
+    [Fact]
+    public Task ChainedAtCall_NoWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                int v = mat.Row(0).At<int>(3);
+            }
+        }
+        """);
+
+    [Fact]
+    public Task ChainedCloneCall_ReportsWarning() => Verify(
+        """
+        class Test
+        {
+            void M(OpenCvSharp.Mat mat)
+            {
+                var copy = {|#0:mat.Row(0)|}.Clone();
+            }
+        }
+        """,
+        DiagnosticResult.CompilerWarning(RowColNotDisposedAnalyzer.DiagnosticId)
+            .WithLocation(0).WithArguments("Row"));
 
     [Fact]
     public Task ColRangeWithoutUsing_ReportsWarning() => Verify(

--- a/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
+++ b/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
@@ -65,7 +65,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NoWarn>CA1303;CA1814;CA1515</NoWarn>
+    <!-- CA1707: test methods intentionally use TypeName_Scenario naming convention -->
+    <NoWarn>CA1303;CA1707;CA1814;CA1515</NoWarn>
   </PropertyGroup>
   <!-- CA1510, CA1512, CA1513 suppressed: Throw helper methods are not available in .NET Standard 2.x and .NET Framework 4.8 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -334,8 +334,8 @@ public class ArucoTest : TestBase
             out var markerCorners, out var markerIds);
 
         // No markers or corners should be detected in a blank image
-        Assert.Equal(0, charucoIds.Length);
-        Assert.Equal(0, markerIds.Length);
+        Assert.Empty(charucoIds);
+        Assert.Empty(markerIds);
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -33,7 +33,9 @@ public class MatTest : TestBase
         using var img = new Mat(new Size(10, 10), MatType.CV_8UC1, Scalar.All(value));
         using var imgB = new Mat<byte>(img);
         var indexer = imgB.GetIndexer();
+#pragma warning disable CS0618
         var genericIndexer = img.GetGenericIndexer<byte>();
+#pragma warning restore CS0618
         var unsafeGenericIndexer = img.GetUnsafeGenericIndexer<byte>();
 
         Assert.Equal(value, indexer[0, 0]);
@@ -61,7 +63,9 @@ public class MatTest : TestBase
         using var img = new Mat(new Size(10, 10), MatType.CV_64FC3, scalarValue);
         using var imgB = new Mat<Vec3d>(img);
         var indexer = imgB.GetIndexer();
+#pragma warning disable CS0618
         var genericIndexer = img.GetGenericIndexer<Vec3d>();
+#pragma warning restore CS0618
         var unsafeGenericIndexer = img.GetUnsafeGenericIndexer<Vec3d>();
 
         Assert.Equal(expectedValue, indexer[0, 0]);

--- a/test/OpenCvSharp.Tests/core/MatTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTest.cs
@@ -33,22 +33,19 @@ public class MatTest : TestBase
         using var img = new Mat(new Size(10, 10), MatType.CV_8UC1, Scalar.All(value));
         using var imgB = new Mat<byte>(img);
         var indexer = imgB.GetIndexer();
-#pragma warning disable CS0618
-        var genericIndexer = img.GetGenericIndexer<byte>();
-#pragma warning restore CS0618
         var unsafeGenericIndexer = img.GetUnsafeGenericIndexer<byte>();
 
         Assert.Equal(value, indexer[0, 0]);
-        Assert.Equal(value, genericIndexer[0, 0]);
+        Assert.Equal(value, img.At<byte>(0, 0));
         Assert.Equal(value, unsafeGenericIndexer[0, 0]);
 
         Assert.Equal(value, indexer[5, 7]);
-        Assert.Equal(value, genericIndexer[5, 7]);
+        Assert.Equal(value, img.At<byte>(5, 7));
         Assert.Equal(value, unsafeGenericIndexer[5, 7]);
 
         indexer[3, 4] = 1;
         Assert.Equal(1, img.Get<byte>(3, 4));
-        genericIndexer[3, 4] = 2;
+        img.At<byte>(3, 4) = 2;
         Assert.Equal(2, img.Get<byte>(3, 4));
         unsafeGenericIndexer[3, 4] = 3;
         Assert.Equal(3, img.Get<byte>(3, 4));
@@ -63,23 +60,20 @@ public class MatTest : TestBase
         using var img = new Mat(new Size(10, 10), MatType.CV_64FC3, scalarValue);
         using var imgB = new Mat<Vec3d>(img);
         var indexer = imgB.GetIndexer();
-#pragma warning disable CS0618
-        var genericIndexer = img.GetGenericIndexer<Vec3d>();
-#pragma warning restore CS0618
         var unsafeGenericIndexer = img.GetUnsafeGenericIndexer<Vec3d>();
 
         Assert.Equal(expectedValue, indexer[0, 0]);
-        Assert.Equal(expectedValue, genericIndexer[0, 0]);
+        Assert.Equal(expectedValue, img.At<Vec3d>(0, 0));
         Assert.Equal(expectedValue, unsafeGenericIndexer[0, 0]);
 
         Assert.Equal(expectedValue, indexer[5, 7]);
-        Assert.Equal(expectedValue, genericIndexer[5, 7]);
+        Assert.Equal(expectedValue, img.At<Vec3d>(5, 7));
         Assert.Equal(expectedValue, unsafeGenericIndexer[5, 7]);
 
         indexer[3, 4] = new Vec3d(2, 3, 4);
         Assert.Equal(new Vec3d(2, 3, 4), img.Get<Vec3d>(3, 4));
 
-        genericIndexer[3, 4] = new Vec3d(3, 4, 5);
+        img.At<Vec3d>(3, 4) = new Vec3d(3, 4, 5);
         Assert.Equal(new Vec3d(3, 4, 5), img.Get<Vec3d>(3, 4));
 
         unsafeGenericIndexer[3, 4] = new Vec3d(4, 5, 6);

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -543,15 +543,14 @@ public class ImgProcTest : TestBase
         if (height != expected.GetLength(0) || width != expected.GetLength(1))
             throw new ArgumentException("size mismatch");
 
-#pragma warning disable CS0618
-        var indexer = img.GetGenericIndexer<Vec3b>();
-#pragma warning restore CS0618
+        var rows = img.AsRows<Vec3b>();
         for (var y = 0; y < height; y++)
         {
+            var row = rows[y];
             for (var x = 0; x < width; x++)
             {
                 var expectedValue = expected[y, x];
-                var actualValue = indexer[y, x];
+                var actualValue = row[x];
                 Assert.True(
                     expectedValue == actualValue,
                     // ReSharper disable once UseStringInterpolation

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -543,7 +543,9 @@ public class ImgProcTest : TestBase
         if (height != expected.GetLength(0) || width != expected.GetLength(1))
             throw new ArgumentException("size mismatch");
 
+#pragma warning disable CS0618
         var indexer = img.GetGenericIndexer<Vec3b>();
+#pragma warning restore CS0618
         for (var y = 0; y < height; y++)
         {
             for (var x = 0; x < width; x++)


### PR DESCRIPTION
Fixes #1775

## Background

`mat.Row(i).At<Vec3b>(col)` silently reads garbage memory. `Row(i)` returns a 2D 1×N
submatrix; `At<T>(int i0)` treats `i0` as a *row* index, so `data + step[0]*col` skips
hundreds of bytes per "column". The root cause was also missing `GC.KeepAlive(this)` in
`Row()`, which could allow the parent `Mat` to be finalized while the native submatrix
pointer is still live.

## Changes

### Bug fix
- `Mat.Row()` / `Mat.Col()`: added `GC.KeepAlive(this)` after the P/Invoke call to
  prevent premature finalization of the parent matrix.

### New Span-based APIs
- `Mat.RowSpan<T>(int row)` — returns a `Span<T>` over a single row (zero allocation,
  ~5 P/Invoke calls per row vs 200k for per-pixel `At<T>`).
- `Mat.AsRows<T>()` — returns a `MatRowAccessor<T>` (ref struct) that exposes each row
  as a `Span<T>` with only 5 P/Invoke calls total, regardless of matrix size.
- `MatRowAccessor<T>` — new `readonly ref struct` in `src/OpenCvSharp/Modules/core/Mat/`.

### `At<T>` misuse guard
- `At<T>(int i0)` now throws `InvalidOperationException` in `#if DEBUG` builds when
  called on a 1-row 2D submatrix, pointing users to `At<T>(0, col)` or `RowSpan<T>`.

### Obsolete Marshal-based indexer
- `GetGenericIndexer<T>()` and the inner `Indexer<T>` class are marked `[Obsolete]`;
  `AsRows<T>()` / `RowSpan<T>()` are the zero-allocation replacements.

### Roslyn analyzers (new project `src/OpenCvSharp.Analyzers`)
| ID | Category | Description |
|----|----------|-------------|
| OCVS001 | Correctness | `mat.Row(i).At<T>(col)` — At(int) on a row submatrix uses wrong stride |
| OCVS002 | Performance | `mat.Rows` / `mat.Cols` / `mat.Dims` in loop condition — P/Invoke on each iteration |
| OCVS003 | Performance | `mat.Row()` / `mat.Col()` inside loop body — allocates submatrix every iteration |
| OCVS004 | Reliability | `Row()`/`Col()`/`RowRange()`/`ColRange()` result not disposed — native handle leak |
| OCVS005 | Reliability | `a + b + c` with `Mat` — intermediate `MatExpr` temp not disposed |

All five analyzers ship as a Roslyn analyzer assembly referenced by `OpenCvSharp.csproj`
(`ReferenceOutputAssembly=false`, `OutputItemType=Analyzer`). 22 xunit tests cover the
happy paths and the no-warning cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New analyzers (OCVS001–OCVS005) that surface warnings for common Mat misuse.
  * RowSpan<T>() and AsRows<T>() for efficient, zero-allocation row access.

* **Bug Fixes**
  * Mat.Row now ensures the parent matrix remains alive across native calls.

* **Deprecations**
  * Legacy generic/unsafe indexers marked obsolete; prefer At<T>() or AsRows<T>().

* **Chores / Tests**
  * Analyzer packaging and comprehensive analyzer test suites added.

* **Documentation**
  * Shipped/unshipped analyzer release notes added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->