### PR TITLE
Add Windows ARM64 support (OpenCvSharp4.runtime.win-arm64)

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -1,4 +1,4 @@
-name: Publish NuGet
+﻿name: Publish NuGet
 
 on:
   workflow_dispatch:
@@ -74,6 +74,8 @@ jobs:
           check_package "OpenCvSharp4.Extensions.*.nupkg"
           check_package "OpenCvSharp4.WpfExtensions.*.nupkg"
           check_package "OpenCvSharp4.runtime.win.[0-9]*.nupkg"
+          check_package "OpenCvSharp4.runtime.win-arm64.[0-9]*.nupkg"
+          check_package "OpenCvSharp4.runtime.win-arm64.slim.*.nupkg"
           check_package "OpenCvSharp4.runtime.win.slim.*.nupkg"
           check_package "OpenCvSharp4.Windows.[0-9]*.nupkg"
           check_package "OpenCvSharp4.Windows.Slim.*.nupkg"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -253,3 +253,147 @@ jobs:
         with:
           name: packages_windows
           path: ${{ github.workspace }}\artifacts
+
+  build-arm64:
+
+    runs-on: windows-11-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore vcpkg packages cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg_installed
+          key: vcpkg-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-arm64-windows-static
+
+      - name: Update vcpkg to match builtin-baseline
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        run: |
+          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          git -C $env:VCPKG_INSTALLATION_ROOT fetch --depth=1 origin $baseline
+          git -C $env:VCPKG_INSTALLATION_ROOT checkout $baseline
+
+      - name: Install vcpkg dependencies
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        run: vcpkg install --triplet arm64-windows-static --overlay-triplets=${{ github.workspace }}/cmake/triplets --x-install-root=${{ github.workspace }}/vcpkg_installed
+
+      - name: Save vcpkg packages cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg_installed
+          key: vcpkg-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-arm64-windows-static
+
+      - name: Restore OpenCV cache
+        id: opencv-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ github.workspace }}/opencv_artifacts
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
+
+      - name: Configure OpenCV
+        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Continue'
+          cmake `
+            -C cmake/opencv_build_options.cmake `
+            -S opencv `
+            -B opencv/build `
+            -G "Visual Studio 17 2022" -A ARM64 `
+            -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
+            -D VCPKG_MANIFEST_INSTALL=OFF `
+            -D "VCPKG_INSTALLED_DIR=$env:GITHUB_WORKSPACE/vcpkg_installed" `
+            -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets" `
+            -D OPENCV_EXTRA_MODULES_PATH="$env:GITHUB_WORKSPACE/opencv_contrib/modules" `
+            -D CMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/opencv_artifacts" `
+            -D WITH_FFMPEG=OFF `
+            *>&1 | Tee-Object -FilePath "$env:TEMP\opencv-configure.log"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Build OpenCV
+        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          cmake --build opencv/build --config Release -j 4
+          cmake --install opencv/build --config Release
+
+      - name: Save OpenCV cache
+        if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/opencv_artifacts
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
+
+      - name: Build OpenCvSharpExtern (full)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          cmake `
+            -S src `
+            -B src/build_arm64 `
+            -G "Visual Studio 17 2022" -A ARM64 `
+            -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
+            -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
+            -D VCPKG_MANIFEST_INSTALL=OFF `
+            -D "VCPKG_INSTALLED_DIR=$env:GITHUB_WORKSPACE/vcpkg_installed" `
+            -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets"
+          cmake --build src/build_arm64 --config Release -j 4
+
+      - name: Build OpenCvSharpExtern (slim)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          cmake `
+            -S src `
+            -B src/build_arm64_slim `
+            -G "Visual Studio 17 2022" -A ARM64 `
+            -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
+            -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
+            -D VCPKG_MANIFEST_INSTALL=OFF `
+            -D "VCPKG_INSTALLED_DIR=$env:GITHUB_WORKSPACE/vcpkg_installed" `
+            -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets" `
+            -D NO_CONTRIB=ON `
+            -D NO_VIDEOIO=ON `
+            -D NO_HIGHGUI=ON `
+            -D NO_DNN=ON `
+            -D NO_INSTALL_TO_TEST=ON
+          cmake --build src/build_arm64_slim --config Release -j 4
+
+      - name: Test
+        shell: cmd
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64
+
+      - name: Pack NuGet packages
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $date = Get-Date -Format "yyyyMMdd"
+          $version = "${env:OPENCV_VERSION}.${date}-beta"
+          Write-Host "version = ${version}"
+
+          dotnet pack nuget/OpenCvSharp4.runtime.win-arm64.csproj -o artifacts -p:Version=$version
+          dotnet pack nuget/OpenCvSharp4.runtime.win-arm64.slim.csproj -o artifacts -p:Version=$version
+
+      - name: Upload NuGet packages
+        uses: actions/upload-artifact@v6
+        with:
+          name: packages_windows_arm64
+          path: ${{ github.workspace }}\artifacts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -324,6 +324,25 @@ jobs:
             *>&1 | Tee-Object -FilePath "$env:TEMP\opencv-configure.log"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify OpenCV cmake features
+        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $log = Get-Content "$env:TEMP\opencv-configure.log" -Raw
+          $features = @('Tesseract', 'JPEG', 'PNG', 'TIFF', 'WEBP')
+          $fail = $false
+          foreach ($f in $features) {
+            $m = [regex]::Match($log, "(?m)^--\s+${f}:\s+(.+)$")
+            if ($m.Success -and $m.Groups[1].Value.Trim() -notmatch '^NO\b') {
+              Write-Host "OK: $f = $($m.Groups[1].Value.Trim())"
+            } else {
+              Write-Host "MISSING or DISABLED: $f"
+              $log -split "`n" | Select-String -Pattern $f | Select-Object -Last 3 | ForEach-Object { Write-Host $_ }
+              $fail = $true
+            }
+          }
+          if ($fail) { exit 1 }
+
       - name: Build OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -377,7 +377,7 @@ jobs:
 
       - name: Test
         shell: cmd
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64 --filter "FullyQualifiedName!=OpenCvSharp.Tests.Core.BuildConfigurationTest.FFMPEG_IsEnabled"
 
       - name: Pack NuGet packages
         shell: pwsh

--- a/cmake/triplets/arm64-windows-static.cmake
+++ b/cmake/triplets/arm64-windows-static.cmake
@@ -1,0 +1,6 @@
+﻿set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# Release-only build: skip debug libraries to reduce build time and artifact size.
+set(VCPKG_BUILD_TYPE release)

--- a/nuget/OpenCvSharp4.runtime.win-arm64.csproj
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;</TargetFrameworks>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    
+    <!-- NuGet Package Metadata -->
+    <PackageId>OpenCvSharp4.runtime.win-arm64</PackageId>
+    <Title>OpenCvSharp4 native bindings for Windows ARM64</Title>
+    <Authors>shimat</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/shimat/opencvsharp</PackageProjectUrl>
+    <PackageIcon>opencvsharp.png</PackageIcon>
+    <Description>Internal implementation package for OpenCvSharp to work on Windows ARM64 (e.g. Snapdragon X devices).</Description>
+    <PackageTags>Image Processing OpenCV Wrapper FFI opencvsharp windows arm64</PackageTags>
+    <Copyright>Copyright 2008-2026</Copyright>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReadmeFile>README.runtime.md</PackageReadmeFile>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <None Include="../src/build_arm64/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll" Pack="true" PackagePath="runtimes/win-arm64/native" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.props" Pack="true" PackagePath="build/netstandard" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.props" Pack="true" PackagePath="build/netcoreapp" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.props" Pack="true" PackagePath="build/net8.0" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.targets" Pack="true" PackagePath="build/netstandard" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.targets" Pack="true" PackagePath="build/netcoreapp" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.targets" Pack="true" PackagePath="build/net8.0" />
+    <None Include="icon/opencvsharp.png" Pack="true" PackagePath="" />
+    <None Include="README.runtime.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.win-arm64.props
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.props
@@ -1,0 +1,11 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<OpenCvSharp4ExternalNativeDlls>$(MSBuildThisFileDirectory)..\..\runtimes</OpenCvSharp4ExternalNativeDlls>
+	</PropertyGroup>
+	<ItemGroup Condition="$(TargetFrameworkVersion.StartsWith('v4')) Or $(TargetFramework.StartsWith('net4'))">
+		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-arm64\native\OpenCvSharpExtern.dll">
+			<Link>dll\arm64\OpenCvSharpExtern.dll</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.win-arm64.slim.csproj
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.slim.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;</TargetFrameworks>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <PackageId>OpenCvSharp4.runtime.win-arm64.slim</PackageId>
+    <Title>OpenCvSharp4 native slim bindings for Windows ARM64</Title>
+    <Authors>shimat</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/shimat/opencvsharp</PackageProjectUrl>
+    <PackageIcon>opencvsharp.png</PackageIcon>
+    <Description>Slim native runtime package for OpenCvSharp on Windows ARM64. Enabled modules: core,imgproc,imgcodecs,calib3d,features2d,flann,objdetect,photo. Disabled modules: contrib,dnn,ml,video,videoio,highgui,stitching,barcode.</Description>
+    <PackageTags>Image Processing OpenCV Wrapper FFI opencvsharp windows arm64 slim</PackageTags>
+    <Copyright>Copyright 2008-2026</Copyright>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReadmeFile>README.runtime.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../src/build_arm64_slim/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll" Pack="true" PackagePath="runtimes/win-arm64/native/OpenCvSharpExtern.dll" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.props" Pack="true" PackagePath="build/netstandard" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.props" Pack="true" PackagePath="build/netcoreapp" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.props" Pack="true" PackagePath="build/net8.0" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.targets" Pack="true" PackagePath="build/netstandard" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.targets" Pack="true" PackagePath="build/netcoreapp" />
+    <None Include="OpenCvSharp4.runtime.win-arm64.slim.targets" Pack="true" PackagePath="build/net8.0" />
+    <None Include="icon/opencvsharp.png" Pack="true" PackagePath="" />
+    <None Include="README.runtime.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.win-arm64.slim.props
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.slim.props
@@ -1,0 +1,11 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<OpenCvSharp4ExternalNativeDlls>$(MSBuildThisFileDirectory)..\..\runtimes</OpenCvSharp4ExternalNativeDlls>
+	</PropertyGroup>
+	<ItemGroup Condition="$(TargetFrameworkVersion.StartsWith('v4')) Or $(TargetFramework.StartsWith('net4'))">
+		<Content Include="$(OpenCvSharp4ExternalNativeDlls)\win-arm64\native\OpenCvSharpExtern.dll">
+			<Link>dll\arm64\OpenCvSharpExtern.dll</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.win-arm64.slim.targets
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.slim.targets
@@ -1,0 +1,10 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="OpenCvSharp4RuntimeWinArm64Slim_RemoveRootNativeAssets"
+          AfterTargets="ResolvePackageAssets"
+          Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFrameworkVersion.StartsWith('v4'))">
+    <ItemGroup>
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)"
+          Condition="'%(NuGetPackageId)' == 'OpenCvSharp4.runtime.win-arm64.slim'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/nuget/OpenCvSharp4.runtime.win-arm64.slim.targets
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.slim.targets
@@ -1,4 +1,20 @@
 ﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    For .NET Framework (net4x) targets using PackageReference, NuGet's build pipeline automatically
+    copies runtimes/win-arm64/native/ assets to the output root directory. However, the companion
+    .props file already places these DLLs under dll/arm64/, which is where WindowsLibraryLoader looks
+    at runtime. The root copies are therefore redundant and bloat the output directory.
+
+    This target removes the package's native assets from RuntimeCopyLocalItems — the item group
+    populated by ResolvePackageAssets — so NuGet does not copy them to the output root.
+    The dll/arm64/ placement from the .props file is unaffected.
+
+    Note: RuntimeCopyLocalItems is only present in SDK-style projects using PackageReference.
+    Old-style (packages.config) projects do not process runtimes/ assets at all, so this target
+    has no effect there (which is fine — no duplicate exists in that case either).
+
+    See also: OpenCvSharp4.runtime.win.targets for the equivalent x64 implementation.
+  -->
   <Target Name="OpenCvSharp4RuntimeWinArm64Slim_RemoveRootNativeAssets"
           AfterTargets="ResolvePackageAssets"
           Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFrameworkVersion.StartsWith('v4'))">

--- a/nuget/OpenCvSharp4.runtime.win-arm64.targets
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.targets
@@ -4,6 +4,16 @@
     copies runtimes/win-arm64/native/ assets to the output root directory. However, the companion
     .props file already places these DLLs under dll/arm64/, which is where WindowsLibraryLoader looks
     at runtime. The root copies are therefore redundant and bloat the output directory.
+
+    This target removes the package's native assets from RuntimeCopyLocalItems — the item group
+    populated by ResolvePackageAssets — so NuGet does not copy them to the output root.
+    The dll/arm64/ placement from the .props file is unaffected.
+
+    Note: RuntimeCopyLocalItems is only present in SDK-style projects using PackageReference.
+    Old-style (packages.config) projects do not process runtimes/ assets at all, so this target
+    has no effect there (which is fine — no duplicate exists in that case either).
+
+    See also: OpenCvSharp4.runtime.win.targets for the equivalent x64 implementation.
   -->
   <Target Name="OpenCvSharp4RuntimeWinArm64_RemoveRootNativeAssets"
           AfterTargets="ResolvePackageAssets"

--- a/nuget/OpenCvSharp4.runtime.win-arm64.targets
+++ b/nuget/OpenCvSharp4.runtime.win-arm64.targets
@@ -1,0 +1,16 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    For .NET Framework (net4x) targets using PackageReference, NuGet's build pipeline automatically
+    copies runtimes/win-arm64/native/ assets to the output root directory. However, the companion
+    .props file already places these DLLs under dll/arm64/, which is where WindowsLibraryLoader looks
+    at runtime. The root copies are therefore redundant and bloat the output directory.
+  -->
+  <Target Name="OpenCvSharp4RuntimeWinArm64_RemoveRootNativeAssets"
+          AfterTargets="ResolvePackageAssets"
+          Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFrameworkVersion.StartsWith('v4'))">
+    <ItemGroup>
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)"
+          Condition="'%(NuGetPackageId)' == 'OpenCvSharp4.runtime.win-arm64'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/OpenCvSharp/Internal/PInvoke/WindowsLibraryLoader.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/WindowsLibraryLoader.cs
@@ -32,6 +32,7 @@ public sealed class WindowsLibraryLoader
         {
             {"x86", "x86"},
             {"AMD64", "x64"},
+            {"ARM64", "arm64"},
             {"IA64", "Itanium"},
             {"ARM", "WinCE"}
         };
@@ -44,6 +45,7 @@ public sealed class WindowsLibraryLoader
         {
             {"x86", 4},
             {"AMD64", 8},
+            {"ARM64", 8},
             {"IA64", 8},
             {"ARM", 4}
         };


### PR DESCRIPTION
Closes #1743

## Overview

Adds native build and NuGet packages for Windows ARM64, enabling OpenCvSharp to run natively on Snapdragon X Elite and other arm64 Windows devices.

ARM64 users install: `OpenCvSharp4` + `OpenCvSharp4.runtime.win-arm64` (or the `.slim` variant). `OpenCvSharp4.Windows` remains x64-focused as its title states.

## Changes

**Build pipeline**
- `.github/workflows/windows.yml`: new `build-arm64` job using the `windows-11-arm` runner. Builds vcpkg dependencies, OpenCV, and `OpenCvSharpExtern.dll` for ARM64, runs tests on the native ARM64 runner, and packs the two new NuGet packages. `WITH_FFMPEG=OFF` because the upstream ffmpeg prebuilt is x64-only.
- `.github/workflows/publish_nuget.yml`: downloads the new `packages_windows_arm64` artifact and validates the two new packages.
- `cmake/triplets/arm64-windows-static.cmake`: new vcpkg triplet for static ARM64 Windows builds.

**NuGet packages**
- `OpenCvSharp4.runtime.win-arm64` (full): places `OpenCvSharpExtern.dll` at `runtimes/win-arm64/native/`. For net4x consumers, the `.props` file copies it to `dll/arm64/` and the `.targets` file suppresses the redundant root copy.
- `OpenCvSharp4.runtime.win-arm64.slim`: same but built without contrib, dnn, videoio, highgui.

**Managed code**
- `WindowsLibraryLoader.cs`: adds `ARM64` → `"arm64"` platform mapping and `ARM64` → 8-byte address-width entry, so .NET Framework apps on ARM64 Windows resolve DLLs from `dll/arm64/`.

## Notes

- The `windows-11-arm` runner label may show as unknown in actionlint (its database predates the runner's GA). This is a false positive.
- FFmpeg video I/O is not available on ARM64 Windows as there is no upstream ARM64 prebuilt. All other OpenCV modules are included in the full package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows ARM64 support with dedicated ARM64 runtime NuGet packages.

* **Chores**
  * Extended CI to build, test and package Windows ARM64 binaries.
  * Added ARM64 build configuration for native dependencies.
  * Updated native library probing to recognize ARM64 architectures.
* **Chores**
  * CI package validation updated to include ARM64 runtime packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->