### PR TITLE
Add geometry/calib functions: solvePnPRefine, decomposeEssentialMat, estimateTranslation2D/3D, fisheye distortPoints overload

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib.FishEye.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.FishEye.cs
@@ -109,6 +109,49 @@ static partial class Cv2
         }
 
         /// <summary>
+        /// Distorts 2D points using the fisheye model. Overload that handles cases when undistorted
+        /// points were obtained with a non-identity camera matrix
+        /// (e.g. the output of EstimateNewCameraMatrixForUndistortRectify).
+        /// </summary>
+        /// <param name="undistorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt;),
+        /// where N is the number of points in the view.</param>
+        /// <param name="distorted">Output array of image points, 1xN/Nx1 2-channel, or vector&lt;Point2f&gt;.</param>
+        /// <param name="kundistorted">Camera intrinsic matrix used as the new camera matrix for undistortion.</param>
+        /// <param name="k">Camera intrinsic matrix.</param>
+        /// <param name="d">Input vector of distortion coefficients.</param>
+        /// <param name="alpha">The skew coefficient.</param>
+        public static void DistortPoints(
+            InputArray undistorted, OutputArray distorted, InputArray kundistorted, InputArray k, InputArray d, double alpha = 0)
+        {
+            if (undistorted is null)
+                throw new ArgumentNullException(nameof(undistorted));
+            if (distorted is null)
+                throw new ArgumentNullException(nameof(distorted));
+            if (kundistorted is null)
+                throw new ArgumentNullException(nameof(kundistorted));
+            if (k is null)
+                throw new ArgumentNullException(nameof(k));
+            if (d is null)
+                throw new ArgumentNullException(nameof(d));
+            undistorted.ThrowIfDisposed();
+            distorted.ThrowIfNotReady();
+            kundistorted.ThrowIfDisposed();
+            k.ThrowIfDisposed();
+            d.ThrowIfDisposed();
+
+            NativeMethods.HandleException(
+                NativeMethods.calib_fisheye_distortPoints2(
+                    undistorted.CvPtr, distorted.CvPtr, kundistorted.CvPtr, k.CvPtr, d.CvPtr, alpha));
+
+            distorted.Fix();
+            GC.KeepAlive(undistorted);
+            GC.KeepAlive(distorted);
+            GC.KeepAlive(kundistorted);
+            GC.KeepAlive(k);
+            GC.KeepAlive(d);
+        }
+
+        /// <summary>
         /// Undistorts 2D points using fisheye model
         /// </summary>
         /// <param name="distorted">Array of object points, 1xN/Nx1 2-channel (or vector&lt;Point2f&gt; ), 

--- a/src/OpenCvSharp/Cv2/Cv2_geometry.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_geometry.cs
@@ -2330,4 +2330,214 @@ static partial class Cv2
         GC.KeepAlive(p);
         dst.Fix();
     }
+
+    /// <summary>
+    /// Refines a pose (rotation and translation) from 3D-2D point correspondences, starting from an
+    /// initial solution, using a Levenberg-Marquardt iterative scheme.
+    /// </summary>
+    /// <param name="objectPoints">Array of object points in the object coordinate space.</param>
+    /// <param name="imagePoints">Array of corresponding image points.</param>
+    /// <param name="cameraMatrix">Input camera intrinsic matrix.</param>
+    /// <param name="distCoeffs">Input vector of distortion coefficients. If empty, zero distortion is assumed.</param>
+    /// <param name="rvec">Input/Output rotation vector. Input values are used as the initial solution.</param>
+    /// <param name="tvec">Input/Output translation vector. Input values are used as the initial solution.</param>
+    /// <param name="criteria">Criteria when to stop the Levenberg-Marquardt iterative algorithm.</param>
+    public static void SolvePnPRefineLM(
+        InputArray objectPoints, InputArray imagePoints, InputArray cameraMatrix, InputArray distCoeffs,
+        InputOutputArray rvec, InputOutputArray tvec, TermCriteria? criteria = null)
+    {
+        if (objectPoints is null)
+            throw new ArgumentNullException(nameof(objectPoints));
+        if (imagePoints is null)
+            throw new ArgumentNullException(nameof(imagePoints));
+        if (cameraMatrix is null)
+            throw new ArgumentNullException(nameof(cameraMatrix));
+        if (distCoeffs is null)
+            throw new ArgumentNullException(nameof(distCoeffs));
+        if (rvec is null)
+            throw new ArgumentNullException(nameof(rvec));
+        if (tvec is null)
+            throw new ArgumentNullException(nameof(tvec));
+        objectPoints.ThrowIfDisposed();
+        imagePoints.ThrowIfDisposed();
+        cameraMatrix.ThrowIfDisposed();
+        distCoeffs.ThrowIfDisposed();
+        rvec.ThrowIfNotReady();
+        tvec.ThrowIfNotReady();
+
+        var c = criteria ?? new TermCriteria(CriteriaTypes.Eps | CriteriaTypes.MaxIter, 20, 1.1920929e-07);
+        NativeMethods.HandleException(
+            NativeMethods.geometry_solvePnPRefineLM(
+                objectPoints.CvPtr, imagePoints.CvPtr, cameraMatrix.CvPtr, distCoeffs.CvPtr,
+                rvec.CvPtr, tvec.CvPtr, c));
+
+        rvec.Fix();
+        tvec.Fix();
+        GC.KeepAlive(objectPoints);
+        GC.KeepAlive(imagePoints);
+        GC.KeepAlive(cameraMatrix);
+        GC.KeepAlive(distCoeffs);
+        GC.KeepAlive(rvec);
+        GC.KeepAlive(tvec);
+    }
+
+    /// <summary>
+    /// Refines a pose (rotation and translation) from 3D-2D point correspondences, starting from an
+    /// initial solution, using a virtual visual servoing (VVS) scheme.
+    /// </summary>
+    /// <param name="objectPoints">Array of object points in the object coordinate space.</param>
+    /// <param name="imagePoints">Array of corresponding image points.</param>
+    /// <param name="cameraMatrix">Input camera intrinsic matrix.</param>
+    /// <param name="distCoeffs">Input vector of distortion coefficients. If empty, zero distortion is assumed.</param>
+    /// <param name="rvec">Input/Output rotation vector. Input values are used as the initial solution.</param>
+    /// <param name="tvec">Input/Output translation vector. Input values are used as the initial solution.</param>
+    /// <param name="criteria">Criteria when to stop the iterative algorithm.</param>
+    /// <param name="vvsLambda">Gain for the virtual visual servoing control law.</param>
+    public static void SolvePnPRefineVVS(
+        InputArray objectPoints, InputArray imagePoints, InputArray cameraMatrix, InputArray distCoeffs,
+        InputOutputArray rvec, InputOutputArray tvec, TermCriteria? criteria = null, double vvsLambda = 1)
+    {
+        if (objectPoints is null)
+            throw new ArgumentNullException(nameof(objectPoints));
+        if (imagePoints is null)
+            throw new ArgumentNullException(nameof(imagePoints));
+        if (cameraMatrix is null)
+            throw new ArgumentNullException(nameof(cameraMatrix));
+        if (distCoeffs is null)
+            throw new ArgumentNullException(nameof(distCoeffs));
+        if (rvec is null)
+            throw new ArgumentNullException(nameof(rvec));
+        if (tvec is null)
+            throw new ArgumentNullException(nameof(tvec));
+        objectPoints.ThrowIfDisposed();
+        imagePoints.ThrowIfDisposed();
+        cameraMatrix.ThrowIfDisposed();
+        distCoeffs.ThrowIfDisposed();
+        rvec.ThrowIfNotReady();
+        tvec.ThrowIfNotReady();
+
+        var c = criteria ?? new TermCriteria(CriteriaTypes.Eps | CriteriaTypes.MaxIter, 20, 1.1920929e-07);
+        NativeMethods.HandleException(
+            NativeMethods.geometry_solvePnPRefineVVS(
+                objectPoints.CvPtr, imagePoints.CvPtr, cameraMatrix.CvPtr, distCoeffs.CvPtr,
+                rvec.CvPtr, tvec.CvPtr, c, vvsLambda));
+
+        rvec.Fix();
+        tvec.Fix();
+        GC.KeepAlive(objectPoints);
+        GC.KeepAlive(imagePoints);
+        GC.KeepAlive(cameraMatrix);
+        GC.KeepAlive(distCoeffs);
+        GC.KeepAlive(rvec);
+        GC.KeepAlive(tvec);
+    }
+
+    /// <summary>
+    /// Decomposes an essential matrix to possible rotations and translation.
+    /// </summary>
+    /// <param name="e">The input essential matrix.</param>
+    /// <param name="r1">One possible rotation matrix.</param>
+    /// <param name="r2">Another possible rotation matrix.</param>
+    /// <param name="t">One possible translation (up to scale).</param>
+    public static void DecomposeEssentialMat(InputArray e, OutputArray r1, OutputArray r2, OutputArray t)
+    {
+        if (e is null)
+            throw new ArgumentNullException(nameof(e));
+        if (r1 is null)
+            throw new ArgumentNullException(nameof(r1));
+        if (r2 is null)
+            throw new ArgumentNullException(nameof(r2));
+        if (t is null)
+            throw new ArgumentNullException(nameof(t));
+        e.ThrowIfDisposed();
+        r1.ThrowIfNotReady();
+        r2.ThrowIfNotReady();
+        t.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.geometry_decomposeEssentialMat(e.CvPtr, r1.CvPtr, r2.CvPtr, t.CvPtr));
+
+        r1.Fix();
+        r2.Fix();
+        t.Fix();
+        GC.KeepAlive(e);
+        GC.KeepAlive(r1);
+        GC.KeepAlive(r2);
+        GC.KeepAlive(t);
+    }
+
+    /// <summary>
+    /// Computes an optimal translation between two 3D point sets using RANSAC.
+    /// </summary>
+    /// <param name="src">First input 3D point set.</param>
+    /// <param name="dst">Second input 3D point set.</param>
+    /// <param name="outVal">Output 3D translation vector (3x1).</param>
+    /// <param name="inliers">Output vector indicating which points are inliers.</param>
+    /// <param name="ransacThreshold">Maximum reprojection error in the RANSAC algorithm to consider a point as an inlier.</param>
+    /// <param name="confidence">Confidence level, between 0 and 1.</param>
+    /// <returns>True if a translation was found.</returns>
+    public static bool EstimateTranslation3D(
+        InputArray src, InputArray dst, OutputArray outVal, OutputArray inliers,
+        double ransacThreshold = 3, double confidence = 0.99)
+    {
+        if (src is null)
+            throw new ArgumentNullException(nameof(src));
+        if (dst is null)
+            throw new ArgumentNullException(nameof(dst));
+        if (outVal is null)
+            throw new ArgumentNullException(nameof(outVal));
+        if (inliers is null)
+            throw new ArgumentNullException(nameof(inliers));
+        src.ThrowIfDisposed();
+        dst.ThrowIfDisposed();
+        outVal.ThrowIfNotReady();
+        inliers.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.geometry_estimateTranslation3D(
+                src.CvPtr, dst.CvPtr, outVal.CvPtr, inliers.CvPtr, ransacThreshold, confidence, out var ret));
+
+        outVal.Fix();
+        inliers.Fix();
+        GC.KeepAlive(src);
+        GC.KeepAlive(dst);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Computes an optimal translation between two 2D point sets.
+    /// </summary>
+    /// <param name="from">First input 2D point set.</param>
+    /// <param name="to">Second input 2D point set.</param>
+    /// <param name="inliers">Output vector indicating which points are inliers (optional).</param>
+    /// <param name="method">Robust method used to compute the transformation.</param>
+    /// <param name="ransacReprojThreshold">Maximum reprojection error in the RANSAC algorithm to consider a point as an inlier.</param>
+    /// <param name="maxIters">The maximum number of robust method iterations.</param>
+    /// <param name="confidence">Confidence level, between 0 and 1.</param>
+    /// <param name="refineIters">Maximum number of iterations of refining algorithm (Levenberg-Marquardt).</param>
+    /// <returns>The estimated 2D translation vector.</returns>
+    public static Vec2d EstimateTranslation2D(
+        InputArray from, InputArray to, OutputArray? inliers = null,
+        RobustEstimationAlgorithms method = RobustEstimationAlgorithms.RANSAC, double ransacReprojThreshold = 3,
+        ulong maxIters = 2000, double confidence = 0.99, ulong refineIters = 0)
+    {
+        if (from is null)
+            throw new ArgumentNullException(nameof(from));
+        if (to is null)
+            throw new ArgumentNullException(nameof(to));
+        from.ThrowIfDisposed();
+        to.ThrowIfDisposed();
+        inliers?.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.geometry_estimateTranslation2D(
+                from.CvPtr, to.CvPtr, ToPtr(inliers),
+                (int)method, ransacReprojThreshold, maxIters, confidence, refineIters, out var ret));
+
+        inliers?.Fix();
+        GC.KeepAlive(from);
+        GC.KeepAlive(to);
+        GC.KeepAlive(inliers);
+        return ret;
+    }
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib_fisheye.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib_fisheye.cs
@@ -19,6 +19,10 @@ static partial class NativeMethods
         IntPtr undistorted, IntPtr distorted, IntPtr K, IntPtr D, double alpha);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus calib_fisheye_distortPoints2(
+        IntPtr undistorted, IntPtr distorted, IntPtr Kundistorted, IntPtr K, IntPtr D, double alpha);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus calib_fisheye_undistortPoints(
         IntPtr distorted, IntPtr undistorted,
         IntPtr K, IntPtr D, IntPtr R, IntPtr P);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
@@ -307,4 +307,29 @@ static partial class NativeMethods
     public static extern ExceptionStatus geometry_findEssentialMat_InputArray2(
         IntPtr points1, IntPtr points2, double focal, Point2d pp,
         int method, double prob, double threshold, IntPtr mask, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_solvePnPRefineLM(
+        IntPtr objectPoints, IntPtr imagePoints, IntPtr cameraMatrix, IntPtr distCoeffs,
+        IntPtr rvec, IntPtr tvec, TermCriteria criteria);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_solvePnPRefineVVS(
+        IntPtr objectPoints, IntPtr imagePoints, IntPtr cameraMatrix, IntPtr distCoeffs,
+        IntPtr rvec, IntPtr tvec, TermCriteria criteria, double vvsLambda);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_decomposeEssentialMat(
+        IntPtr e, IntPtr r1, IntPtr r2, IntPtr t);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_estimateTranslation3D(
+        IntPtr src, IntPtr dst, IntPtr outVal, IntPtr inliers,
+        double ransacThreshold, double confidence, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_estimateTranslation2D(
+        IntPtr from, IntPtr to, IntPtr inliers,
+        int method, double ransacReprojThreshold, ulong maxIters, double confidence, ulong refineIters,
+        out Vec2d returnValue);
 }

--- a/src/OpenCvSharpExtern/calib_fisheye.h
+++ b/src/OpenCvSharpExtern/calib_fisheye.h
@@ -34,6 +34,14 @@ CVAPI(ExceptionStatus) calib_fisheye_distortPoints(
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) calib_fisheye_distortPoints2(
+    cv::_InputArray *undistorted, cv::_OutputArray *distorted, cv::_InputArray *Kundistorted, cv::_InputArray *K, cv::_InputArray *D, double alpha)
+{
+    BEGIN_WRAP
+    cv::fisheye::distortPoints(*undistorted, *distorted, *Kundistorted, *K, *D, alpha);
+    END_WRAP
+}
+
 CVAPI(ExceptionStatus) calib_fisheye_undistortPoints(
     cv::_InputArray *distorted, cv::_OutputArray *undistorted,
     cv::_InputArray *K, cv::_InputArray *D, cv::_InputArray *R, cv::_InputArray *P)

--- a/src/OpenCvSharpExtern/geometry.h
+++ b/src/OpenCvSharpExtern/geometry.h
@@ -723,4 +723,52 @@ CVAPI(ExceptionStatus) geometry_findEssentialMat_InputArray2(
     END_WRAP
 }
 
+
+CVAPI(ExceptionStatus) geometry_solvePnPRefineLM(
+    cv::_InputArray *objectPoints, cv::_InputArray *imagePoints, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
+    cv::_InputOutputArray *rvec, cv::_InputOutputArray *tvec, MyCvTermCriteria criteria)
+{
+    BEGIN_WRAP
+    cv::solvePnPRefineLM(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, cpp(criteria));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) geometry_solvePnPRefineVVS(
+    cv::_InputArray *objectPoints, cv::_InputArray *imagePoints, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
+    cv::_InputOutputArray *rvec, cv::_InputOutputArray *tvec, MyCvTermCriteria criteria, double vvsLambda)
+{
+    BEGIN_WRAP
+    cv::solvePnPRefineVVS(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, cpp(criteria), vvsLambda);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) geometry_decomposeEssentialMat(
+    cv::_InputArray *e, cv::_OutputArray *r1, cv::_OutputArray *r2, cv::_OutputArray *t)
+{
+    BEGIN_WRAP
+    cv::decomposeEssentialMat(*e, *r1, *r2, *t);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) geometry_estimateTranslation3D(
+    cv::_InputArray *src, cv::_InputArray *dst, cv::_OutputArray *out, cv::_OutputArray *inliers,
+    double ransacThreshold, double confidence, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = cv::estimateTranslation3D(*src, *dst, *out, *inliers, ransacThreshold, confidence) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) geometry_estimateTranslation2D(
+    cv::_InputArray *from, cv::_InputArray *to, cv::_OutputArray *inliers,
+    int method, double ransacReprojThreshold, uint64_t maxIters, double confidence, uint64_t refineIters,
+    cv::Vec2d *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = cv::estimateTranslation2D(
+        *from, *to, entity(inliers), method, ransacReprojThreshold,
+        static_cast<size_t>(maxIters), confidence, static_cast<size_t>(refineIters));
+    END_WRAP
+}
+
 #endif // NO_GEOMETRY

--- a/test/OpenCvSharp.Tests/calib3d/GeometryFunctionsTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/GeometryFunctionsTest.cs
@@ -1,0 +1,168 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Calib3D;
+
+// Tests for the OpenCV 5 geometry/calib functions added to OpenCvSharp:
+// SolvePnPRefineLM/VVS, DecomposeEssentialMat, EstimateTranslation2D/3D and the
+// fisheye DistortPoints overload with a separate undistorted-camera matrix.
+public class GeometryFunctionsTest : TestBase
+{
+    private static readonly double[,] CameraMatrix =
+    {
+        { 800, 0, 320 },
+        { 0, 800, 240 },
+        { 0, 0, 1 }
+    };
+
+    private static Point3f[] ObjectPoints => new[]
+    {
+        new Point3f(0, 0, 0), new Point3f(1, 0, 0), new Point3f(0, 1, 0), new Point3f(1, 1, 0),
+        new Point3f(0, 0, 1), new Point3f(1, 0, 1), new Point3f(0, 1, 1), new Point3f(1, 1, 1)
+    };
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SolvePnPRefine(bool useVvs)
+    {
+        var rvecTrue = new[] { 0.1, -0.05, 0.02 };
+        var tvecTrue = new[] { 0.1, 0.2, -8.0 };
+        var dist = new double[5];
+        var objPts = ObjectPoints;
+
+        Cv2.ProjectPoints(objPts, rvecTrue, tvecTrue, CameraMatrix, dist, out var imgPts, out _);
+
+        using var objMat = Mat.FromPixelData(objPts.Length, 1, MatType.CV_32FC3, objPts);
+        using var imgMat = Mat.FromPixelData(imgPts.Length, 1, MatType.CV_32FC2, imgPts);
+        using var camMat = Mat.FromPixelData(3, 3, MatType.CV_64FC1, CameraMatrix);
+        using var distMat = Mat.FromPixelData(5, 1, MatType.CV_64FC1, dist);
+        using var rvecMat = Mat.FromPixelData(3, 1, MatType.CV_64FC1, (double[])rvecTrue.Clone());
+        using var tvecMat = Mat.FromPixelData(3, 1, MatType.CV_64FC1, (double[])tvecTrue.Clone());
+
+        // Starting from the exact solution, the refinement must keep the pose near the truth.
+        if (useVvs)
+            Cv2.SolvePnPRefineVVS(objMat, imgMat, camMat, distMat, rvecMat, tvecMat);
+        else
+            Cv2.SolvePnPRefineLM(objMat, imgMat, camMat, distMat, rvecMat, tvecMat);
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.True(Math.Abs(rvecMat.Get<double>(i) - rvecTrue[i]) < 1e-3, $"rvec[{i}]");
+            Assert.True(Math.Abs(tvecMat.Get<double>(i) - tvecTrue[i]) < 1e-3, $"tvec[{i}]");
+        }
+    }
+
+    [Fact]
+    public void DecomposeEssentialMat()
+    {
+        // E = [t]_x * R, with R = I and t = (0, 0, 1)  =>  E = [[0,-1,0],[1,0,0],[0,0,0]]
+        using var e = Mat.FromPixelData(3, 3, MatType.CV_64FC1, new double[]
+        {
+            0, -1, 0,
+            1, 0, 0,
+            0, 0, 0
+        });
+        using var r1 = new Mat();
+        using var r2 = new Mat();
+        using var t = new Mat();
+
+        Cv2.DecomposeEssentialMat(e, r1, r2, t);
+
+        Assert.Equal(3, r1.Rows);
+        Assert.Equal(3, r1.Cols);
+        Assert.Equal(3, r2.Rows);
+        Assert.Equal(3, r2.Cols);
+        Assert.Equal(3, (int)t.Total());
+
+        // Both candidate rotations must be proper rotation matrices.
+        Assert.True(Math.Abs(Cv2.Determinant(r1) - 1.0) < 1e-6);
+        Assert.True(Math.Abs(Cv2.Determinant(r2) - 1.0) < 1e-6);
+
+        // The translation is recovered up to scale (unit norm) along z.
+        using var tD = new Mat();
+        t.ConvertTo(tD, MatType.CV_64F);
+        var norm = Math.Sqrt(
+            (tD.Get<double>(0) * tD.Get<double>(0)) +
+            (tD.Get<double>(1) * tD.Get<double>(1)) +
+            (tD.Get<double>(2) * tD.Get<double>(2)));
+        Assert.True(Math.Abs(norm - 1.0) < 1e-6);
+        Assert.True(Math.Abs(tD.Get<double>(2)) > 0.99);
+    }
+
+    [Fact]
+    public void EstimateTranslation3D()
+    {
+        var t = new[] { 1.0, 2.0, 3.0 };
+
+        // Use exactly the minimal sample size (4 points) so the estimator solves directly
+        // instead of going through random RANSAC sampling (deterministic result).
+        var src = new float[]
+        {
+            0, 0, 0,
+            10, 0, 0,
+            0, 10, 0,
+            0, 0, 10
+        };
+        var dst = new float[src.Length];
+        for (var i = 0; i < src.Length; i++)
+            dst[i] = (float)(src[i] + t[i % 3]);
+
+        using var srcMat = Mat.FromPixelData(4, 1, MatType.CV_32FC3, src);
+        using var dstMat = Mat.FromPixelData(4, 1, MatType.CV_32FC3, dst);
+        using var outMat = new Mat();
+        using var inliers = new Mat();
+
+        var found = Cv2.EstimateTranslation3D(srcMat, dstMat, outMat, inliers);
+        Assert.True(found);
+
+        using var outD = new Mat();
+        outMat.ConvertTo(outD, MatType.CV_64F);
+        outD.GetArray(out double[] outVals);
+        Assert.Equal(3, outVals.Length);
+        Assert.True(Math.Abs(outVals[0] - t[0]) < 1e-2);
+        Assert.True(Math.Abs(outVals[1] - t[1]) < 1e-2);
+        Assert.True(Math.Abs(outVals[2] - t[2]) < 1e-2);
+    }
+
+    [Fact]
+    public void EstimateTranslation2D()
+    {
+        var tx = 5.0;
+        var ty = -3.0;
+        var from = new Point2f[20];
+        var to = new Point2f[20];
+        var rng = new Random(7);
+        for (var i = 0; i < from.Length; i++)
+        {
+            from[i] = new Point2f((float)rng.NextDouble() * 100, (float)rng.NextDouble() * 100);
+            to[i] = new Point2f((float)(from[i].X + tx), (float)(from[i].Y + ty));
+        }
+
+        using var fromMat = Mat.FromPixelData(from.Length, 1, MatType.CV_32FC2, from);
+        using var toMat = Mat.FromPixelData(to.Length, 1, MatType.CV_32FC2, to);
+
+        var result = Cv2.EstimateTranslation2D(fromMat, toMat);
+        Assert.True(Math.Abs(result.Item0 - tx) < 1e-2);
+        Assert.True(Math.Abs(result.Item1 - ty) < 1e-2);
+    }
+
+    [Fact]
+    public void FishEyeDistortPointsWithUndistortedMatrix()
+    {
+        var pts = new[] { new Point2f(0.1f, 0.05f), new Point2f(-0.2f, 0.15f), new Point2f(0.0f, 0.0f) };
+        using var undistorted = Mat.FromPixelData(pts.Length, 1, MatType.CV_32FC2, pts);
+        using var distorted = new Mat();
+        using var k = Mat.FromPixelData(3, 3, MatType.CV_64FC1, new double[]
+        {
+            300, 0, 160,
+            0, 300, 120,
+            0, 0, 1
+        });
+        using var kUndistorted = k.Clone();
+        using var d = Mat.FromPixelData(4, 1, MatType.CV_64FC1, new[] { 0.1, 0.01, 0.0, 0.0 });
+
+        Cv2.FishEye.DistortPoints(undistorted, distorted, kUndistorted, k, d);
+
+        Assert.Equal(pts.Length, (int)distorted.Total());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the previously-missing OpenCV 5 geometry/calib functions from #1924.

### New functions (on `Cv2`)
- **`SolvePnPRefineLM`** / **`SolvePnPRefineVVS`** — refine a pose (rvec/tvec) from an initial solution. LM takes a `TermCriteria`; VVS additionally takes a `vvsLambda` gain. `rvec`/`tvec` are `InputOutputArray` (read initial, write refined).
- **`DecomposeEssentialMat`** — decompose an essential matrix into the two candidate rotations and the translation `(R1, R2, t)`.
- **`EstimateTranslation2D`** — returns the optimal 2D translation as `Vec2d`.
- **`EstimateTranslation3D`** — RANSAC estimate of an optimal 3D translation; returns whether one was found plus the inlier mask.
- **`FishEye.DistortPoints`** overload taking a separate undistorted-camera matrix `Kundistorted` (the basic fisheye `distortPoints(K, D)` was already wrapped; this is the new OpenCV 5 overload).

### Native bridge
- New entry points in `geometry.h` (`solvePnPRefineLM/VVS`, `decomposeEssentialMat`, `estimateTranslation2D/3D`) and `calib_fisheye.h` (`distortPoints2`).
- `distortPoints` lives under `cv::fisheye::` in OpenCV 5, so the overload is added to the fisheye wrappers, not the generic geometry ones.

## Test
`GeometryFunctionsTest` covers all five via `Cv2`:
- Pose-refinement round-trip (LM + VVS) starting from the exact solution.
- Essential-matrix decomposition: rotation determinants ≈ 1 and unit-norm translation.
- Exact 2D/3D translation recovery.
- Fisheye distort smoke test.

Rebuilt `OpenCvSharpExtern` locally; full Calib3D suite green (26 passed, 1 pre-existing skip).

Note: `calibrateMultiview` / `registerCameras` (multi-view calibration) remain tracked separately in #1924.

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
