### PR TITLE
Migrate Windows CI to Visual Studio 2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,7 +75,7 @@ jobs:
             -C cmake/opencv_build_options.cmake `
             -S opencv `
             -B opencv/build `
-            -G "Visual Studio 17 2022" -A x64 `
+            -G "Visual Studio 18 2026" -A x64 `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=x64-windows-static `
             -D VCPKG_MANIFEST_INSTALL=OFF `
@@ -133,7 +133,7 @@ jobs:
           cmake `
             -S src `
             -B src/build `
-            -G "Visual Studio 17 2022" -A x64 `
+            -G "Visual Studio 18 2026" -A x64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=x64-windows-static `
@@ -149,7 +149,7 @@ jobs:
           cmake `
             -S src `
             -B src/build_slim `
-            -G "Visual Studio 17 2022" -A x64 `
+            -G "Visual Studio 18 2026" -A x64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=x64-windows-static `
@@ -312,7 +312,7 @@ jobs:
             -C cmake/opencv_build_options.cmake `
             -S opencv `
             -B opencv/build `
-            -G "Visual Studio 17 2022" -A ARM64 `
+            -G "Visual Studio 18 2026" -A ARM64 `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
             -D VCPKG_MANIFEST_INSTALL=OFF `
@@ -364,7 +364,7 @@ jobs:
           cmake `
             -S src `
             -B src/build_arm64 `
-            -G "Visual Studio 17 2022" -A ARM64 `
+            -G "Visual Studio 18 2026" -A ARM64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
@@ -380,7 +380,7 @@ jobs:
           cmake `
             -S src `
             -B src/build_arm64_slim `
-            -G "Visual Studio 17 2022" -A ARM64 `
+            -G "Visual Studio 18 2026" -A ARM64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -312,7 +312,7 @@ jobs:
             -C cmake/opencv_build_options.cmake `
             -S opencv `
             -B opencv/build `
-            -G "Visual Studio 18 2026" -A ARM64 `
+            -G "Visual Studio 17 2022" -A ARM64 `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
             -D VCPKG_MANIFEST_INSTALL=OFF `
@@ -364,7 +364,7 @@ jobs:
           cmake `
             -S src `
             -B src/build_arm64 `
-            -G "Visual Studio 18 2026" -A ARM64 `
+            -G "Visual Studio 17 2022" -A ARM64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
@@ -380,7 +380,7 @@ jobs:
           cmake `
             -S src `
             -B src/build_arm64_slim `
-            -G "Visual Studio 18 2026" -A ARM64 `
+            -G "Visual Studio 17 2022" -A ARM64 `
             -D CMAKE_PREFIX_PATH="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D CMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ For more installation options, see the [Installation](#installation) section bel
 ## Requirements
 * [.NET 8](https://www.microsoft.com/net/download) or later / .NET Standard 2.0 / .NET Standard 2.1
 * .NET Framework 4.6.1 or later is supported via the .NET Standard 2.0 target (WpfExtensions also directly targets .NET Framework 4.8)
-* (Windows) [Visual C++ 2022 Redistributable Package](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 * (Windows Server) Media Foundation
 ```
 PS1> Install-WindowsFeature Server-Media-Foundation

--- a/nuget/README.managed.md
+++ b/nuget/README.managed.md
@@ -34,7 +34,6 @@ For more installation options, see [Installation on GitHub](https://github.com/s
 ## Requirements
 
 ### Windows
-- [Visual C++ 2022 Redistributable](https://support.microsoft.com/help/2977003/)
 - (Windows Server only) Media Foundation:
   ```powershell
   Install-WindowsFeature Server-Media-Foundation


### PR DESCRIPTION
The `windows-2025` runner image replaced Visual Studio 2022 with Visual Studio 2026, so the hardcoded CMake generator `Visual Studio 17 2022` now fails with "could not find any instance of Visual Studio".

https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/#windows-2025-visual-studio-2026-image-migration

Update the generator to `Visual Studio 18 2026` in all 6 cmake invocations in `.github/workflows/windows.yml` (x64: OpenCV, Extern full, Extern slim; ARM64: the same three).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows Server 2025 CI x64 CMake toolchain to use Visual Studio 18 2026 instead of Visual Studio 17 2022.
* **Documentation**
  * Removed the Windows requirement for the Visual C++ 2022 Redistributable from the main README.
  * Removed the Visual C++ 2022 Redistributable note from the managed NuGet README’s Windows requirements section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->