### PR TITLE
Remove unused Ptr_xxx_get P/Invoke declarations from features2d NativeMethods

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features2d/NativeMethods_features2d_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features2d/NativeMethods_features2d_Feature2D.cs
@@ -62,9 +62,6 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_SIFT_delete(IntPtr ptr);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_SIFT_get(IntPtr ptr, out IntPtr returnValue);
-
     #endregion
 
     #region BRISK
@@ -93,9 +90,6 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_BRISK_delete(IntPtr ptr);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_BRISK_get(IntPtr ptr, out IntPtr returnValue);
-
     #endregion
 
     #region ORB
@@ -107,9 +101,6 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_ORB_delete(IntPtr ptr);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_ORB_get(IntPtr ptr, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_ORB_setMaxFeatures(IntPtr obj, int val);
@@ -170,9 +161,6 @@ static partial class NativeMethods
     public static extern ExceptionStatus features2d_Ptr_MSER_delete(IntPtr ptr);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_MSER_get(IntPtr ptr, out IntPtr returnValue);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_MSER_detectRegions(
         IntPtr obj, IntPtr image, IntPtr msers, IntPtr bboxes);
 
@@ -211,9 +199,6 @@ static partial class NativeMethods
     public static extern ExceptionStatus features2d_Ptr_FastFeatureDetector_delete(IntPtr ptr);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_FastFeatureDetector_get(IntPtr ptr, out IntPtr returnValue);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_FastFeatureDetector_setThreshold(IntPtr obj, int threshold);
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_FastFeatureDetector_getThreshold(IntPtr obj, out int returnValue);
@@ -244,9 +229,6 @@ static partial class NativeMethods
     public static extern ExceptionStatus features2d_Ptr_AgastFeatureDetector_delete(IntPtr ptr);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_AgastFeatureDetector_get(IntPtr ptr, out IntPtr returnValue);
-        
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_AgastFeatureDetector_setThreshold(IntPtr obj, int val);
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_AgastFeatureDetector_getThreshold(IntPtr obj, out int returnValue);
@@ -268,9 +250,6 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_GFTTDetector_create(int maxCorners, double qualityLevel, 
         double minDistance, int blockSize, int useHarrisDetector, double k, out IntPtr returnValue);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_GFTTDetector_get(IntPtr ptr, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_GFTTDetector_delete(IntPtr ptr);
@@ -316,9 +295,6 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_SimpleBlobDetector_delete(IntPtr ptr);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_SimpleBlobDetector_get(IntPtr ptr, out IntPtr returnValue);
-
     #endregion
 
     #region KAZE
@@ -330,9 +306,6 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_KAZE_delete(IntPtr ptr);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_KAZE_get(IntPtr ptr, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_KAZE_setDiffusivity(IntPtr obj, int val);
@@ -375,9 +348,6 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_Ptr_AKAZE_delete(IntPtr ptr);
-
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus features2d_Ptr_AKAZE_get(IntPtr ptr, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features2d_AKAZE_setDescriptorType(IntPtr obj, int val);


### PR DESCRIPTION
## Summary

Cleanup of dead code found while investigating the #1846 migration.

All feature detector `Create()` methods (SIFT, BRISK, ORB, MSER, FastFeatureDetector, AgastFeatureDetector, GFTTDetector, SimpleBlobDetector, KAZE, AKAZE) retrieve the raw pointer via the shared `features2d_Ptr_Feature2D_get`. The individual `Ptr_xxx_get` declarations were added to `NativeMethods_features2d_Feature2D.cs` during #1846 but:

- Are never called anywhere in the managed codebase
- Have no corresponding C++ implementations in `features2d_Feature2D.h`

Removes all 10 dead declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal method declarations for feature detection algorithms (SIFT, BRISK, ORB, MSER, FastFeatureDetector, AgastFeatureDetector, GFTTDetector, SimpleBlobDetector, KAZE, AKAZE). Core functionality remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->