### PR TITLE
Add ptcloud mesh / point cloud I/O: loadPointCloud, savePointCloud, loadMesh, saveMesh

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
@@ -1,4 +1,5 @@
 ﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo
@@ -229,5 +230,126 @@ static partial class Cv2
         planeCoefficients.Fix();
         GC.KeepAlive(points3d);
         GC.KeepAlive(normals);
+    }
+
+    /// <summary>
+    /// Loads a point cloud from a file (.ply / .obj). The file format is chosen by the extension.
+    /// </summary>
+    /// <param name="filename">Name of the file.</param>
+    /// <param name="vertices">Output vertex coordinates, each value contains 3 floats.</param>
+    /// <param name="normals">Output per-vertex normals, each value contains 3 floats (optional).</param>
+    /// <param name="rgb">Output per-vertex colors, each value contains 3 floats (optional).</param>
+    public static void LoadPointCloud(string filename, OutputArray vertices, OutputArray? normals = null, OutputArray? rgb = null)
+    {
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+        if (vertices is null)
+            throw new ArgumentNullException(nameof(vertices));
+        vertices.ThrowIfNotReady();
+        normals?.ThrowIfNotReady();
+        rgb?.ThrowIfNotReady();
+
+        NativeMethods.HandleException(
+            NativeMethods.ptcloud_loadPointCloud(filename, vertices.CvPtr, ToPtr(normals), ToPtr(rgb)));
+
+        vertices.Fix();
+        normals?.Fix();
+        rgb?.Fix();
+    }
+
+    /// <summary>
+    /// Saves a point cloud to a file (.ply / .obj). The file format is chosen by the extension.
+    /// </summary>
+    /// <param name="filename">Name of the file.</param>
+    /// <param name="vertices">Vertex coordinates, each value contains 3 floats.</param>
+    /// <param name="normals">Per-vertex normals, each value contains 3 floats (optional).</param>
+    /// <param name="rgb">Per-vertex colors, each value contains 3 floats (optional).</param>
+    public static void SavePointCloud(string filename, InputArray vertices, InputArray? normals = null, InputArray? rgb = null)
+    {
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+        if (vertices is null)
+            throw new ArgumentNullException(nameof(vertices));
+        vertices.ThrowIfDisposed();
+        normals?.ThrowIfDisposed();
+        rgb?.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.ptcloud_savePointCloud(filename, vertices.CvPtr, ToPtr(normals), ToPtr(rgb)));
+
+        GC.KeepAlive(vertices);
+        GC.KeepAlive(normals);
+        GC.KeepAlive(rgb);
+    }
+
+    /// <summary>
+    /// Loads a mesh from a file (.ply / .obj). The file format is chosen by the extension.
+    /// </summary>
+    /// <param name="filename">Name of the file.</param>
+    /// <param name="vertices">Output vertex coordinates, each value contains 3 floats.</param>
+    /// <param name="indices">Output per-face list of vertex indices; each element is a vector of ints.</param>
+    /// <param name="normals">Output per-vertex normals, each value contains 3 floats (optional).</param>
+    /// <param name="colors">Output per-vertex colors, each value contains 3 floats (optional).</param>
+    /// <param name="texCoords">Output per-vertex texture coordinates, each value contains 2 or 3 floats (optional).</param>
+    public static void LoadMesh(
+        string filename, OutputArray vertices, out Mat[] indices,
+        OutputArray? normals = null, OutputArray? colors = null, OutputArray? texCoords = null)
+    {
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+        if (vertices is null)
+            throw new ArgumentNullException(nameof(vertices));
+        vertices.ThrowIfNotReady();
+        normals?.ThrowIfNotReady();
+        colors?.ThrowIfNotReady();
+        texCoords?.ThrowIfNotReady();
+
+        using var indicesVec = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.ptcloud_loadMesh(
+                filename, vertices.CvPtr, indicesVec.CvPtr, ToPtr(normals), ToPtr(colors), ToPtr(texCoords)));
+
+        vertices.Fix();
+        normals?.Fix();
+        colors?.Fix();
+        texCoords?.Fix();
+        indices = indicesVec.ToArray();
+    }
+
+    /// <summary>
+    /// Saves a mesh to a file (.ply / .obj). The file format is chosen by the extension.
+    /// </summary>
+    /// <param name="filename">Name of the file.</param>
+    /// <param name="vertices">Vertex coordinates, each value contains 3 floats.</param>
+    /// <param name="indices">Per-face list of vertex indices; each element is a vector of ints.</param>
+    /// <param name="normals">Per-vertex normals, each value contains 3 floats (optional).</param>
+    /// <param name="colors">Per-vertex colors, each value contains 3 floats (optional).</param>
+    /// <param name="texCoords">Per-vertex texture coordinates, each value contains 2 or 3 floats (optional).</param>
+    public static void SaveMesh(
+        string filename, InputArray vertices, IEnumerable<Mat> indices,
+        InputArray? normals = null, InputArray? colors = null, InputArray? texCoords = null)
+    {
+        if (filename is null)
+            throw new ArgumentNullException(nameof(filename));
+        if (vertices is null)
+            throw new ArgumentNullException(nameof(vertices));
+        if (indices is null)
+            throw new ArgumentNullException(nameof(indices));
+        vertices.ThrowIfDisposed();
+        normals?.ThrowIfDisposed();
+        colors?.ThrowIfDisposed();
+        texCoords?.ThrowIfDisposed();
+
+        var indicesArray = indices as Mat[] ?? indices.ToArray();
+        using var indicesVec = new VectorOfMat(indicesArray);
+        NativeMethods.HandleException(
+            NativeMethods.ptcloud_saveMesh(
+                filename, vertices.CvPtr, indicesVec.CvPtr, ToPtr(normals), ToPtr(colors), ToPtr(texCoords)));
+
+        GC.KeepAlive(vertices);
+        GC.KeepAlive(normals);
+        GC.KeepAlive(colors);
+        GC.KeepAlive(texCoords);
+        GC.KeepAlive(indicesArray);
     }
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_io.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_io.cs
@@ -1,0 +1,81 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // ReSharper disable InconsistentNaming
+
+    // loadPointCloud
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_loadPointCloud")]
+    public static extern ExceptionStatus ptcloud_loadPointCloud_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_loadPointCloud")]
+    public static extern ExceptionStatus ptcloud_loadPointCloud_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+
+    public static ExceptionStatus ptcloud_loadPointCloud(string filename, IntPtr vertices, IntPtr normals, IntPtr rgb)
+        => IsWindows()
+            ? ptcloud_loadPointCloud_Windows(filename, vertices, normals, rgb)
+            : ptcloud_loadPointCloud_NotWindows(filename, vertices, normals, rgb);
+
+    // savePointCloud
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_savePointCloud")]
+    public static extern ExceptionStatus ptcloud_savePointCloud_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_savePointCloud")]
+    public static extern ExceptionStatus ptcloud_savePointCloud_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+
+    public static ExceptionStatus ptcloud_savePointCloud(string filename, IntPtr vertices, IntPtr normals, IntPtr rgb)
+        => IsWindows()
+            ? ptcloud_savePointCloud_Windows(filename, vertices, normals, rgb)
+            : ptcloud_savePointCloud_NotWindows(filename, vertices, normals, rgb);
+
+    // loadMesh
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_loadMesh")]
+    public static extern ExceptionStatus ptcloud_loadMesh_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_loadMesh")]
+    public static extern ExceptionStatus ptcloud_loadMesh_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+
+    public static ExceptionStatus ptcloud_loadMesh(string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords)
+        => IsWindows()
+            ? ptcloud_loadMesh_Windows(filename, vertices, indices, normals, colors, texCoords)
+            : ptcloud_loadMesh_NotWindows(filename, vertices, indices, normals, colors, texCoords);
+
+    // saveMesh
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_saveMesh")]
+    public static extern ExceptionStatus ptcloud_saveMesh_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "ptcloud_saveMesh")]
+    public static extern ExceptionStatus ptcloud_saveMesh_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+
+    public static ExceptionStatus ptcloud_saveMesh(string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords)
+        => IsWindows()
+            ? ptcloud_saveMesh_Windows(filename, vertices, indices, normals, colors, texCoords)
+            : ptcloud_saveMesh_NotWindows(filename, vertices, indices, normals, colors, texCoords);
+}

--- a/src/OpenCvSharpExtern/ptcloud.cpp
+++ b/src/OpenCvSharpExtern/ptcloud.cpp
@@ -6,3 +6,4 @@
 #include "ptcloud_Odometry.h"
 #include "ptcloud_RgbdNormals.h"
 #include "ptcloud_depth.h"
+#include "ptcloud_io.h"

--- a/src/OpenCvSharpExtern/ptcloud_io.h
+++ b/src/OpenCvSharpExtern/ptcloud_io.h
@@ -1,0 +1,46 @@
+﻿#pragma once
+
+#ifndef NO_PTCLOUD
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+#include <opencv2/ptcloud.hpp>
+
+CVAPI(ExceptionStatus) ptcloud_loadPointCloud(
+    const char *filename, cv::_OutputArray *vertices, cv::_OutputArray *normals, cv::_OutputArray *rgb)
+{
+    BEGIN_WRAP
+    cv::loadPointCloud(filename, *vertices, entity(normals), entity(rgb));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) ptcloud_savePointCloud(
+    const char *filename, cv::_InputArray *vertices, cv::_InputArray *normals, cv::_InputArray *rgb)
+{
+    BEGIN_WRAP
+    cv::savePointCloud(filename, *vertices, entity(normals), entity(rgb));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) ptcloud_loadMesh(
+    const char *filename, cv::_OutputArray *vertices, std::vector<cv::Mat> *indices,
+    cv::_OutputArray *normals, cv::_OutputArray *colors, cv::_OutputArray *texCoords)
+{
+    BEGIN_WRAP
+    cv::loadMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) ptcloud_saveMesh(
+    const char *filename, cv::_InputArray *vertices, std::vector<cv::Mat> *indices,
+    cv::_InputArray *normals, cv::_InputArray *colors, cv::_InputArray *texCoords)
+{
+    BEGIN_WRAP
+    cv::saveMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
+    END_WRAP
+}
+
+#endif // NO_PTCLOUD

--- a/test/OpenCvSharp.Tests/ptcloud/PtCloudIoTest.cs
+++ b/test/OpenCvSharp.Tests/ptcloud/PtCloudIoTest.cs
@@ -1,0 +1,89 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.PtCloud;
+
+// Tests for the OpenCV 5 ptcloud mesh / point cloud I/O (loadPointCloud / savePointCloud /
+// loadMesh / saveMesh) added to OpenCvSharp.
+public class PtCloudIoTest : TestBase
+{
+    private static readonly float[] Vertices =
+    {
+        0f, 0f, 0f,
+        1f, 0f, 0f,
+        0f, 1f, 0f,
+        1f, 1f, 1f
+    };
+
+    [Theory]
+    [InlineData(".ply")]
+    [InlineData(".obj")]
+    public void PointCloudRoundTrip(string ext)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ocvs_pc_{Guid.NewGuid():N}{ext}");
+        try
+        {
+            using var src = Mat.FromPixelData(4, 1, MatType.CV_32FC3, (float[])Vertices.Clone());
+            Cv2.SavePointCloud(path, src);
+            Assert.True(File.Exists(path));
+
+            using var loaded = new Mat();
+            Cv2.LoadPointCloud(path, loaded);
+
+            Assert.Equal(4, (int)loaded.Total());
+
+            using var flat = loaded.Reshape(1, (int)loaded.Total() * loaded.Channels());
+            flat.GetArray(out float[] vals);
+            Assert.Equal(Vertices.Length, vals.Length);
+            for (var i = 0; i < Vertices.Length; i++)
+                Assert.True(Math.Abs(vals[i] - Vertices[i]) < 1e-4, $"vertex component {i}");
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void MeshRoundTrip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ocvs_mesh_{Guid.NewGuid():N}.ply");
+        try
+        {
+            using var verts = Mat.FromPixelData(4, 1, MatType.CV_32FC3, (float[])Vertices.Clone());
+
+            // Tetrahedron: 4 triangular faces.
+            var faces = new[]
+            {
+                new[] { 0, 1, 2 },
+                new[] { 0, 1, 3 },
+                new[] { 0, 2, 3 },
+                new[] { 1, 2, 3 }
+            };
+            var indexMats = faces.Select(f => Mat.FromPixelData(1, 3, MatType.CV_32SC1, f)).ToArray();
+            try
+            {
+                Cv2.SaveMesh(path, verts, indexMats);
+                Assert.True(File.Exists(path));
+
+                using var loadedVerts = new Mat();
+                Cv2.LoadMesh(path, loadedVerts, out var loadedIndices);
+
+                Assert.Equal(4, (int)loadedVerts.Total());
+                Assert.Equal(faces.Length, loadedIndices.Length);
+                foreach (var idx in loadedIndices)
+                    idx.Dispose();
+            }
+            finally
+            {
+                foreach (var m in indexMats)
+                    m.Dispose();
+            }
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the OpenCV 5 `ptcloud` module's mesh / point cloud file I/O (from #1924).

### New functions (on `Cv2`)
- **`LoadPointCloud`** / **`SavePointCloud`** — vertices plus optional per-vertex normals and RGB.
- **`LoadMesh`** / **`SaveMesh`** — vertices, per-face index arrays (returned/accepted as `Mat[]` via `VectorOfMat`, since `indices` is `(Output|Input)ArrayOfArrays`), plus optional normals / colors / texture coordinates.

File format (`.ply` / `.obj`) is chosen from the filename extension.

### Native bridge
- New `ptcloud_io.h` with the four entry points; included from `ptcloud.cpp`.
- File-path strings use the existing Windows/NotWindows marshaling split.

## Test
`PtCloudIoTest`:
- Point cloud round-trip for both `.ply` and `.obj` (save → load → compare 4 vertices component-wise).
- Tetrahedron mesh round-trip (`.ply`): 4 vertices + 4 triangular faces survive save/load.

Rebuilt `OpenCvSharpExtern` locally; full PtCloud suite green (16 passed).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
