### PR TITLE
Fix MergeDebevec/MergeMertens segfault caused by C++/C# calling convention mismatch

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_HDR.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_HDR.cs
@@ -68,8 +68,6 @@ static partial class NativeMethods
     public static extern ExceptionStatus photo_CalibrateCRF_process(
         IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times);
 
-    // TODO Exception Handling
-
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus photo_createMergeDebevec(out IntPtr returnValue);
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -85,9 +83,9 @@ static partial class NativeMethods
     public static extern ExceptionStatus photo_Ptr_MergeMertens_get(IntPtr obj, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern void photo_MergeExposures_process(
+    public static extern ExceptionStatus photo_MergeExposures_process(
         IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times, IntPtr response);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern IntPtr photo_MergeMertens_process(IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst);
+    public static extern ExceptionStatus photo_MergeMertens_process(IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst);
 }

--- a/src/OpenCvSharp/Modules/photo/MergeExposures.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeExposures.cs
@@ -35,7 +35,8 @@ public abstract class MergeExposures : Algorithm
         if (srcArray.Length != timesArray.Length)
             throw new OpenCvSharpException("src.Count() != times.Count");
             
-        NativeMethods.photo_MergeExposures_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr, timesArray, response.CvPtr);
+        NativeMethods.HandleException(
+            NativeMethods.photo_MergeExposures_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr, timesArray, response.CvPtr));
 
         dst.Fix();
         GC.KeepAlive(this);

--- a/src/OpenCvSharp/Modules/photo/MergeMertens.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeMertens.cs
@@ -48,7 +48,8 @@ public sealed class MergeMertens : MergeExposures
 
         var srcArray = src.Select(s => s.CvPtr).ToArray();
 
-        NativeMethods.photo_MergeMertens_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr);
+        NativeMethods.HandleException(
+            NativeMethods.photo_MergeMertens_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr));
 
         GC.KeepAlive(this);
         GC.KeepAlive(src);

--- a/src/OpenCvSharpExtern/photo_HDR.h
+++ b/src/OpenCvSharpExtern/photo_HDR.h
@@ -146,11 +146,11 @@ CVAPI(ExceptionStatus) photo_CalibrateCRF_process(
     END_WRAP
 }
 
-// TODO Exception Handling
-
-CVAPI(cv::Ptr<cv::MergeDebevec>*) photo_createMergeDebevec()
+CVAPI(ExceptionStatus) photo_createMergeDebevec(cv::Ptr<cv::MergeDebevec>** returnValue)
 {
-    return clone(cv::createMergeDebevec());
+    BEGIN_WRAP
+    *returnValue = clone(cv::createMergeDebevec());
+    END_WRAP
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_delete(cv::Ptr<cv::MergeDebevec>* obj)
 {
@@ -165,9 +165,11 @@ CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_get(cv::Ptr<cv::MergeDebevec>* obj
     END_WRAP
 }
 
-CVAPI(cv::Ptr<cv::MergeMertens>*) photo_createMergeMertens()
+CVAPI(ExceptionStatus) photo_createMergeMertens(cv::Ptr<cv::MergeMertens>** returnValue)
 {
-    return clone(cv::createMergeMertens());
+    BEGIN_WRAP
+    *returnValue = clone(cv::createMergeMertens());
+    END_WRAP
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_delete(cv::Ptr<cv::MergeMertens>* obj)
 {
@@ -182,39 +184,32 @@ CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_get(cv::Ptr<cv::MergeMertens>* obj
     END_WRAP
 }
 
-CVAPI(void) photo_MergeExposures_process(
+CVAPI(ExceptionStatus) photo_MergeExposures_process(
     cv::MergeExposures* obj,
     cv::Mat** srcImgs, int srcImgsLength, cv::_OutputArray* dst, float* times, cv::_InputArray* response)
 {
-    // Build Mat Vector of images
+    BEGIN_WRAP
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
-
-    // Build float Vector of times
     std::vector<float> times_vec(srcImgsLength);
-
     for (int i = 0; i < srcImgsLength; i++) {
         srcImgsVec[i] = *srcImgs[i];
         times_vec[i] = times[i];
     }
-
     obj->process(srcImgsVec, *dst, times_vec, *response);
+    END_WRAP
 }
 
-CVAPI(void) photo_MergeMertens_process(
+CVAPI(ExceptionStatus) photo_MergeMertens_process(
     cv::MergeMertens* obj,
     cv::Mat** srcImgs, int srcImgsLength, cv::_OutputArray* dst)
 {
-    // Build Mat Vector of images
+    BEGIN_WRAP
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
-
-    // Build float Vector of times
-    std::vector<float> times_vec(srcImgsLength);
-
     for (int i = 0; i < srcImgsLength; i++) {
         srcImgsVec[i] = *srcImgs[i];
     }
-
     obj->process(srcImgsVec, *dst);
+    END_WRAP
 }
 
 #endif // NO_PHOTO

--- a/src/OpenCvSharpExtern/photo_HDR.h
+++ b/src/OpenCvSharpExtern/photo_HDR.h
@@ -152,26 +152,34 @@ CVAPI(cv::Ptr<cv::MergeDebevec>*) photo_createMergeDebevec()
 {
     return clone(cv::createMergeDebevec());
 }
-CVAPI(void) photo_Ptr_MergeDebevec_delete(cv::Ptr<cv::MergeDebevec>* obj)
+CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_delete(cv::Ptr<cv::MergeDebevec>* obj)
 {
+    BEGIN_WRAP
     delete obj;
+    END_WRAP
 }
-CVAPI(cv::MergeDebevec*) photo_Ptr_MergeDebevec_get(cv::Ptr<cv::MergeDebevec>* obj)
+CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_get(cv::Ptr<cv::MergeDebevec>* obj, cv::MergeDebevec **returnValue)
 {
-    return obj->get();
+    BEGIN_WRAP
+    *returnValue = obj->get();
+    END_WRAP
 }
 
 CVAPI(cv::Ptr<cv::MergeMertens>*) photo_createMergeMertens()
 {
     return clone(cv::createMergeMertens());
 }
-CVAPI(void) photo_Ptr_MergeMertens_delete(cv::Ptr<cv::MergeMertens>* obj)
+CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_delete(cv::Ptr<cv::MergeMertens>* obj)
 {
+    BEGIN_WRAP
     delete obj;
+    END_WRAP
 }
-CVAPI(cv::MergeMertens*) photo_Ptr_MergeMertens_get(cv::Ptr<cv::MergeMertens>* obj)
+CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_get(cv::Ptr<cv::MergeMertens>* obj, cv::MergeMertens **returnValue)
 {
-    return obj->get();
+    BEGIN_WRAP
+    *returnValue = obj->get();
+    END_WRAP
 }
 
 CVAPI(void) photo_MergeExposures_process(

--- a/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
+++ b/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace OpenCvSharp.Tests.Photo;
 

--- a/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
+++ b/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
@@ -1,0 +1,89 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Photo;
+
+public class MergeExposuresTest : TestBase
+{
+    private static Mat[] CreateExposureImages() =>
+    [
+        new Mat(100, 100, MatType.CV_8UC3, new Scalar(64, 64, 64)),
+        new Mat(100, 100, MatType.CV_8UC3, new Scalar(128, 128, 128)),
+        new Mat(100, 100, MatType.CV_8UC3, new Scalar(192, 192, 192)),
+    ];
+
+    #region MergeDebevec
+
+    [Fact]
+    public void MergeDebevecCreate()
+    {
+        using var merger = MergeDebevec.Create();
+        Assert.NotEqual(IntPtr.Zero, merger.RawPtr);
+    }
+
+    [Fact]
+    public void MergeDebevecProcess()
+    {
+        var images = CreateExposureImages();
+        try
+        {
+            float[] times = [0.25f, 0.5f, 1.0f];
+
+            // Linear inverse CRF: response[i] = i/255 for each channel
+            var responseData = new Vec3f[256];
+            for (int i = 0; i < 256; i++)
+            {
+                float v = i / 255.0f;
+                responseData[i] = new Vec3f(v, v, v);
+            }
+            using var response = new Mat(256, 1, MatType.CV_32FC3);
+            response.SetArray(responseData);
+
+            using var dst = new Mat();
+            using var merger = MergeDebevec.Create();
+            merger.Process(images, dst, times, response);
+
+            Assert.False(dst.Empty());
+            Assert.Equal(MatType.CV_32FC3, dst.Type());
+            Assert.Equal(100, dst.Rows);
+            Assert.Equal(100, dst.Cols);
+        }
+        finally
+        {
+            foreach (var img in images) img.Dispose();
+        }
+    }
+
+    #endregion
+
+    #region MergeMertens
+
+    [Fact]
+    public void MergeMertensCreate()
+    {
+        using var merger = MergeMertens.Create();
+        Assert.NotEqual(IntPtr.Zero, merger.RawPtr);
+    }
+
+    [Fact]
+    public void MergeMertensProcess()
+    {
+        var images = CreateExposureImages();
+        try
+        {
+            using var dst = new Mat();
+            using var merger = MergeMertens.Create();
+            merger.Process(images, dst);
+
+            Assert.False(dst.Empty());
+            Assert.Equal(MatType.CV_32FC3, dst.Type());
+            Assert.Equal(100, dst.Rows);
+            Assert.Equal(100, dst.Cols);
+        }
+        finally
+        {
+            foreach (var img in images) img.Dispose();
+        }
+    }
+
+    #endregion
+}

--- a/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
+++ b/test/OpenCvSharp.Tests/photo/MergeExposuresTest.cs
@@ -4,12 +4,14 @@ namespace OpenCvSharp.Tests.Photo;
 
 public class MergeExposuresTest : TestBase
 {
+#pragma warning disable CA2000
     private static Mat[] CreateExposureImages() =>
     [
         new Mat(100, 100, MatType.CV_8UC3, new Scalar(64, 64, 64)),
         new Mat(100, 100, MatType.CV_8UC3, new Scalar(128, 128, 128)),
         new Mat(100, 100, MatType.CV_8UC3, new Scalar(192, 192, 192)),
     ];
+#pragma warning restore CA2000
 
     #region MergeDebevec
 


### PR DESCRIPTION
## Summary

Same class of bug as #1876.

`MergeDebevec` and `MergeMertens` are affected by the same calling-convention mismatch introduced in #1846: the C# P/Invoke declarations for `photo_Ptr_MergeDebevec_get/delete` and `photo_Ptr_MergeMertens_get/delete`
were updated to the new `ExceptionStatus` + out-parameter convention, but the C++ implementations in `photo_HDR.h` were left in the old direct-return style.

This causes `RawPtr` to be populated with garbage/null on construction, leading to a segfault when any method is called on these objects.

## Fix

Update the four C++ functions to the convention already used by the surrounding code in the same file (`CalibrateDebevec`, `CalibrateRobertson`, etc.): return `ExceptionStatus`, wrap with `BEGIN_WRAP`/`END_WRAP`, and pass the result via an output pointer parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for HDR exposure-merge operations: native failures are now translated and surfaced as managed exceptions, providing more reliable failure reporting during merge processing.
* **Tests**
  * Added tests for MergeDebevec and MergeMertens creation and processing. Tests use synthetic images to validate non-null creations, output format/type and dimensions, and ensure proper resource disposal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->