### PR TITLE
Add high-level dnn Model API (Model + Classification/Detection/Segmentation/Keypoints)

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Model.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Model.cs
@@ -1,0 +1,217 @@
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+// ReSharper disable InconsistentNaming
+static partial class NativeMethods
+{
+    // ------------------------------------------------------------------------
+    // Model (base class)
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_Model_new_String")]
+    public static extern ExceptionStatus dnn_Model_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_Model_new_String")]
+    public static extern ExceptionStatus dnn_Model_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_Model_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_Model_new_String_Windows(model, config, out returnValue)
+            : dnn_Model_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputSize(IntPtr model, Size size);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputMean(IntPtr model, Scalar mean);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputScale(IntPtr model, Scalar scale);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputCrop(IntPtr model, int crop);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputSwapRB(IntPtr model, int swapRB);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setInputParams(
+        IntPtr model, double scale, Size size, Scalar mean, int swapRB, int crop);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Model_setOutputNames(IntPtr model, string[] outNames, int outNamesLength);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_predict(IntPtr model, IntPtr frame, IntPtr outs);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setPreferableBackend(IntPtr model, int backendId);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_setPreferableTarget(IntPtr model, int targetId);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Model_enableWinograd(IntPtr model, int useWinograd);
+
+    // ------------------------------------------------------------------------
+    // ClassificationModel
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_ClassificationModel_new_String")]
+    public static extern ExceptionStatus dnn_ClassificationModel_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_ClassificationModel_new_String")]
+    public static extern ExceptionStatus dnn_ClassificationModel_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_ClassificationModel_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_ClassificationModel_new_String_Windows(model, config, out returnValue)
+            : dnn_ClassificationModel_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_ClassificationModel_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_ClassificationModel_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_ClassificationModel_setEnableSoftmaxPostProcessing(IntPtr model, int enable);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_ClassificationModel_getEnableSoftmaxPostProcessing(IntPtr model, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_ClassificationModel_classify(IntPtr model, IntPtr frame, out int classId, out float conf);
+
+    // ------------------------------------------------------------------------
+    // DetectionModel
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_DetectionModel_new_String")]
+    public static extern ExceptionStatus dnn_DetectionModel_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_DetectionModel_new_String")]
+    public static extern ExceptionStatus dnn_DetectionModel_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_DetectionModel_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_DetectionModel_new_String_Windows(model, config, out returnValue)
+            : dnn_DetectionModel_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_DetectionModel_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_DetectionModel_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_DetectionModel_setNmsAcrossClasses(IntPtr model, int value);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_DetectionModel_getNmsAcrossClasses(IntPtr model, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_DetectionModel_detect(
+        IntPtr model, IntPtr frame, IntPtr classIds, IntPtr confidences, IntPtr boxes,
+        float confThreshold, float nmsThreshold);
+
+    // ------------------------------------------------------------------------
+    // SegmentationModel
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_SegmentationModel_new_String")]
+    public static extern ExceptionStatus dnn_SegmentationModel_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_SegmentationModel_new_String")]
+    public static extern ExceptionStatus dnn_SegmentationModel_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_SegmentationModel_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_SegmentationModel_new_String_Windows(model, config, out returnValue)
+            : dnn_SegmentationModel_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_SegmentationModel_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_SegmentationModel_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_SegmentationModel_segment(IntPtr model, IntPtr frame, IntPtr mask);
+
+    // ------------------------------------------------------------------------
+    // KeypointsModel
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_KeypointsModel_new_String")]
+    public static extern ExceptionStatus dnn_KeypointsModel_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_KeypointsModel_new_String")]
+    public static extern ExceptionStatus dnn_KeypointsModel_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_KeypointsModel_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_KeypointsModel_new_String_Windows(model, config, out returnValue)
+            : dnn_KeypointsModel_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_KeypointsModel_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_KeypointsModel_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_KeypointsModel_estimate(IntPtr model, IntPtr frame, IntPtr keypoints, float thresh);
+}

--- a/src/OpenCvSharp/Modules/dnn/ClassificationModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/ClassificationModel.cs
@@ -1,0 +1,92 @@
+using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for classification models.
+/// ClassificationModel allows to set params for preprocessing input image.
+/// ClassificationModel creates net from file with trained weights and config,
+/// sets preprocessing input, runs forward pass and return top-1 prediction.
+/// </summary>
+public class ClassificationModel : Model
+{
+    /// <summary>
+    /// Create classification model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public ClassificationModel(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_ClassificationModel_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_ClassificationModel_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public ClassificationModel(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_ClassificationModel_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_ClassificationModel_delete);
+    }
+
+    /// <summary>
+    /// Set enable/disable softmax post processing option.
+    /// </summary>
+    /// <param name="enable">Set enable softmax post processing.</param>
+    public void SetEnableSoftmaxPostProcessing(bool enable)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_ClassificationModel_setEnableSoftmaxPostProcessing(CvPtr, enable ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get enable/disable softmax post processing option.
+    /// </summary>
+    /// <returns>true if softmax post processing is enabled.</returns>
+    public bool GetEnableSoftmaxPostProcessing()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_ClassificationModel_getEnableSoftmaxPostProcessing(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net and return top-1 prediction.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="classId">Top-1 predicted class id.</param>
+    /// <param name="conf">Top-1 prediction confidence.</param>
+    public void Classify(InputArray frame, out int classId, out float conf)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_ClassificationModel_classify(CvPtr, frame.CvPtr, out classId, out conf));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/DetectionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/DetectionModel.cs
@@ -1,0 +1,110 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for object detection networks.
+/// DetectionModel allows to set params for preprocessing input image.
+/// DetectionModel creates net from file with trained weights and config,
+/// sets preprocessing input, runs forward pass and return result detections.
+/// </summary>
+public class DetectionModel : Model
+{
+    /// <summary>
+    /// Create detection model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public DetectionModel(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_DetectionModel_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_DetectionModel_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public DetectionModel(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_DetectionModel_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_DetectionModel_delete);
+    }
+
+    /// <summary>
+    /// nmsAcrossClasses defaults to false,
+    /// such that when non max suppression is used during the detect() function, it will do so per-class.
+    /// This function allows you to toggle this behaviour.
+    /// </summary>
+    /// <param name="value">The new value for nmsAcrossClasses.</param>
+    public void SetNmsAcrossClasses(bool value)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_DetectionModel_setNmsAcrossClasses(CvPtr, value ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Getter for nmsAcrossClasses. This variable defaults to false,
+    /// such that when non max suppression is used during the detect() function, it will do so only per-class.
+    /// </summary>
+    /// <returns>true if nms is performed across classes.</returns>
+    public bool GetNmsAcrossClasses()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_DetectionModel_getNmsAcrossClasses(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net and return result detections.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="classIds">Class indexes in result detection.</param>
+    /// <param name="confidences">A set of corresponding confidences.</param>
+    /// <param name="boxes">A set of bounding boxes.</param>
+    /// <param name="confThreshold">A threshold used to filter boxes by confidences.</param>
+    /// <param name="nmsThreshold">A threshold used in non maximum suppression.</param>
+    public void Detect(
+        InputArray frame, out int[] classIds, out float[] confidences, out Rect[] boxes,
+        float confThreshold = 0.5f, float nmsThreshold = 0.0f)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var classIdsVec = new VectorOfInt32();
+        using var confidencesVec = new VectorOfFloat();
+        using var boxesVec = new VectorOfRect();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_DetectionModel_detect(
+                CvPtr, frame.CvPtr, classIdsVec.CvPtr, confidencesVec.CvPtr, boxesVec.CvPtr,
+                confThreshold, nmsThreshold));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+
+        classIds = classIdsVec.ToArray();
+        confidences = confidencesVec.ToArray();
+        boxes = boxesVec.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/KeypointsModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/KeypointsModel.cs
@@ -1,0 +1,70 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for keypoints models.
+/// KeypointsModel allows to set params for preprocessing input image.
+/// KeypointsModel creates net from file with trained weights and config,
+/// sets preprocessing input, runs forward pass and returns the x and y coordinates of each detected keypoint.
+/// </summary>
+public class KeypointsModel : Model
+{
+    /// <summary>
+    /// Create keypoints model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public KeypointsModel(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_KeypointsModel_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_KeypointsModel_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public KeypointsModel(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_KeypointsModel_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_KeypointsModel_delete);
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="thresh">minimum confidence threshold to select a keypoint.</param>
+    /// <returns>a vector holding the x and y coordinates of each detected keypoint.</returns>
+    public Point2f[] Estimate(InputArray frame, float thresh = 0.5f)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var keypointsVec = new VectorOfPoint2f();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_KeypointsModel_estimate(CvPtr, frame.CvPtr, keypointsVec.CvPtr, thresh));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+        return keypointsVec.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/Model.cs
+++ b/src/OpenCvSharp/Modules/dnn/Model.cs
@@ -1,0 +1,229 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class is presented high-level API for neural networks.
+/// It allows to set params for preprocessing input image. It creates net from file with
+/// trained weights and config, sets preprocessing input and runs forward pass.
+/// </summary>
+public class Model : CvObject
+{
+    #region Init &amp; Disposal
+
+    /// <summary>
+    /// For derived classes that construct the native object themselves.
+    /// </summary>
+    protected Model()
+    {
+    }
+
+    /// <summary>
+    /// Create model from deep learning network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public Model(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_Model_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public Model(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_Model_delete);
+    }
+
+    /// <summary>
+    /// Sets the underlying native handle together with the correct destructor.
+    /// </summary>
+    /// <param name="p">native pointer</param>
+    /// <param name="deleter">native destructor for the concrete model type</param>
+    protected void SetHandle(IntPtr p, Func<IntPtr, ExceptionStatus> deleter)
+    {
+        if (deleter is null)
+            throw new ArgumentNullException(nameof(deleter));
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, true,
+            h => NativeMethods.HandleException(deleter(h))));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Set input size for frame.
+    /// </summary>
+    /// <param name="size">New input size.</param>
+    /// <remarks>If shape of the new blob less than 0, then frame size not change.</remarks>
+    public void SetInputSize(Size size)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputSize(CvPtr, size));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set input size for frame.
+    /// </summary>
+    /// <param name="width">New input width.</param>
+    /// <param name="height">New input height.</param>
+    public void SetInputSize(int width, int height) => SetInputSize(new Size(width, height));
+
+    /// <summary>
+    /// Set mean value for frame.
+    /// </summary>
+    /// <param name="mean">Scalar with mean values which are subtracted from channels.</param>
+    public void SetInputMean(Scalar mean)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputMean(CvPtr, mean));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set scalefactor value for frame.
+    /// </summary>
+    /// <param name="scale">Multiplier for frame values.</param>
+    public void SetInputScale(Scalar scale)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputScale(CvPtr, scale));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set flag crop for frame.
+    /// </summary>
+    /// <param name="crop">Flag which indicates whether image will be cropped after resize or not.</param>
+    public void SetInputCrop(bool crop)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputCrop(CvPtr, crop ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set flag swapRB for frame.
+    /// </summary>
+    /// <param name="swapRB">Flag which indicates that swap first and last channels.</param>
+    public void SetInputSwapRB(bool swapRB)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputSwapRB(CvPtr, swapRB ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set output names for frame.
+    /// </summary>
+    /// <param name="outNames">Names for output layers.</param>
+    public void SetOutputNames(IEnumerable<string> outNames)
+    {
+        if (outNames is null)
+            throw new ArgumentNullException(nameof(outNames));
+        ThrowIfDisposed();
+
+        var outNamesArray = outNames as string[] ?? outNames.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setOutputNames(CvPtr, outNamesArray, outNamesArray.Length));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set preprocessing parameters for frame.
+    /// </summary>
+    /// <param name="scale">Multiplier for frame values.</param>
+    /// <param name="size">New input size.</param>
+    /// <param name="mean">Scalar with mean values which are subtracted from channels.</param>
+    /// <param name="swapRB">Flag which indicates that swap first and last channels.</param>
+    /// <param name="crop">Flag which indicates whether image will be cropped after resize or not.</param>
+    public void SetInputParams(double scale = 1.0, Size? size = null, Scalar? mean = null, bool swapRB = false, bool crop = false)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setInputParams(
+                CvPtr, scale, size ?? new Size(), mean ?? new Scalar(), swapRB ? 1 : 0, crop ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net and return the output @p blobs.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <returns>Allocated output blobs, which will store results of the computation.</returns>
+    public Mat[] Predict(InputArray frame)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var outsVec = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_predict(CvPtr, frame.CvPtr, outsVec.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+        return outsVec.ToArray();
+    }
+
+    /// <summary>
+    /// Ask network to use specific computation backend where it supported.
+    /// </summary>
+    /// <param name="backendId">backend identifier.</param>
+    public void SetPreferableBackend(Backend backendId)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setPreferableBackend(CvPtr, (int)backendId));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Ask network to make computations on specific target device.
+    /// </summary>
+    /// <param name="targetId">target identifier.</param>
+    public void SetPreferableTarget(Target targetId)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_setPreferableTarget(CvPtr, (int)targetId));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Enables or disables the Winograd convolution optimization.
+    /// </summary>
+    /// <param name="useWinograd">true to enable, false to disable.</param>
+    public void EnableWinograd(bool useWinograd)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Model_enableWinograd(CvPtr, useWinograd ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/SegmentationModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/SegmentationModel.cs
@@ -1,0 +1,70 @@
+using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for segmentation models.
+/// SegmentationModel allows to set params for preprocessing input image.
+/// SegmentationModel creates net from file with trained weights and config,
+/// sets preprocessing input, runs forward pass and returns the class prediction for each pixel.
+/// </summary>
+public class SegmentationModel : Model
+{
+    /// <summary>
+    /// Create segmentation model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public SegmentationModel(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_SegmentationModel_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_SegmentationModel_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public SegmentationModel(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_SegmentationModel_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_SegmentationModel_delete);
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="mask">Allocated class prediction for each pixel.</param>
+    public void Segment(InputArray frame, OutputArray mask)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        if (mask is null)
+            throw new ArgumentNullException(nameof(mask));
+        frame.ThrowIfDisposed();
+        mask.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_SegmentationModel_segment(CvPtr, frame.CvPtr, mask.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+        mask.Fix();
+    }
+}

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="cuda.h" />
     <ClInclude Include="cuda_GpuMat.h" />
     <ClInclude Include="dnn.h" />
+    <ClInclude Include="dnn_Model.h" />
     <ClInclude Include="dnn_Net.h" />
     <ClInclude Include="dnn_superres.h" />
     <ClInclude Include="face_Facemark.h" />

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
@@ -294,6 +294,9 @@
     <ClInclude Include="dnn_Net.h">
       <Filter>Header Files\dnn</Filter>
     </ClInclude>
+    <ClInclude Include="dnn_Model.h">
+      <Filter>Header Files\dnn</Filter>
+    </ClInclude>
     <ClInclude Include="dnn.h">
       <Filter>Header Files\dnn</Filter>
     </ClInclude>

--- a/src/OpenCvSharpExtern/dnn.cpp
+++ b/src/OpenCvSharpExtern/dnn.cpp
@@ -1,3 +1,4 @@
 // ReSharper disable CppUnusedIncludeDirective
 #include "dnn.h"
 #include "dnn_Net.h"
+#include "dnn_Model.h"

--- a/src/OpenCvSharpExtern/dnn_Model.h
+++ b/src/OpenCvSharpExtern/dnn_Model.h
@@ -1,0 +1,297 @@
+#pragma once
+
+#ifndef NO_DNN
+
+#ifndef _WINRT_DLL
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+// ----------------------------------------------------------------------------
+// Model (base class)
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_Model_new_String(const char *model, const char *config, cv::dnn::Model **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::Model(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_new_Net(cv::dnn::Net *network, cv::dnn::Model **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::Model(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_delete(cv::dnn::Model *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputSize(cv::dnn::Model *model, const MyCvSize size)
+{
+    BEGIN_WRAP
+    model->setInputSize(cpp(size));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputMean(cv::dnn::Model *model, const MyCvScalar mean)
+{
+    BEGIN_WRAP
+    model->setInputMean(cpp(mean));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputScale(cv::dnn::Model *model, const MyCvScalar scale)
+{
+    BEGIN_WRAP
+    model->setInputScale(cpp(scale));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputCrop(cv::dnn::Model *model, const int crop)
+{
+    BEGIN_WRAP
+    model->setInputCrop(crop != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputSwapRB(cv::dnn::Model *model, const int swapRB)
+{
+    BEGIN_WRAP
+    model->setInputSwapRB(swapRB != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setInputParams(
+    cv::dnn::Model *model, const double scale, const MyCvSize size, const MyCvScalar mean, const int swapRB, const int crop)
+{
+    BEGIN_WRAP
+    model->setInputParams(scale, cpp(size), cpp(mean), swapRB != 0, crop != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setOutputNames(cv::dnn::Model *model, const char **outNames, const int outNamesLength)
+{
+    BEGIN_WRAP
+    std::vector<cv::String> outNamesVec(outNamesLength);
+    for (auto i = 0; i < outNamesLength; i++)
+    {
+        outNamesVec[i] = outNames[i];
+    }
+    model->setOutputNames(outNamesVec);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_predict(cv::dnn::Model *model, cv::_InputArray *frame, std::vector<cv::Mat> *outs)
+{
+    BEGIN_WRAP
+    model->predict(*frame, *outs);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setPreferableBackend(cv::dnn::Model *model, const int backendId)
+{
+    BEGIN_WRAP
+    model->setPreferableBackend(static_cast<cv::dnn::Backend>(backendId));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_setPreferableTarget(cv::dnn::Model *model, const int targetId)
+{
+    BEGIN_WRAP
+    model->setPreferableTarget(static_cast<cv::dnn::Target>(targetId));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Model_enableWinograd(cv::dnn::Model *model, const int useWinograd)
+{
+    BEGIN_WRAP
+    model->enableWinograd(useWinograd != 0);
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// ClassificationModel
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_new_String(
+    const char *model, const char *config, cv::dnn::ClassificationModel **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::ClassificationModel(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_new_Net(cv::dnn::Net *network, cv::dnn::ClassificationModel **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::ClassificationModel(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_delete(cv::dnn::ClassificationModel *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_setEnableSoftmaxPostProcessing(
+    cv::dnn::ClassificationModel *model, const int enable)
+{
+    BEGIN_WRAP
+    model->setEnableSoftmaxPostProcessing(enable != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_getEnableSoftmaxPostProcessing(
+    cv::dnn::ClassificationModel *model, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getEnableSoftmaxPostProcessing() ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_ClassificationModel_classify(
+    cv::dnn::ClassificationModel *model, cv::_InputArray *frame, int *classId, float *conf)
+{
+    BEGIN_WRAP
+    model->classify(*frame, *classId, *conf);
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// DetectionModel
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_new_String(
+    const char *model, const char *config, cv::dnn::DetectionModel **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::DetectionModel(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_new_Net(cv::dnn::Net *network, cv::dnn::DetectionModel **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::DetectionModel(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_delete(cv::dnn::DetectionModel *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_setNmsAcrossClasses(cv::dnn::DetectionModel *model, const int value)
+{
+    BEGIN_WRAP
+    model->setNmsAcrossClasses(value != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_getNmsAcrossClasses(cv::dnn::DetectionModel *model, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getNmsAcrossClasses() ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_DetectionModel_detect(
+    cv::dnn::DetectionModel *model, cv::_InputArray *frame,
+    std::vector<int> *classIds, std::vector<float> *confidences, std::vector<cv::Rect> *boxes,
+    const float confThreshold, const float nmsThreshold)
+{
+    BEGIN_WRAP
+    model->detect(*frame, *classIds, *confidences, *boxes, confThreshold, nmsThreshold);
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// SegmentationModel
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_SegmentationModel_new_String(
+    const char *model, const char *config, cv::dnn::SegmentationModel **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::SegmentationModel(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_SegmentationModel_new_Net(cv::dnn::Net *network, cv::dnn::SegmentationModel **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::SegmentationModel(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_SegmentationModel_delete(cv::dnn::SegmentationModel *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_SegmentationModel_segment(
+    cv::dnn::SegmentationModel *model, cv::_InputArray *frame, cv::_OutputArray *mask)
+{
+    BEGIN_WRAP
+    model->segment(*frame, *mask);
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// KeypointsModel
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_KeypointsModel_new_String(
+    const char *model, const char *config, cv::dnn::KeypointsModel **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::KeypointsModel(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_KeypointsModel_new_Net(cv::dnn::Net *network, cv::dnn::KeypointsModel **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::KeypointsModel(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_KeypointsModel_delete(cv::dnn::KeypointsModel *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_KeypointsModel_estimate(
+    cv::dnn::KeypointsModel *model, cv::_InputArray *frame, std::vector<cv::Point2f> *keypoints, const float thresh)
+{
+    BEGIN_WRAP
+    const auto result = model->estimate(*frame, thresh);
+    keypoints->assign(result.begin(), result.end());
+    END_WRAP
+}
+
+#endif // !#ifndef _WINRT_DLL
+
+#endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/ModelTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/ModelTest.cs
@@ -1,69 +1,126 @@
+using System.Runtime.InteropServices;
 using OpenCvSharp.Dnn;
 using Xunit;
 
 namespace OpenCvSharp.Tests.Dnn;
 
-// High-level dnn Model API smoke tests.
-// These verify the native P/Invoke wiring (constructors, base setters, destructors)
-// without requiring a downloaded model file.
+// Tests for the high-level dnn Model API.
+//
+// The end-to-end tests reuse the MNIST TensorFlow model and digit images that
+// already ship in the repository (also used by TensorflowTest), so they run in
+// CI without downloading anything. They prove the full pipeline really works:
+// input preprocessing -> forward pass -> result decoding.
+//
+// The remaining lifecycle tests cover model types for which no committed model
+// is available; they still verify that the native constructors, base setters
+// and destructors are wired up correctly.
 public class ModelTest : TestBase
 {
-    [Fact]
-    public void ModelFromNetAndSetParams()
-    {
-        using var net = new Net();
-        using var model = new Model(net);
+    // The native dnn backend is only available on Windows or Linux builds here.
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
-        model.SetInputSize(new Size(224, 224));
-        model.SetInputSize(224, 224);
-        model.SetInputMean(new Scalar(104, 117, 123));
-        model.SetInputScale(new Scalar(1.0 / 255));
-        model.SetInputCrop(false);
-        model.SetInputSwapRB(true);
-        model.SetInputParams(1.0 / 255, new Size(224, 224), new Scalar(0, 0, 0), true, false);
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Theory(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    [InlineData("MNIST_5.png", 5)]
+    [InlineData("MNIST_9.png", 9)]
+    public void ClassificationModelRecognizesMnistDigit(string imageFileName, int expectedDigit)
+    {
+        using var image = LoadImage(Path.Combine("Dnn", imageFileName), ImreadModes.Grayscale);
+
+        using var model = new ClassificationModel(MnistModelPath);
+        // scale 1/255, input size = image size (the digit images already match the model input), grayscale.
+        model.SetInputParams(1.0 / 255.0, image.Size());
+
+        model.Classify(image, out var classId, out var conf);
+
+        Assert.Equal(expectedDigit, classId);
+        Assert.True(conf > 0, $"confidence should be positive but was {conf}");
     }
 
-    [Fact]
-    public void ClassificationModelLifecycle()
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ModelPredictReturnsProbabilities()
     {
-        using var net = new Net();
-        using var model = new ClassificationModel(net);
+        using var image = LoadImage(Path.Combine("Dnn", "MNIST_9.png"), ImreadModes.Grayscale);
+
+        using var model = new Model(MnistModelPath);
+        model.SetInputParams(1.0 / 255.0, image.Size());
+
+        var outputs = model.Predict(image);
+        try
+        {
+            Assert.NotEmpty(outputs);
+
+            // The single output blob holds the per-class scores; argmax must be 9.
+            using var strip = outputs[0].Reshape(1, (int)outputs[0].Total());
+            var minIdx = new[] { -1 };
+            var maxIdx = new[] { -1 };
+            strip.MinMaxIdx(minIdx, maxIdx);
+            Assert.Equal(9, maxIdx[0]);
+        }
+        finally
+        {
+            foreach (var o in outputs)
+                o.Dispose();
+        }
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ModelFromNetSharesBaseSetters()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        using var model = new Model(net!);
+        model.SetInputSize(new Size(26, 26));
+        model.SetInputSize(26, 26);
+        model.SetInputMean(new Scalar(0));
+        model.SetInputScale(new Scalar(1.0 / 255));
+        model.SetInputCrop(false);
+        model.SetInputSwapRB(false);
+        model.SetInputParams(1.0 / 255.0, new Size(26, 26), new Scalar(0), false, false);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ClassificationModelSoftmaxToggle()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        using var model = new ClassificationModel(net!);
 
         model.SetEnableSoftmaxPostProcessing(true);
         Assert.True(model.GetEnableSoftmaxPostProcessing());
         model.SetEnableSoftmaxPostProcessing(false);
         Assert.False(model.GetEnableSoftmaxPostProcessing());
-
-        model.SetInputParams(1.0, new Size(224, 224));
     }
 
-    [Fact]
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
     public void DetectionModelLifecycle()
     {
-        using var net = new Net();
-        using var model = new DetectionModel(net);
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        using var model = new DetectionModel(net!);
 
         model.SetNmsAcrossClasses(true);
         Assert.True(model.GetNmsAcrossClasses());
         model.SetNmsAcrossClasses(false);
         Assert.False(model.GetNmsAcrossClasses());
 
-        model.SetInputParams(1.0 / 255, new Size(416, 416), new Scalar(), true);
+        model.SetInputParams(1.0 / 255.0, new Size(26, 26));
     }
 
-    [Fact]
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
     public void SegmentationModelLifecycle()
     {
-        using var net = new Net();
-        using var model = new SegmentationModel(net);
-        model.SetInputParams(1.0, new Size(513, 513));
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        using var model = new SegmentationModel(net!);
+        model.SetInputParams(1.0 / 255.0, new Size(26, 26));
     }
 
-    [Fact]
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
     public void KeypointsModelLifecycle()
     {
-        using var net = new Net();
-        using var model = new KeypointsModel(net);
-        model.SetInputParams(1.0 / 255, new Size(368, 368));
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        using var model = new KeypointsModel(net!);
+        model.SetInputParams(1.0 / 255.0, new Size(26, 26));
     }
 }

--- a/test/OpenCvSharp.Tests/dnn/ModelTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/ModelTest.cs
@@ -1,0 +1,69 @@
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// High-level dnn Model API smoke tests.
+// These verify the native P/Invoke wiring (constructors, base setters, destructors)
+// without requiring a downloaded model file.
+public class ModelTest : TestBase
+{
+    [Fact]
+    public void ModelFromNetAndSetParams()
+    {
+        using var net = new Net();
+        using var model = new Model(net);
+
+        model.SetInputSize(new Size(224, 224));
+        model.SetInputSize(224, 224);
+        model.SetInputMean(new Scalar(104, 117, 123));
+        model.SetInputScale(new Scalar(1.0 / 255));
+        model.SetInputCrop(false);
+        model.SetInputSwapRB(true);
+        model.SetInputParams(1.0 / 255, new Size(224, 224), new Scalar(0, 0, 0), true, false);
+    }
+
+    [Fact]
+    public void ClassificationModelLifecycle()
+    {
+        using var net = new Net();
+        using var model = new ClassificationModel(net);
+
+        model.SetEnableSoftmaxPostProcessing(true);
+        Assert.True(model.GetEnableSoftmaxPostProcessing());
+        model.SetEnableSoftmaxPostProcessing(false);
+        Assert.False(model.GetEnableSoftmaxPostProcessing());
+
+        model.SetInputParams(1.0, new Size(224, 224));
+    }
+
+    [Fact]
+    public void DetectionModelLifecycle()
+    {
+        using var net = new Net();
+        using var model = new DetectionModel(net);
+
+        model.SetNmsAcrossClasses(true);
+        Assert.True(model.GetNmsAcrossClasses());
+        model.SetNmsAcrossClasses(false);
+        Assert.False(model.GetNmsAcrossClasses());
+
+        model.SetInputParams(1.0 / 255, new Size(416, 416), new Scalar(), true);
+    }
+
+    [Fact]
+    public void SegmentationModelLifecycle()
+    {
+        using var net = new Net();
+        using var model = new SegmentationModel(net);
+        model.SetInputParams(1.0, new Size(513, 513));
+    }
+
+    [Fact]
+    public void KeypointsModelLifecycle()
+    {
+        using var net = new Net();
+        using var model = new KeypointsModel(net);
+        model.SetInputParams(1.0 / 255, new Size(368, 368));
+    }
+}


### PR DESCRIPTION
## Summary

The OpenCvSharp5 DNN wrapper only covered the minimal "read + `Net.Forward`" path. The OpenCV 5 high-level **Model API** (input preprocessing + `predict` helpers) was completely missing. This PR adds the high-priority core of that API.

This is the first increment of the DNN coverage work (priority group "A — high-level Model API"). The remaining Text models (`TextRecognitionModel`, `TextDetectionModel`, `_EAST`, `_DB`) and later priorities (TFLite reader, `blobFromImageWithParams`, `NMSBoxesBatched`/`softNMSBoxes`, etc.) will follow in separate PRs.

## What's added

| Layer | File |
|---|---|
| Native C++ | `src/OpenCvSharpExtern/dnn_Model.h` (included from `dnn.cpp`, registered in vcxproj/filters) |
| P/Invoke | `NativeMethods_dnn_Model.cs` |
| Managed wrappers | `Model.cs`, `ClassificationModel.cs`, `DetectionModel.cs`, `SegmentationModel.cs`, `KeypointsModel.cs` |
| Tests | `dnn/ModelTest.cs` (model-free smoke tests) |

### API

- **`Model`** (base): `SetInputSize` / `SetInputMean` / `SetInputScale` / `SetInputCrop` /
  `SetInputSwapRB` / `SetInputParams` / `SetOutputNames` / `Predict` /
  `SetPreferableBackend` / `SetPreferableTarget` / `EnableWinograd`.
  Constructible from a file path (`model`, `config`) or from a `Net`.
- **`ClassificationModel`**: `Classify`, `SetEnableSoftmaxPostProcessing` / `Get...`
- **`DetectionModel`**: `Detect`, `SetNmsAcrossClasses` / `Get...`
- **`SegmentationModel`**: `Segment`
- **`KeypointsModel`**: `Estimate`

## Implementation notes

- Each derived type is destroyed via its own `delete`; the shared base methods upcast   the derived pointer to `cv::dnn::Model*`. This is safe under single inheritance (no pointer adjustment), so the base setters can be reused for every derived model.
- `Model::setInputScale` takes `cv::Scalar` in OpenCV 5 (it was `double` in early 4.x);
  the wrapper matches the 5.x signature.

## Verification

- Managed library (`OpenCvSharp`) and the test project build locally with **0 errors**.
- The native layer requires a full OpenCV 5 build, so it is validated by **CI**.
- `ModelTest.cs` exercises the constructors, base setters and destructors of all five
  types without needing a downloaded model, so CI verifies the P/Invoke wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
