### PR TITLE
Fix LineSegmentDetector segfault caused by C++/C# calling convention mismatch

### DIFF
--- a/src/OpenCvSharpExtern/imgproc_LineSegmentDetector.h
+++ b/src/OpenCvSharpExtern/imgproc_LineSegmentDetector.h
@@ -38,12 +38,16 @@ CVAPI(cv::Ptr<cv::LineSegmentDetector>*) imgproc_createLineSegmentDetector(
         refine, scale, sigma_scale, quant, ang_th, log_eps, density_th, n_bins));
 }
 
-CVAPI(void) imgproc_Ptr_LineSegmentDetector_delete(cv::Ptr<cv::LineSegmentDetector> *obj)
+CVAPI(ExceptionStatus) imgproc_Ptr_LineSegmentDetector_delete(cv::Ptr<cv::LineSegmentDetector> *obj)
 {
+    BEGIN_WRAP
     delete obj;
+    END_WRAP
 }
 
-CVAPI(cv::LineSegmentDetector*) imgproc_Ptr_LineSegmentDetector_get(cv::Ptr<cv::LineSegmentDetector> *obj)
+CVAPI(ExceptionStatus) imgproc_Ptr_LineSegmentDetector_get(cv::Ptr<cv::LineSegmentDetector> *obj, cv::LineSegmentDetector **returnValue)
 {
-    return obj->get();
+    BEGIN_WRAP
+    *returnValue = obj->get();
+    END_WRAP
 }

--- a/test/OpenCvSharp.Tests/imgproc/LineSegmentDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/LineSegmentDetectorTest.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.ImgProc;
+
+public class LineSegmentDetectorTest : TestBase
+{
+    [Fact]
+    public void CreateAndDetect()
+    {
+        using var image = new Mat(500, 500, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.Line(image, new Point(50, 50), new Point(450, 50), new Scalar(0, 0, 0), 2);
+
+        using var lsd = LineSegmentDetector.Create();
+        Assert.NotEqual(IntPtr.Zero, lsd.RawPtr);
+
+        lsd.Detect(image, out var lines, out _, out _, out _);
+        Assert.NotEmpty(lines);
+    }
+
+    [Fact]
+    public void DetectOutputArray()
+    {
+        using var image = new Mat(500, 500, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.Line(image, new Point(50, 50), new Point(450, 50), new Scalar(0, 0, 0), 2);
+
+        using var lsd = LineSegmentDetector.Create();
+        using var lines = new Mat();
+        lsd.Detect(image, lines);
+        Assert.False(lines.Empty());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1876.

`LineSegmentDetector.Create()` returned an instance with a null `RawPtr` in 4.13.0.20260427, causing a segfault on `Detect()`.

## Root cause

PR #1846 updated the C# P/Invoke declarations for
`imgproc_Ptr_LineSegmentDetector_get` and `imgproc_Ptr_LineSegmentDetector_delete` to the new `ExceptionStatus` + out-parameter convention, but the corresponding C++ implementations in `imgproc_LineSegmentDetector.h` were left in the old
direct-return style. The calling-convention mismatch caused `rawPtr` to be populated with garbage/null, leading to the segfault.

## Fix

Update the two C++ functions to match the convention already used everywhere else in the codebase (e.g. `bgsegm.h`, `calib3d_StereoMatcher.h`):

- Return `ExceptionStatus` instead of `void` / raw pointer
- Wrap the body with `BEGIN_WRAP` / `END_WRAP`
- Pass the result via an output pointer parameter

Also adds `LineSegmentDetectorTest` covering the exact repro case from the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for LineSegmentDetector functionality, covering object creation, line detection operations, and various output handling scenarios.

* **Refactor**
  * Updated LineSegmentDetector API interfaces with enhanced error handling and resource management patterns for improved stability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->