### PR TITLE
Add high-level dnn text Model API (TextRecognition + TextDetection EAST/DB)

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
@@ -1,0 +1,168 @@
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+// ReSharper disable InconsistentNaming
+static partial class NativeMethods
+{
+    // ------------------------------------------------------------------------
+    // TextRecognitionModel
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextRecognitionModel_new_String")]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextRecognitionModel_new_String")]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_TextRecognitionModel_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_TextRecognitionModel_new_String_Windows(model, config, out returnValue)
+            : dnn_TextRecognitionModel_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_setDecodeType(
+        IntPtr model, [MarshalAs(UnmanagedType.LPStr)] string decodeType);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_getDecodeType(IntPtr model, IntPtr outString);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_setDecodeOptsCTCPrefixBeamSearch(
+        IntPtr model, int beamSize, int vocPruneSize);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_setVocabulary(
+        IntPtr model, string[] vocabulary, int vocabularyLength);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_getVocabulary(IntPtr model, IntPtr outVec);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextRecognitionModel_recognize(IntPtr model, IntPtr frame, IntPtr outString);
+
+    // ------------------------------------------------------------------------
+    // TextDetectionModel (base; shared by EAST and DB)
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_detect(
+        IntPtr model, IntPtr frame, IntPtr detections, IntPtr confidences);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_detectTextRectangles(
+        IntPtr model, IntPtr frame, IntPtr detections, IntPtr confidences);
+
+    // ------------------------------------------------------------------------
+    // TextDetectionModel_EAST
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextDetectionModel_EAST_new_String")]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextDetectionModel_EAST_new_String")]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_TextDetectionModel_EAST_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_TextDetectionModel_EAST_new_String_Windows(model, config, out returnValue)
+            : dnn_TextDetectionModel_EAST_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_setConfidenceThreshold(IntPtr model, float confThreshold);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_getConfidenceThreshold(IntPtr model, out float returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_setNMSThreshold(IntPtr model, float nmsThreshold);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_EAST_getNMSThreshold(IntPtr model, out float returnValue);
+
+    // ------------------------------------------------------------------------
+    // TextDetectionModel_DB
+    // ------------------------------------------------------------------------
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextDetectionModel_DB_new_String")]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_new_String_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_TextDetectionModel_DB_new_String")]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_new_String_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_TextDetectionModel_DB_new_String(string model, string? config, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_TextDetectionModel_DB_new_String_Windows(model, config, out returnValue)
+            : dnn_TextDetectionModel_DB_new_String_NotWindows(model, config, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_new_Net(IntPtr network, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_delete(IntPtr model);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_setBinaryThreshold(IntPtr model, float binaryThreshold);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_getBinaryThreshold(IntPtr model, out float returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_setPolygonThreshold(IntPtr model, float polygonThreshold);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_getPolygonThreshold(IntPtr model, out float returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_setUnclipRatio(IntPtr model, double unclipRatio);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_getUnclipRatio(IntPtr model, out double returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_setMaxCandidates(IntPtr model, int maxCandidates);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_TextDetectionModel_DB_getMaxCandidates(IntPtr model, out int returnValue);
+}

--- a/src/OpenCvSharp/Modules/dnn/TextDetectionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextDetectionModel.cs
@@ -1,0 +1,75 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Base class for text detection networks.
+/// This is an abstract base; use <see cref="TextDetectionModelEAST"/> or
+/// <see cref="TextDetectionModelDB"/>.
+/// </summary>
+public abstract class TextDetectionModel : Model
+{
+    /// <summary>
+    /// For derived classes that construct the native object themselves.
+    /// </summary>
+    protected TextDetectionModel()
+    {
+    }
+
+    /// <summary>
+    /// Performs detection. Given the input @p frame, prepare network input, run network inference, post-process network
+    /// output and return result detections. Each result is quadrangle's 4 points in this order:
+    /// bottom-left, top-left, top-right, bottom-right.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="detections">array with detections' quadrangles (4 points per result).</param>
+    /// <param name="confidences">array with detection confidences.</param>
+    public void Detect(InputArray frame, out Point[][] detections, out float[] confidences)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var detectionsVec = new VectorOfVectorPoint();
+        using var confidencesVec = new VectorOfFloat();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_detect(CvPtr, frame.CvPtr, detectionsVec.CvPtr, confidencesVec.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+
+        detections = detectionsVec.ToArray();
+        confidences = confidencesVec.ToArray();
+    }
+
+    /// <summary>
+    /// Performs detection. Given the input @p frame, prepare network input, run network inference, post-process network
+    /// output and return result detections. Each result is rotated rectangle.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="detections">array with detections' RotatedRect results.</param>
+    /// <param name="confidences">array with detection confidences.</param>
+    public void DetectTextRectangles(InputArray frame, out RotatedRect[] detections, out float[] confidences)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var detectionsVec = new VectorOfRotatedRect();
+        using var confidencesVec = new VectorOfFloat();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_detectTextRectangles(CvPtr, frame.CvPtr, detectionsVec.CvPtr, confidencesVec.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+
+        detections = detectionsVec.ToArray();
+        confidences = confidencesVec.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/TextDetectionModelDB.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextDetectionModelDB.cs
@@ -1,0 +1,145 @@
+using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for text detection DL networks compatible with DB model.
+/// </summary>
+public class TextDetectionModelDB : TextDetectionModel
+{
+    /// <summary>
+    /// Create text detection model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public TextDetectionModelDB(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_TextDetectionModel_DB_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public TextDetectionModelDB(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_TextDetectionModel_DB_delete);
+    }
+
+    /// <summary>
+    /// Set the detection binary threshold.
+    /// </summary>
+    /// <param name="binaryThreshold">the detection binary threshold</param>
+    public void SetBinaryThreshold(float binaryThreshold)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_setBinaryThreshold(CvPtr, binaryThreshold));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the detection binary threshold.
+    /// </summary>
+    /// <returns>the detection binary threshold</returns>
+    public float GetBinaryThreshold()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_getBinaryThreshold(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Set the polygon threshold.
+    /// </summary>
+    /// <param name="polygonThreshold">the polygon threshold</param>
+    public void SetPolygonThreshold(float polygonThreshold)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_setPolygonThreshold(CvPtr, polygonThreshold));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the polygon threshold.
+    /// </summary>
+    /// <returns>the polygon threshold</returns>
+    public float GetPolygonThreshold()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_getPolygonThreshold(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Set the unclip ratio.
+    /// </summary>
+    /// <param name="unclipRatio">the unclip ratio</param>
+    public void SetUnclipRatio(double unclipRatio)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_setUnclipRatio(CvPtr, unclipRatio));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the unclip ratio.
+    /// </summary>
+    /// <returns>the unclip ratio</returns>
+    public double GetUnclipRatio()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_getUnclipRatio(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Set the max candidates of polygons.
+    /// </summary>
+    /// <param name="maxCandidates">the max candidates of polygons</param>
+    public void SetMaxCandidates(int maxCandidates)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_setMaxCandidates(CvPtr, maxCandidates));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the max candidates of polygons.
+    /// </summary>
+    /// <returns>the max candidates of polygons</returns>
+    public int GetMaxCandidates()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_DB_getMaxCandidates(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/TextDetectionModelEAST.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextDetectionModelEAST.cs
@@ -1,0 +1,95 @@
+using OpenCvSharp.Internal;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for text detection DL networks compatible with EAST model.
+/// </summary>
+public class TextDetectionModelEAST : TextDetectionModel
+{
+    /// <summary>
+    /// Create text detection model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public TextDetectionModelEAST(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_TextDetectionModel_EAST_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public TextDetectionModelEAST(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_TextDetectionModel_EAST_delete);
+    }
+
+    /// <summary>
+    /// Set the detection confidence threshold.
+    /// </summary>
+    /// <param name="confThreshold">A threshold used to filter boxes by confidences.</param>
+    public void SetConfidenceThreshold(float confThreshold)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_setConfidenceThreshold(CvPtr, confThreshold));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the detection confidence threshold.
+    /// </summary>
+    /// <returns>the detection confidence threshold</returns>
+    public float GetConfidenceThreshold()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_getConfidenceThreshold(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Set the detection NMS filter threshold.
+    /// </summary>
+    /// <param name="nmsThreshold">A threshold used in non maximum suppression.</param>
+    public void SetNMSThreshold(float nmsThreshold)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_setNMSThreshold(CvPtr, nmsThreshold));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the detection NMS filter threshold.
+    /// </summary>
+    /// <returns>the detection NMS filter threshold</returns>
+    public float GetNMSThreshold()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextDetectionModel_EAST_getNMSThreshold(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
@@ -1,0 +1,144 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable UnusedMember.Global
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This class represents high-level API for text recognition networks.
+/// TextRecognitionModel allows to set params for preprocessing input image.
+/// TextRecognitionModel creates net from file with trained weights and config,
+/// sets preprocessing input, runs forward pass and return recognition result.
+/// For TextRecognitionModel, CRNN-CTC is supported.
+/// </summary>
+public class TextRecognitionModel : Model
+{
+    /// <summary>
+    /// Create text recognition model from network represented in one of the supported formats.
+    /// An order of @p model and @p config arguments does not matter.
+    /// </summary>
+    /// <param name="model">Binary file contains trained weights.</param>
+    /// <param name="config">Text file contains network configuration.</param>
+    public TextRecognitionModel(string model, string? config = null)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_new_String(model, config, out var p));
+        SetHandle(p, NativeMethods.dnn_TextRecognitionModel_delete);
+    }
+
+    /// <summary>
+    /// Create model from deep learning network.
+    /// </summary>
+    /// <param name="network">Net object.</param>
+    public TextRecognitionModel(Net network)
+    {
+        if (network is null)
+            throw new ArgumentNullException(nameof(network));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_new_Net(network.CvPtr, out var p));
+        GC.KeepAlive(network);
+        SetHandle(p, NativeMethods.dnn_TextRecognitionModel_delete);
+    }
+
+    /// <summary>
+    /// Set the decoding method of translating the network output into string.
+    /// </summary>
+    /// <param name="decodeType">The decoding method of translating the network output into string, currently supported type:
+    /// - "CTC-greedy" greedy decoding for the output of CTC-based methods
+    /// - "CTC-prefix-beam-search" Prefix beam search decoding for the output of CTC-based methods</param>
+    public void SetDecodeType(string decodeType)
+    {
+        if (decodeType is null)
+            throw new ArgumentNullException(nameof(decodeType));
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_setDecodeType(CvPtr, decodeType));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the decoding method.
+    /// </summary>
+    /// <returns>the decoding method</returns>
+    public string GetDecodeType()
+    {
+        ThrowIfDisposed();
+        using var result = new StdString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_getDecodeType(CvPtr, result.CvPtr));
+        GC.KeepAlive(this);
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Set the decoding method options for "CTC-prefix-beam-search" decode usage.
+    /// </summary>
+    /// <param name="beamSize">Beam size for search</param>
+    /// <param name="vocPruneSize">Parameter to optimize big vocabulary search,
+    /// only take top @p vocPruneSize tokens in each search step, @p vocPruneSize &lt;= 0 stands for disable this prune.</param>
+    public void SetDecodeOptsCTCPrefixBeamSearch(int beamSize, int vocPruneSize = 0)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_setDecodeOptsCTCPrefixBeamSearch(CvPtr, beamSize, vocPruneSize));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Set the vocabulary for recognition.
+    /// </summary>
+    /// <param name="vocabulary">the associated vocabulary of the network.</param>
+    public void SetVocabulary(IEnumerable<string> vocabulary)
+    {
+        if (vocabulary is null)
+            throw new ArgumentNullException(nameof(vocabulary));
+        ThrowIfDisposed();
+
+        var vocabularyArray = vocabulary as string[] ?? vocabulary.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_setVocabulary(CvPtr, vocabularyArray, vocabularyArray.Length));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Get the vocabulary for recognition.
+    /// </summary>
+    /// <returns>vocabulary the associated vocabulary of the network.</returns>
+    public string?[] GetVocabulary()
+    {
+        ThrowIfDisposed();
+        using var resultVec = new VectorOfString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_getVocabulary(CvPtr, resultVec.CvPtr));
+        GC.KeepAlive(this);
+        return resultVec.ToArray();
+    }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net and return recognition result.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <returns>The text recognition result.</returns>
+    public string Recognize(InputArray frame)
+    {
+        ThrowIfDisposed();
+        if (frame is null)
+            throw new ArgumentNullException(nameof(frame));
+        frame.ThrowIfDisposed();
+
+        using var result = new StdString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_recognize(CvPtr, frame.CvPtr, result.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(frame);
+        return result.ToString();
+    }
+}

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
@@ -110,6 +110,7 @@
     <ClInclude Include="cuda_GpuMat.h" />
     <ClInclude Include="dnn.h" />
     <ClInclude Include="dnn_Model.h" />
+    <ClInclude Include="dnn_TextModel.h" />
     <ClInclude Include="dnn_Net.h" />
     <ClInclude Include="dnn_superres.h" />
     <ClInclude Include="face_Facemark.h" />

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
@@ -297,6 +297,9 @@
     <ClInclude Include="dnn_Model.h">
       <Filter>Header Files\dnn</Filter>
     </ClInclude>
+    <ClInclude Include="dnn_TextModel.h">
+      <Filter>Header Files\dnn</Filter>
+    </ClInclude>
     <ClInclude Include="dnn.h">
       <Filter>Header Files\dnn</Filter>
     </ClInclude>

--- a/src/OpenCvSharpExtern/dnn.cpp
+++ b/src/OpenCvSharpExtern/dnn.cpp
@@ -2,3 +2,4 @@
 #include "dnn.h"
 #include "dnn_Net.h"
 #include "dnn_Model.h"
+#include "dnn_TextModel.h"

--- a/src/OpenCvSharpExtern/dnn_TextModel.h
+++ b/src/OpenCvSharpExtern/dnn_TextModel.h
@@ -1,0 +1,271 @@
+#pragma once
+
+#ifndef NO_DNN
+
+#ifndef _WINRT_DLL
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+// ----------------------------------------------------------------------------
+// TextRecognitionModel
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_new_String(
+    const char *model, const char *config, cv::dnn::TextRecognitionModel **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::TextRecognitionModel(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_new_Net(
+    cv::dnn::Net *network, cv::dnn::TextRecognitionModel **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::TextRecognitionModel(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_delete(cv::dnn::TextRecognitionModel *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setDecodeType(
+    cv::dnn::TextRecognitionModel *model, const char *decodeType)
+{
+    BEGIN_WRAP
+    model->setDecodeType(decodeType);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_getDecodeType(
+    cv::dnn::TextRecognitionModel *model, std::string *outString)
+{
+    BEGIN_WRAP
+    outString->assign(model->getDecodeType());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setDecodeOptsCTCPrefixBeamSearch(
+    cv::dnn::TextRecognitionModel *model, const int beamSize, const int vocPruneSize)
+{
+    BEGIN_WRAP
+    model->setDecodeOptsCTCPrefixBeamSearch(beamSize, vocPruneSize);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setVocabulary(
+    cv::dnn::TextRecognitionModel *model, const char **vocabulary, const int vocabularyLength)
+{
+    BEGIN_WRAP
+    std::vector<std::string> vocabularyVec(vocabularyLength);
+    for (auto i = 0; i < vocabularyLength; i++)
+    {
+        vocabularyVec[i] = vocabulary[i];
+    }
+    model->setVocabulary(vocabularyVec);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_getVocabulary(
+    cv::dnn::TextRecognitionModel *model, std::vector<std::string> *outVec)
+{
+    BEGIN_WRAP
+    const auto result = model->getVocabulary();
+    outVec->assign(result.begin(), result.end());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_recognize(
+    cv::dnn::TextRecognitionModel *model, cv::_InputArray *frame, std::string *outString)
+{
+    BEGIN_WRAP
+    outString->assign(model->recognize(*frame));
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// TextDetectionModel (base; methods are shared by EAST and DB via upcast)
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_detect(
+    cv::dnn::TextDetectionModel *model, cv::_InputArray *frame,
+    std::vector<std::vector<cv::Point>> *detections, std::vector<float> *confidences)
+{
+    BEGIN_WRAP
+    model->detect(*frame, *detections, *confidences);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_detectTextRectangles(
+    cv::dnn::TextDetectionModel *model, cv::_InputArray *frame,
+    std::vector<cv::RotatedRect> *detections, std::vector<float> *confidences)
+{
+    BEGIN_WRAP
+    model->detectTextRectangles(*frame, *detections, *confidences);
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// TextDetectionModel_EAST
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_new_String(
+    const char *model, const char *config, cv::dnn::TextDetectionModel_EAST **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::TextDetectionModel_EAST(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_new_Net(
+    cv::dnn::Net *network, cv::dnn::TextDetectionModel_EAST **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::TextDetectionModel_EAST(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_delete(cv::dnn::TextDetectionModel_EAST *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_setConfidenceThreshold(
+    cv::dnn::TextDetectionModel_EAST *model, const float confThreshold)
+{
+    BEGIN_WRAP
+    model->setConfidenceThreshold(confThreshold);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_getConfidenceThreshold(
+    cv::dnn::TextDetectionModel_EAST *model, float *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getConfidenceThreshold();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_setNMSThreshold(
+    cv::dnn::TextDetectionModel_EAST *model, const float nmsThreshold)
+{
+    BEGIN_WRAP
+    model->setNMSThreshold(nmsThreshold);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_getNMSThreshold(
+    cv::dnn::TextDetectionModel_EAST *model, float *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getNMSThreshold();
+    END_WRAP
+}
+
+// ----------------------------------------------------------------------------
+// TextDetectionModel_DB
+// ----------------------------------------------------------------------------
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_new_String(
+    const char *model, const char *config, cv::dnn::TextDetectionModel_DB **returnValue)
+{
+    BEGIN_WRAP
+    const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
+    *returnValue = new cv::dnn::TextDetectionModel_DB(model, configStr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_new_Net(
+    cv::dnn::Net *network, cv::dnn::TextDetectionModel_DB **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::TextDetectionModel_DB(*network);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_delete(cv::dnn::TextDetectionModel_DB *model)
+{
+    BEGIN_WRAP
+    delete model;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setBinaryThreshold(
+    cv::dnn::TextDetectionModel_DB *model, const float binaryThreshold)
+{
+    BEGIN_WRAP
+    model->setBinaryThreshold(binaryThreshold);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getBinaryThreshold(
+    cv::dnn::TextDetectionModel_DB *model, float *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getBinaryThreshold();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setPolygonThreshold(
+    cv::dnn::TextDetectionModel_DB *model, const float polygonThreshold)
+{
+    BEGIN_WRAP
+    model->setPolygonThreshold(polygonThreshold);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getPolygonThreshold(
+    cv::dnn::TextDetectionModel_DB *model, float *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getPolygonThreshold();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setUnclipRatio(
+    cv::dnn::TextDetectionModel_DB *model, const double unclipRatio)
+{
+    BEGIN_WRAP
+    model->setUnclipRatio(unclipRatio);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getUnclipRatio(
+    cv::dnn::TextDetectionModel_DB *model, double *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getUnclipRatio();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setMaxCandidates(
+    cv::dnn::TextDetectionModel_DB *model, const int maxCandidates)
+{
+    BEGIN_WRAP
+    model->setMaxCandidates(maxCandidates);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getMaxCandidates(
+    cv::dnn::TextDetectionModel_DB *model, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = model->getMaxCandidates();
+    END_WRAP
+}
+
+#endif // !#ifndef _WINRT_DLL
+
+#endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/TextModelTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/TextModelTest.cs
@@ -1,0 +1,113 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Tests for the high-level dnn text Model API.
+//
+// The end-to-end EAST test downloads the EAST model (same as EastTextDetectionTest),
+// so it is marked Explicit and does not run in the normal CI pass. The lifecycle
+// tests construct each text model from an empty Net and exercise the setters/getters,
+// verifying the native constructors, destructors and accessors are wired up.
+public class TextModelTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    // https://github.com/opencv/opencv_extra/blob/master/testdata/dnn/download_models.py
+    private const string EastModelUrl = "https://www.dropbox.com/s/r2ingd0l3zt8hxs/frozen_east_text_detection.tar.gz?dl=1";
+    private const string EastRawModelPath = "_data/model/frozen_east_text_detection.tar.gz";
+    private const string EastModelPath = "_data/model/frozen_east_text_detection.pb";
+    private static readonly object lockObj = new();
+
+    [ExplicitTheory]
+    [InlineData("_data/image/abbey_road.jpg")]
+    public void TextDetectionModelEastDetectsText(string imageFileName)
+    {
+        PrepareEastModel();
+
+        using var img = new Mat(imageFileName);
+
+        using var model = new TextDetectionModelEAST(EastModelPath);
+        model.SetConfidenceThreshold(0.5f);
+        model.SetNMSThreshold(0.4f);
+        // EAST expects the input size to be a multiple of 32.
+        model.SetInputParams(1.0, new Size(320, 320), new Scalar(123.68, 116.78, 103.94), true);
+
+        model.DetectTextRectangles(img, out var detections, out var confidences);
+
+        Assert.NotEmpty(detections);
+        Assert.Equal(detections.Length, confidences.Length);
+        Assert.All(confidences, c => Assert.True(c >= 0.5f, $"confidence {c} below threshold"));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void TextRecognitionModelLifecycle()
+    {
+        using var net = new Net();
+        using var model = new TextRecognitionModel(net);
+
+        model.SetDecodeType("CTC-greedy");
+        Assert.Equal("CTC-greedy", model.GetDecodeType());
+
+        var vocabulary = new[] { "a", "b", "c" };
+        model.SetVocabulary(vocabulary);
+        Assert.Equal(vocabulary, model.GetVocabulary());
+
+        model.SetDecodeOptsCTCPrefixBeamSearch(10);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void TextDetectionModelEastLifecycle()
+    {
+        using var net = new Net();
+        using var model = new TextDetectionModelEAST(net);
+
+        model.SetConfidenceThreshold(0.5f);
+        Assert.Equal(0.5f, model.GetConfidenceThreshold());
+        model.SetNMSThreshold(0.4f);
+        Assert.Equal(0.4f, model.GetNMSThreshold());
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void TextDetectionModelDbLifecycle()
+    {
+        using var net = new Net();
+        using var model = new TextDetectionModelDB(net);
+
+        model.SetBinaryThreshold(0.3f);
+        Assert.Equal(0.3f, model.GetBinaryThreshold());
+        model.SetPolygonThreshold(0.5f);
+        Assert.Equal(0.5f, model.GetPolygonThreshold());
+        model.SetUnclipRatio(2.0);
+        Assert.Equal(2.0, model.GetUnclipRatio());
+        model.SetMaxCandidates(200);
+        Assert.Equal(200, model.GetMaxCandidates());
+    }
+
+    private static void PrepareEastModel()
+    {
+        lock (lockObj)
+        {
+            if (!File.Exists(EastRawModelPath))
+            {
+                var contents = FileDownloader.DownloadData(new Uri(EastModelUrl));
+                File.WriteAllBytes(EastRawModelPath, contents);
+            }
+
+            if (!File.Exists(EastModelPath))
+            {
+                using var inputStream = new FileStream(EastRawModelPath, FileMode.Open, FileAccess.Read);
+                using var gzipStream = new GZipInputStream(inputStream);
+                using var tarArchive = TarArchive.CreateInputTarArchive(gzipStream, Encoding.UTF8);
+                tarArchive.ExtractContents(Path.GetDirectoryName(EastRawModelPath)!);
+            }
+
+            Assert.True(File.Exists(EastModelPath), $"'{EastModelPath}' not found");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1917. Completes priority group **A (high-level Model API)** by adding
the remaining **text models** from OpenCV 5's dnn module.

## What's added

| Layer | File |
|---|---|
| Native C++ | `src/OpenCvSharpExtern/dnn_TextModel.h` (included from `dnn.cpp`, registered in vcxproj/filters) |
| P/Invoke | `NativeMethods_dnn_TextModel.cs` |
| Managed wrappers | `TextRecognitionModel.cs`, `TextDetectionModel.cs` (abstract base), `TextDetectionModelEAST.cs`, `TextDetectionModelDB.cs` |
| Tests | `dnn/TextModelTest.cs` |

### API

- **`TextRecognitionModel`**: `SetDecodeType`/`GetDecodeType`,
  `SetDecodeOptsCTCPrefixBeamSearch`, `SetVocabulary`/`GetVocabulary`, `Recognize`
- **`TextDetectionModel`** (abstract base): `Detect` (quadrangles + confidences) and
  `DetectTextRectangles` (RotatedRects + confidences) — shared by EAST and DB
- **`TextDetectionModelEAST`**: `SetConfidenceThreshold`/`Get`, `SetNMSThreshold`/`Get`
- **`TextDetectionModelDB`**: `SetBinaryThreshold`/`Get`, `SetPolygonThreshold`/`Get`,
  `SetUnclipRatio`/`Get`, `SetMaxCandidates`/`Get`

All classes build from a file path or from a `Net` and inherit the base `Model`
preprocessing setters. The base `TextDetectionModel` methods upcast the derived
pointer to `cv::dnn::TextDetectionModel*` (single inheritance, no pointer adjustment).

## Verification

Built `OpenCvSharpExtern` locally against OpenCV 5.0.0 and ran the suite:

- 3 lifecycle tests pass — constructors, setters/getters, and **vocabulary** /
  **decode-type** round-trips for all three model types.
- The **EAST end-to-end** test (temporarily un-skipped for the run) downloads the EAST
  model and detects text rectangles on `abbey_road.jpg` with confidences above the
  threshold. It ships as `[ExplicitTheory]`, matching the existing `EastTextDetectionTest`.
- Full dnn suite stays green (**25 passed / 4 explicit-skipped**).

## Notes

- `TextRecognitionModel.recognize` batch overload (with `roiRects`) is intentionally
  omitted for now — `InputArrayOfArrays` marshaling is awkward and the overload is
  rarely used. Can be added later if needed.

## Next

With group A complete, the next increment is priority **B** (`readNetFromTFLite`,
`blobFromImageWithParams`, `NMSBoxesBatched`/`softNMSBoxes`, `imagesFromBlob`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
