### PR TITLE
Add dnn TFLite reader, blobFromImageWithParams, imagesFromBlob, batched/soft NMS

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -178,4 +178,61 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
     public static extern ExceptionStatus dnn_resetMyriadDevice();
+
+    // readNetFromTFLite
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_readNetFromTFLite")]
+    public static extern ExceptionStatus dnn_readNetFromTFLite_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_readNetFromTFLite")]
+    public static extern ExceptionStatus dnn_readNetFromTFLite_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string model, out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_readNetFromTFLite(string model, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_readNetFromTFLite_Windows(model, out returnValue)
+            : dnn_readNetFromTFLite_NotWindows(model, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "dnn_readNetFromTFLite_InputArray")]
+    public static extern unsafe ExceptionStatus dnn_readNetFromTFLite(
+        byte* bufferModel, IntPtr lenModel, out IntPtr returnValue);
+
+    // blobFromImageWithParams
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_blobFromImageWithParams(
+        IntPtr image, Scalar scalefactor, Size size, Scalar mean,
+        int swapRB, int ddepth, int datalayout, int paddingmode, Scalar borderValue, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_blobFromImagesWithParams(
+        IntPtr[] images, int imagesLength, Scalar scalefactor, Size size, Scalar mean,
+        int swapRB, int ddepth, int datalayout, int paddingmode, Scalar borderValue, out IntPtr returnValue);
+
+    // imagesFromBlob
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_imagesFromBlob(IntPtr blob, IntPtr images);
+
+    // NMSBoxesBatched
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_NMSBoxesBatched_Rect(
+        IntPtr bboxes, IntPtr scores, IntPtr classIds,
+        float score_threshold, float nms_threshold, IntPtr indices, float eta, int top_k);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_NMSBoxesBatched_Rect2d(
+        IntPtr bboxes, IntPtr scores, IntPtr classIds,
+        float score_threshold, float nms_threshold, IntPtr indices, float eta, int top_k);
+
+    // softNMSBoxes
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_softNMSBoxes_Rect(
+        IntPtr bboxes, IntPtr scores, IntPtr updated_scores,
+        float score_threshold, float nms_threshold, IntPtr indices, UIntPtr top_k, float sigma, int method);
 }

--- a/src/OpenCvSharp/Modules/dnn/CvDnn.cs
+++ b/src/OpenCvSharp/Modules/dnn/CvDnn.cs
@@ -122,6 +122,52 @@ public static class CvDnn
     }
 
     /// <summary>
+    /// Reads a network model stored in TFLite (https://www.tensorflow.org/lite) framework's format.
+    /// </summary>
+    /// <param name="model">path to the .tflite file with binary flatbuffers description of the network architecture.</param>
+    /// <returns></returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(string model)
+    {
+        return Net.ReadNetFromTFLite(model);
+    }
+
+    /// <summary>
+    /// Reads a network model stored in TFLite framework's format from memory.
+    /// </summary>
+    /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
+    /// <returns></returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(byte[] bufferModel)
+    {
+        return Net.ReadNetFromTFLite(bufferModel);
+    }
+
+    /// <summary>
+    /// Reads a network model stored in TFLite framework's format from memory.
+    /// </summary>
+    /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
+    /// <returns></returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel)
+    {
+        return Net.ReadNetFromTFLite(bufferModel);
+    }
+
+    /// <summary>
+    /// Reads a network model stored in TFLite framework's format from stream.
+    /// </summary>
+    /// <param name="bufferModelStream">stream containing the content of the tflite file.</param>
+    /// <returns></returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(Stream bufferModelStream)
+    {
+        if (bufferModelStream is null)
+            throw new ArgumentNullException(nameof(bufferModelStream));
+        return Net.ReadNetFromTFLite(StreamToArray(bufferModelStream));
+    }
+
+    /// <summary>
     /// Creates blob from .pb file.
     /// </summary>
     /// <param name="path">path to the .pb file with input tensor.</param>
@@ -193,6 +239,70 @@ public static class CvDnn
                 imagesPointers, imagesPointers.Length, scaleFactor, size, mean, swapRB ? 1 : 0, crop ? 1 : 0,
                 out var ret));
         return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Creates 4-dimensional blob from image with given params.
+    /// This function is an extension of <see cref="BlobFromImage(Mat, double, Size, Scalar, bool, bool)"/> to meet more image preprocess needs.
+    /// </summary>
+    /// <param name="image">input image (all with 1-, 3- or 4-channels).</param>
+    /// <param name="param">params with preprocessing parameters. If null, default params are used.</param>
+    /// <returns>4-dimensional Mat.</returns>
+    public static Mat BlobFromImageWithParams(InputArray image, Image2BlobParams? param = null)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        image.ThrowIfDisposed();
+        param ??= new Image2BlobParams();
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_blobFromImageWithParams(
+                image.CvPtr, param.ScaleFactor, param.Size, param.Mean,
+                param.SwapRB ? 1 : 0, (int)param.Depth, (int)param.DataLayout, (int)param.PaddingMode, param.BorderValue,
+                out var ret));
+        GC.KeepAlive(image);
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Creates 4-dimensional blob from series of images with given params.
+    /// </summary>
+    /// <param name="images">input images (all with 1-, 3- or 4-channels).</param>
+    /// <param name="param">params with preprocessing parameters. If null, default params are used.</param>
+    /// <returns>4-dimensional Mat.</returns>
+    public static Mat BlobFromImagesWithParams(IEnumerable<Mat> images, Image2BlobParams? param = null)
+    {
+        if (images is null)
+            throw new ArgumentNullException(nameof(images));
+        param ??= new Image2BlobParams();
+
+        var imagesPointers = images.Select(x => x.CvPtr).ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_blobFromImagesWithParams(
+                imagesPointers, imagesPointers.Length, param.ScaleFactor, param.Size, param.Mean,
+                param.SwapRB ? 1 : 0, (int)param.Depth, (int)param.DataLayout, (int)param.PaddingMode, param.BorderValue,
+                out var ret));
+        GC.KeepAlive(images);
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Parse a 4D blob and output the images it contains as 2D arrays through a simpler data structure (std::vector&lt;cv::Mat&gt;).
+    /// </summary>
+    /// <param name="blob">4 dimensional array (images, channels, height, width) in floating point precision (CV_32F) from
+    /// which you would like to extract the images.</param>
+    /// <returns>array of 2D Mat containing the images extracted from the blob in floating point precision (CV_32F).</returns>
+    public static Mat[] ImagesFromBlob(Mat blob)
+    {
+        if (blob is null)
+            throw new ArgumentNullException(nameof(blob));
+        blob.ThrowIfDisposed();
+
+        using var imagesVec = new Internal.Vectors.VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_imagesFromBlob(blob.CvPtr, imagesVec.CvPtr));
+        GC.KeepAlive(blob);
+        return imagesVec.ToArray();
     }
 
     /// <summary>
@@ -308,8 +418,118 @@ public static class CvDnn
     }
 
     /// <summary>
+    /// Performs batched non maximum suppression on given boxes and corresponding scores across different classes.
+    /// </summary>
+    /// <param name="bboxes">a set of bounding boxes to apply NMS.</param>
+    /// <param name="scores">a set of corresponding confidences.</param>
+    /// <param name="classIds">a set of corresponding class ids. Ids are integer and usually start from 0.</param>
+    /// <param name="scoreThreshold">a threshold used to filter boxes by score.</param>
+    /// <param name="nmsThreshold">a threshold used in non maximum suppression.</param>
+    /// <param name="indices">the kept indices of bboxes after NMS.</param>
+    /// <param name="eta">a coefficient in adaptive threshold formula</param>
+    /// <param name="topK">if `&gt;0`, keep at most @p top_k picked indices.</param>
+    // ReSharper disable once IdentifierTypo
+    public static void NMSBoxesBatched(IEnumerable<Rect> bboxes, IEnumerable<float> scores, IEnumerable<int> classIds,
+        float scoreThreshold, float nmsThreshold,
+        out int[] indices,
+        float eta = 1.0f, int topK = 0)
+    {
+        if (bboxes is null)
+            throw new ArgumentNullException(nameof(bboxes));
+        if (scores is null)
+            throw new ArgumentNullException(nameof(scores));
+        if (classIds is null)
+            throw new ArgumentNullException(nameof(classIds));
+
+        // ReSharper disable once IdentifierTypo
+        using var bboxesVec = new VectorOfRect(bboxes);
+        using var scoresVec = new VectorOfFloat(scores);
+        using var classIdsVec = new VectorOfInt32(classIds);
+        using var indicesVec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_NMSBoxesBatched_Rect(
+                bboxesVec.CvPtr, scoresVec.CvPtr, classIdsVec.CvPtr, scoreThreshold, nmsThreshold,
+                indicesVec.CvPtr, eta, topK));
+        indices = indicesVec.ToArray();
+    }
+
+    /// <summary>
+    /// Performs batched non maximum suppression on given boxes and corresponding scores across different classes.
+    /// </summary>
+    /// <param name="bboxes">a set of bounding boxes to apply NMS.</param>
+    /// <param name="scores">a set of corresponding confidences.</param>
+    /// <param name="classIds">a set of corresponding class ids. Ids are integer and usually start from 0.</param>
+    /// <param name="scoreThreshold">a threshold used to filter boxes by score.</param>
+    /// <param name="nmsThreshold">a threshold used in non maximum suppression.</param>
+    /// <param name="indices">the kept indices of bboxes after NMS.</param>
+    /// <param name="eta">a coefficient in adaptive threshold formula</param>
+    /// <param name="topK">if `&gt;0`, keep at most @p top_k picked indices.</param>
+    // ReSharper disable once IdentifierTypo
+    public static void NMSBoxesBatched(IEnumerable<Rect2d> bboxes, IEnumerable<float> scores, IEnumerable<int> classIds,
+        float scoreThreshold, float nmsThreshold,
+        out int[] indices,
+        float eta = 1.0f, int topK = 0)
+    {
+        if (bboxes is null)
+            throw new ArgumentNullException(nameof(bboxes));
+        if (scores is null)
+            throw new ArgumentNullException(nameof(scores));
+        if (classIds is null)
+            throw new ArgumentNullException(nameof(classIds));
+
+        // ReSharper disable once IdentifierTypo
+        using var bboxesVec = new VectorOfRect2d(bboxes);
+        using var scoresVec = new VectorOfFloat(scores);
+        using var classIdsVec = new VectorOfInt32(classIds);
+        using var indicesVec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_NMSBoxesBatched_Rect2d(
+                bboxesVec.CvPtr, scoresVec.CvPtr, classIdsVec.CvPtr, scoreThreshold, nmsThreshold,
+                indicesVec.CvPtr, eta, topK));
+        indices = indicesVec.ToArray();
+    }
+
+    /// <summary>
+    /// Performs soft non maximum suppression given boxes and corresponding scores.
+    /// Reference: https://arxiv.org/abs/1704.04503
+    /// </summary>
+    /// <param name="bboxes">a set of bounding boxes to apply Soft NMS.</param>
+    /// <param name="scores">a set of corresponding confidences.</param>
+    /// <param name="updatedScores">a set of corresponding updated confidences.</param>
+    /// <param name="scoreThreshold">a threshold used to filter boxes by score.</param>
+    /// <param name="nmsThreshold">a threshold used in non maximum suppression.</param>
+    /// <param name="indices">the kept indices of bboxes after NMS.</param>
+    /// <param name="topK">keep at most @p top_k picked indices.</param>
+    /// <param name="sigma">parameter of Gaussian weighting.</param>
+    /// <param name="method">Gaussian or linear.</param>
+    // ReSharper disable once IdentifierTypo
+    public static void SoftNMSBoxes(IEnumerable<Rect> bboxes, IEnumerable<float> scores,
+        out float[] updatedScores,
+        float scoreThreshold, float nmsThreshold,
+        out int[] indices,
+        int topK = 0, float sigma = 0.5f, SoftNMSMethod method = SoftNMSMethod.SOFTNMS_GAUSSIAN)
+    {
+        if (bboxes is null)
+            throw new ArgumentNullException(nameof(bboxes));
+        if (scores is null)
+            throw new ArgumentNullException(nameof(scores));
+
+        // ReSharper disable once IdentifierTypo
+        using var bboxesVec = new VectorOfRect(bboxes);
+        using var scoresVec = new VectorOfFloat(scores);
+        using var updatedScoresVec = new VectorOfFloat();
+        using var indicesVec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_softNMSBoxes_Rect(
+                bboxesVec.CvPtr, scoresVec.CvPtr, updatedScoresVec.CvPtr, scoreThreshold, nmsThreshold,
+                indicesVec.CvPtr, new UIntPtr((uint)topK), sigma, (int)method));
+        indices = indicesVec.ToArray();
+        updatedScores = updatedScoresVec.ToArray();
+    }
+
+    /// <summary>
     /// Release a Myriad device is binded by OpenCV.
-    /// 
+    ///
     /// Single Myriad device cannot be shared across multiple processes which uses Inference Engine's Myriad plugin.
     /// </summary>
     public static void ResetMyriadDevice()

--- a/src/OpenCvSharp/Modules/dnn/DataLayout.cs
+++ b/src/OpenCvSharp/Modules/dnn/DataLayout.cs
@@ -1,0 +1,21 @@
+#pragma warning disable CS1591
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Enum of data layout for model inference.
+/// </summary>
+public enum DataLayout
+{
+    UNKNOWN = 0,
+    ND = 1,
+    NCHW = 2,
+    NCDHW = 3,
+    NHWC = 4,
+    NDHWC = 5,
+    PLANAR = 6,
+    BLOCK = 7,
+}

--- a/src/OpenCvSharp/Modules/dnn/Image2BlobParams.cs
+++ b/src/OpenCvSharp/Modules/dnn/Image2BlobParams.cs
@@ -1,0 +1,86 @@
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+// ReSharper disable CommentTypo
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Processing params of image to blob.
+/// It includes all possible image processing operations and corresponding parameters.
+/// </summary>
+/// <seealso cref="CvDnn.BlobFromImageWithParams(InputArray, Image2BlobParams)"/>
+public class Image2BlobParams
+{
+    /// <summary>
+    /// scalefactor multiplier for input image values.
+    /// </summary>
+    public Scalar ScaleFactor { get; set; } = new(1.0, 1.0, 1.0, 1.0);
+
+    /// <summary>
+    /// spatial size for output image.
+    /// </summary>
+    public Size Size { get; set; }
+
+    /// <summary>
+    /// scalar with mean values which are subtracted from channels.
+    /// </summary>
+    public Scalar Mean { get; set; }
+
+    /// <summary>
+    /// flag which indicates that swap first and last channels.
+    /// </summary>
+    public bool SwapRB { get; set; }
+
+    /// <summary>
+    /// depth of output blob. Choose CV_32F or CV_8U.
+    /// </summary>
+    public MatType Depth { get; set; } = MatType.CV_32F;
+
+    /// <summary>
+    /// order of output dimensions.
+    /// </summary>
+    public DataLayout DataLayout { get; set; } = DataLayout.NCHW;
+
+    /// <summary>
+    /// element of image processing mode.
+    /// </summary>
+    public ImagePaddingMode PaddingMode { get; set; } = ImagePaddingMode.NULL;
+
+    /// <summary>
+    /// border value used with the LETTERBOX padding mode.
+    /// </summary>
+    public Scalar BorderValue { get; set; }
+
+    /// <summary>
+    /// Creates parameters with default values.
+    /// </summary>
+    public Image2BlobParams()
+    {
+    }
+
+    /// <summary>
+    /// Creates parameters with the specified values.
+    /// </summary>
+    /// <param name="scaleFactor">multiplier for input image values.</param>
+    /// <param name="size">spatial size for output image.</param>
+    /// <param name="mean">scalar with mean values which are subtracted from channels.</param>
+    /// <param name="swapRB">flag which indicates that swap first and last channels.</param>
+    /// <param name="depth">depth of output blob. Choose CV_32F or CV_8U.</param>
+    /// <param name="dataLayout">order of output dimensions.</param>
+    /// <param name="paddingMode">element of image processing mode.</param>
+    /// <param name="borderValue">border value used with the LETTERBOX padding mode.</param>
+    public Image2BlobParams(
+        Scalar scaleFactor, Size size = default, Scalar mean = default, bool swapRB = false,
+        MatType? depth = null, DataLayout dataLayout = DataLayout.NCHW,
+        ImagePaddingMode paddingMode = ImagePaddingMode.NULL, Scalar borderValue = default)
+    {
+        ScaleFactor = scaleFactor;
+        Size = size;
+        Mean = mean;
+        SwapRB = swapRB;
+        Depth = depth ?? MatType.CV_32F;
+        DataLayout = dataLayout;
+        PaddingMode = paddingMode;
+        BorderValue = borderValue;
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/ImagePaddingMode.cs
+++ b/src/OpenCvSharp/Modules/dnn/ImagePaddingMode.cs
@@ -1,0 +1,29 @@
+#pragma warning disable CS1591
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Enum of image processing mode.
+/// To facilitate the specialization pre-processing requirements of the dnn model.
+/// For example, the letter box often used in the Yolo series of models.
+/// </summary>
+public enum ImagePaddingMode
+{
+    /// <summary>
+    /// Default. Resize to required input size without extra processing.
+    /// </summary>
+    NULL = 0,
+
+    /// <summary>
+    /// Crop after resize.
+    /// </summary>
+    CROP_CENTER = 1,
+
+    /// <summary>
+    /// Resize image to the desired size while preserving the aspect ratio of original image.
+    /// </summary>
+    LETTERBOX = 2,
+}

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -246,6 +246,60 @@ public class Net : CvObject
         }
     }
 
+    /// <summary>
+    /// Reads a network model stored in TFLite (https://www.tensorflow.org/lite) framework's format.
+    /// </summary>
+    /// <param name="model">path to the .tflite file with binary flatbuffers description of the network architecture.</param>
+    /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(string model)
+    {
+        if (model is null)
+            throw new ArgumentNullException(nameof(model));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_readNetFromTFLite(model, out var p));
+        return (p == IntPtr.Zero) ? null : new Net(p);
+    }
+
+    /// <summary>
+    /// Reads a network model stored in TFLite framework's format from memory.
+    /// </summary>
+    /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
+    /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(byte[] bufferModel)
+    {
+        if (bufferModel is null)
+            throw new ArgumentNullException(nameof(bufferModel));
+
+        var ret = ReadNetFromTFLite(new ReadOnlySpan<byte>(bufferModel));
+        GC.KeepAlive(bufferModel);
+        return ret;
+    }
+
+    /// <summary>
+    /// Reads a network model stored in TFLite framework's format from memory.
+    /// </summary>
+    /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
+    /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    // ReSharper disable once InconsistentNaming
+    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel)
+    {
+        if (bufferModel.IsEmpty)
+            throw new ArgumentException("Empty span", nameof(bufferModel));
+        unsafe
+        {
+            fixed (byte* bufferModelPtr = bufferModel)
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.dnn_readNetFromTFLite(
+                        bufferModelPtr, new IntPtr(bufferModel.Length), out var p));
+                return (p == IntPtr.Zero) ? null : new Net(p);
+            }
+        }
+    }
+
     #endregion
 
     #region Methods

--- a/src/OpenCvSharp/Modules/dnn/SoftNMSMethod.cs
+++ b/src/OpenCvSharp/Modules/dnn/SoftNMSMethod.cs
@@ -1,0 +1,15 @@
+#pragma warning disable CS1591
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Enum of Soft NMS methods.
+/// </summary>
+public enum SoftNMSMethod
+{
+    SOFTNMS_LINEAR = 1,
+    SOFTNMS_GAUSSIAN = 2,
+}

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -134,6 +134,91 @@ CVAPI(ExceptionStatus) dnn_resetMyriadDevice()
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, cv::dnn::Net **returnValue)
+{
+    BEGIN_WRAP
+    const auto net = cv::dnn::readNetFromTFLite(model);
+    *returnValue = new cv::dnn::Net(net);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_readNetFromTFLite_InputArray(const char *bufferModel, size_t lenModel, cv::dnn::Net **returnValue)
+{
+    BEGIN_WRAP
+    const auto net = cv::dnn::readNetFromTFLite(bufferModel, lenModel);
+    *returnValue = new cv::dnn::Net(net);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_blobFromImageWithParams(
+    cv::_InputArray *image, const MyCvScalar scalefactor, const MyCvSize size, const MyCvScalar mean,
+    const int swapRB, const int ddepth, const int datalayout, const int paddingmode, const MyCvScalar borderValue,
+    cv::Mat **returnValue)
+{
+    BEGIN_WRAP
+    const cv::dnn::Image2BlobParams param(
+        cpp(scalefactor), cpp(size), cpp(mean), swapRB != 0, ddepth,
+        static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
+    const auto blob = cv::dnn::blobFromImageWithParams(*image, param);
+    *returnValue = new cv::Mat(blob);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_blobFromImagesWithParams(
+    cv::Mat **images, const int imagesLength, const MyCvScalar scalefactor, const MyCvSize size, const MyCvScalar mean,
+    const int swapRB, const int ddepth, const int datalayout, const int paddingmode, const MyCvScalar borderValue,
+    cv::Mat **returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::Mat> imagesVec;
+    toVec(images, imagesLength, imagesVec);
+    const cv::dnn::Image2BlobParams param(
+        cpp(scalefactor), cpp(size), cpp(mean), swapRB != 0, ddepth,
+        static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
+    const auto blob = cv::dnn::blobFromImagesWithParams(imagesVec, param);
+    *returnValue = new cv::Mat(blob);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_imagesFromBlob(cv::Mat *blob, std::vector<cv::Mat> *images)
+{
+    BEGIN_WRAP
+    cv::dnn::imagesFromBlob(*blob, *images);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect(
+    std::vector<cv::Rect> *bboxes, std::vector<float> *scores, std::vector<int> *classIds,
+    const float score_threshold, const float nms_threshold,
+    std::vector<int> *indices, const float eta, const int top_k)
+{
+    BEGIN_WRAP
+    cv::dnn::NMSBoxesBatched(*bboxes, *scores, *classIds, score_threshold, nms_threshold, *indices, eta, top_k);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect2d(
+    std::vector<cv::Rect2d> *bboxes, std::vector<float> *scores, std::vector<int> *classIds,
+    const float score_threshold, const float nms_threshold,
+    std::vector<int> *indices, const float eta, const int top_k)
+{
+    BEGIN_WRAP
+    cv::dnn::NMSBoxesBatched(*bboxes, *scores, *classIds, score_threshold, nms_threshold, *indices, eta, top_k);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_softNMSBoxes_Rect(
+    std::vector<cv::Rect> *bboxes, std::vector<float> *scores, std::vector<float> *updated_scores,
+    const float score_threshold, const float nms_threshold,
+    std::vector<int> *indices, const size_t top_k, const float sigma, const int method)
+{
+    BEGIN_WRAP
+    cv::dnn::softNMSBoxes(
+        *bboxes, *scores, *updated_scores, score_threshold, nms_threshold, *indices,
+        top_k, sigma, static_cast<cv::dnn::SoftNMSMethod>(method));
+    END_WRAP
+}
+
 #endif // !#ifndef _WINRT_DLL
 
 #endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/BlobAndNmsTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/BlobAndNmsTest.cs
@@ -1,0 +1,126 @@
+using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Tests for the priority-B dnn additions: blobFromImageWithParams / blobFromImagesWithParams,
+// imagesFromBlob, NMSBoxesBatched, softNMSBoxes and readNetFromTFLite.
+public class BlobAndNmsTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void BlobFromImageWithParamsMatchesBlobFromImage()
+    {
+        using var img = LoadImage("lenna.png");
+
+        using var expected = CvDnn.BlobFromImage(
+            img, 1.0, new Size(224, 224), new Scalar(0, 0, 0), swapRB: false, crop: false);
+
+        var param = new Image2BlobParams(
+            new Scalar(1, 1, 1, 1), new Size(224, 224), new Scalar(0, 0, 0), swapRB: false);
+        using var actual = CvDnn.BlobFromImageWithParams(img, param);
+
+        Assert.Equal(expected.Dims, actual.Dims);
+        for (var i = 0; i < expected.Dims; i++)
+            Assert.Equal(expected.Size(i), actual.Size(i));
+        // Same preprocessing parameters must produce the same blob.
+        Assert.True(Cv2.Norm(expected, actual, NormTypes.L1) < 1e-3, "blobs differ");
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void BlobFromImageWithParamsLetterbox()
+    {
+        using var img = LoadImage("lenna.png");
+
+        var param = new Image2BlobParams(
+            new Scalar(1.0 / 255), new Size(416, 416), new Scalar(0, 0, 0), swapRB: true)
+        {
+            PaddingMode = ImagePaddingMode.LETTERBOX,
+        };
+        using var blob = CvDnn.BlobFromImageWithParams(img, param);
+
+        // NCHW: [1, 3, 416, 416]
+        Assert.Equal(4, blob.Dims);
+        Assert.Equal(1, blob.Size(0));
+        Assert.Equal(3, blob.Size(1));
+        Assert.Equal(416, blob.Size(2));
+        Assert.Equal(416, blob.Size(3));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ImagesFromBlobRoundTrip()
+    {
+        using var img1 = LoadImage("lenna.png");
+        using var img2 = LoadImage("mandrill.png");
+
+        using var blob = CvDnn.BlobFromImages(
+            new[] { img1, img2 }, 1.0, new Size(100, 100), new Scalar(0, 0, 0), swapRB: false, crop: false);
+
+        var images = CvDnn.ImagesFromBlob(blob);
+        try
+        {
+            Assert.Equal(2, images.Length);
+            foreach (var image in images)
+            {
+                Assert.Equal(100, image.Rows);
+                Assert.Equal(100, image.Cols);
+                Assert.Equal(3, image.Channels());
+            }
+        }
+        finally
+        {
+            foreach (var image in images)
+                image.Dispose();
+        }
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void NMSBoxesBatched()
+    {
+        var bboxes = new[]
+        {
+            new Rect(10, 10, 20, 20),
+            new Rect(100, 100, 20, 20),
+            new Rect(1000, 1000, 20, 20),
+        };
+        var scores = new[] { 1.0f, 0.1f, 0.6f };
+        var classIds = new[] { 0, 0, 0 };
+
+        CvDnn.NMSBoxesBatched(bboxes, scores, classIds, 0.5f, 0.4f, out var indices);
+
+        Assert.Equal(2, indices.Length);
+        Assert.Equal(0, indices[0]);
+        Assert.Equal(2, indices[1]);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void SoftNMSBoxes()
+    {
+        var bboxes = new[]
+        {
+            new Rect(10, 10, 20, 20),
+            new Rect(100, 100, 20, 20),
+            new Rect(1000, 1000, 20, 20),
+        };
+        var scores = new[] { 1.0f, 0.1f, 0.6f };
+
+        CvDnn.SoftNMSBoxes(bboxes, scores, out var updatedScores, 0.5f, 0.4f, out var indices);
+
+        Assert.NotEmpty(indices);
+        Assert.Equal(indices.Length, updatedScores.Length);
+        Assert.All(updatedScores, s => Assert.True(s >= 0f));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    // ReSharper disable once InconsistentNaming
+    public void ReadNetFromTFLiteInvalidBufferThrows()
+    {
+        // A non-tflite buffer must fail inside OpenCV (proves the native entry point is wired),
+        // not with a P/Invoke EntryPointNotFoundException.
+        var garbage = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Assert.ThrowsAny<OpenCVException>(() => CvDnn.ReadNetFromTFLite(garbage));
+    }
+}


### PR DESCRIPTION
## Summary

Priority group **B** of the dnn coverage work (follows the high-level Model API in
#1917 / #1918). Adds the OpenCV 5 preprocessing / post-processing helpers that were
missing from the wrapper.

## What's added

| Area | API |
|---|---|
| TFLite reader | `CvDnn.ReadNetFromTFLite` and `Net.ReadNetFromTFLite` — file path, `byte[]`, `ReadOnlySpan<byte>`, `Stream` (mirrors the ONNX readers) |
| Blob w/ params | `CvDnn.BlobFromImageWithParams` / `BlobFromImagesWithParams` via a new `Image2BlobParams` class (ScaleFactor, Size, Mean, SwapRB, Depth, DataLayout, PaddingMode, BorderValue) — enables letterbox / center-crop preprocessing |
| Unpack blob | `CvDnn.ImagesFromBlob` |
| Post-process | `CvDnn.NMSBoxesBatched` (Rect & Rect2d), `CvDnn.SoftNMSBoxes` (Rect) |
| Enums | `DataLayout`, `ImagePaddingMode`, `SoftNMSMethod` |

## Note for reviewers

In OpenCV 5 the `DataLayout` enum **moved from `cv::dnn` to the `cv` namespace**
(`core/mat.hpp`). The native wrapper uses `cv::DataLayout` accordingly. This is exactly
the kind of relocation worth watching during the 5.x migration.

## Verification

Built `OpenCvSharpExtern` locally against OpenCV 5.0.0 and ran the suite — **6 new
tests pass, full dnn suite green** (28 passed / 3 explicit-skipped):

- `blobFromImageWithParams` produces the **same blob** as `blobFromImage` for matching
  params; `LETTERBOX` yields the requested NCHW shape `[1,3,416,416]`.
- `imagesFromBlob` round-trips `blobFromImages` (2 images, 100×100, 3ch).
- `NMSBoxesBatched` returns the expected kept indices; `softNMSBoxes` returns indices
  with a matching number of updated scores.
- `readNetFromTFLite` on an invalid buffer raises `OpenCVException` (entry point wired),
  not a P/Invoke failure. A full TFLite inference test was not added (no committed
  `.tflite` model); the reader is a thin mirror of the already-proven ONNX reader.

## Next

This completes priorities A and B. Remaining (priority C/D/E, lower value): KV-cache
control, `Net` layer-introspection methods, `getAvailableBackends`/`getAvailableTargets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
