### PR TITLE
Add dnn Net introspection: params, layer types, KV cache, getAvailable*, model format

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -178,4 +178,13 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
     public static extern ExceptionStatus dnn_resetMyriadDevice();
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_getAvailableTargets(int be, IntPtr targets);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_getAvailableBackends(IntPtr backends, IntPtr targets);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_enableModelDiagnostics(int isDiagnosticsMode);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
@@ -76,4 +76,42 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
     public static extern ExceptionStatus dnn_Net_getPerfProfile(IntPtr net, IntPtr timings, out long returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Net_setInputShape(
+        IntPtr net, [MarshalAs(UnmanagedType.LPStr)] string inputName, int[] shape, int shapeLength);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getParam(IntPtr net, int layer, int numParam, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_setParam(IntPtr net, int layer, int numParam, IntPtr blob);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getLayerTypes(IntPtr net, IntPtr outVec);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Net_getLayersCount(
+        IntPtr net, [MarshalAs(UnmanagedType.LPStr)] string layerType, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_enableWinograd(IntPtr net, int useWinograd);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Net_dumpToPbtxt(IntPtr net, [MarshalAs(UnmanagedType.LPStr)] string path);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getModelFormat(IntPtr net, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_enableKVCache(IntPtr net);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_disableKVCache(IntPtr net);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_resetKVCache(IntPtr net);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_printPerfProfile(IntPtr net);
 }

--- a/src/OpenCvSharp/Modules/dnn/CvDnn.cs
+++ b/src/OpenCvSharp/Modules/dnn/CvDnn.cs
@@ -318,6 +318,50 @@ public static class CvDnn
             NativeMethods.dnn_resetMyriadDevice());
     }
 
+    /// <summary>
+    /// Returns the list of available computation targets for the given backend.
+    /// </summary>
+    /// <param name="backend">backend identifier.</param>
+    /// <returns>available targets.</returns>
+    public static Target[] GetAvailableTargets(Backend backend)
+    {
+        using var targetsVec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_getAvailableTargets((int)backend, targetsVec.CvPtr));
+        return targetsVec.ToArray().Select(x => (Target)x).ToArray();
+    }
+
+    /// <summary>
+    /// Returns the list of available (backend, target) pairs supported by this build.
+    /// </summary>
+    /// <returns>available backend/target pairs.</returns>
+    public static (Backend Backend, Target Target)[] GetAvailableBackends()
+    {
+        using var backendsVec = new VectorOfInt32();
+        using var targetsVec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_getAvailableBackends(backendsVec.CvPtr, targetsVec.CvPtr));
+
+        var backends = backendsVec.ToArray();
+        var targets = targetsVec.ToArray();
+        var result = new (Backend, Target)[backends.Length];
+        for (var i = 0; i < backends.Length; i++)
+            result[i] = ((Backend)backends[i], (Target)targets[i]);
+        return result;
+    }
+
+    /// <summary>
+    /// Enables detailed logging of the DNN model loading with CV DNN API.
+    /// Diagnostic mode provides detailed logging of the model loading stage to explore
+    /// potential problems (ex.: not implemented layer type).
+    /// </summary>
+    /// <param name="isDiagnosticsMode">indicates whether diagnostic mode should be set.</param>
+    public static void EnableModelDiagnostics(bool isDiagnosticsMode)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.dnn_enableModelDiagnostics(isDiagnosticsMode ? 1 : 0));
+    }
+
     private static byte[] StreamToArray(this Stream stream)
     {
         if (!stream.CanRead) 

--- a/src/OpenCvSharp/Modules/dnn/ModelFormat.cs
+++ b/src/OpenCvSharp/Modules/dnn/ModelFormat.cs
@@ -1,0 +1,32 @@
+#pragma warning disable CS1591
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Enum of the original framework format a Net was loaded from.
+/// </summary>
+public enum ModelFormat
+{
+    /// <summary>
+    /// Some generic model format.
+    /// </summary>
+    Generic = 0,
+
+    /// <summary>
+    /// ONNX model.
+    /// </summary>
+    ONNX = 1,
+
+    /// <summary>
+    /// TensorFlow model.
+    /// </summary>
+    TF = 2,
+
+    /// <summary>
+    /// TFLite model.
+    /// </summary>
+    TFLite = 3,
+}

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -536,5 +536,198 @@ public class Net : CvObject
         return ret;
     }
 
+    /// <summary>
+    /// Specify shape of network input.
+    /// </summary>
+    /// <param name="inputName">name of the input layer.</param>
+    /// <param name="shape">the shape of the input blob.</param>
+    public void SetInputShape(string inputName, IEnumerable<int> shape)
+    {
+        if (inputName is null)
+            throw new ArgumentNullException(nameof(inputName));
+        if (shape is null)
+            throw new ArgumentNullException(nameof(shape));
+        ThrowIfDisposed();
+
+        var shapeArray = shape as int[] ?? shape.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_setInputShape(CvPtr, inputName, shapeArray, shapeArray.Length));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Returns parameter blob of the layer.
+    /// </summary>
+    /// <param name="layer">id of the layer.</param>
+    /// <param name="numParam">index of the layer parameter in the Layer::blobs array.</param>
+    /// <returns></returns>
+    public Mat GetParam(int layer, int numParam = 0)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getParam(CvPtr, layer, numParam, out var ret));
+        GC.KeepAlive(this);
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns parameter blob of the layer.
+    /// </summary>
+    /// <param name="layerName">name of the layer.</param>
+    /// <param name="numParam">index of the layer parameter in the Layer::blobs array.</param>
+    /// <returns></returns>
+    public Mat GetParam(string layerName, int numParam = 0)
+    {
+        if (layerName is null)
+            throw new ArgumentNullException(nameof(layerName));
+        return GetParam(GetLayerId(layerName), numParam);
+    }
+
+    /// <summary>
+    /// Sets the new value for the learned param of the layer.
+    /// </summary>
+    /// <param name="layer">id of the layer.</param>
+    /// <param name="numParam">index of the layer parameter in the Layer::blobs array.</param>
+    /// <param name="blob">the new value.</param>
+    public void SetParam(int layer, int numParam, Mat blob)
+    {
+        if (blob is null)
+            throw new ArgumentNullException(nameof(blob));
+        ThrowIfDisposed();
+        blob.ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_setParam(CvPtr, layer, numParam, blob.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(blob);
+    }
+
+    /// <summary>
+    /// Sets the new value for the learned param of the layer.
+    /// </summary>
+    /// <param name="layerName">name of the layer.</param>
+    /// <param name="numParam">index of the layer parameter in the Layer::blobs array.</param>
+    /// <param name="blob">the new value.</param>
+    public void SetParam(string layerName, int numParam, Mat blob)
+    {
+        if (layerName is null)
+            throw new ArgumentNullException(nameof(layerName));
+        SetParam(GetLayerId(layerName), numParam, blob);
+    }
+
+    /// <summary>
+    /// Returns list of types for layer used in model.
+    /// </summary>
+    /// <returns></returns>
+    public string?[] GetLayerTypes()
+    {
+        ThrowIfDisposed();
+        using var resultVec = new VectorOfString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getLayerTypes(CvPtr, resultVec.CvPtr));
+        GC.KeepAlive(this);
+        return resultVec.ToArray();
+    }
+
+    /// <summary>
+    /// Returns count of layers of specified type.
+    /// </summary>
+    /// <param name="layerType">type.</param>
+    /// <returns>count of layers</returns>
+    public int GetLayersCount(string layerType)
+    {
+        if (layerType is null)
+            throw new ArgumentNullException(nameof(layerType));
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getLayersCount(CvPtr, layerType, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Enables or disables the Winograd convolution optimization.
+    /// </summary>
+    /// <param name="useWinograd">true to enable, false to disable.</param>
+    public void EnableWinograd(bool useWinograd)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_enableWinograd(CvPtr, useWinograd ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Dump net structure, hyperparameters, backend, target and fusion to a pbtxt file.
+    /// </summary>
+    /// <remarks>Requires the network's output blobs to be allocated (e.g. after the input
+    /// shape is known and the net has been set up); otherwise OpenCV raises an exception.</remarks>
+    /// <param name="path">path to output file with .pbtxt extension.</param>
+    public void DumpToPbtxt(string path)
+    {
+        if (path is null)
+            throw new ArgumentNullException(nameof(path));
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_dumpToPbtxt(CvPtr, path));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Returns the original framework format the network was loaded from.
+    /// </summary>
+    /// <returns></returns>
+    public ModelFormat GetModelFormat()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getModelFormat(CvPtr, out var ret));
+        GC.KeepAlive(this);
+        return (ModelFormat)ret;
+    }
+
+    /// <summary>
+    /// Enables the Key-Value (KV) cache, used to accelerate inference of transformer / LLM models.
+    /// </summary>
+    public void EnableKVCache()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_enableKVCache(CvPtr));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Disables the Key-Value (KV) cache.
+    /// </summary>
+    public void DisableKVCache()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_disableKVCache(CvPtr));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Resets the Key-Value (KV) cache contents.
+    /// </summary>
+    public void ResetKVCache()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_resetKVCache(CvPtr));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Prints per-layer performance profile to the standard output.
+    /// </summary>
+    public void PrintPerfProfile()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_printPerfProfile(CvPtr));
+        GC.KeepAlive(this);
+    }
+
     #endregion
 }

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -134,6 +134,37 @@ CVAPI(ExceptionStatus) dnn_resetMyriadDevice()
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) dnn_getAvailableTargets(const int be, std::vector<int> *targets)
+{
+    BEGIN_WRAP
+    const auto v = cv::dnn::getAvailableTargets(static_cast<cv::dnn::Backend>(be));
+    targets->clear();
+    for (const auto t : v)
+        targets->push_back(static_cast<int>(t));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_getAvailableBackends(std::vector<int> *backends, std::vector<int> *targets)
+{
+    BEGIN_WRAP
+    const auto v = cv::dnn::getAvailableBackends();
+    backends->clear();
+    targets->clear();
+    for (const auto &p : v)
+    {
+        backends->push_back(static_cast<int>(p.first));
+        targets->push_back(static_cast<int>(p.second));
+    }
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_enableModelDiagnostics(const int isDiagnosticsMode)
+{
+    BEGIN_WRAP
+    cv::dnn::enableModelDiagnostics(isDiagnosticsMode != 0);
+    END_WRAP
+}
+
 #endif // !#ifndef _WINRT_DLL
 
 #endif // NO_DNN

--- a/src/OpenCvSharpExtern/dnn_Net.h
+++ b/src/OpenCvSharpExtern/dnn_Net.h
@@ -204,6 +204,94 @@ CVAPI(ExceptionStatus) dnn_Net_getPerfProfile(cv::dnn::Net* net, std::vector<dou
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) dnn_Net_setInputShape(cv::dnn::Net* net, const char *inputName, const int *shape, const int shapeLength)
+{
+    BEGIN_WRAP
+    const cv::MatShape shapeObj(shape, shape + shapeLength);
+    net->setInputShape(inputName, shapeObj);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getParam(cv::dnn::Net* net, const int layer, const int numParam, cv::Mat **returnValue)
+{
+    BEGIN_WRAP
+    const auto m = net->getParam(layer, numParam);
+    *returnValue = new cv::Mat(m);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_setParam(cv::dnn::Net* net, const int layer, const int numParam, cv::Mat *blob)
+{
+    BEGIN_WRAP
+    net->setParam(layer, numParam, *blob);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getLayerTypes(cv::dnn::Net* net, std::vector<cv::String> *outVec)
+{
+    BEGIN_WRAP
+    std::vector<cv::String> result;
+    net->getLayerTypes(result);
+    outVec->assign(result.begin(), result.end());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getLayersCount(cv::dnn::Net* net, const char *layerType, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = net->getLayersCount(layerType);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_enableWinograd(cv::dnn::Net* net, const int useWinograd)
+{
+    BEGIN_WRAP
+    net->enableWinograd(useWinograd != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_dumpToPbtxt(cv::dnn::Net* net, const char *path)
+{
+    BEGIN_WRAP
+    net->dumpToPbtxt(path);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getModelFormat(cv::dnn::Net* net, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = static_cast<int>(net->getModelFormat());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_enableKVCache(cv::dnn::Net* net)
+{
+    BEGIN_WRAP
+    net->enableKVCache();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_disableKVCache(cv::dnn::Net* net)
+{
+    BEGIN_WRAP
+    net->disableKVCache();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_resetKVCache(cv::dnn::Net* net)
+{
+    BEGIN_WRAP
+    net->resetKVCache();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_printPerfProfile(cv::dnn::Net* net)
+{
+    BEGIN_WRAP
+    net->printPerfProfile();
+    END_WRAP
+}
+
 #endif // !#ifndef _WINRT_DLL
 
 #endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/NetIntrospectionTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/NetIntrospectionTest.cs
@@ -1,0 +1,128 @@
+using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Tests for the priority-C/D dnn Net introspection additions.
+// Uses the committed MNIST TensorFlow model so the real-net tests run in CI.
+public class NetIntrospectionTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetModelFormatReturnsTensorflow()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+        Assert.Equal(ModelFormat.TF, net!.GetModelFormat());
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetLayerTypesAndCount()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        var types = net!.GetLayerTypes();
+        Assert.NotEmpty(types);
+
+        // For every reported layer type, the count must be at least 1.
+        foreach (var t in types)
+        {
+            if (string.IsNullOrEmpty(t))
+                continue;
+            Assert.True(net.GetLayersCount(t!) >= 1, $"count for '{t}' should be >= 1");
+        }
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetParamAndSetParamAreWired()
+    {
+        // The committed TF models do not expose weights via getParam (TF imports conv
+        // weights as separate Const inputs rather than into Layer::blobs), so a real
+        // round-trip cannot be demonstrated with the available test data. Verify instead
+        // that both calls reach OpenCV and fail there (entry points wired correctly),
+        // rather than failing with a P/Invoke error.
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        Assert.ThrowsAny<OpenCVException>(() => net!.GetParam(99999));
+
+        using var blob = new Mat(1, 1, MatType.CV_32F, Scalar.All(0));
+        Assert.ThrowsAny<OpenCVException>(() => net!.SetParam(99999, 0, blob));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void SetInputShapeRejectsUnknownInput()
+    {
+        // Verifies the call reaches OpenCV (which validates the input name) rather than
+        // failing in the P/Invoke layer. A valid-input success path is model-specific and
+        // not asserted here.
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+        Assert.ThrowsAny<OpenCVException>(() => net!.SetInputShape("___no_such_input___", new[] { 1, 1, 1, 1 }));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void DumpToPbtxtIsWired()
+    {
+        // dumpToPbtxt requires the net's output blobs to be allocated. OpenCV frees
+        // intermediate blobs after a forward pass, so a simple happy-path file write is
+        // not reliably reachable from a unit test; verify instead that the call reaches
+        // OpenCV (raises OpenCVException about the missing blobs) rather than failing in
+        // the P/Invoke layer.
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        var path = Path.Combine(Path.GetTempPath(), $"opencvsharp_dump_{Guid.NewGuid():N}.pbtxt");
+        try
+        {
+            Assert.ThrowsAny<OpenCVException>(() => net!.DumpToPbtxt(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void EnableWinogradAndKVCacheDoNotThrow()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        net!.EnableWinograd(true);
+        net.EnableWinograd(false);
+        net.EnableKVCache();
+        net.ResetKVCache();
+        net.DisableKVCache();
+        net.PrintPerfProfile();
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetAvailableTargetsContainsCpu()
+    {
+        var targets = CvDnn.GetAvailableTargets(Backend.OPENCV);
+        Assert.Contains(Target.CPU, targets);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetAvailableBackendsNotEmpty()
+    {
+        var backends = CvDnn.GetAvailableBackends();
+        Assert.NotEmpty(backends);
+        Assert.Contains(backends, p => p.Backend == Backend.OPENCV && p.Target == Target.CPU);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void EnableModelDiagnosticsDoesNotThrow()
+    {
+        CvDnn.EnableModelDiagnostics(true);
+        CvDnn.EnableModelDiagnostics(false);
+    }
+}


### PR DESCRIPTION
## Summary

Priority groups **C/D** of the dnn coverage work (follows #1917 / #1918 / #1919). This
finishes the dnn coverage effort. Per the discussion, only the members that are genuinely
useful **and** express cleanly in C# were wrapped; the C++-only ones are intentionally
skipped (see below).

## What's added

**`Net`:**
- `SetInputShape(name, shape)`
- `GetParam` / `SetParam` (by layer id and by layer name)
- `GetLayerTypes`, `GetLayersCount`
- `GetModelFormat` (+ new `ModelFormat` enum)
- `EnableWinograd`, `DumpToPbtxt`, `PrintPerfProfile`
- `EnableKVCache` / `DisableKVCache` / `ResetKVCache` (transformer / LLM KV-cache control)

**`CvDnn` (free functions):**
- `GetAvailableTargets(Backend)`, `GetAvailableBackends()`, `EnableModelDiagnostics(bool)`

## Intentionally NOT wrapped

Documented in `docs/opencv5/dnn-coverage.md`:

- **`getFLOPS` / `getLayersShapes` / `getLayerShapes` / `getMemoryConsumption`** — awkward in
  5.0 (`MatShape` is now a struct, plus `netInputTypes` and nested
  `vector<vector<MatShape>>`); modest value, can be added later if requested.
- **`Layer` class, `getLayer` / `addLayer` / `registerOutput` / `getLayerInputs`** — these
  exist mainly to *author custom layers*, which requires subclassing `cv::dnn::Layer` in
  C++ and registering it. Doing that from C# would need a per-`forward` managed-callback
  bridge with blob marshaling on every call — impractical and slow. Pure-C# consumers load
  models, they don't author layers.
- **`forwardAsync` / `AsyncArray`** — async-backend only, low value, needs an `AsyncArray`
  wrapper.

## Notes for reviewers

- `MatShape` changed in OpenCV 5 from a `std::vector<int>` alias to a real `cv::MatShape`
  struct; `SetInputShape` constructs it natively from an int range.
- The committed TF models don't expose conv weights through `getParam` (TF imports them as
  separate `Const` inputs, not into `Layer::blobs`), and `dumpToPbtxt` needs allocated
  output blobs (OpenCV frees intermediates after `forward`). So `GetParam`/`SetParam`,
  `SetInputShape` and `DumpToPbtxt` are verified via their **error path** (they reach
  OpenCV and raise `OpenCVException`, not a P/Invoke failure). The remaining members are
  verified with real assertions.

## Verification

Built `OpenCvSharpExtern` locally against OpenCV 5.0.0 — **9 `NetIntrospectionTest` cases
pass, full dnn suite green (31 passed / 3 explicit-skipped)**.

## Status

This completes the dnn coverage rollout (priorities A, B, C/D). The facade-naming
restructure (`CvDnn` → `Cv2.Dnn`, family-wide) is tracked separately in #1921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
