### PR TITLE
Add imgproc TrueType text rendering: FontFace + FontFace-based PutText/GetTextSize

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -5030,6 +5030,75 @@ static partial class Cv2
         return ret;
     }
 
+    /// <summary>
+    /// Draws a text string using the specified TrueType font (OpenCV 5). Symbols that cannot be
+    /// rendered using the specified font are replaced by question marks.
+    /// </summary>
+    /// <param name="img">Image.</param>
+    /// <param name="text">Text string to be drawn (UTF-8 / Unicode is supported).</param>
+    /// <param name="org">Bottom-left corner of the first character of the printed text (see <see cref="PutTextFlags"/>).</param>
+    /// <param name="color">Text color.</param>
+    /// <param name="fontFace">The font to use for the text.</param>
+    /// <param name="size">Font size in pixels (by default) or pts.</param>
+    /// <param name="weight">Font weight, 100..1000 (400 is "regular", 700 is "bold"). 0 uses the weight set via <see cref="FontFace.SetInstance"/>.</param>
+    /// <param name="flags">Various flags, see <see cref="PutTextFlags"/>.</param>
+    /// <param name="wrap">Optional text wrapping range. Null uses the default behavior.</param>
+    /// <returns>The coordinates in pixels from where the text can be continued.</returns>
+    public static Point PutText(
+        InputOutputArray img, string text, Point org, Scalar color, FontFace fontFace, int size,
+        int weight = 0, PutTextFlags flags = PutTextFlags.AlignLeft, Range? wrap = null)
+    {
+        if (img is null)
+            throw new ArgumentNullException(nameof(img));
+        if (text is null)
+            throw new ArgumentNullException(nameof(text));
+        if (fontFace is null)
+            throw new ArgumentNullException(nameof(fontFace));
+        img.ThrowIfDisposed();
+        fontFace.ThrowIfDisposed();
+
+        var w = wrap ?? new Range(0, 0);
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_putText_FontFace(
+                img.CvPtr, text, org, color, fontFace.CvPtr, size, weight, (int)flags, w.Start, w.End, out var ret));
+
+        img.Fix();
+        GC.KeepAlive(img);
+        GC.KeepAlive(fontFace);
+        return ret;
+    }
+
+    /// <summary>
+    /// Calculates the bounding rect for the text rendered with the specified TrueType font (OpenCV 5).
+    /// </summary>
+    /// <param name="imgsize">Size of the target image; can be empty.</param>
+    /// <param name="text">Text string to be measured (UTF-8 / Unicode is supported).</param>
+    /// <param name="org">Bottom-left corner of the first character (see <see cref="PutTextFlags"/>).</param>
+    /// <param name="fontFace">The font to use for the text.</param>
+    /// <param name="size">Font size in pixels (by default) or pts.</param>
+    /// <param name="weight">Font weight, 100..1000. 0 uses the default/instance weight.</param>
+    /// <param name="flags">Various flags, see <see cref="PutTextFlags"/>.</param>
+    /// <param name="wrap">Optional text wrapping range. Null uses the default behavior.</param>
+    /// <returns>The bounding rectangle of the text.</returns>
+    public static Rect GetTextSize(
+        Size imgsize, string text, Point org, FontFace fontFace, int size,
+        int weight = 0, PutTextFlags flags = PutTextFlags.AlignLeft, Range? wrap = null)
+    {
+        if (text is null)
+            throw new ArgumentNullException(nameof(text));
+        if (fontFace is null)
+            throw new ArgumentNullException(nameof(fontFace));
+        fontFace.ThrowIfDisposed();
+
+        var w = wrap ?? new Range(0, 0);
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_getTextSize_FontFace(
+                imgsize, text, org, fontFace.CvPtr, size, weight, (int)flags, w.Start, w.End, out var ret));
+
+        GC.KeepAlive(fontFace);
+        return ret;
+    }
+
     #endregion
 
     /// <summary>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
@@ -1,0 +1,70 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // ReSharper disable InconsistentNaming
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_FontFace_new1(out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "imgproc_FontFace_new2")]
+    public static extern ExceptionStatus imgproc_FontFace_new2_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string fontPathOrName, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "imgproc_FontFace_new2")]
+    public static extern ExceptionStatus imgproc_FontFace_new2_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string fontPathOrName, out IntPtr returnValue);
+
+    public static ExceptionStatus imgproc_FontFace_new2(string fontPathOrName, out IntPtr returnValue)
+        => IsWindows()
+            ? imgproc_FontFace_new2_Windows(fontPathOrName, out returnValue)
+            : imgproc_FontFace_new2_NotWindows(fontPathOrName, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_FontFace_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "imgproc_FontFace_set")]
+    public static extern ExceptionStatus imgproc_FontFace_set_NotWindows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string fontPathOrName, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "imgproc_FontFace_set")]
+    public static extern ExceptionStatus imgproc_FontFace_set_Windows(
+        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string fontPathOrName, out int returnValue);
+
+    public static ExceptionStatus imgproc_FontFace_set(IntPtr obj, string fontPathOrName, out int returnValue)
+        => IsWindows()
+            ? imgproc_FontFace_set_Windows(obj, fontPathOrName, out returnValue)
+            : imgproc_FontFace_set_NotWindows(obj, fontPathOrName, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_FontFace_getName(IntPtr obj, IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_FontFace_setInstance(IntPtr obj, int[] @params, int paramsLength, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_FontFace_getInstance(IntPtr obj, IntPtr @params, out int returnValue);
+
+    // putText / getTextSize with FontFace (text is UTF-8 for full Unicode support)
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus imgproc_putText_FontFace(
+        IntPtr img, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org, Scalar color,
+        IntPtr fface, int size, int weight, int flags, int wrapStart, int wrapEnd, out Point returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus imgproc_getTextSize_FontFace(
+        Size imgsize, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org,
+        IntPtr fface, int size, int weight, int flags, int wrapStart, int wrapEnd, out Rect returnValue);
+}

--- a/src/OpenCvSharp/Modules/imgproc/Enum/PutTextFlags.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Enum/PutTextFlags.cs
@@ -1,0 +1,44 @@
+﻿namespace OpenCvSharp;
+
+/// <summary>
+/// Flags for the FontFace-based <see cref="Cv2.PutText(InputOutputArray, string, Point, Scalar, FontFace, int, int, PutTextFlags, OpenCvSharp.Range?)"/>
+/// and <see cref="Cv2.GetTextSize(Size, string, Point, FontFace, int, int, PutTextFlags, OpenCvSharp.Range?)"/> (OpenCV 5).
+/// </summary>
+[Flags]
+public enum PutTextFlags
+{
+    /// <summary>
+    /// Put the text to the right from the origin.
+    /// </summary>
+    AlignLeft = 0,
+
+    /// <summary>
+    /// Center the text at the origin (not implemented yet in OpenCV).
+    /// </summary>
+    AlignCenter = 1,
+
+    /// <summary>
+    /// Put the text to the left of the origin.
+    /// </summary>
+    AlignRight = 2,
+
+    /// <summary>
+    /// Alignment mask.
+    /// </summary>
+    AlignMask = 3,
+
+    /// <summary>
+    /// Treat the target image as having a top-left origin (default).
+    /// </summary>
+    OriginTL = 0,
+
+    /// <summary>
+    /// Treat the target image as having a bottom-left origin.
+    /// </summary>
+    OriginBL = 32,
+
+    /// <summary>
+    /// Wrap text to the next line if it does not fit.
+    /// </summary>
+    Wrap = 128
+}

--- a/src/OpenCvSharp/Modules/imgproc/FontFace.cs
+++ b/src/OpenCvSharp/Modules/imgproc/FontFace.cs
@@ -1,0 +1,113 @@
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// TrueType font face used by the FontFace-based <see cref="Cv2.PutText(InputOutputArray, string, Point, Scalar, FontFace, int, int, PutTextFlags, OpenCvSharp.Range?)"/>
+/// and <see cref="Cv2.GetTextSize(Size, string, Point, FontFace, int, int, PutTextFlags, OpenCvSharp.Range?)"/> (OpenCV 5).
+/// </summary>
+public class FontFace : CvObject
+{
+    /// <summary>
+    /// Loads the default embedded font.
+    /// </summary>
+    public FontFace()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_FontFace_new1(out var p));
+        if (p == IntPtr.Zero)
+            throw new OpenCvSharpException($"Failed to create {nameof(FontFace)}");
+        InitSafeHandle(p);
+    }
+
+    /// <summary>
+    /// Loads the font at the specified path or with the specified embedded name.
+    /// </summary>
+    /// <param name="fontPathOrName">Either a path to a custom font or the name of an embedded font
+    /// ("sans", "italic" or "uni"). An empty string means the default embedded font.</param>
+    public FontFace(string fontPathOrName)
+    {
+        if (fontPathOrName is null)
+            throw new ArgumentNullException(nameof(fontPathOrName));
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_FontFace_new2(fontPathOrName, out var p));
+        if (p == IntPtr.Zero)
+            throw new OpenCvSharpException($"Failed to create {nameof(FontFace)}");
+        InitSafeHandle(p);
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.imgproc_FontFace_delete(h))));
+    }
+
+    /// <summary>
+    /// Loads a new font face.
+    /// </summary>
+    /// <param name="fontPathOrName">Either a path to a custom font or the name of an embedded font.</param>
+    /// <returns>True on success.</returns>
+    public bool Set(string fontPathOrName)
+    {
+        if (fontPathOrName is null)
+            throw new ArgumentNullException(nameof(fontPathOrName));
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_FontFace_set(CvPtr, fontPathOrName, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Gets the current font name.
+    /// </summary>
+    public string Name
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var stdString = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.imgproc_FontFace_getName(CvPtr, stdString.CvPtr));
+            GC.KeepAlive(this);
+            return stdString.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Sets the current variable-font instance.
+    /// </summary>
+    /// <param name="params">The list of pairs key1, value1, key2, value2, ... Values are in 16.16 fixed-point
+    /// format (integer values must be shifted left by 16, i.e. multiplied by 65536).</param>
+    /// <returns>True on success.</returns>
+    public bool SetInstance(int[] @params)
+    {
+        if (@params is null)
+            throw new ArgumentNullException(nameof(@params));
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_FontFace_setInstance(CvPtr, @params, @params.Length, out var ret));
+        GC.KeepAlive(this);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Gets the current variable-font instance parameters.
+    /// </summary>
+    /// <param name="params">Output list of key/value pairs.</param>
+    /// <returns>True on success.</returns>
+    public bool GetInstance(out int[] @params)
+    {
+        ThrowIfDisposed();
+
+        using var vec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_FontFace_getInstance(CvPtr, vec.CvPtr, out var ret));
+        GC.KeepAlive(this);
+        @params = vec.ToArray();
+        return ret != 0;
+    }
+}

--- a/src/OpenCvSharpExtern/imgproc.cpp
+++ b/src/OpenCvSharpExtern/imgproc.cpp
@@ -7,3 +7,4 @@
 #include "imgproc_Segmentation.h"
 #include "imgproc_LineSegmentDetector.h"
 #include "imgproc_undistort.h"
+#include "imgproc_FontFace.h"

--- a/src/OpenCvSharpExtern/imgproc_FontFace.h
+++ b/src/OpenCvSharpExtern/imgproc_FontFace.h
@@ -1,0 +1,91 @@
+﻿#pragma once
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region FontFace
+
+CVAPI(ExceptionStatus) imgproc_FontFace_new1(cv::FontFace **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::FontFace();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_new2(const char *fontPathOrName, cv::FontFace **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::FontFace(cv::String(fontPathOrName));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_delete(cv::FontFace *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_set(cv::FontFace *obj, const char *fontPathOrName, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->set(cv::String(fontPathOrName)) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_getName(cv::FontFace *obj, std::string *returnValue)
+{
+    BEGIN_WRAP
+    returnValue->assign(obj->getName());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_setInstance(cv::FontFace *obj, int *params, int paramsLength, int *returnValue)
+{
+    BEGIN_WRAP
+    const std::vector<int> v(params, params + paramsLength);
+    *returnValue = obj->setInstance(v) ? 1 : 0;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(cv::FontFace *obj, std::vector<int> *params, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->getInstance(*params) ? 1 : 0;
+    END_WRAP
+}
+
+#pragma endregion
+
+#pragma region putText / getTextSize with FontFace
+
+CVAPI(ExceptionStatus) imgproc_putText_FontFace(
+    cv::_InputOutputArray *img, const char *text, MyCvPoint org, MyCvScalar color,
+    cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
+    MyCvPoint *returnValue)
+{
+    BEGIN_WRAP
+    const auto p = cv::putText(
+        *img, cv::String(text), cpp(org), cpp(color), *fface, size, weight,
+        static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
+    *returnValue = c(p);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_getTextSize_FontFace(
+    MyCvSize imgsize, const char *text, MyCvPoint org,
+    cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
+    MyCvRect *returnValue)
+{
+    BEGIN_WRAP
+    const auto r = cv::getTextSize(
+        cpp(imgsize), cv::String(text), cpp(org), *fface, size, weight,
+        static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
+    *returnValue = c(r);
+    END_WRAP
+}
+
+#pragma endregion

--- a/test/OpenCvSharp.Tests/imgproc/FontFaceTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/FontFaceTest.cs
@@ -1,0 +1,71 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.ImgProc;
+
+// Tests for the OpenCV 5 built-in TrueType text rendering (FontFace + FontFace-based
+// PutText / GetTextSize + PutTextFlags).
+public class FontFaceTest : TestBase
+{
+    [Fact]
+    public void CreateDefault()
+    {
+        using var ff = new FontFace();
+        Assert.NotNull(ff.Name);
+    }
+
+    [Theory]
+    [InlineData("sans")]
+    [InlineData("uni")]
+    public void CreateEmbedded(string name)
+    {
+        using var ff = new FontFace(name);
+        Assert.False(string.IsNullOrEmpty(ff.Name));
+    }
+
+    [Fact]
+    public void GetTextSizeReturnsPositive()
+    {
+        using var ff = new FontFace();
+        var rect = Cv2.GetTextSize(new Size(400, 200), "Hello", new Point(0, 100), ff, 32);
+        Assert.True(rect.Width > 0, "width should be positive");
+        Assert.True(rect.Height > 0, "height should be positive");
+    }
+
+    [Fact]
+    public void PutTextDrawsPixels()
+    {
+        using var img = new Mat(200, 400, MatType.CV_8UC1, Scalar.All(0));
+        using var ff = new FontFace();
+
+        var next = Cv2.PutText(img, "Hello", new Point(10, 100), Scalar.All(255), ff, 32);
+
+        Assert.True(Cv2.CountNonZero(img) > 0, "text should have drawn some pixels");
+        Assert.True(next.X > 10, "cursor should advance to the right");
+    }
+
+    [Fact]
+    public void PutTextUnicode()
+    {
+        using var img = new Mat(200, 400, MatType.CV_8UC1, Scalar.All(0));
+        using var ff = new FontFace("uni");
+
+        // Greek + cyrillic characters require a Unicode-capable font.
+        Cv2.PutText(img, "Δλ Привет", new Point(10, 100), Scalar.All(255), ff, 32);
+
+        Assert.True(Cv2.CountNonZero(img) > 0, "unicode text should have drawn some pixels");
+    }
+
+    [Fact]
+    public void SetAndGetInstance()
+    {
+        using var ff = new FontFace();
+
+        // 'wght' axis = CV_FOURCC('w','g','h','t'); value in 16.16 fixed point (700.0).
+        var wght = 'w' | ('g' << 8) | ('h' << 16) | ('t' << 24);
+        ff.SetInstance(new[] { wght, 700 << 16 });
+
+        // Must reach OpenCV without a P/Invoke failure; the exact contents are font-dependent.
+        ff.GetInstance(out var instance);
+        Assert.NotNull(instance);
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the OpenCV 5 built-in STB TrueType text renderer (which replaces the contrib `freetype` module) — from #1924.

### New API
- **`FontFace`** class: default font, embedded fonts (`"sans"`, `"italic"`, `"uni"`), or a custom font path. Exposes `Set`, `Name`, and `SetInstance` / `GetInstance` for variable-font axes (e.g. `wght`, `slnt`).
- **`Cv2.PutText`** / **`Cv2.GetTextSize`** overloads taking a `FontFace` (font `size`, `weight`, `PutTextFlags`, optional wrap `Range`). `PutText` returns the continuation point; `GetTextSize` returns the bounding `Rect`.
- **`PutTextFlags`** enum (align / origin / wrap).

Text is marshaled as **UTF-8**, so full Unicode renders correctly (unlike the legacy Hershey `PutText`, which is ANSI).

### Native bridge
- New `imgproc_FontFace.h` (included from `imgproc.cpp`).
- Font path/name strings use the Windows/NotWindows marshaling split; text content uses UTF-8.

## Test
`FontFaceTest`:
- FontFace creation: default + embedded (`sans`, `uni`).
- `GetTextSize` returns a positive-sized rect.
- `PutText` draws pixels and advances the cursor (ASCII).
- `PutText` with a Unicode string (Greek + Cyrillic) using the `uni` font draws pixels.
- `SetInstance` / `GetInstance` round-trip wiring.

Rebuilt `OpenCvSharpExtern` locally; full ImgProc suite green (142 passed).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
