### PR TITLE
Fix IL3000 trimming warning in WindowsLibraryLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Personal notes (not for version control)
+docs/issue-backlog-ja.md
+
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
 [Bb]in/
 [Oo]bj/

--- a/docs/issue-backlog.md
+++ b/docs/issue-backlog.md
@@ -1,0 +1,120 @@
+# Issue Backlog
+
+> Last updated: 2026-05-30  
+> Scope: issues closed as stale that appear actionable, plus open issues under investigation.
+
+Check off items as they are resolved.
+
+---
+
+## ✅ Quick wins (small, self-contained fixes)
+
+### [ ] #1766 — IL3000 warning with PublishTrimmed / PublishAoT
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1766
+- **Root cause**: `WindowsLibraryLoader.cs` uses `Assembly.Location`, which always returns an empty string in single-file / AoT apps, triggering the IL3000 trimming warning.
+- **Fix**: Replace `Assembly.Location` with `AppContext.BaseDirectory` (one-line change).
+- **Effort**: Low
+
+---
+
+### [ ] #1704 — Assembly version reported as `0.0.0.0`
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1704
+- **Root cause**: `AssemblyVersion` and `FileVersion` in the managed assemblies are not aligned with the NuGet package version, which breaks Windows Installer upgrade detection.
+- **Fix**: Set `<AssemblyVersion>` and `<FileVersion>` to `$(Version)` in `Directory.Build.props`.
+- **Effort**: Low
+
+---
+
+## 🔧 Medium effort
+
+### [ ] #1765 — Native DLLs copied twice when targeting .NET Framework 4.8
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1765
+- **Root cause**: NuGet restore already copies the `runtimes/` DLLs to the output directory, but the package's custom `.targets` file copies them again into `dll/x64`, resulting in duplicates.
+- **Fix**: Add a condition to the custom copy task in the `.targets` file so it is skipped when NuGet has already handled the copy (i.e., on net48 targets).
+- **Effort**: Medium
+
+---
+
+### [ ] #1753 — `NativeMethods` static constructor fires too early
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1753
+- **Root cause**: `NativeMethods` calls `TryPInvoke` in its static constructor, which runs before user code has a chance to register a custom `NativeLibrary.SetDllImportResolver`. Custom native loaders therefore cannot intercept the first P/Invoke.
+- **Fix**: Switch to lazy initialization, or expose a public `Initialize()` method that users can call before any OpenCvSharp type is first referenced.
+- **Effort**: Medium
+
+---
+
+### [ ] #1731 — WASM runtime fails to publish under .NET 9 with trimming/linking enabled
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1731
+- **Root cause**: `OpenCvSharp4.runtime.wasm` ships `OpenCvSharpExtern.a` compiled with Emscripten 3.1.32 (.NET 8 era). .NET 9 uses Emscripten 3.1.56, whose C++ stdlib ABI differs, causing `undefined symbol` linker errors.
+- **Fix**: Rebuild `OpenCvSharpExtern.a` with Emscripten 3.1.56 and publish a `net9.0`-targeting package. Add a .NET 9 + Emscripten 3.1.56 build step to `.github/workflows/wasm.yml`.
+- **Effort**: Medium
+
+---
+
+## 🏗️ Large effort
+
+### [ ] #1743 — No NuGet runtime package for Windows ARM64
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1743
+- **Note**: A community fork (`xavave/opencvsharp.win.arm64`) has already done this work and can serve as a reference.
+- **Fix**: Build `OpenCvSharpExtern.dll` for ARM64 Windows, package it under `runtimes/win-arm64/native/`, and add an ARM64 Windows CI build.
+- **Effort**: Large
+
+---
+
+### [ ] #1737 — Camera calibration with `CharucoBoard` not supported
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1737
+- **Note**: A community fork (`xavave`) has implemented this and can serve as a reference.
+- **Fix**: Add wrappers for `CharucoBoard` and the `Cv2.Aruco.CalibrateCamera` overloads in the aruco module.
+- **Effort**: Large
+
+---
+
+## ⏸️ On hold (need more information)
+
+### #1774 — Suspected memory leak in `CvtColor BGR2RGBA`
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1774
+- **Note**: Cannot confirm this is a wrapper bug without a verified minimal repro showing native heap growth (e.g. via a native heap profiler). Revisit if a clean repro is provided.
+
+### #1748 — `libssl.lib` linked in `OpenCvSharpExtern.vcxproj`
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1748
+- **Note**: Unclear whether this is a stale leftover or a genuine dependency. Needs inspection of the `.vcxproj` linker settings.
+
+### #1745 — Intermittent `AccessViolationException` in `CLAHE.Apply`
+
+- **State**: closed (stale)
+- **URL**: https://github.com/shimat/opencvsharp/issues/1745
+- **Note**: Occurs roughly once every few days. Hard to attribute to the wrapper layer without a repro. Likely a race condition or memory corruption in native OpenCV. Revisit if a repro is found.
+
+---
+
+## 📋 Open issues under investigation
+
+### #1863 — Crash in `BarcodeDetector` (0xc0000409)
+
+- **State**: open
+- **URL**: https://github.com/shimat/opencvsharp/issues/1863
+- **Note**: Cannot reproduce with our own tests. Waiting for a stack trace and full environment details from the reporter.
+
+### #1789 — `ConcatLayer` throws "Inconsistent shape"
+
+- **State**: open
+- **URL**: https://github.com/shimat/opencvsharp/issues/1789
+- **Note**: Reportedly fixed in OpenCV 4.10, but the reporter sees it on 4.11. Likely an ONNX export configuration issue. Cannot investigate without the model file.

--- a/src/OpenCvSharp/Internal/PInvoke/WindowsLibraryLoader.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/WindowsLibraryLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -136,19 +135,13 @@ public sealed class WindowsLibraryLoader
                     if (dllHandle != IntPtr.Zero) return;
                 }
 
-                // Try loading from executing assembly domain
-                var executingAssembly = GetType().GetTypeInfo().Assembly;
-                var baseDirectory = Path.GetDirectoryName(executingAssembly.Location) ?? "";
-                dllHandle = LoadLibraryInternal(dllName, baseDirectory, processArch);
-                if (dllHandle != IntPtr.Zero) return;
-
                 // Gets the pathname of the base directory that the assembly resolver uses to probe for assemblies.
+                // AppContext.BaseDirectory is preferred over Assembly.Location because the latter returns an empty
+                // string in single-file / AoT published apps and triggers IL3000 trimming warnings.
                 // https://github.com/dotnet/corefx/issues/2221
-#if !NET40
-                baseDirectory = AppContext.BaseDirectory;
+                var baseDirectory = AppContext.BaseDirectory;
                 dllHandle = LoadLibraryInternal(dllName, baseDirectory, processArch);
                 if (dllHandle != IntPtr.Zero) return;
-#endif
 
                 // Finally try the working directory
                 baseDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());


### PR DESCRIPTION
Fixes #1766

## Problem

`WindowsLibraryLoader.LoadLibrary` used `Assembly.Location` to determine the base directory for native DLL lookup. In single-file and AoT published apps, `Assembly.Location` always returns an empty string and causes the IL3000 trimming warning at publish time.

## Changes

- Replace `Assembly.Location` with `AppContext.BaseDirectory`, which is   the correct alternative for all publish modes including single-file and AoT.
- Remove the now-redundant second lookup: the previous code already fell   back to `AppContext.BaseDirectory` on the very next attempt, making the   `Assembly.Location` path both broken and unnecessary.
- Remove the dead `#if !NET40` / `#else` guard. `NET40` is never defined   in this project. The minimum consumable framework via `netstandard2.0`   is .NET 4.6.1, where `AppContext.BaseDirectory` is unconditionally  available.
- Remove the now-unused `using System.Reflection` import.

`AppContext.BaseDirectory` is available across all current target frameworks (`netstandard2.0`, `netstandard2.1`, `net8.0`), so there is no regression for any supported target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive issue backlog documentation with structured categorization of issues by effort level (quick wins, medium effort, large effort, on hold) and investigation status with tracking information.

* **Chores**
  * Updated version control configuration to exclude additional project files.
  * Simplified Windows library loading by consolidating implementation approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->