### PR TITLE
Add missing SolvePnPMethod enum values (AP3P, IPPE, IPPE_SQUARE, SQPNP)

### DIFF
--- a/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
+++ b/src/OpenCvSharp/Modules/calib3d/Enum/SolvePnPFlags.cs
@@ -33,6 +33,27 @@ public enum SolvePnPMethod
     /// A.Penate-Sanchez, J.Andrade-Cetto, F.Moreno-Noguer. "Exhaustive Linearization for Robust Camera Pose and Focal Length Estimation"
     /// </summary>
     UPNP = 4,
+
+    /// <summary>
+    /// T. Ke, S. Roumeliotis. "An Efficient Algebraic Solution to the Perspective-Three-Point Problem"
+    /// </summary>
+    AP3P = 5,
+
+    /// <summary>
+    /// Infinitesimal Plane-Based Pose Estimation. Object points must be coplanar.
+    /// </summary>
+    IPPE = 6,
+
+    /// <summary>
+    /// Infinitesimal Plane-Based Pose Estimation.
+    /// This is a special case suitable for marker pose estimation. 4 coplanar object points must be defined.
+    /// </summary>
+    IPPE_SQUARE = 7,
+
+    /// <summary>
+    /// G. Terzakis, M. Lourakis. "A Consistently Fast and Globally Optimal Solution to the Perspective-n-Point Problem"
+    /// </summary>
+    SQPNP = 8,
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Fixes #1895.

The `SolvePnPMethod` enum was missing the last 4 values defined in OpenCV's
`calib3d.hpp`. This PR adds them to match the OpenCV 4.13.0 definition:

- `AP3P = 5`
- `IPPE = 6`
- `IPPE_SQUARE = 7`
- `SQPNP = 8`

Each value includes an XML doc comment referencing the corresponding paper,
consistent with the existing entries.

Reference: https://github.com/opencv/opencv/blob/4.13.0/modules/calib3d/include/opencv2/calib3d.hpp#L563

## Notes

The obsolete `SolvePnPFlags` enum (marked `[Obsolete(..., true)]`, which is a
compile-time error) was intentionally left unchanged, since it is no longer usable.

## Test

`dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release` succeeds with 0 errors
(net8.0 / netstandard2.0 / netstandard2.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended camera pose estimation capabilities with four new algorithms: AP3P, IPPE, IPPE_SQUARE, and SQPNP for improved flexibility in solving perspective-n-point problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->