### PR TITLE
Add imgproc additions: INTER_NEAREST_EXACT, Filter2DParams overload, findContoursLinkRuns

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -340,7 +340,38 @@ static partial class Cv2
         GC.KeepAlive(kernel);
         dst.Fix();
     }
-        
+
+    /// <summary>
+    /// Convolves an image with the kernel (OpenCV 5 parameter-struct overload).
+    /// </summary>
+    /// <param name="src">input image.</param>
+    /// <param name="dst">output image of the same size and the same number of channels as src.</param>
+    /// <param name="kernel">convolution kernel (or rather a correlation kernel), a single-channel floating point matrix.</param>
+    /// <param name="params">filtering parameters (anchor, border, depth, scale, shift). Null uses the defaults.</param>
+    public static void Filter2D(InputArray src, OutputArray dst, InputArray kernel, Filter2DParams? @params = null)
+    {
+        if (src is null)
+            throw new ArgumentNullException(nameof(src));
+        if (dst is null)
+            throw new ArgumentNullException(nameof(dst));
+        if (kernel is null)
+            throw new ArgumentNullException(nameof(kernel));
+        src.ThrowIfDisposed();
+        dst.ThrowIfNotReady();
+        kernel.ThrowIfDisposed();
+
+        var p = @params ?? new Filter2DParams();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_filter2Dp(
+                src.CvPtr, dst.CvPtr, kernel.CvPtr,
+                p.AnchorX, p.AnchorY, (int)p.BorderType, p.BorderValue, p.Ddepth, p.Scale, p.Shift));
+
+        GC.KeepAlive(src);
+        GC.KeepAlive(dst);
+        GC.KeepAlive(kernel);
+        dst.Fix();
+    }
+
     /// <summary>
     /// Applies separable linear filter to an image
     /// </summary>
@@ -2970,6 +3001,50 @@ static partial class Cv2
         GC.KeepAlive(image);
 
         return contoursVec.ToArray();
+    }
+
+    /// <summary>
+    /// Finds contours in a binary image using the link-runs algorithm (OpenCV 5). This is an
+    /// alternative to <see cref="FindContours(InputArray, out Point[][], out HierarchyIndex[], RetrievalModes, ContourApproximationModes, Point?)"/>
+    /// with reduced memory consumption; it always uses the equivalent of RETR_CCOMP retrieval.
+    /// </summary>
+    /// <param name="image">Source, an 8-bit single-channel binary image.</param>
+    /// <param name="contours">Detected contours. Each contour is stored as a vector of points.</param>
+    /// <param name="hierarchy">Output vector containing information about the image topology
+    /// (next/previous/first-child/parent indices for each contour).</param>
+    public static void FindContoursLinkRuns(InputArray image, out Point[][] contours, out HierarchyIndex[] hierarchy)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        image.ThrowIfDisposed();
+
+        using var contoursVec = new VectorOfVectorPoint();
+        using var hierarchyVec = new VectorOfVec4i();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_findContoursLinkRuns1(image.CvPtr, contoursVec.CvPtr, hierarchyVec.CvPtr));
+
+        contours = contoursVec.ToArray();
+        hierarchy = hierarchyVec.ToArray().Select(HierarchyIndex.FromVec4i).ToArray();
+        GC.KeepAlive(image);
+    }
+
+    /// <summary>
+    /// Finds contours in a binary image using the link-runs algorithm (OpenCV 5), without hierarchy output.
+    /// </summary>
+    /// <param name="image">Source, an 8-bit single-channel binary image.</param>
+    /// <param name="contours">Detected contours. Each contour is stored as a vector of points.</param>
+    public static void FindContoursLinkRuns(InputArray image, out Point[][] contours)
+    {
+        if (image is null)
+            throw new ArgumentNullException(nameof(image));
+        image.ThrowIfDisposed();
+
+        using var contoursVec = new VectorOfVectorPoint();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_findContoursLinkRuns2(image.CvPtr, contoursVec.CvPtr));
+
+        contours = contoursVec.ToArray();
+        GC.KeepAlive(image);
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -53,6 +53,10 @@ static partial class NativeMethods
         double delta, int borderType);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_filter2Dp(IntPtr src, IntPtr dst, IntPtr kernel,
+        int anchorX, int anchorY, int borderType, Scalar borderValue, int ddepth, double scale, double shift);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus imgproc_sepFilter2D(IntPtr src, IntPtr dst, MatType ddepth, IntPtr kernelX,
         IntPtr kernelY, Point anchor, double delta, int borderType);
 
@@ -332,6 +336,12 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus imgproc_findContours2_OutputArray(IntPtr image, IntPtr contours,
         int mode, int method, Point offset);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_findContoursLinkRuns1(IntPtr image, IntPtr contours, IntPtr hierarchy);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus imgproc_findContoursLinkRuns2(IntPtr image, IntPtr contours);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus imgproc_approxPolyDP_InputArray(IntPtr curve, IntPtr approxCurve,

--- a/src/OpenCvSharp/Modules/imgproc/Enum/InterpolationFlags.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Enum/InterpolationFlags.cs
@@ -39,6 +39,12 @@ public enum InterpolationFlags
     LinearExact = 5,
 
     /// <summary>
+    /// Bit exact nearest neighbor interpolation. This will produce same results as
+    /// the nearest neighbor method in PIL, scikit-image or Matlab.
+    /// </summary>
+    NearestExact = 6,
+
+    /// <summary>
     /// mask for interpolation codes
     /// </summary>
     Max = 7,

--- a/src/OpenCvSharp/Modules/imgproc/Filter2DParams.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Filter2DParams.cs
@@ -1,0 +1,43 @@
+﻿namespace OpenCvSharp;
+
+/// <summary>
+/// Parameters for the OpenCV 5 <see cref="Cv2.Filter2D(InputArray, OutputArray, InputArray, Filter2DParams)"/> overload.
+/// Mirrors cv::Filter2DParams; all fields are optional and default to the OpenCV defaults.
+/// </summary>
+public class Filter2DParams
+{
+    /// <summary>
+    /// Anchor X. -1 means the anchor is at the kernel center.
+    /// </summary>
+    public int AnchorX { get; set; } = -1;
+
+    /// <summary>
+    /// Anchor Y. -1 means the anchor is at the kernel center.
+    /// </summary>
+    public int AnchorY { get; set; } = -1;
+
+    /// <summary>
+    /// Pixel extrapolation method.
+    /// </summary>
+    public BorderTypes BorderType { get; set; } = BorderTypes.Default;
+
+    /// <summary>
+    /// Border value used in case of a constant border.
+    /// </summary>
+    public Scalar BorderValue { get; set; } = new Scalar();
+
+    /// <summary>
+    /// Desired depth of the destination image. -1 means the same depth as the source.
+    /// </summary>
+    public int Ddepth { get; set; } = -1;
+
+    /// <summary>
+    /// Optional scale factor applied to the filtered pixels.
+    /// </summary>
+    public double Scale { get; set; } = 1.0;
+
+    /// <summary>
+    /// Optional value added to the filtered pixels.
+    /// </summary>
+    public double Shift { get; set; }
+}

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -95,6 +95,22 @@ CVAPI(ExceptionStatus) imgproc_filter2D(cv::_InputArray *src, cv::_OutputArray *
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) imgproc_filter2Dp(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
+                             int anchorX, int anchorY, int borderType, MyCvScalar borderValue, int ddepth, double scale, double shift)
+{
+    BEGIN_WRAP
+    cv::Filter2DParams params;
+    params.anchorX = anchorX;
+    params.anchorY = anchorY;
+    params.borderType = borderType;
+    params.borderValue = cpp(borderValue);
+    params.ddepth = ddepth;
+    params.scale = scale;
+    params.shift = shift;
+    cv::filter2D(*src, *dst, *kernel, params);
+    END_WRAP
+}
+
 CVAPI(ExceptionStatus) imgproc_sepFilter2D(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                                 cv::_InputArray *kernelX, cv::_InputArray *kernelY,
                                 MyCvPoint anchor, double delta, int borderType)
@@ -697,6 +713,21 @@ CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(cv::_InputArray *image,
 {
     BEGIN_WRAP
     cv::findContours(*image, *contours, mode, method, cpp(offset));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(cv::_InputArray *image,
+                                          std::vector<std::vector<cv::Point> > *contours, std::vector<cv::Vec4i> *hierarchy)
+{
+    BEGIN_WRAP
+    cv::findContoursLinkRuns(*image, *contours, *hierarchy);
+    END_WRAP
+}
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(cv::_InputArray *image,
+                                          std::vector<std::vector<cv::Point> > *contours)
+{
+    BEGIN_WRAP
+    cv::findContoursLinkRuns(*image, *contours);
     END_WRAP
 }
 

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcMediumTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcMediumTest.cs
@@ -1,0 +1,74 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.ImgProc;
+
+// Tests for the OpenCV 5 imgproc additions: INTER_NEAREST_EXACT, the Filter2DParams-based
+// filter2D overload, and findContoursLinkRuns.
+public class ImgProcMediumTest : TestBase
+{
+    [Fact]
+    public void NearestExactEnumValue()
+    {
+        Assert.Equal(6, (int)InterpolationFlags.NearestExact);
+    }
+
+    [Fact]
+    public void ResizeNearestExact()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 0, 255, 255, 0 });
+        using var dst = new Mat();
+        Cv2.Resize(src, dst, new Size(4, 4), 0, 0, InterpolationFlags.NearestExact);
+
+        Assert.Equal(4, dst.Rows);
+        Assert.Equal(4, dst.Cols);
+    }
+
+    [Fact]
+    public void Filter2DWithParams()
+    {
+        using var src = new Mat(5, 5, MatType.CV_8UC1, Scalar.All(10));
+        using var kernel = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new[] { 1.0f });
+        using var dst = new Mat();
+
+        // scale = 2 -> each pixel becomes 10 * 1 * 2 = 20.
+        Cv2.Filter2D(src, dst, kernel, new Filter2DParams { Scale = 2.0 });
+
+        Assert.Equal(MatType.CV_8UC1, dst.Type());
+        Assert.Equal(20, dst.At<byte>(2, 2));
+    }
+
+    [Fact]
+    public void Filter2DWithDefaultParams()
+    {
+        using var src = new Mat(5, 5, MatType.CV_8UC1, Scalar.All(10));
+        using var kernel = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new[] { 1.0f });
+        using var dst = new Mat();
+
+        Cv2.Filter2D(src, dst, kernel);
+
+        Assert.Equal(10, dst.At<byte>(2, 2));
+    }
+
+    [Fact]
+    public void FindContoursLinkRunsWithHierarchy()
+    {
+        using var img = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(img, new Rect(20, 20, 40, 40), Scalar.All(255), -1);
+
+        Cv2.FindContoursLinkRuns(img, out var contours, out var hierarchy);
+
+        Assert.NotEmpty(contours);
+        Assert.Equal(contours.Length, hierarchy.Length);
+    }
+
+    [Fact]
+    public void FindContoursLinkRunsWithoutHierarchy()
+    {
+        using var img = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(img, new Rect(20, 20, 40, 40), Scalar.All(255), -1);
+
+        Cv2.FindContoursLinkRuns(img, out var contours);
+
+        Assert.NotEmpty(contours);
+    }
+}


### PR DESCRIPTION
## Summary

Additive OpenCV 5 imgproc API gaps from #1924 (the larger `AlgorithmHint` change is deliberately a separate PR — see below).

### New API
- **`InterpolationFlags.NearestExact`** (`INTER_NEAREST_EXACT = 6`) — bit-exact / Pillow-compatible nearest-neighbor resampling.
- **`Cv2.Filter2D(src, dst, kernel, Filter2DParams)`** overload + the **`Filter2DParams`** class (`AnchorX`/`AnchorY`, `BorderType`, `BorderValue`, `Ddepth`, `Scale`, `Shift`).
- **`Cv2.FindContoursLinkRuns`** (with and without hierarchy) — the link-runs contour finder, a reduced-memory alternative to `FindContours`.

### Native bridge
- New entry points `imgproc_filter2Dp`, `imgproc_findContoursLinkRuns1/2` in `imgproc.h`.

## Test
`ImgProcMediumTest`:
- `NearestExact` enum value + nearest-exact resize.
- `Filter2D` with params (scale applied: 10 → 20) and with defaults (passthrough).
- Link-runs contour finding on a filled rectangle (with/without hierarchy).

Rebuilt `OpenCvSharpExtern` locally; full ImgProc suite green (141 passed).

## Deferred

The `AlgorithmHint` parameter (added to `warpAffine` / `warpPerspective` / `remap` / `GaussianBlur` / `cvtColor` / `cvtColorTwoPlane` in OpenCV 5) modifies many widely-used existing signatures, so it is left for its own focused PR to keep this change additive and low-risk. Still tracked in #1924.

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
