### PR TITLE
Centralize and fix assembly versioning

### DIFF
--- a/docs/issue-backlog.md
+++ b/docs/issue-backlog.md
@@ -9,7 +9,7 @@ Check off items as they are resolved.
 
 ## ✅ Quick wins (small, self-contained fixes)
 
-### [ ] #1766 — IL3000 warning with PublishTrimmed / PublishAoT
+### [x] #1766 — IL3000 warning with PublishTrimmed / PublishAoT
 
 - **State**: closed (stale)
 - **URL**: https://github.com/shimat/opencvsharp/issues/1766
@@ -23,9 +23,10 @@ Check off items as they are resolved.
 
 - **State**: closed (stale)
 - **URL**: https://github.com/shimat/opencvsharp/issues/1704
-- **Root cause**: `AssemblyVersion` and `FileVersion` in the managed assemblies are not aligned with the NuGet package version, which breaks Windows Installer upgrade detection.
-- **Fix**: Set `<AssemblyVersion>` and `<FileVersion>` to `$(Version)` in `Directory.Build.props`.
-- **Effort**: Low
+- **Root cause**: `AssemblyVersion` and `FileVersion` were not aligned with the NuGet package version. The csproj now has them hardcoded to `4.13.0.0`, so the `0.0.0.0` symptom may already be resolved. The remaining issue is that these values must be updated manually on each release.
+- **Note**: Because OpenCvSharp is a strong-named assembly (`SignAssembly=true`), bumping `AssemblyVersion` on every release would be a breaking change for .NET Framework consumers (binding redirects required). The recommended approach is to keep `AssemblyVersion` pinned to the major version (e.g. `4.0.0.0`) and only align `FileVersion` / `InformationalVersion` with the NuGet package version automatically via CI.
+- **Fix**: Keep `AssemblyVersion` at `4.0.0.0` (major-pinned); automate `FileVersion` and `InformationalVersion` from `$(Version)` in the release pipeline.
+- **Effort**: Low–Medium
 
 ---
 

--- a/docs/issue-backlog.md
+++ b/docs/issue-backlog.md
@@ -25,7 +25,7 @@ Check off items as they are resolved.
 - **URL**: https://github.com/shimat/opencvsharp/issues/1704
 - **Root cause**: `AssemblyVersion` and `FileVersion` were not aligned with the NuGet package version. The csproj now has them hardcoded to `4.13.0.0`, so the `0.0.0.0` symptom may already be resolved. The remaining issue is that these values must be updated manually on each release.
 - **Note**: Because OpenCvSharp is a strong-named assembly (`SignAssembly=true`), bumping `AssemblyVersion` on every release would be a breaking change for .NET Framework consumers (binding redirects required). The recommended approach is to keep `AssemblyVersion` pinned to the major version (e.g. `4.0.0.0`) and only align `FileVersion` / `InformationalVersion` with the NuGet package version automatically via CI.
-- **Fix**: Keep `AssemblyVersion` at `4.0.0.0` (major-pinned); automate `FileVersion` and `InformationalVersion` from `$(Version)` in the release pipeline.
+- **Fix**: Keep `AssemblyVersion` at `4.0.0.0` (major-pinned); `FileVersion` is intentionally pinned to `4.0.0.0` in `Directory.Build.props` (due to Windows PE/FILEVERSION 65535-per-component limits and the project comment in `Directory.Build.props`); `InformationalVersion` remains automated from `$(Version)` by the SDK. The recommended approach is to pin `AssemblyVersion` to the major version (e.g., `4.0.0.0`) and automate only `InformationalVersion` in CI.
 - **Effort**: Low–Medium
 
 ---

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,24 @@
+<Project>
+  <PropertyGroup>
+    <!--
+      AssemblyVersion is pinned to the major version (4.0.0.0) to avoid breaking
+      strong-named binding for .NET Framework consumers. Bumping AssemblyVersion on
+      every release would require consumers to add binding redirects in app.config,
+      which is a breaking change.
+
+      FileVersion is also pinned to 4.0.0.0 because the date-based 4th component
+      used in NuGet package versions (e.g. 4.13.0.20260530) exceeds the 65535
+      per-component limit of the Windows FILEVERSION PE resource.
+
+      InformationalVersion is NOT set here; the .NET SDK automatically populates it
+      with $(Version) (e.g. "4.13.0.20260530-beta+<commitsha>") at pack/build time,
+      which is the human-readable version visible in file properties ("Product version")
+      and most tooling.
+
+      Individual projects may override these values when they have specific requirements
+      (e.g. OpenCvSharp.Analyzers pins to 1.0.0.0 independently).
+    -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
+  </PropertyGroup>
+</Project>

--- a/src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj
+++ b/src/OpenCvSharp.Extensions/OpenCvSharp.Extensions.csproj
@@ -20,9 +20,6 @@
     <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>4.13.0.0</AssemblyVersion>
-    <FileVersion>4.13.0.0</FileVersion>
-    
     <!-- NuGet Package Metadata -->
     <Title>OpenCvSharp GDI+ extension library.</Title>
     <Authors>shimat</Authors>

--- a/src/OpenCvSharp.WpfExtensions/OpenCvSharp.WpfExtensions.csproj
+++ b/src/OpenCvSharp.WpfExtensions/OpenCvSharp.WpfExtensions.csproj
@@ -26,8 +26,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>4.13.0.0</AssemblyVersion>
-    <FileVersion>4.13.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageReadmeFile>README.managed.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -21,9 +21,6 @@
     <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>4.13.0.0</AssemblyVersion>
-    <FileVersion>4.13.0.0</FileVersion>
-    
     <!-- NuGet Package Metadata -->
     <Title>OpenCvSharp core library. A package of separate native bindings for your OS is required.</Title>
     <Authors>shimat</Authors>


### PR DESCRIPTION
Fixes #1704

## Problem

`AssemblyVersion` and `FileVersion` were hardcoded to `4.13.0.0` in each library project individually, and were not updated automatically at release time. Simply syncing them to the NuGet package version is not safe either: the date-based 4th component (e.g. `20260530`) exceeds the 65535 per-component limit of the Windows FILEVERSION PE resource, and bumping `AssemblyVersion` on every release is a breaking change for .NET Framework consumers of a strong-named assembly (binding redirects would be required).

## Changes

Add `src/Directory.Build.props` to define assembly versioning policy in one place:

- **`AssemblyVersion` → `4.0.0.0`** (major-pinned). Strong-named assemblies should keep `AssemblyVersion` stable across minor/patch releases. .NET Framework consumers bind to this value; changing it forces `app.config` binding redirects.

- **`FileVersion` → `4.0.0.0`** (pinned). The date-based 4th component (e.g. `20260530`) exceeds 65535, the Windows FILEVERSION resource limit, so it cannot be used directly.

- **`InformationalVersion`** — not set here; the .NET SDK automatically populates it with the full `$(Version)` string including the pre-release suffix and commit SHA (e.g. `4.13.0.20260530-beta+<sha>`). This is the human-readable version visible in Windows file properties ("Product version") and is automatically correct whenever `dotnet pack -p:Version=...` is used in CI.

Remove the now-redundant hardcoded `AssemblyVersion`/`FileVersion` entries from `OpenCvSharp.csproj`, `OpenCvSharp.Extensions.csproj`, and `OpenCvSharp.WpfExtensions.csproj`.

`OpenCvSharp.Analyzers.csproj` is intentionally left unchanged; it already pins to `1.0.0.0` at the project level with an explanatory comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized assembly/versioning defaults so projects inherit consistent AssemblyVersion/FileVersion pinned to 4.0.0.0 and per-project explicit values removed.
* **Documentation**
  * Updated issue backlog: marked the IL3000 quick-win resolved and rewrote versioning guidance to recommend major-pinned AssemblyVersion/FileVersion while automating InformationalVersion; effort estimate updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shimat/opencvsharp/pull/1885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->