### PR TITLE
Fix MatType.IsInteger for OpenCV 5 integer depths; clarify Mat.Dims docs

### DIFF
--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -2870,7 +2870,9 @@ public partial class Mat : CvObject
     }
 
     /// <summary>
-    /// the array dimensionality, >= 2
+    /// The array dimensionality. In OpenCV 5 this can also be 0 (a scalar; rows == cols == total() == 1)
+    /// or 1 (a 1D array; dims == rows == 1, cols == total() == N); use <see cref="Empty"/> to tell an
+    /// empty matrix apart from a 0D scalar.
     /// </summary>
     public int Dims
     {

--- a/src/OpenCvSharp/Modules/core/Struct/MatType.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/MatType.cs
@@ -55,9 +55,12 @@ public readonly record struct MatType(int value) : IEquatable<int>
     public int Depth => value & (CV_DEPTH_MAX - 1);
 
     /// <summary>
-    /// 
+    /// Returns true if the depth is an integer type.
+    /// Mirrors OpenCV's CV_IS_INT_TYPE: integer depths are CV_8U, CV_8S, CV_16U, CV_16S,
+    /// CV_32S, CV_Bool, CV_64U, CV_64S and CV_32U (the bitmask 0x1e1f), while CV_32F, CV_64F,
+    /// CV_16F and CV_16BF are floating-point.
     /// </summary>
-    public bool IsInteger => Depth < CV_32F;
+    public bool IsInteger => ((1 << Depth) & 0x1e1f) != 0;
 
     /// <summary>
     /// 

--- a/test/OpenCvSharp.Tests/core/MatTypeTest.cs
+++ b/test/OpenCvSharp.Tests/core/MatTypeTest.cs
@@ -202,4 +202,25 @@ public class MatTypeTest : TestBase
         Assert.Equal(127, MatType.CV_8UC(127).Channels);
         Assert.Throws<OpenCvSharpException>(() => MatType.CV_8UC(128));
     }
+
+    [Fact]
+    public void IsIntegerCoversNewDepths()
+    {
+        // Integer depths (mirrors OpenCV's CV_IS_INT_TYPE bitmask 0x1e1f).
+        Assert.True(MatType.CV_8UC1.IsInteger);
+        Assert.True(MatType.CV_8SC1.IsInteger);
+        Assert.True(MatType.CV_16UC1.IsInteger);
+        Assert.True(MatType.CV_16SC1.IsInteger);
+        Assert.True(MatType.CV_32SC1.IsInteger);
+        Assert.True(MatType.CV_BoolC1.IsInteger);
+        Assert.True(MatType.CV_64UC1.IsInteger);
+        Assert.True(MatType.CV_64SC1.IsInteger);
+        Assert.True(MatType.CV_32UC1.IsInteger);
+
+        // Floating-point depths.
+        Assert.False(MatType.CV_32FC1.IsInteger);
+        Assert.False(MatType.CV_64FC1.IsInteger);
+        Assert.False(MatType.CV_16FC1.IsInteger);
+        Assert.False(MatType.CV_16BFC1.IsInteger);
+    }
 }


### PR DESCRIPTION
## Summary

The low-priority fix/verification items from #1924 (managed-only — no native change).

- **`MatType.IsInteger` bug fix**: it used `Depth < CV_32F`, which misclassified the new OpenCV 5 integer depths (`CV_Bool`, `CV_64U`, `CV_64S`, `CV_32U`) as non-integer. Now uses OpenCV's `CV_IS_INT_TYPE` bitmask (`0x1e1f`), so all integer depths are recognized and `CV_32F` / `CV_64F` / `CV_16F` / `CV_16BF` are correctly excluded.
- **`Mat.Dims` docs**: dropped the stale ">= 2"; in OpenCV 5 dims can also be 0 (scalar) or 1 (1D array).
- **objdetect verification**: `CascadeClassifier` / `HOGDescriptor` were relocated to the contrib `xobjdetect` module in OpenCV 5. This is already handled — `include_opencv.h` includes `<opencv2/xobjdetect.hpp>` and the existing wrappers resolve `cv::CascadeClassifier` / `cv::HOGDescriptor` from there. No change required.

## Test
`MatTypeTest.IsIntegerCoversNewDepths` asserts integer vs floating-point classification across all 13 OpenCV 5 depths.

Core suite green (267 passed).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
