### PR TITLE
Add USAC PolishingMethod + findFundamentalMat UsacParams overload

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_geometry.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_geometry.cs
@@ -1411,6 +1411,39 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Calculates a fundamental matrix from the corresponding points in two images, using the
+    /// USAC robust estimation framework (OpenCV 5).
+    /// </summary>
+    /// <param name="points1">Array of N points from the first image.</param>
+    /// <param name="points2">Array of the second image points of the same size and format as points1.</param>
+    /// <param name="mask">Output array of N elements; every element marks an inlier (1) or outlier (0).</param>
+    /// <param name="params">USAC parameters. Null uses the defaults.</param>
+    /// <returns>The estimated fundamental matrix.</returns>
+    public static Mat FindFundamentalMat(InputArray points1, InputArray points2, OutputArray mask, UsacParams? @params)
+    {
+        if (points1 is null)
+            throw new ArgumentNullException(nameof(points1));
+        if (points2 is null)
+            throw new ArgumentNullException(nameof(points2));
+        if (mask is null)
+            throw new ArgumentNullException(nameof(mask));
+        points1.ThrowIfDisposed();
+        points2.ThrowIfDisposed();
+        mask.ThrowIfNotReady();
+
+        var p = (@params ?? new UsacParams()).ToNativeStruct();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_findFundamentalMat_UsacParams(
+                points1.CvPtr, points2.CvPtr, ToPtr(mask), ref p, out var ret));
+
+        GC.KeepAlive(points1);
+        GC.KeepAlive(points2);
+        GC.KeepAlive(mask);
+        mask.Fix();
+        return new Mat(ret);
+    }
+
+    /// <summary>
     /// For points in an image of a stereo pair, computes the corresponding epilines in the other image.
     /// </summary>
     /// <param name="points">Input points. N \times 1 or 1 x N matrix of type CV_32FC2 or CV_64FC2.</param>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
@@ -167,6 +167,11 @@ static partial class NativeMethods
         out IntPtr returnValue);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_findFundamentalMat_UsacParams(
+        IntPtr points1, IntPtr points2, IntPtr mask, ref WUsacParams @params,
+        out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus geometry_findFundamentalMat_arrayF64(
         Point2d[] points1, int points1Size,
         Point2d[] points2, int points2Size,

--- a/src/OpenCvSharp/Modules/geometry/UsacParams.cs
+++ b/src/OpenCvSharp/Modules/geometry/UsacParams.cs
@@ -17,6 +17,8 @@ public record UsacParams
     public SamplingMethod Sampler { get; set; } = SamplingMethod.UNIFORM;
     public ScoreMethod Score { get; set; } = ScoreMethod.MSAC;
     public double Threshold { get; set; } = 1.5;
+    public PolishingMethod FinalPolisher { get; set; } = PolishingMethod.COV_POLISHER;
+    public int FinalPolisherIterations { get; set; } = 3;
 
     public WUsacParams ToNativeStruct() => new()
     {
@@ -31,6 +33,8 @@ public record UsacParams
         Sampler = Sampler,
         Score = Score,
         Threshold = Threshold,
+        FinalPolisher = FinalPolisher,
+        FinalPolisherIterations = FinalPolisherIterations,
     };
 }
 
@@ -49,6 +53,8 @@ public struct WUsacParams
     public SamplingMethod Sampler;
     public ScoreMethod Score;
     public double Threshold;
+    public PolishingMethod FinalPolisher;
+    public int FinalPolisherIterations;
 }
 
 // ReSharper disable InconsistentNaming
@@ -81,8 +87,16 @@ public enum ScoreMethod
 }
 
 public enum NeighborSearchMethod
-{ 
-    FLANN_KNN, 
-    GRID, 
-    FLANN_RADIUS 
+{
+    FLANN_KNN,
+    GRID,
+    FLANN_RADIUS
+}
+
+public enum PolishingMethod
+{
+    NONE_POLISHER,
+    LSQ_POLISHER,
+    MAGSAC,
+    COV_POLISHER
 }

--- a/src/OpenCvSharpExtern/geometry.h
+++ b/src/OpenCvSharpExtern/geometry.h
@@ -21,6 +21,8 @@ struct CV_EXPORTS_W_SIMPLE MyUsacParams
     cv::SamplingMethod sampler;
     cv::ScoreMethod score;
     double threshold;
+    cv::PolishingMethod finalPolisher;
+    int finalPolisherIterations;
 };
 
 CVAPI(ExceptionStatus) geometry_Rodrigues(cv::_InputArray *src, cv::_OutputArray *dst, cv::_OutputArray *jacobian)
@@ -76,7 +78,33 @@ CVAPI(ExceptionStatus) geometry_findHomography_UsacParams(
     p.sampler = params->sampler;
     p.score = params->score;
     p.threshold = params->threshold;
+    p.final_polisher = params->finalPolisher;
+    p.final_polisher_iterations = params->finalPolisherIterations;
     const auto ret = cv::findHomography(*srcPoints, *dstPoints, entity(mask), p);
+    *returnValue = new cv::Mat(ret);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) geometry_findFundamentalMat_UsacParams(
+    cv::_InputArray* points1, cv::_InputArray* points2, cv::_OutputArray* mask, MyUsacParams *params,
+    cv::Mat** returnValue)
+{
+    BEGIN_WRAP
+    cv::UsacParams p;
+    p.confidence = params->confidence;
+    p.isParallel = params->isParallel != 0;
+    p.loIterations = params->loIterations;
+    p.loMethod = params->loMethod;
+    p.loSampleSize = params->loSampleSize;
+    p.maxIterations = params->maxIterations;
+    p.neighborsSearch = params->neighborsSearch;
+    p.randomGeneratorState = params->randomGeneratorState;
+    p.sampler = params->sampler;
+    p.score = params->score;
+    p.threshold = params->threshold;
+    p.final_polisher = params->finalPolisher;
+    p.final_polisher_iterations = params->finalPolisherIterations;
+    const auto ret = cv::findFundamentalMat(*points1, *points2, entity(mask), p);
     *returnValue = new cv::Mat(ret);
     END_WRAP
 }

--- a/test/OpenCvSharp.Tests/calib3d/UsacParamsTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/UsacParamsTest.cs
@@ -1,0 +1,47 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Calib3D;
+
+// Tests for the OpenCV 5 USAC additions: the PolishingMethod enum / UsacParams.FinalPolisher
+// fields and the findFundamentalMat UsacParams overload.
+public class UsacParamsTest : TestBase
+{
+    [Fact]
+    public void DefaultsMatchOpenCv()
+    {
+        var p = new UsacParams();
+        // cv::UsacParams() sets final_polisher = COV_POLISHER and final_polisher_iterations = 3.
+        Assert.Equal(PolishingMethod.COV_POLISHER, p.FinalPolisher);
+        Assert.Equal(3, p.FinalPolisherIterations);
+    }
+
+    [Fact]
+    public void PolishingMethodValues()
+    {
+        Assert.Equal(0, (int)PolishingMethod.NONE_POLISHER);
+        Assert.Equal(1, (int)PolishingMethod.LSQ_POLISHER);
+        Assert.Equal(2, (int)PolishingMethod.MAGSAC);
+        Assert.Equal(3, (int)PolishingMethod.COV_POLISHER);
+    }
+
+    [Fact]
+    public void FindFundamentalMatUsac()
+    {
+        var points1 = Enumerable.Range(1, 12).Select(i => new Point2f(i * 10, (i * 7 % 13) * 11)).ToArray();
+        var points2 = points1.Select(p => new Point2f(p.X + (p.X / 10), p.Y - 2)).ToArray();
+
+        using var m1 = Mat.FromArray(points1);
+        using var m2 = Mat.FromArray(points2);
+        using var mask = new Mat();
+        var usacParams = new UsacParams
+        {
+            FinalPolisher = PolishingMethod.LSQ_POLISHER,
+            FinalPolisherIterations = 5,
+        };
+
+        // Smoke test: the USAC overload must reach OpenCV and return a matrix (possibly empty)
+        // without a P/Invoke failure.
+        using var f = Cv2.FindFundamentalMat(m1, m2, mask, usacParams);
+        Assert.NotNull(f);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the OpenCV 5 USAC surface from #1924.

- **`PolishingMethod`** enum (`NONE_POLISHER` / `LSQ_POLISHER` / `MAGSAC` / `COV_POLISHER`).
- **`UsacParams.FinalPolisher`** and **`UsacParams.FinalPolisherIterations`** fields (defaults `COV_POLISHER` / `3`, matching `cv::UsacParams()`). Threaded through `WUsacParams` and the native `MyUsacParams` struct (and applied in the existing `findHomography` USAC path too).
- **`Cv2.FindFundamentalMat(points1, points2, mask, UsacParams)`** overload + the native `geometry_findFundamentalMat_UsacParams` entry point.

## Test
`UsacParamsTest`:
- `UsacParams` defaults (`COV_POLISHER` / `3`).
- `PolishingMethod` enum values.
- `findFundamentalMat` USAC overload smoke test (with a non-default polisher).

Rebuilt `OpenCvSharpExtern` locally; full Calib3D suite green (29 passed) — confirms the widened `UsacParams` struct still round-trips through the existing `findHomography` USAC overload.

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
