### PR TITLE
Fix: include OpenCvSharp.Analyzers.dll in NuGet package (analyzers/dotnet/cs/)

### DIFF
--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -46,11 +46,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Include the analyzer in this package under analyzers/dotnet/cs/ -->
+    <!-- OutputItemType="Analyzer" enables the analyzer during in-solution builds.
+         The None item below is also required to place the DLL under analyzers/dotnet/cs/
+         inside the NuGet package; OutputItemType alone does not trigger packaging. -->
     <ProjectReference Include="..\OpenCvSharp.Analyzers\OpenCvSharp.Analyzers.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
                       SetTargetFramework="TargetFramework=netstandard2.0" />
+    <None Include="..\OpenCvSharp.Analyzers\bin\$(Configuration)\netstandard2.0\OpenCvSharp.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />


### PR DESCRIPTION
## Summary

- `ProjectReference` with `OutputItemType="Analyzer"` enables the Roslyn analyzers during in-solution builds, but does **not** cause the DLL to appear in the NuGet package under `analyzers/dotnet/cs/`
- As a result, consumers of the `OpenCvSharp4` NuGet package never saw the OCVS001–OCVS005 warnings (e.g. `mat.Row(1).At<byte>(1)`)
- Fix: add an explicit `None` item with `Pack="true"` and `PackagePath="analyzers/dotnet/cs"` pointing at the built `OpenCvSharp.Analyzers.dll`

## What changed

`src/OpenCvSharp/OpenCvSharp.csproj` — added:

```xml
<None Include="..\OpenCvSharp.Analyzers\bin\$(Configuration)\netstandard2.0\OpenCvSharp.Analyzers.dll"
      Pack="true"
      PackagePath="analyzers/dotnet/cs"
      Visible="false" />
```

## Verification

Ran `dotnet pack` before and after:

- **Before**: `analyzers/dotnet/cs/` absent from `.nupkg`
- **After**: `analyzers/dotnet/cs/OpenCvSharp.Analyzers.dll` present in `.nupkg`

## Reviewer notes

The `None` item references the build output path, so `OpenCvSharp.Analyzers` must be built before packing `OpenCvSharp`. This ordering is already guaranteed in normal solution builds and CI (the `ProjectReference` dependency ensures the analyzer project builds first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved NuGet package configuration to ensure analyzers are properly included in the distributed package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->