### PR TITLE
Add OpenCV 5 features wrappers: ALIKED, DISK, LightGlue, ANNIndex, AffineFeature

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
@@ -1,0 +1,86 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // ReSharper disable InconsistentNaming
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_create(int dim, int distType, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_ANNIndex_get(IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_ANNIndex_delete(IntPtr ptr);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_addItems(IntPtr obj, IntPtr features);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_build(IntPtr obj, int trees);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_knnSearch(
+        IntPtr obj, IntPtr query, IntPtr indices, IntPtr dists, int knn, int search_k);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_save")]
+    public static extern ExceptionStatus features_ANNIndex_save_NotWindows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_save")]
+    public static extern ExceptionStatus features_ANNIndex_save_Windows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
+
+    public static ExceptionStatus features_ANNIndex_save(IntPtr obj, string filename, int prefault)
+        => IsWindows()
+            ? features_ANNIndex_save_Windows(obj, filename, prefault)
+            : features_ANNIndex_save_NotWindows(obj, filename, prefault);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_load")]
+    public static extern ExceptionStatus features_ANNIndex_load_NotWindows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_load")]
+    public static extern ExceptionStatus features_ANNIndex_load_Windows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
+
+    public static ExceptionStatus features_ANNIndex_load(IntPtr obj, string filename, int prefault)
+        => IsWindows()
+            ? features_ANNIndex_load_Windows(obj, filename, prefault)
+            : features_ANNIndex_load_NotWindows(obj, filename, prefault);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_getTreeNumber(IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_getItemNumber(IntPtr obj, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_setOnDiskBuild")]
+    public static extern ExceptionStatus features_ANNIndex_setOnDiskBuild_NotWindows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ANNIndex_setOnDiskBuild")]
+    public static extern ExceptionStatus features_ANNIndex_setOnDiskBuild_Windows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, out int returnValue);
+
+    public static ExceptionStatus features_ANNIndex_setOnDiskBuild(IntPtr obj, string filename, out int returnValue)
+        => IsWindows()
+            ? features_ANNIndex_setOnDiskBuild_Windows(obj, filename, out returnValue)
+            : features_ANNIndex_setOnDiskBuild_NotWindows(obj, filename, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ANNIndex_setSeed(IntPtr obj, int seed);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
@@ -116,4 +116,40 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features_Ptr_FlannBasedMatcher_delete(IntPtr ptr);
+
+    #region LightGlueMatcher
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_LightGlueMatcher_create")]
+    public static extern ExceptionStatus features_LightGlueMatcher_create_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string modelPath, float scoreThreshold, int backend, int target, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_LightGlueMatcher_create")]
+    public static extern ExceptionStatus features_LightGlueMatcher_create_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string modelPath, float scoreThreshold, int backend, int target, out IntPtr returnValue);
+
+    public static ExceptionStatus features_LightGlueMatcher_create(string modelPath, float scoreThreshold, int backend, int target, out IntPtr returnValue)
+        => IsWindows()
+            ? features_LightGlueMatcher_create_Windows(modelPath, scoreThreshold, backend, target, out returnValue)
+            : features_LightGlueMatcher_create_NotWindows(modelPath, scoreThreshold, backend, target, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_LightGlueMatcher_create_buffer(
+        byte[] modelData, IntPtr modelDataLength, float scoreThreshold, int backend, int target, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_LightGlueMatcher_setPairInfo(
+        IntPtr obj, IntPtr queryKpts, IntPtr trainKpts, Size queryImageSize, Size trainImageSize);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_LightGlueMatcher_clearPairInfo(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_LightGlueMatcher_get(IntPtr ptr, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_LightGlueMatcher_delete(IntPtr ptr);
+
+    #endregion
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
@@ -244,4 +244,87 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus features_Ptr_Feature2D_get(IntPtr obj, out IntPtr returnValue);
+
+    #region AffineFeature
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_AffineFeature_create(
+        IntPtr backend, int maxTilt, int minTilt, float tiltStep, float rotateStepBase, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_AffineFeature_setViewParams(
+        IntPtr obj, float[] tilts, int tiltsLength, float[] rolls, int rollsLength);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_AffineFeature_getViewParams(IntPtr obj, IntPtr tilts, IntPtr rolls);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_AffineFeature_delete(IntPtr ptr);
+
+    #endregion
+
+    #region DISK
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_DISK_create")]
+    public static extern ExceptionStatus features_DISK_create_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string modelPath, int maxKeypoints, float scoreThreshold, Size imageSize, int backendId, int targetId, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_DISK_create")]
+    public static extern ExceptionStatus features_DISK_create_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string modelPath, int maxKeypoints, float scoreThreshold, Size imageSize, int backendId, int targetId, out IntPtr returnValue);
+
+    public static ExceptionStatus features_DISK_create(string modelPath, int maxKeypoints, float scoreThreshold, Size imageSize, int backendId, int targetId, out IntPtr returnValue)
+        => IsWindows()
+            ? features_DISK_create_Windows(modelPath, maxKeypoints, scoreThreshold, imageSize, backendId, targetId, out returnValue)
+            : features_DISK_create_NotWindows(modelPath, maxKeypoints, scoreThreshold, imageSize, backendId, targetId, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_create_buffer(
+        byte[] bufferModel, IntPtr bufferModelLength, int maxKeypoints, float scoreThreshold, Size imageSize, int backendId, int targetId, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_setMaxKeypoints(IntPtr obj, int maxKeypoints);
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_getMaxKeypoints(IntPtr obj, out int returnValue);
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_setScoreThreshold(IntPtr obj, float threshold);
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_getScoreThreshold(IntPtr obj, out float returnValue);
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_setImageSize(IntPtr obj, Size size);
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_DISK_getImageSize(IntPtr obj, out Size returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_DISK_delete(IntPtr ptr);
+
+    #endregion
+
+    #region ALIKED
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ALIKED_create")]
+    public static extern ExceptionStatus features_ALIKED_create_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string modelPath, Size inputSize, int normalizeDescriptors, int engine, int backend, int target, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "features_ALIKED_create")]
+    public static extern ExceptionStatus features_ALIKED_create_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string modelPath, Size inputSize, int normalizeDescriptors, int engine, int backend, int target, out IntPtr returnValue);
+
+    public static ExceptionStatus features_ALIKED_create(string modelPath, Size inputSize, int normalizeDescriptors, int engine, int backend, int target, out IntPtr returnValue)
+        => IsWindows()
+            ? features_ALIKED_create_Windows(modelPath, inputSize, normalizeDescriptors, engine, backend, target, out returnValue)
+            : features_ALIKED_create_NotWindows(modelPath, inputSize, normalizeDescriptors, engine, backend, target, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_ALIKED_create_buffer(
+        byte[] modelData, IntPtr modelDataLength, Size inputSize, int normalizeDescriptors, int engine, int backend, int target, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus features_Ptr_ALIKED_delete(IntPtr ptr);
+
+    #endregion
 }

--- a/src/OpenCvSharp/Modules/features/ALIKED.cs
+++ b/src/OpenCvSharp/Modules/features/ALIKED.cs
@@ -1,0 +1,70 @@
+﻿using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// ALIKED: deep learning based local feature detector and descriptor (OpenCV 5).
+/// Runs an ONNX model through the DNN module. Requires OpenCV built with the dnn module.
+/// </summary>
+public class ALIKED : Feature2D
+{
+    /// <summary>
+    /// Creates instance by raw pointer cv::ALIKED*
+    /// </summary>
+    private ALIKED(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features_Ptr_ALIKED_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates ALIKED from a model file path.
+    /// </summary>
+    /// <param name="modelPath">Path to the ONNX model file.</param>
+    /// <param name="inputSize">Input image size for the network. Default is 640x640.</param>
+    /// <param name="normalizeDescriptors">Whether to L2-normalize descriptors. Default is true.</param>
+    /// <param name="engine">DNN engine type (cv::dnn::EngineType). Default is 2 (ENGINE_NEW).</param>
+    /// <param name="backend">DNN backend (see <see cref="Dnn.Backend"/>). Default is 0 (DEFAULT).</param>
+    /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
+    public static ALIKED Create(
+        string modelPath, Size? inputSize = null, bool normalizeDescriptors = true,
+        int engine = 2, int backend = 0, int target = 0)
+    {
+        if (modelPath is null)
+            throw new ArgumentNullException(nameof(modelPath));
+        var size = inputSize ?? new Size(640, 640);
+
+        NativeMethods.HandleException(
+            NativeMethods.features_ALIKED_create(
+                modelPath, size, normalizeDescriptors ? 1 : 0, engine, backend, target, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
+        return new ALIKED(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates ALIKED from an in-memory ONNX model buffer.
+    /// </summary>
+    /// <param name="modelData">Buffer containing the model data.</param>
+    /// <param name="inputSize">Input image size for the network. Default is 640x640.</param>
+    /// <param name="normalizeDescriptors">Whether to L2-normalize descriptors. Default is true.</param>
+    /// <param name="engine">DNN engine type (cv::dnn::EngineType). Default is 2 (ENGINE_NEW).</param>
+    /// <param name="backend">DNN backend (see <see cref="Dnn.Backend"/>). Default is 0 (DEFAULT).</param>
+    /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
+    public static ALIKED CreateFromMemory(
+        byte[] modelData, Size? inputSize = null, bool normalizeDescriptors = true,
+        int engine = 2, int backend = 0, int target = 0)
+    {
+        if (modelData is null)
+            throw new ArgumentNullException(nameof(modelData));
+        var size = inputSize ?? new Size(640, 640);
+
+        NativeMethods.HandleException(
+            NativeMethods.features_ALIKED_create_buffer(
+                modelData, new IntPtr(modelData.Length), size, normalizeDescriptors ? 1 : 0, engine, backend, target, out var smartPtr));
+        GC.KeepAlive(modelData);
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
+        return new ALIKED(smartPtr, rawPtr);
+    }
+}

--- a/src/OpenCvSharp/Modules/features/ANNIndex.cs
+++ b/src/OpenCvSharp/Modules/features/ANNIndex.cs
@@ -1,0 +1,169 @@
+﻿using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Approximate nearest neighbor index backed by Annoy (OpenCV 5), a modern alternative to FLANN.
+/// </summary>
+public class ANNIndex : CvPtrObject
+{
+    /// <summary>
+    /// Creates instance from a cv::Ptr&lt;cv::ANNIndex&gt;* smart pointer and the raw cv::ANNIndex*.
+    /// </summary>
+    private ANNIndex(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features_Ptr_ANNIndex_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates an instance of the Annoy index with the given parameters.
+    /// </summary>
+    /// <param name="dim">The dimension of the feature vector.</param>
+    /// <param name="distType">Metric used to calculate the distance between two feature vectors.</param>
+    public static ANNIndex Create(int dim, ANNIndexDistance distType = ANNIndexDistance.Euclidean)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.features_ANNIndex_create(dim, (int)distType, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_ANNIndex_get(smartPtr, out var rawPtr));
+        return new ANNIndex(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Adds feature vectors to the index.
+    /// </summary>
+    /// <param name="features">Matrix containing the feature vectors to index (num_features x feature_dimension).</param>
+    public void AddItems(InputArray features)
+    {
+        ThrowIfDisposed();
+        if (features is null)
+            throw new ArgumentNullException(nameof(features));
+        features.ThrowIfDisposed();
+
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_addItems(RawPtr, features.CvPtr));
+        GC.KeepAlive(this);
+        GC.KeepAlive(features);
+    }
+
+    /// <summary>
+    /// Builds the index.
+    /// </summary>
+    /// <param name="trees">Number of trees in the index. -1 determines the number automatically.</param>
+    public void Build(int trees = -1)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_build(RawPtr, trees));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Performs a K-nearest neighbor search for the given query vector(s) using the index.
+    /// </summary>
+    /// <param name="query">The query vector(s).</param>
+    /// <param name="indices">Output matrix that will contain the indices of the K-nearest neighbors found.</param>
+    /// <param name="dists">Output matrix that will contain the distances to the K-nearest neighbors found.</param>
+    /// <param name="knn">Number of nearest neighbors to search for.</param>
+    /// <param name="searchK">The maximum number of nodes to inspect; defaults to trees x knn when -1.</param>
+    public void KnnSearch(InputArray query, OutputArray indices, OutputArray dists, int knn, int searchK = -1)
+    {
+        ThrowIfDisposed();
+        if (query is null)
+            throw new ArgumentNullException(nameof(query));
+        if (indices is null)
+            throw new ArgumentNullException(nameof(indices));
+        if (dists is null)
+            throw new ArgumentNullException(nameof(dists));
+        query.ThrowIfDisposed();
+        indices.ThrowIfNotReady();
+        dists.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.features_ANNIndex_knnSearch(RawPtr, query.CvPtr, indices.CvPtr, dists.CvPtr, knn, searchK));
+        GC.KeepAlive(this);
+        GC.KeepAlive(query);
+        indices.Fix();
+        dists.Fix();
+    }
+
+    /// <summary>
+    /// Saves the index to disk. After saving, no more vectors can be added.
+    /// </summary>
+    /// <param name="filename">Filename of the index to be saved.</param>
+    /// <param name="prefault">If true, pre-reads the entire file into memory.</param>
+    public void Save(string filename, bool prefault = false)
+    {
+        ThrowIfDisposed();
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_save(RawPtr, filename, prefault ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Loads (mmaps) an index from disk.
+    /// </summary>
+    /// <param name="filename">Filename of the index to be loaded.</param>
+    /// <param name="prefault">If true, pre-reads the entire file into memory.</param>
+    public void Load(string filename, bool prefault = false)
+    {
+        ThrowIfDisposed();
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_load(RawPtr, filename, prefault ? 1 : 0));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Returns the number of trees in the index.
+    /// </summary>
+    public int GetTreeNumber()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getTreeNumber(RawPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the number of feature vectors in the index.
+    /// </summary>
+    public int GetItemNumber()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getItemNumber(RawPtr, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
+    /// <summary>
+    /// Prepares to build the index in the specified file instead of in RAM
+    /// (call before adding items; no need to save after build).
+    /// </summary>
+    /// <param name="filename">Filename of the index to be built.</param>
+    /// <returns>True on success.</returns>
+    public bool SetOnDiskBuild(string filename)
+    {
+        ThrowIfDisposed();
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setOnDiskBuild(RawPtr, filename, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Initializes the random number generator with the given seed.
+    /// Only effective before adding items / calling build() or load().
+    /// </summary>
+    /// <param name="seed">The seed of the random number generator.</param>
+    public void SetSeed(int seed)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setSeed(RawPtr, seed));
+        GC.KeepAlive(this);
+    }
+}

--- a/src/OpenCvSharp/Modules/features/AffineFeature.cs
+++ b/src/OpenCvSharp/Modules/features/AffineFeature.cs
@@ -1,0 +1,80 @@
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Class implementing the AKAZE-style affine-invariant feature wrapper (ASIFT and friends).
+/// It wraps another <see cref="Feature2D"/> backend and applies it over a set of simulated
+/// affine (tilt/rotation) views of the image. See Y. Yu, J.M. Morel "ASIFT".
+/// </summary>
+public class AffineFeature : Feature2D
+{
+    /// <summary>
+    /// Creates instance by raw pointer cv::AffineFeature*
+    /// </summary>
+    private AffineFeature(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features_Ptr_AffineFeature_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates an AffineFeature detector/extractor over the given backend.
+    /// </summary>
+    /// <param name="backend">The detector/extractor used as backend (e.g. SIFT).</param>
+    /// <param name="maxTilt">The highest power index of tilt factor. 5 is used in the paper as tilt sampling range n.</param>
+    /// <param name="minTilt">The lowest power index of tilt factor. 0 is used in the paper.</param>
+    /// <param name="tiltStep">Tilt sampling step in Algorithm 1 in the paper.</param>
+    /// <param name="rotateStepBase">Rotation sampling step factor b in Algorithm 1 in the paper.</param>
+    public static AffineFeature Create(
+        Feature2D backend, int maxTilt = 5, int minTilt = 0,
+        float tiltStep = 1.4142135623730951f, float rotateStepBase = 72)
+    {
+        if (backend is null)
+            throw new ArgumentNullException(nameof(backend));
+
+        NativeMethods.HandleException(
+            NativeMethods.features_AffineFeature_create(
+                backend.SmartPtr, maxTilt, minTilt, tiltStep, rotateStepBase, out var smartPtr));
+        GC.KeepAlive(backend);
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
+        return new AffineFeature(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Sets the tilt and rotation view sampling parameters.
+    /// </summary>
+    /// <param name="tilts">Tilt sampling values.</param>
+    /// <param name="rolls">Roll (rotation) sampling values, in degrees.</param>
+    public void SetViewParams(float[] tilts, float[] rolls)
+    {
+        if (tilts is null)
+            throw new ArgumentNullException(nameof(tilts));
+        if (rolls is null)
+            throw new ArgumentNullException(nameof(rolls));
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.features_AffineFeature_setViewParams(RawPtr, tilts, tilts.Length, rolls, rolls.Length));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Gets the tilt and rotation view sampling parameters.
+    /// </summary>
+    /// <param name="tilts">Output tilt sampling values.</param>
+    /// <param name="rolls">Output roll (rotation) sampling values, in degrees.</param>
+    public void GetViewParams(out float[] tilts, out float[] rolls)
+    {
+        ThrowIfDisposed();
+
+        using var tiltsVec = new VectorOfFloat();
+        using var rollsVec = new VectorOfFloat();
+        NativeMethods.HandleException(
+            NativeMethods.features_AffineFeature_getViewParams(RawPtr, tiltsVec.CvPtr, rollsVec.CvPtr));
+        GC.KeepAlive(this);
+        tilts = tiltsVec.ToArray();
+        rolls = rollsVec.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/features/DISK.cs
+++ b/src/OpenCvSharp/Modules/features/DISK.cs
@@ -1,0 +1,129 @@
+﻿using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// DISK: deep learning based local feature detector and descriptor (OpenCV 5).
+/// Runs an ONNX model through the DNN module. Requires OpenCV built with the dnn module.
+/// </summary>
+public class DISK : Feature2D
+{
+    /// <summary>
+    /// Creates instance by raw pointer cv::DISK*
+    /// </summary>
+    private DISK(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features_Ptr_DISK_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a DISK detector from a model file path.
+    /// </summary>
+    /// <param name="modelPath">Path to the DISK ONNX model.</param>
+    /// <param name="maxKeypoints">Maximum number of keypoints to return per image; -1 keeps all detections.</param>
+    /// <param name="scoreThreshold">Discard keypoints with network score strictly below this value.</param>
+    /// <param name="imageSize">Target input size fed to the network. Default (empty) falls back to the network's
+    /// fixed 1024x1024 input. When overriding, both dimensions must be positive multiples of 16.</param>
+    /// <param name="backendId">DNN backend identifier (see <see cref="Dnn.Backend"/>); 0 = default.</param>
+    /// <param name="targetId">DNN target identifier (see <see cref="Dnn.Target"/>); 0 = CPU.</param>
+    public static DISK Create(
+        string modelPath, int maxKeypoints = -1, float scoreThreshold = 0.0f,
+        Size imageSize = default, int backendId = 0, int targetId = 0)
+    {
+        if (modelPath is null)
+            throw new ArgumentNullException(nameof(modelPath));
+
+        NativeMethods.HandleException(
+            NativeMethods.features_DISK_create(modelPath, maxKeypoints, scoreThreshold, imageSize, backendId, targetId, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
+        return new DISK(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates a DISK detector from an in-memory ONNX model buffer.
+    /// </summary>
+    /// <param name="bufferModel">A buffer containing the contents of the DISK ONNX model.</param>
+    /// <param name="maxKeypoints">Maximum number of keypoints to return per image; -1 keeps all detections.</param>
+    /// <param name="scoreThreshold">Discard keypoints with network score strictly below this value.</param>
+    /// <param name="imageSize">Target input size fed to the network. Default (empty) falls back to the network's
+    /// fixed 1024x1024 input. When overriding, both dimensions must be positive multiples of 16.</param>
+    /// <param name="backendId">DNN backend identifier (see <see cref="Dnn.Backend"/>); 0 = default.</param>
+    /// <param name="targetId">DNN target identifier (see <see cref="Dnn.Target"/>); 0 = CPU.</param>
+    public static DISK CreateFromMemory(
+        byte[] bufferModel, int maxKeypoints = -1, float scoreThreshold = 0.0f,
+        Size imageSize = default, int backendId = 0, int targetId = 0)
+    {
+        if (bufferModel is null)
+            throw new ArgumentNullException(nameof(bufferModel));
+
+        NativeMethods.HandleException(
+            NativeMethods.features_DISK_create_buffer(
+                bufferModel, new IntPtr(bufferModel.Length), maxKeypoints, scoreThreshold, imageSize, backendId, targetId, out var smartPtr));
+        GC.KeepAlive(bufferModel);
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
+        return new DISK(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Maximum number of keypoints to return per image; -1 keeps all detections.
+    /// </summary>
+    public int MaxKeypoints
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_getMaxKeypoints(RawPtr, out var ret));
+            GC.KeepAlive(this);
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_setMaxKeypoints(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Keypoints with network score strictly below this value are discarded.
+    /// </summary>
+    public float ScoreThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_getScoreThreshold(RawPtr, out var ret));
+            GC.KeepAlive(this);
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_setScoreThreshold(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Target input size fed to the network.
+    /// </summary>
+    public Size ImageSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_getImageSize(RawPtr, out var ret));
+            GC.KeepAlive(this);
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.features_DISK_setImageSize(RawPtr, value));
+            GC.KeepAlive(this);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/features/Enum/ANNIndexDistance.cs
+++ b/src/OpenCvSharp/Modules/features/Enum/ANNIndexDistance.cs
@@ -1,0 +1,34 @@
+﻿// ReSharper disable once CheckNamespace
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Metrics used by <see cref="ANNIndex"/> to calculate the distance between two feature vectors.
+/// </summary>
+public enum ANNIndexDistance
+{
+    /// <summary>
+    /// Euclidean distance (DIST_EUCLIDEAN).
+    /// </summary>
+    Euclidean = 0,
+
+    /// <summary>
+    /// Manhattan (L1) distance (DIST_MANHATTAN).
+    /// </summary>
+    Manhattan = 1,
+
+    /// <summary>
+    /// Angular distance (DIST_ANGULAR).
+    /// </summary>
+    Angular = 2,
+
+    /// <summary>
+    /// Hamming distance (DIST_HAMMING).
+    /// </summary>
+    Hamming = 3,
+
+    /// <summary>
+    /// Dot-product distance (DIST_DOTPRODUCT).
+    /// </summary>
+    DotProduct = 4
+}

--- a/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
@@ -1,0 +1,92 @@
+﻿using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// LightGlue: a deep learning based descriptor matcher with an attention mechanism (OpenCV 5).
+/// Runs an ONNX model through the DNN module. Requires OpenCV built with the dnn module.
+/// </summary>
+public class LightGlueMatcher : DescriptorMatcher
+{
+    private LightGlueMatcher(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.features_Ptr_LightGlueMatcher_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a LightGlueMatcher from a model file path.
+    /// </summary>
+    /// <param name="modelPath">Path to the ONNX model file.</param>
+    /// <param name="scoreThreshold">Match confidence threshold.</param>
+    /// <param name="backend">DNN backend (see <see cref="Dnn.Backend"/>). Default is 0 (DEFAULT).</param>
+    /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
+    public static LightGlueMatcher Create(string modelPath, float scoreThreshold = 0.0f, int backend = 0, int target = 0)
+    {
+        if (modelPath is null)
+            throw new ArgumentNullException(nameof(modelPath));
+
+        NativeMethods.HandleException(
+            NativeMethods.features_LightGlueMatcher_create(modelPath, scoreThreshold, backend, target, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_LightGlueMatcher_get(smartPtr, out var rawPtr));
+        return new LightGlueMatcher(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates a LightGlueMatcher from an in-memory ONNX model buffer.
+    /// </summary>
+    /// <param name="modelData">Buffer containing the model data.</param>
+    /// <param name="scoreThreshold">Match confidence threshold.</param>
+    /// <param name="backend">DNN backend (see <see cref="Dnn.Backend"/>). Default is 0 (DEFAULT).</param>
+    /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
+    public static LightGlueMatcher CreateFromMemory(byte[] modelData, float scoreThreshold = 0.0f, int backend = 0, int target = 0)
+    {
+        if (modelData is null)
+            throw new ArgumentNullException(nameof(modelData));
+
+        NativeMethods.HandleException(
+            NativeMethods.features_LightGlueMatcher_create_buffer(
+                modelData, new IntPtr(modelData.Length), scoreThreshold, backend, target, out var smartPtr));
+        GC.KeepAlive(modelData);
+        NativeMethods.HandleException(
+            NativeMethods.features_Ptr_LightGlueMatcher_get(smartPtr, out var rawPtr));
+        return new LightGlueMatcher(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Sets the keypoint and image size context for the next match() call.
+    /// Must be called before match()/knnMatch()/radiusMatch() unless using automatic context
+    /// from in-process ALIKED instances.
+    /// </summary>
+    /// <param name="queryKpts">Query image keypoints (Nx2 float matrix with x,y coordinates).</param>
+    /// <param name="trainKpts">Train image keypoints (Nx2 float matrix with x,y coordinates).</param>
+    /// <param name="queryImageSize">Size of the query image (width, height).</param>
+    /// <param name="trainImageSize">Size of the train image (width, height).</param>
+    public void SetPairInfo(InputArray queryKpts, InputArray trainKpts, Size queryImageSize = default, Size trainImageSize = default)
+    {
+        ThrowIfDisposed();
+        if (queryKpts is null)
+            throw new ArgumentNullException(nameof(queryKpts));
+        if (trainKpts is null)
+            throw new ArgumentNullException(nameof(trainKpts));
+        queryKpts.ThrowIfDisposed();
+        trainKpts.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.features_LightGlueMatcher_setPairInfo(RawPtr, queryKpts.CvPtr, trainKpts.CvPtr, queryImageSize, trainImageSize));
+        GC.KeepAlive(this);
+        GC.KeepAlive(queryKpts);
+        GC.KeepAlive(trainKpts);
+    }
+
+    /// <summary>
+    /// Clears stored pair context information.
+    /// </summary>
+    public void ClearPairInfo()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.features_LightGlueMatcher_clearPairInfo(RawPtr));
+        GC.KeepAlive(this);
+    }
+}

--- a/src/OpenCvSharpExtern/features.cpp
+++ b/src/OpenCvSharpExtern/features.cpp
@@ -2,3 +2,4 @@
 #include "features.h"
 #include "features_DescriptorMatcher.h"
 #include "features_Feature2D.h"
+#include "features_ANNIndex.h"

--- a/src/OpenCvSharpExtern/features_ANNIndex.h
+++ b/src/OpenCvSharpExtern/features_ANNIndex.h
@@ -1,0 +1,97 @@
+﻿#pragma once
+
+#ifndef NO_FEATURES
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) features_ANNIndex_create(int dim, int distType, cv::Ptr<cv::ANNIndex> **returnValue)
+{
+    BEGIN_WRAP
+    const auto ptr = cv::ANNIndex::create(dim, static_cast<cv::ANNIndex::Distance>(distType));
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_ANNIndex_get(cv::Ptr<cv::ANNIndex> *ptr, cv::ANNIndex **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_ANNIndex_delete(cv::Ptr<cv::ANNIndex> *ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_addItems(cv::ANNIndex *obj, cv::_InputArray *features)
+{
+    BEGIN_WRAP
+    obj->addItems(*features);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_build(cv::ANNIndex *obj, int trees)
+{
+    BEGIN_WRAP
+    obj->build(trees);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_knnSearch(
+    cv::ANNIndex *obj, cv::_InputArray *query, cv::_OutputArray *indices, cv::_OutputArray *dists, int knn, int search_k)
+{
+    BEGIN_WRAP
+    obj->knnSearch(*query, *indices, *dists, knn, search_k);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_save(cv::ANNIndex *obj, const char *filename, int prefault)
+{
+    BEGIN_WRAP
+    obj->save(cv::String(filename), prefault != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_load(cv::ANNIndex *obj, const char *filename, int prefault)
+{
+    BEGIN_WRAP
+    obj->load(cv::String(filename), prefault != 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_getTreeNumber(cv::ANNIndex *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getTreeNumber();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_getItemNumber(cv::ANNIndex *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getItemNumber();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_setOnDiskBuild(cv::ANNIndex *obj, const char *filename, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->setOnDiskBuild(cv::String(filename)) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ANNIndex_setSeed(cv::ANNIndex *obj, int seed)
+{
+    BEGIN_WRAP
+    obj->setSeed(seed);
+    END_WRAP
+}
+
+#endif // NO_FEATURES

--- a/src/OpenCvSharpExtern/features_DescriptorMatcher.h
+++ b/src/OpenCvSharpExtern/features_DescriptorMatcher.h
@@ -279,4 +279,65 @@ CVAPI(ExceptionStatus) features_Ptr_FlannBasedMatcher_delete(cv::Ptr<cv::FlannBa
 
 #pragma endregion
 
+
+#ifdef HAVE_OPENCV_DNN
+
+#pragma region LightGlueMatcher
+
+CVAPI(ExceptionStatus) features_LightGlueMatcher_create(
+    const char *modelPath, float scoreThreshold, int backend, int target,
+    cv::Ptr<cv::LightGlueMatcher> **returnValue)
+{
+    BEGIN_WRAP
+    const auto ptr = cv::LightGlueMatcher::create(cv::String(modelPath), scoreThreshold, backend, target);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_LightGlueMatcher_create_buffer(
+    const uchar *modelData, size_t modelDataLength, float scoreThreshold, int backend, int target,
+    cv::Ptr<cv::LightGlueMatcher> **returnValue)
+{
+    BEGIN_WRAP
+    const std::vector<uchar> buf(modelData, modelData + modelDataLength);
+    const auto ptr = cv::LightGlueMatcher::create(buf, scoreThreshold, backend, target);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_LightGlueMatcher_setPairInfo(
+    cv::LightGlueMatcher *obj, cv::_InputArray *queryKpts, cv::_InputArray *trainKpts,
+    MyCvSize queryImageSize, MyCvSize trainImageSize)
+{
+    BEGIN_WRAP
+    obj->setPairInfo(*queryKpts, *trainKpts, cpp(queryImageSize), cpp(trainImageSize));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_LightGlueMatcher_clearPairInfo(cv::LightGlueMatcher *obj)
+{
+    BEGIN_WRAP
+    obj->clearPairInfo();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_LightGlueMatcher_get(
+    cv::Ptr<cv::LightGlueMatcher> *ptr, cv::LightGlueMatcher **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = ptr->get();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_LightGlueMatcher_delete(cv::Ptr<cv::LightGlueMatcher> *ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+#pragma endregion
+
+#endif // HAVE_OPENCV_DNN
+
 #endif // NO_FEATURES

--- a/src/OpenCvSharpExtern/features_Feature2D.h
+++ b/src/OpenCvSharpExtern/features_Feature2D.h
@@ -635,4 +635,164 @@ CVAPI(ExceptionStatus) features_Ptr_Feature2D_get(cv::Ptr<cv::Feature2D> *obj, c
     *returnValue = obj->get();
     END_WRAP
 }
+
+
+#pragma region AffineFeature
+
+CVAPI(ExceptionStatus) features_AffineFeature_create(
+    cv::Ptr<cv::Feature2D> *backend, int maxTilt, int minTilt, float tiltStep, float rotateStepBase,
+    cv::Ptr<cv::AffineFeature> **returnValue)
+{
+    BEGIN_WRAP
+    const auto ptr = cv::AffineFeature::create(*backend, maxTilt, minTilt, tiltStep, rotateStepBase);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_AffineFeature_setViewParams(
+    cv::AffineFeature *obj, float *tilts, int tiltsLength, float *rolls, int rollsLength)
+{
+    BEGIN_WRAP
+    const std::vector<float> tiltsVec(tilts, tilts + tiltsLength);
+    const std::vector<float> rollsVec(rolls, rolls + rollsLength);
+    obj->setViewParams(tiltsVec, rollsVec);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_AffineFeature_getViewParams(
+    cv::AffineFeature *obj, std::vector<float> *tilts, std::vector<float> *rolls)
+{
+    BEGIN_WRAP
+    obj->getViewParams(*tilts, *rolls);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_AffineFeature_delete(cv::Ptr<cv::AffineFeature> *ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+#pragma endregion
+
+
+#ifdef HAVE_OPENCV_DNN
+
+#pragma region DISK
+
+CVAPI(ExceptionStatus) features_DISK_create(
+    const char *modelPath, int maxKeypoints, float scoreThreshold, MyCvSize imageSize, int backendId, int targetId,
+    cv::Ptr<cv::DISK> **returnValue)
+{
+    BEGIN_WRAP
+    const auto ptr = cv::DISK::create(cv::String(modelPath), maxKeypoints, scoreThreshold, cpp(imageSize), backendId, targetId);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_DISK_create_buffer(
+    const uchar *bufferModel, size_t bufferModelLength, int maxKeypoints, float scoreThreshold, MyCvSize imageSize, int backendId, int targetId,
+    cv::Ptr<cv::DISK> **returnValue)
+{
+    BEGIN_WRAP
+    const std::vector<uchar> buf(bufferModel, bufferModel + bufferModelLength);
+    const auto ptr = cv::DISK::create(buf, maxKeypoints, scoreThreshold, cpp(imageSize), backendId, targetId);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_DISK_setMaxKeypoints(cv::DISK *obj, int maxKeypoints)
+{
+    BEGIN_WRAP
+    obj->setMaxKeypoints(maxKeypoints);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) features_DISK_getMaxKeypoints(cv::DISK *obj, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getMaxKeypoints();
+    END_WRAP
+}
+CVAPI(ExceptionStatus) features_DISK_setScoreThreshold(cv::DISK *obj, float threshold)
+{
+    BEGIN_WRAP
+    obj->setScoreThreshold(threshold);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) features_DISK_getScoreThreshold(cv::DISK *obj, float *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getScoreThreshold();
+    END_WRAP
+}
+CVAPI(ExceptionStatus) features_DISK_setImageSize(cv::DISK *obj, MyCvSize size)
+{
+    BEGIN_WRAP
+    obj->setImageSize(cpp(size));
+    END_WRAP
+}
+CVAPI(ExceptionStatus) features_DISK_getImageSize(cv::DISK *obj, MyCvSize *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = c(obj->getImageSize());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_DISK_delete(cv::Ptr<cv::DISK> *ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+#pragma endregion
+
+
+#pragma region ALIKED
+
+CVAPI(ExceptionStatus) features_ALIKED_create(
+    const char *modelPath, MyCvSize inputSize, int normalizeDescriptors, int engine, int backend, int target,
+    cv::Ptr<cv::ALIKED> **returnValue)
+{
+    BEGIN_WRAP
+    cv::ALIKED::Params params;
+    params.inputSize = cpp(inputSize);
+    params.normalizeDescriptors = normalizeDescriptors != 0;
+    params.engine = engine;
+    params.backend = backend;
+    params.target = target;
+    const auto ptr = cv::ALIKED::create(cv::String(modelPath), params);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_ALIKED_create_buffer(
+    const uchar *modelData, size_t modelDataLength, MyCvSize inputSize, int normalizeDescriptors, int engine, int backend, int target,
+    cv::Ptr<cv::ALIKED> **returnValue)
+{
+    BEGIN_WRAP
+    const std::vector<uchar> buf(modelData, modelData + modelDataLength);
+    cv::ALIKED::Params params;
+    params.inputSize = cpp(inputSize);
+    params.normalizeDescriptors = normalizeDescriptors != 0;
+    params.engine = engine;
+    params.backend = backend;
+    params.target = target;
+    const auto ptr = cv::ALIKED::create(buf, params);
+    *returnValue = clone(ptr);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) features_Ptr_ALIKED_delete(cv::Ptr<cv::ALIKED> *ptr)
+{
+    BEGIN_WRAP
+    delete ptr;
+    END_WRAP
+}
+
+#pragma endregion
+
+#endif // HAVE_OPENCV_DNN
+
 #endif // NO_FEATURES

--- a/test/OpenCvSharp.Tests/features/ANNIndexTest.cs
+++ b/test/OpenCvSharp.Tests/features/ANNIndexTest.cs
@@ -1,0 +1,76 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+// ReSharper disable once InconsistentNaming
+public class ANNIndexTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        using var index = ANNIndex.Create(8);
+        Assert.NotEqual(IntPtr.Zero, index.RawPtr);
+    }
+
+    [Fact]
+    public void AddBuildAndSearch()
+    {
+        const int dim = 8;
+        const int count = 100;
+
+        using var features = new Mat(count, dim, MatType.CV_32F);
+        Cv2.Randu(features, 0, 1);
+
+        // Make a known row that we will query for.
+        using var query = features.Row(42).Clone();
+
+        using var index = ANNIndex.Create(dim, ANNIndexDistance.Euclidean);
+        index.SetSeed(42);
+        index.AddItems(features);
+        index.Build(10);
+
+        Assert.Equal(count, index.GetItemNumber());
+        Assert.True(index.GetTreeNumber() >= 1);
+
+        using var indices = new Mat();
+        using var dists = new Mat();
+        index.KnnSearch(query, indices, dists, knn: 5);
+
+        Assert.Equal(5, indices.Total());
+        Assert.Equal(5, dists.Total());
+
+        // The nearest neighbor of row 42 should be row 42 itself.
+        var nearest = indices.Get<int>(0);
+        Assert.Equal(42, nearest);
+    }
+
+    [Fact]
+    public void SaveAndLoad()
+    {
+        const int dim = 4;
+        using var features = new Mat(20, dim, MatType.CV_32F);
+        Cv2.Randu(features, 0, 1);
+
+        var path = Path.Combine(Path.GetTempPath(), $"annoy_{Guid.NewGuid():N}.ann");
+        try
+        {
+            using (var index = ANNIndex.Create(dim))
+            {
+                index.AddItems(features);
+                index.Build(5);
+                index.Save(path);
+            }
+
+            Assert.True(File.Exists(path));
+
+            using var loaded = ANNIndex.Create(dim);
+            loaded.Load(path);
+            Assert.Equal(20, loaded.GetItemNumber());
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/features/AffineFeatureTest.cs
+++ b/test/OpenCvSharp.Tests/features/AffineFeatureTest.cs
@@ -1,0 +1,40 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+// ReSharper disable once InconsistentNaming
+public class AffineFeatureTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        using var backend = SIFT.Create();
+        using var affine = AffineFeature.Create(backend);
+        Assert.NotEqual(IntPtr.Zero, affine.RawPtr);
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var gray = LoadImage("lenna.png", 0);
+        using var backend = SIFT.Create();
+        using var affine = AffineFeature.Create(backend, maxTilt: 2);
+        var keyPoints = affine.Detect(gray);
+        Assert.NotEmpty(keyPoints);
+    }
+
+    [Fact]
+    public void SetAndGetViewParams()
+    {
+        using var backend = SIFT.Create();
+        using var affine = AffineFeature.Create(backend);
+
+        var tilts = new[] { 1.0f, 2.0f, 3.0f };
+        var rolls = new[] { 0.0f, 45.0f, 90.0f };
+        affine.SetViewParams(tilts, rolls);
+
+        affine.GetViewParams(out var outTilts, out var outRolls);
+        Assert.Equal(tilts, outTilts);
+        Assert.Equal(rolls, outRolls);
+    }
+}

--- a/test/OpenCvSharp.Tests/features/DiskAlikedLightGlueTest.cs
+++ b/test/OpenCvSharp.Tests/features/DiskAlikedLightGlueTest.cs
@@ -1,0 +1,50 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+// DISK / ALIKED / LightGlueMatcher require ONNX model files that are not committed to the repo.
+// These tests verify that the P/Invoke entry points are wired correctly: loading a non-existent
+// model must reach OpenCV and raise an OpenCVException (not fail in the P/Invoke layer).
+public class DiskAlikedLightGlueTest : TestBase
+{
+    private static string MissingModel => Path.Combine(Path.GetTempPath(), $"__no_such_model_{Guid.NewGuid():N}.onnx");
+
+    [Fact]
+    public void DiskCreateWithMissingModelThrows()
+    {
+        Assert.ThrowsAny<OpenCVException>(() => DISK.Create(MissingModel));
+    }
+
+    [Fact]
+    public void DiskCreateFromMemoryWithGarbageThrows()
+    {
+        var garbage = new byte[] { 1, 2, 3, 4 };
+        Assert.ThrowsAny<OpenCVException>(() => DISK.CreateFromMemory(garbage));
+    }
+
+    [Fact]
+    public void AlikedCreateWithMissingModelThrows()
+    {
+        Assert.ThrowsAny<OpenCVException>(() => ALIKED.Create(MissingModel));
+    }
+
+    [Fact]
+    public void AlikedCreateFromMemoryWithGarbageThrows()
+    {
+        var garbage = new byte[] { 1, 2, 3, 4 };
+        Assert.ThrowsAny<OpenCVException>(() => ALIKED.CreateFromMemory(garbage));
+    }
+
+    [Fact]
+    public void LightGlueCreateWithMissingModelThrows()
+    {
+        Assert.ThrowsAny<OpenCVException>(() => LightGlueMatcher.Create(MissingModel));
+    }
+
+    [Fact]
+    public void LightGlueCreateFromMemoryWithGarbageThrows()
+    {
+        var garbage = new byte[] { 1, 2, 3, 4 };
+        Assert.ThrowsAny<OpenCVException>(() => LightGlueMatcher.CreateFromMemory(garbage));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining **features** (formerly features2d) module classes from #1924 (OpenCV 5 API coverage).

### New wrappers
- **`ALIKED`** / **`DISK`** — deep-learning local feature detectors & descriptors (`Feature2D`, ONNX via the dnn module). Each exposes `Create` (model file path) and `CreateFromMemory` (in-memory buffer). DISK additionally exposes `MaxKeypoints` / `ScoreThreshold` / `ImageSize`.
- **`LightGlueMatcher`** — attention-based descriptor matcher (`DescriptorMatcher`) with `SetPairInfo` / `ClearPairInfo`.
- **`ANNIndex`** — Annoy-based approximate nearest neighbor index (modern FLANN alternative): `AddItems` / `Build` / `KnnSearch` / `Save` / `Load` / `GetTreeNumber` / `GetItemNumber` / `SetOnDiskBuild` / `SetSeed`, plus the `ANNIndexDistance` enum.
- **`AffineFeature`** — affine-invariant (ASIFT-style) wrapper over a backend `Feature2D`, with `SetViewParams` / `GetViewParams`.

### Native bridge
- DNN-dependent classes (DISK, ALIKED, LightGlueMatcher) are guarded with `#ifdef HAVE_OPENCV_DNN`.
- Model-path / index-path string entry points use the existing Windows/NotWindows marshaling split for correct Unicode handling.
- `ANNIndex` lives in a new `features_ANNIndex.h` (it is neither `Feature2D` nor `DescriptorMatcher`); the others are added to the existing grouped headers.

## Test
- `AffineFeatureTest` and `ANNIndexTest` exercise the classes end-to-end (detect over SIFT backend; add/build/knnSearch round-trip + save/load).
- `DiskAlikedLightGlueTest` verifies entry-point wiring (missing model / garbage buffer → `OpenCVException`), since the ONNX models are not committed to the repo.
- Rebuilt `OpenCvSharpExtern` locally; full Features suite green (51 passed).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
