### PR TITLE
Add DNN engine selection (EngineType) and sync Backend/Target enums

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -15,28 +15,31 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromTensorflow")]
     public static extern ExceptionStatus dnn_readNetFromTensorflow_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model, 
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config, 
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+        int engine,
         out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromTensorflow")]
     public static extern ExceptionStatus dnn_readNetFromTensorflow_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model, 
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config, 
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
+        int engine,
         out IntPtr returnValue);
 
-    public static ExceptionStatus dnn_readNetFromTensorflow(string model, string? config, out IntPtr returnValue)
+    public static ExceptionStatus dnn_readNetFromTensorflow(string model, string? config, int engine, out IntPtr returnValue)
     {
         if (IsWindows())
-            return dnn_readNetFromTensorflow_Windows(model, config, out returnValue);
-        return dnn_readNetFromTensorflow_NotWindows(model, config, out returnValue);
+            return dnn_readNetFromTensorflow_Windows(model, config, engine, out returnValue);
+        return dnn_readNetFromTensorflow_NotWindows(model, config, engine, out returnValue);
     }
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "dnn_readNetFromTensorflow_InputArray")]
     public static extern unsafe ExceptionStatus dnn_readNetFromTensorflow(
         byte* bufferModel, IntPtr modelDataLength,
         byte* bufferConfig, IntPtr configDataLength,
+        int engine,
         out IntPtr returnValue);
 
     // readNet
@@ -45,23 +48,25 @@ static partial class NativeMethods
         EntryPoint = "dnn_readNet")]
     public static extern ExceptionStatus dnn_readNet_NotWindows(
         [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string config, 
-        [MarshalAs(UnmanagedType.LPStr)] string framework, 
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string config,
+        [MarshalAs(UnmanagedType.LPStr)] string framework,
+        int engine,
         out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNet")]
     public static extern ExceptionStatus dnn_readNet_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model, 
-        [MarshalAs(StringUnmanagedTypeWindows)] string config, 
+        [MarshalAs(StringUnmanagedTypeWindows)] string model,
+        [MarshalAs(StringUnmanagedTypeWindows)] string config,
         [MarshalAs(UnmanagedType.LPStr)] string framework,
+        int engine,
         out IntPtr returnValue);
 
-    public static ExceptionStatus dnn_readNet(string model, string config, string framework, out IntPtr returnValue)
+    public static ExceptionStatus dnn_readNet(string model, string config, string framework, int engine, out IntPtr returnValue)
     {
         if (IsWindows())
-            return dnn_readNet_Windows(model, config, framework, out returnValue);
-        return dnn_readNet_NotWindows(model, config, framework, out returnValue);
+            return dnn_readNet_Windows(model, config, framework, engine, out returnValue);
+        return dnn_readNet_NotWindows(model, config, framework, engine, out returnValue);
     }
 
     // readNetFromModelOptimizer
@@ -92,25 +97,27 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromONNX")]
     public static extern ExceptionStatus dnn_readNetFromONNX_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string onnxFile, 
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string onnxFile,
+        int engine,
         out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromONNX")]
     public static extern ExceptionStatus dnn_readNetFromONNX_Windows(
         [MarshalAs(StringUnmanagedTypeWindows)] string onnxFile,
+        int engine,
         out IntPtr returnValue);
 
-    public static ExceptionStatus dnn_readNetFromONNX(string onnxFile, out IntPtr returnValue)
+    public static ExceptionStatus dnn_readNetFromONNX(string onnxFile, int engine, out IntPtr returnValue)
     {
         if (IsWindows())
-            return dnn_readNetFromONNX_Windows(onnxFile, out returnValue);
-        return dnn_readNetFromONNX_NotWindows(onnxFile, out returnValue);
+            return dnn_readNetFromONNX_Windows(onnxFile, engine, out returnValue);
+        return dnn_readNetFromONNX_NotWindows(onnxFile, engine, out returnValue);
     }
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "dnn_readNetFromONNX_InputArray")]
     public static extern unsafe ExceptionStatus dnn_readNetFromONNX(
-        byte* buffer, IntPtr sizeBuffer, out IntPtr returnValue);
+        byte* buffer, IntPtr sizeBuffer, int engine, out IntPtr returnValue);
 
     // readTensorFromONNX
 
@@ -193,21 +200,21 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromTFLite")]
     public static extern ExceptionStatus dnn_readNetFromTFLite_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model, out IntPtr returnValue);
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string model, int engine, out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
         EntryPoint = "dnn_readNetFromTFLite")]
     public static extern ExceptionStatus dnn_readNetFromTFLite_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model, out IntPtr returnValue);
+        [MarshalAs(StringUnmanagedTypeWindows)] string model, int engine, out IntPtr returnValue);
 
-    public static ExceptionStatus dnn_readNetFromTFLite(string model, out IntPtr returnValue)
+    public static ExceptionStatus dnn_readNetFromTFLite(string model, int engine, out IntPtr returnValue)
         => IsWindows()
-            ? dnn_readNetFromTFLite_Windows(model, out returnValue)
-            : dnn_readNetFromTFLite_NotWindows(model, out returnValue);
+            ? dnn_readNetFromTFLite_Windows(model, engine, out returnValue)
+            : dnn_readNetFromTFLite_NotWindows(model, engine, out returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "dnn_readNetFromTFLite_InputArray")]
     public static extern unsafe ExceptionStatus dnn_readNetFromTFLite(
-        byte* bufferModel, IntPtr lenModel, out IntPtr returnValue);
+        byte* bufferModel, IntPtr lenModel, int engine, out IntPtr returnValue);
 
     // blobFromImageWithParams
 

--- a/src/OpenCvSharp/Modules/dnn/Backend.cs
+++ b/src/OpenCvSharp/Modules/dnn/Backend.cs
@@ -19,10 +19,22 @@ public enum Backend
     //! OpenCV is built with Intel's Inference Engine library or
     //! DNN_BACKEND_OPENCV otherwise.
     // ReSharper disable once InconsistentNaming
-    DEFAULT,
-    HALIDE,
-    INFERENCE_ENGINE,
-    OPENCV,
-    VKCOM,
-    CUDA
+    DEFAULT = 0,
+
+    /// <summary>
+    /// Removed in OpenCV 5. The numeric value is kept so the remaining members keep their original values.
+    /// </summary>
+    [Obsolete("The Halide backend was removed in OpenCV 5.")]
+    HALIDE = 1,
+
+    /// <summary>
+    /// Intel OpenVINO computational backend.
+    /// </summary>
+    INFERENCE_ENGINE = 2,
+    OPENCV = 3,
+    VKCOM = 4,
+    CUDA = 5,
+    WEBNN = 6,
+    TIMVX = 7,
+    CANN = 8
 }

--- a/src/OpenCvSharp/Modules/dnn/CvDnn.cs
+++ b/src/OpenCvSharp/Modules/dnn/CvDnn.cs
@@ -20,9 +20,10 @@ public static class CvDnn
     /// <returns>Resulting Net object is built by text graph using weights from a binary one that
     /// let us make it more flexible.</returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(string model, string? config = null)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(string model, string? config = null, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromTensorflow(model, config);
+        return Net.ReadNetFromTensorflow(model, config, engine);
     }
 
     /// <summary>
@@ -32,9 +33,10 @@ public static class CvDnn
     /// <param name="bufferConfig">buffer containing the content of the pbtxt file (optional)</param>
     /// <returns></returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(byte[] bufferModel, byte[]? bufferConfig = null)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(byte[] bufferModel, byte[]? bufferConfig = null, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromTensorflow(bufferModel, bufferConfig);
+        return Net.ReadNetFromTensorflow(bufferModel, bufferConfig, engine);
     }
 
     /// <summary>
@@ -44,13 +46,15 @@ public static class CvDnn
     /// <param name="bufferConfig">buffer containing the content of the pbtxt file (optional)</param>
     /// <returns></returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(Stream bufferModel, Stream? bufferConfig = null)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(Stream bufferModel, Stream? bufferConfig = null, EngineType engine = EngineType.Auto)
     {
         if (bufferModel is null)
             throw new ArgumentNullException(nameof(bufferModel));
         return Net.ReadNetFromTensorflow(
             bufferModel.StreamToArray(),
-            bufferConfig?.StreamToArray());
+            bufferConfig?.StreamToArray(),
+            engine);
     }
 
     /// <summary>
@@ -74,9 +78,10 @@ public static class CvDnn
     /// *                  * `*.xml` (DLDT, https://software.intel.com/openvino-toolkit)</param>
     /// <param name="framework">Explicit framework name tag to determine a format.</param>
     /// <returns></returns>
-    public static Net ReadNet(string model, string config = "", string framework = "")
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net ReadNet(string model, string config = "", string framework = "", EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNet(model, config, framework);
+        return Net.ReadNet(model, config, framework, engine);
     }
         
     /// <summary>
@@ -84,9 +89,10 @@ public static class CvDnn
     /// </summary>
     /// <param name="onnxFile"></param>
     /// <returns></returns>
-    public static Net? ReadNetFromOnnx(string onnxFile)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromOnnx(string onnxFile, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromONNX(onnxFile);
+        return Net.ReadNetFromONNX(onnxFile, engine);
     }
 
     /// <summary>
@@ -94,9 +100,10 @@ public static class CvDnn
     /// </summary>
     /// <param name="onnxFileData">memory of the first byte of the buffer.</param>
     /// <returns></returns>
-    public static Net? ReadNetFromOnnx(byte[] onnxFileData)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromOnnx(byte[] onnxFileData, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromONNX(onnxFileData);
+        return Net.ReadNetFromONNX(onnxFileData, engine);
     }
 
     /// <summary>
@@ -104,9 +111,10 @@ public static class CvDnn
     /// </summary>
     /// <param name="onnxFileData">memory of the first byte of the buffer.</param>
     /// <returns></returns>
-    public static Net? ReadNetFromOnnx(ReadOnlySpan<byte> onnxFileData)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromOnnx(ReadOnlySpan<byte> onnxFileData, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromONNX(onnxFileData);
+        return Net.ReadNetFromONNX(onnxFileData, engine);
     }
 
     /// <summary>
@@ -114,11 +122,12 @@ public static class CvDnn
     /// </summary>
     /// <param name="onnxFileStream">memory of the first byte of the buffer.</param>
     /// <returns></returns>
-    public static Net? ReadNetFromOnnx(Stream onnxFileStream)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromOnnx(Stream onnxFileStream, EngineType engine = EngineType.Auto)
     {
         if (onnxFileStream is null)
             throw new ArgumentNullException(nameof(onnxFileStream));
-        return ReadNetFromOnnx(StreamToArray(onnxFileStream));
+        return ReadNetFromOnnx(StreamToArray(onnxFileStream), engine);
     }
 
     /// <summary>
@@ -126,10 +135,11 @@ public static class CvDnn
     /// </summary>
     /// <param name="model">path to the .tflite file with binary flatbuffers description of the network architecture.</param>
     /// <returns></returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(string model)
+    public static Net? ReadNetFromTFLite(string model, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromTFLite(model);
+        return Net.ReadNetFromTFLite(model, engine);
     }
 
     /// <summary>
@@ -137,10 +147,11 @@ public static class CvDnn
     /// </summary>
     /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
     /// <returns></returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(byte[] bufferModel)
+    public static Net? ReadNetFromTFLite(byte[] bufferModel, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromTFLite(bufferModel);
+        return Net.ReadNetFromTFLite(bufferModel, engine);
     }
 
     /// <summary>
@@ -148,10 +159,11 @@ public static class CvDnn
     /// </summary>
     /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
     /// <returns></returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel)
+    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel, EngineType engine = EngineType.Auto)
     {
-        return Net.ReadNetFromTFLite(bufferModel);
+        return Net.ReadNetFromTFLite(bufferModel, engine);
     }
 
     /// <summary>
@@ -159,12 +171,13 @@ public static class CvDnn
     /// </summary>
     /// <param name="bufferModelStream">stream containing the content of the tflite file.</param>
     /// <returns></returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(Stream bufferModelStream)
+    public static Net? ReadNetFromTFLite(Stream bufferModelStream, EngineType engine = EngineType.Auto)
     {
         if (bufferModelStream is null)
             throw new ArgumentNullException(nameof(bufferModelStream));
-        return Net.ReadNetFromTFLite(StreamToArray(bufferModelStream));
+        return Net.ReadNetFromTFLite(StreamToArray(bufferModelStream), engine);
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/dnn/EngineType.cs
+++ b/src/OpenCvSharp/Modules/dnn/EngineType.cs
@@ -1,0 +1,32 @@
+﻿#pragma warning disable CS1591
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Enum of DNN inference engines that can be selected when reading a network (OpenCV 5).
+/// </summary>
+public enum EngineType
+{
+    /// <summary>
+    /// Force use of the old (classic) DNN engine, similar to the 4.x branch.
+    /// </summary>
+    Classic = 1,
+
+    /// <summary>
+    /// Force use of the new DNN engine. The new engine does not support non-CPU back-ends for now.
+    /// </summary>
+    New = 2,
+
+    /// <summary>
+    /// Try to use the new engine and then fall back to the classic version. This is the default.
+    /// </summary>
+    Auto = 3,
+
+    /// <summary>
+    /// Try to use the ONNX Runtime wrapper (ONNX only, requires a build with WITH_ONNXRUNTIME=ON).
+    /// </summary>
+    Ort = 4
+}

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -82,13 +82,14 @@ public class Net : CvObject
     /// <returns>Resulting Net object is built by text graph using weights from a binary one that
     /// let us make it more flexible.</returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(string model, string? config = null)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(string model, string? config = null, EngineType engine = EngineType.Auto)
     {
         if (model is null)
             throw new ArgumentNullException(nameof(model));
 
         NativeMethods.HandleException(
-            NativeMethods.dnn_readNetFromTensorflow(model, config, out var p));
+            NativeMethods.dnn_readNetFromTensorflow(model, config, (int)engine, out var p));
         return (p == IntPtr.Zero) ? null : new Net(p);
     }
 
@@ -99,14 +100,16 @@ public class Net : CvObject
     /// <param name="bufferConfig">buffer containing the content of the pbtxt file (optional)</param>
     /// <returns></returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(byte[] bufferModel, byte[]? bufferConfig = null)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(byte[] bufferModel, byte[]? bufferConfig = null, EngineType engine = EngineType.Auto)
     {
         if (bufferModel is null)
             throw new ArgumentNullException(nameof(bufferModel));
-            
+
         var ret = ReadNetFromTensorflow(
             new ReadOnlySpan<byte>(bufferModel),
-            bufferConfig is null ? ReadOnlySpan<byte>.Empty : new ReadOnlySpan<byte>(bufferConfig));
+            bufferConfig is null ? ReadOnlySpan<byte>.Empty : new ReadOnlySpan<byte>(bufferConfig),
+            engine);
         GC.KeepAlive(bufferModel);
         GC.KeepAlive(bufferConfig);
         return ret;
@@ -119,11 +122,12 @@ public class Net : CvObject
     /// <param name="bufferConfig">buffer containing the content of the pbtxt file (optional)</param>
     /// <returns></returns>
     /// <remarks>This is shortcut consisting from createTensorflowImporter and Net::populateNet calls.</remarks>
-    public static Net? ReadNetFromTensorflow(ReadOnlySpan<byte> bufferModel, ReadOnlySpan<byte> bufferConfig = default)
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net? ReadNetFromTensorflow(ReadOnlySpan<byte> bufferModel, ReadOnlySpan<byte> bufferConfig = default, EngineType engine = EngineType.Auto)
     {
         if (bufferModel.IsEmpty)
             throw new ArgumentException("Empty span", nameof(bufferModel));
-            
+
         unsafe
         {
             fixed (byte* bufferModelPtr = bufferModel)
@@ -133,6 +137,7 @@ public class Net : CvObject
                     NativeMethods.dnn_readNetFromTensorflow(
                         bufferModelPtr, new IntPtr(bufferModel.Length),
                         bufferConfigPtr, new IntPtr(bufferConfig.Length),
+                        (int)engine,
                         out var p));
                 return (p == IntPtr.Zero) ? null : new Net(p);
             }
@@ -160,7 +165,8 @@ public class Net : CvObject
     /// *                  * `*.xml` (DLDT, https://software.intel.com/openvino-toolkit)</param>
     /// <param name="framework">Explicit framework name tag to determine a format.</param>
     /// <returns></returns>
-    public static Net ReadNet(string model, string config = "", string framework = "")
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
+    public static Net ReadNet(string model, string config = "", string framework = "", EngineType engine = EngineType.Auto)
     {
         if (string.IsNullOrEmpty(model))
             throw new ArgumentException("message is null or empty", nameof(model));
@@ -168,7 +174,7 @@ public class Net : CvObject
         framework ??= "";
 
         NativeMethods.HandleException(
-            NativeMethods.dnn_readNet(model, config, framework, out var p));
+            NativeMethods.dnn_readNet(model, config, framework, (int)engine, out var p));
         return new Net(p);
     }
 
@@ -196,14 +202,15 @@ public class Net : CvObject
     /// </summary>
     /// <param name="onnxFile">path to the .onnx file with text description of the network architecture.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromONNX(string onnxFile)
+    public static Net? ReadNetFromONNX(string onnxFile, EngineType engine = EngineType.Auto)
     {
         if (onnxFile is null)
             throw new ArgumentNullException(nameof(onnxFile));
 
         NativeMethods.HandleException(
-            NativeMethods.dnn_readNetFromONNX(onnxFile, out var p));
+            NativeMethods.dnn_readNetFromONNX(onnxFile, (int)engine, out var p));
         return (p == IntPtr.Zero) ? null : new Net(p);
     }
 
@@ -212,14 +219,15 @@ public class Net : CvObject
     /// </summary>
     /// <param name="onnxFileData">memory of the first byte of the buffer.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromONNX(byte[] onnxFileData)
+    public static Net? ReadNetFromONNX(byte[] onnxFileData, EngineType engine = EngineType.Auto)
     {
         if (onnxFileData is null)
             throw new ArgumentNullException(nameof(onnxFileData));
-            
+
         var ret = ReadNetFromONNX(
-            new ReadOnlySpan<byte>(onnxFileData));
+            new ReadOnlySpan<byte>(onnxFileData), engine);
         GC.KeepAlive(onnxFileData);
         return ret;
     }
@@ -229,8 +237,9 @@ public class Net : CvObject
     /// </summary>
     /// <param name="onnxFileData">memory of the first byte of the buffer.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromONNX(ReadOnlySpan<byte> onnxFileData)
+    public static Net? ReadNetFromONNX(ReadOnlySpan<byte> onnxFileData, EngineType engine = EngineType.Auto)
     {
         if (onnxFileData.IsEmpty)
             throw new ArgumentException("Empty span", nameof(onnxFileData));
@@ -240,7 +249,7 @@ public class Net : CvObject
             {
                 NativeMethods.HandleException(
                     NativeMethods.dnn_readNetFromONNX(
-                        onnxFileDataPtr, new IntPtr(onnxFileData.Length), out var p));
+                        onnxFileDataPtr, new IntPtr(onnxFileData.Length), (int)engine, out var p));
                 return (p == IntPtr.Zero) ? null : new Net(p);
             }
         }
@@ -251,14 +260,15 @@ public class Net : CvObject
     /// </summary>
     /// <param name="model">path to the .tflite file with binary flatbuffers description of the network architecture.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(string model)
+    public static Net? ReadNetFromTFLite(string model, EngineType engine = EngineType.Auto)
     {
         if (model is null)
             throw new ArgumentNullException(nameof(model));
 
         NativeMethods.HandleException(
-            NativeMethods.dnn_readNetFromTFLite(model, out var p));
+            NativeMethods.dnn_readNetFromTFLite(model, (int)engine, out var p));
         return (p == IntPtr.Zero) ? null : new Net(p);
     }
 
@@ -267,13 +277,14 @@ public class Net : CvObject
     /// </summary>
     /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(byte[] bufferModel)
+    public static Net? ReadNetFromTFLite(byte[] bufferModel, EngineType engine = EngineType.Auto)
     {
         if (bufferModel is null)
             throw new ArgumentNullException(nameof(bufferModel));
 
-        var ret = ReadNetFromTFLite(new ReadOnlySpan<byte>(bufferModel));
+        var ret = ReadNetFromTFLite(new ReadOnlySpan<byte>(bufferModel), engine);
         GC.KeepAlive(bufferModel);
         return ret;
     }
@@ -283,8 +294,9 @@ public class Net : CvObject
     /// </summary>
     /// <param name="bufferModel">buffer containing the content of the tflite file.</param>
     /// <returns>Network object that ready to do forward, throw an exception in failure cases.</returns>
+    /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     // ReSharper disable once InconsistentNaming
-    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel)
+    public static Net? ReadNetFromTFLite(ReadOnlySpan<byte> bufferModel, EngineType engine = EngineType.Auto)
     {
         if (bufferModel.IsEmpty)
             throw new ArgumentException("Empty span", nameof(bufferModel));
@@ -294,7 +306,7 @@ public class Net : CvObject
             {
                 NativeMethods.HandleException(
                     NativeMethods.dnn_readNetFromTFLite(
-                        bufferModelPtr, new IntPtr(bufferModel.Length), out var p));
+                        bufferModelPtr, new IntPtr(bufferModel.Length), (int)engine, out var p));
                 return (p == IntPtr.Zero) ? null : new Net(p);
             }
         }

--- a/src/OpenCvSharp/Modules/dnn/Target.cs
+++ b/src/OpenCvSharp/Modules/dnn/Target.cs
@@ -22,5 +22,11 @@ public enum Target
     FPGA,
     CUDA,
     CUDA_FP16,
-    HDDL
+    HDDL,
+    NPU,
+
+    /// <summary>
+    /// Only the ARM platform is supported. Low precision computing, accelerates model inference.
+    /// </summary>
+    CPU_FP16
 }

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -10,29 +10,29 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
-    const auto net = cv::dnn::readNetFromTensorflow(model, configStr);
+    const auto net = cv::dnn::readNetFromTensorflow(model, configStr, engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNetFromTensorflow_InputArray(const char *model,size_t lenModel, const char *config, size_t lenConfig, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromTensorflow_InputArray(const char *model,size_t lenModel, const char *config, size_t lenConfig, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
-    const auto net = cv::dnn::readNetFromTensorflow(model, lenModel, config, lenConfig);
+    const auto net = cv::dnn::readNetFromTensorflow(model, lenModel, config, lenConfig, engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const char *framework, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const char *framework, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
     const auto configStr = (config == nullptr) ? "" : cv::String(config);
     const auto frameworkStr = (framework == nullptr) ? "" : cv::String(framework);
-    const auto net = cv::dnn::readNet(model, configStr, frameworkStr);
+    const auto net = cv::dnn::readNet(model, configStr, frameworkStr, engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
@@ -45,18 +45,19 @@ CVAPI(ExceptionStatus) dnn_readNetFromModelOptimizer(const char *xml, const char
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNetFromONNX(const char *onnxFile, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromONNX(const char *onnxFile, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
-    const auto net = cv::dnn::readNetFromONNX(onnxFile);
+    // Wrap in cv::String to disambiguate from the (const char* buffer, size_t, int) overload.
+    const auto net = cv::dnn::readNetFromONNX(cv::String(onnxFile), engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNetFromONNX_InputArray(const char* buffer, size_t sizeBuffer, cv::dnn::Net** returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromONNX_InputArray(const char* buffer, size_t sizeBuffer, int engine, cv::dnn::Net** returnValue)
 {
     BEGIN_WRAP
-    const auto net = cv::dnn::readNetFromONNX(buffer, sizeBuffer);
+    const auto net = cv::dnn::readNetFromONNX(buffer, sizeBuffer, engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
@@ -165,18 +166,19 @@ CVAPI(ExceptionStatus) dnn_enableModelDiagnostics(const int isDiagnosticsMode)
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
-    const auto net = cv::dnn::readNetFromTFLite(model);
+    // Wrap in cv::String to disambiguate from the (const char* buffer, size_t, int) overload.
+    const auto net = cv::dnn::readNetFromTFLite(cv::String(model), engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) dnn_readNetFromTFLite_InputArray(const char *bufferModel, size_t lenModel, cv::dnn::Net **returnValue)
+CVAPI(ExceptionStatus) dnn_readNetFromTFLite_InputArray(const char *bufferModel, size_t lenModel, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
-    const auto net = cv::dnn::readNetFromTFLite(bufferModel, lenModel);
+    const auto net = cv::dnn::readNetFromTFLite(bufferModel, lenModel, engine);
     *returnValue = new cv::dnn::Net(net);
     END_WRAP
 }

--- a/test/OpenCvSharp.Tests/dnn/EngineSelectionTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/EngineSelectionTest.cs
@@ -1,0 +1,67 @@
+﻿using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Tests for the OpenCV 5 DNN engine selection feature (EngineType) and the
+// Backend/Target enum values that were re-synced with OpenCV 5.
+public class EngineSelectionTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Fact]
+    public void EngineTypeValuesMatchOpenCv()
+    {
+        // Must match cv::dnn::EngineType in modules/dnn/include/opencv2/dnn/dnn.hpp
+        Assert.Equal(1, (int)EngineType.Classic);
+        Assert.Equal(2, (int)EngineType.New);
+        Assert.Equal(3, (int)EngineType.Auto);
+        Assert.Equal(4, (int)EngineType.Ort);
+    }
+
+    [Fact]
+    public void BackendValuesMatchOpenCv()
+    {
+        // Must match cv::dnn::Backend in OpenCV 5 (Halide removed, value 1 left as a gap).
+        Assert.Equal(0, (int)Backend.DEFAULT);
+        Assert.Equal(2, (int)Backend.INFERENCE_ENGINE);
+        Assert.Equal(3, (int)Backend.OPENCV);
+        Assert.Equal(4, (int)Backend.VKCOM);
+        Assert.Equal(5, (int)Backend.CUDA);
+        Assert.Equal(6, (int)Backend.WEBNN);
+        Assert.Equal(7, (int)Backend.TIMVX);
+        Assert.Equal(8, (int)Backend.CANN);
+    }
+
+    [Fact]
+    public void TargetValuesMatchOpenCv()
+    {
+        // Must match cv::dnn::Target in OpenCV 5.
+        Assert.Equal(0, (int)Target.CPU);
+        Assert.Equal(8, (int)Target.HDDL);
+        Assert.Equal(9, (int)Target.NPU);
+        Assert.Equal(10, (int)Target.CPU_FP16);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ReadNetFromTensorflowWithClassicEngine()
+    {
+        // The classic engine parses every legacy format, so the committed TF model loads.
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath, engine: EngineType.Classic);
+        Assert.NotNull(net);
+        Assert.False(net!.Empty());
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ReadNetFromTensorflowWithAutoEngine()
+    {
+        // Auto is the default; it must keep working for the TF model.
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath, engine: EngineType.Auto);
+        Assert.NotNull(net);
+        Assert.False(net!.Empty());
+    }
+}


### PR DESCRIPTION
## Summary

First item from #1924 (OpenCV 5 API coverage): expose DNN inference engine selection and re-sync the `Backend` / `Target` enums with OpenCV 5.

### Engine selection
- New `EngineType` enum (`Classic=1` / `New=2` / `Auto=3` / `Ort=4`), matching `cv::dnn::EngineType`.
- Added an `EngineType engine = EngineType.Auto` parameter to the read APIs on `Net` and `CvDnn`: `ReadNet`, `ReadNetFromONNX`, `ReadNetFromTensorflow`, `ReadNetFromTFLite` (string / byte[] / `ReadOnlySpan<byte>` / `Stream` overloads).
- Native bridge (`dnn.h`) and P/Invoke signatures threaded through the `int engine` argument. The string-path ONNX/TFLite calls are wrapped in `cv::String(...)` to disambiguate from the `(const char*, size_t, int)` buffer overloads.

### Backend / Target enum sync
- `Backend`: added `WEBNN` / `TIMVX` / `CANN`. `HALIDE` was removed in OpenCV 5; its value `1` is kept as a gap (marked `[Obsolete]`) so the remaining members keep their OpenCV-matching numeric values.
- `Target`: added `NPU` / `CPU_FP16`.

## Test
- New `EngineSelectionTest`: verifies the enum numeric values match OpenCV 5 and that `ReadNetFromTensorflow` loads the committed MNIST model with `Classic` and `Auto` engines.
- Rebuilt `OpenCvSharpExtern` locally; full `dnn` suite green (45 passed, 4 network-dependent skips).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
