### PR TITLE
Fix: correct FFmpeg DLL path in runtime.win package and detect dotnet pack failures

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -53,18 +53,39 @@ jobs:
       - run: |
           ls -l
 
-      - name: Validate windows slim packages exist
+      - name: Validate expected packages exist
         run: |
           set -euo pipefail
 
-          runtime_count=$(find "$PWD" -type f -name "OpenCvSharp4.runtime.win.slim*.nupkg" | wc -l)
-          windows_slim_count=$(find "$PWD" -type f -name "OpenCvSharp4.Windows.Slim*.nupkg" | wc -l)
+          failed=0
+          check_package() {
+            local pattern="$1"
+            local count
+            count=$(find "$PWD" -maxdepth 4 -type f -name "${pattern}" | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "MISSING: $pattern"
+              failed=$((failed + 1))
+            else
+              echo "OK: $pattern"
+            fi
+          }
 
-          if [ "$runtime_count" -eq 0 ] || [ "$windows_slim_count" -eq 0 ]; then
-            echo "Expected Windows slim NuGet packages were not found in downloaded artifacts."
-            echo "runtime.win.slim count: $runtime_count"
-            echo "Windows.Slim count: $windows_slim_count"
-            echo "Detected .nupkg files:"
+          check_package "OpenCvSharp4.4.*.nupkg"
+          check_package "OpenCvSharp4.Extensions.*.nupkg"
+          check_package "OpenCvSharp4.WpfExtensions.*.nupkg"
+          check_package "OpenCvSharp4.runtime.win.[0-9]*.nupkg"
+          check_package "OpenCvSharp4.runtime.win.slim.*.nupkg"
+          check_package "OpenCvSharp4.Windows.[0-9]*.nupkg"
+          check_package "OpenCvSharp4.Windows.Slim.*.nupkg"
+          check_package "OpenCvSharp4.runtime.linux-arm.*.nupkg"
+          check_package "OpenCvSharp4.runtime.linux-arm64.*.nupkg"
+          check_package "OpenCvSharp4.runtime.wasm.*.nupkg"
+          check_package "OpenCvSharp4.official.runtime.linux-x64.[0-9]*.nupkg"
+          check_package "OpenCvSharp4.official.runtime.linux-x64.slim.*.nupkg"
+
+          if [ "$failed" -gt 0 ]; then
+            echo ""
+            echo "ERROR: $failed expected package(s) not found. Detected .nupkg files:"
             find "$PWD" -maxdepth 4 -type f -name "*.nupkg" -print
             exit 1
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -227,19 +227,27 @@ jobs:
 
           # Pack main libraries (dotnet pack triggers build implicitly)
           dotnet pack src/OpenCvSharp/OpenCvSharp.csproj -c Release -o artifacts -p:Version=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj -c Release -o artifacts -p:Version=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack src/OpenCvSharp.WpfExtensions/OpenCvSharp.WpfExtensions.csproj -c Release -o artifacts -p:Version=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Pack runtime packages
           dotnet pack nuget/OpenCvSharp4.runtime.win.csproj -o artifacts -p:Version=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack nuget/OpenCvSharp4.runtime.win.slim.csproj -o artifacts -p:Version=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Add local artifacts as NuGet source for meta-package
           dotnet nuget add source "${env:GITHUB_WORKSPACE}\artifacts" --name LocalPackages
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Pack meta-package (depends on packages built above)
           dotnet pack nuget/OpenCvSharp4.Windows.csproj -o artifacts -p:Version=$version -p:PackageVersion=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack nuget/OpenCvSharp4.Windows.Slim.csproj -o artifacts -p:Version=$version -p:PackageVersion=$version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Run ReleaseMaker
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -119,6 +119,10 @@ jobs:
           path: ${{ github.workspace }}/opencv_artifacts
           key: opencv-${{ env.OPENCV_VERSION }}-windows-x64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
 
+      - name: List opencv_artifacts directory structure
+        shell: pwsh
+        run: Get-ChildItem -Recurse "$env:GITHUB_WORKSPACE/opencv_artifacts" -Filter "*.dll" | Select-Object FullName
+
       # Commented out: FFmpeg backend is included in opencv_videoio_ffmpeg DLLs
       # If video tests fail, uncomment this step
       #- name: Install Server-Media-Foundation

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -119,10 +119,6 @@ jobs:
           path: ${{ github.workspace }}/opencv_artifacts
           key: opencv-${{ env.OPENCV_VERSION }}-windows-x64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
 
-      - name: List opencv_artifacts directory structure
-        shell: pwsh
-        run: Get-ChildItem -Recurse "$env:GITHUB_WORKSPACE/opencv_artifacts" -Filter "*.dll" | Select-Object FullName
-
       # Commented out: FFmpeg backend is included in opencv_videoio_ffmpeg DLLs
       # If video tests fail, uncomment this step
       #- name: Install Server-Media-Foundation

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -217,9 +217,10 @@ jobs:
           Write-Host "Security hardening verified: no actionable failures."
 
       - name: Pack NuGet packages
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
 
           $date = Get-Date -Format "yyyyMMdd"
           $version = "${env:OPENCV_VERSION}.${date}-beta"
@@ -227,27 +228,19 @@ jobs:
 
           # Pack main libraries (dotnet pack triggers build implicitly)
           dotnet pack src/OpenCvSharp/OpenCvSharp.csproj -c Release -o artifacts -p:Version=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj -c Release -o artifacts -p:Version=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack src/OpenCvSharp.WpfExtensions/OpenCvSharp.WpfExtensions.csproj -c Release -o artifacts -p:Version=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Pack runtime packages
           dotnet pack nuget/OpenCvSharp4.runtime.win.csproj -o artifacts -p:Version=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack nuget/OpenCvSharp4.runtime.win.slim.csproj -o artifacts -p:Version=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Add local artifacts as NuGet source for meta-package
           dotnet nuget add source "${env:GITHUB_WORKSPACE}\artifacts" --name LocalPackages
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Pack meta-package (depends on packages built above)
           dotnet pack nuget/OpenCvSharp4.Windows.csproj -o artifacts -p:Version=$version -p:PackageVersion=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet pack nuget/OpenCvSharp4.Windows.Slim.csproj -o artifacts -p:Version=$version -p:PackageVersion=$version
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Run ReleaseMaker
         shell: powershell

--- a/nuget/OpenCvSharp4.runtime.win.csproj
+++ b/nuget/OpenCvSharp4.runtime.win.csproj
@@ -23,6 +23,7 @@
   
   <ItemGroup>
     <None Include="../src/build/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <None Include="../opencv_artifacts/x64/vc17/bin/opencv_videoio_ffmpeg4130_64.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netstandard" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netcoreapp" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/net8.0" />

--- a/nuget/OpenCvSharp4.runtime.win.csproj
+++ b/nuget/OpenCvSharp4.runtime.win.csproj
@@ -23,7 +23,6 @@
   
   <ItemGroup>
     <None Include="../src/build/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <None Include="../opencv_artifacts/bin/opencv_videoio_ffmpeg4130_64.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netstandard" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netcoreapp" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/net8.0" />


### PR DESCRIPTION
## Summary

- **`nuget/OpenCvSharp4.runtime.win.csproj`**: Fix the path to `opencv_videoio_ffmpeg4130_64.dll`. The Visual Studio generator installs it to `opencv_artifacts/x64/vc17/bin/`, not `opencv_artifacts/bin/`, causing `dotnet pack` to fail with "Could not find a part of the path".
- **`.github/workflows/windows.yml`**: Switch `Pack NuGet packages` step from `shell: powershell` (Windows PowerShell 5.1) to `shell: pwsh` (PowerShell 7) and add `$PSNativeCommandUseErrorActionPreference = $true`. This makes native command failures (e.g. `dotnet pack`) respect `$ErrorActionPreference = "Stop"`, so errors are no longer silently ignored.

## Root cause

`dotnet pack nuget/OpenCvSharp4.runtime.win.csproj` was failing with:
```
error : Could not find a part of the path 'D:\a\opencvsharp\opencvsharp\opencv_artifacts\bin'
```

Because the `Pack NuGet packages` step did not detect native command failures, execution continued silently. This caused a cascade: `OpenCvSharp4.Windows` also failed to pack (it depends on `OpenCvSharp4.runtime.win` being present in the local artifact source). Both packages were missing from the NuGet publish run.
The correct DLL path was confirmed by inspecting the `opencv_artifacts` directory structure in CI:
`opencv_artifacts/x64/vc17/bin/opencv_videoio_ffmpeg4130_64.dll`

## Test plan
- [ ] `windows.yml` CI completes successfully and both `OpenCvSharp4.runtime.win.*.nupkg` and `OpenCvSharp4.Windows.*.nupkg` are produced
- [ ] If a `dotnet pack` step fails in the future, the workflow step fails immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced NuGet package validation in the CI/CD pipeline with improved error detection for missing packages
  * Updated Windows native library source path in the runtime package for better consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->