### PR TITLE
Add DNN Tokenizer and Net tracing/profiling/finalizeNet/registerOutput

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
@@ -114,4 +114,23 @@ static partial class NativeMethods
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern ExceptionStatus dnn_Net_printPerfProfile(IntPtr net);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_finalizeNet(IntPtr net);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_setTracingMode(IntPtr net, int tracingMode);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getTracingMode(IntPtr net, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_setProfilingMode(IntPtr net, int profilingMode);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getProfilingMode(IntPtr net, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Net_registerOutput(
+        IntPtr net, [MarshalAs(UnmanagedType.LPUTF8Str)] string outputName, int layerId, int outputPort, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Tokenizer.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Tokenizer.cs
@@ -1,0 +1,38 @@
+﻿using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // ReSharper disable InconsistentNaming
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_Tokenizer_load")]
+    public static extern ExceptionStatus dnn_Tokenizer_load_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string modelConfig, out IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true,
+        EntryPoint = "dnn_Tokenizer_load")]
+    public static extern ExceptionStatus dnn_Tokenizer_load_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string modelConfig, out IntPtr returnValue);
+
+    public static ExceptionStatus dnn_Tokenizer_load(string modelConfig, out IntPtr returnValue)
+        => IsWindows()
+            ? dnn_Tokenizer_load_Windows(modelConfig, out returnValue)
+            : dnn_Tokenizer_load_NotWindows(modelConfig, out returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Tokenizer_delete(IntPtr obj);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+    public static extern ExceptionStatus dnn_Tokenizer_encode(
+        IntPtr obj, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, IntPtr returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Tokenizer_decode(IntPtr obj, int[] tokens, int tokensLength, IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -795,5 +795,80 @@ public class Net : CvObject
         GC.KeepAlive(this);
     }
 
+    /// <summary>
+    /// Finalizes the network (new DNN engine, OpenCV 5). The first forward() does this
+    /// automatically; calling it early pays the one-time setup cost at a predictable point
+    /// and surfaces configuration errors before inference.
+    /// </summary>
+    public void FinalizeNet()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_finalizeNet(CvPtr));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Gets or sets the tracing mode of the new DNN engine (OpenCV 5).
+    /// </summary>
+    public TracingMode TracingMode
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Net_getTracingMode(CvPtr, out var ret));
+            GC.KeepAlive(this);
+            return (TracingMode)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Net_setTracingMode(CvPtr, (int)value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the profiling mode of the new DNN engine (OpenCV 5).
+    /// </summary>
+    public ProfilingMode ProfilingMode
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Net_getProfilingMode(CvPtr, out var ret));
+            GC.KeepAlive(this);
+            return (ProfilingMode)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Net_setProfilingMode(CvPtr, (int)value));
+            GC.KeepAlive(this);
+        }
+    }
+
+    /// <summary>
+    /// Registers a network output by name (new DNN engine, OpenCV 5).
+    /// </summary>
+    /// <param name="outputName">Name to register the output under.</param>
+    /// <param name="layerId">Id of the producing layer.</param>
+    /// <param name="outputPort">Output port of the producing layer.</param>
+    /// <returns>The index of the registered output.</returns>
+    public int RegisterOutput(string outputName, int layerId, int outputPort)
+    {
+        if (outputName is null)
+            throw new ArgumentNullException(nameof(outputName));
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_registerOutput(CvPtr, outputName, layerId, outputPort, out var ret));
+        GC.KeepAlive(this);
+        return ret;
+    }
+
     #endregion
 }

--- a/src/OpenCvSharp/Modules/dnn/ProfilingMode.cs
+++ b/src/OpenCvSharp/Modules/dnn/ProfilingMode.cs
@@ -1,0 +1,26 @@
+﻿#pragma warning disable CS1591
+
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Profiling mode for the new DNN engine (OpenCV 5). See Net.ProfilingMode.
+/// </summary>
+public enum ProfilingMode
+{
+    /// <summary>
+    /// Don't do any profiling.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Collect summary statistics by layer type and print them at the end, sorted by execution time.
+    /// </summary>
+    Summary = 1,
+
+    /// <summary>
+    /// Print the execution time of each single layer.
+    /// </summary>
+    Detailed = 2
+}

--- a/src/OpenCvSharp/Modules/dnn/Tokenizer.cs
+++ b/src/OpenCvSharp/Modules/dnn/Tokenizer.cs
@@ -1,0 +1,72 @@
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Tokenizer for LLM / VLM text (OpenCV 5). Provides a simple API to encode text to token ids
+/// and decode token ids back to text (BPE, e.g. gpt2 / gpt4 families).
+/// </summary>
+public class Tokenizer : CvObject
+{
+    private Tokenizer(IntPtr ptr)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, ownsHandle: true,
+            static h => NativeMethods.HandleException(NativeMethods.dnn_Tokenizer_delete(h))));
+    }
+
+    /// <summary>
+    /// Loads a tokenizer from a model directory. The directory must contain a config.json
+    /// (with a supported <c>model_type</c>, e.g. "gpt2" or "gpt4") and a tokenizer.json.
+    /// </summary>
+    /// <param name="modelConfig">Path prefix to the model directory. File names are concatenated directly,
+    /// so it must end with an appropriate path separator.</param>
+    /// <returns>A ready-to-use Tokenizer.</returns>
+    public static Tokenizer Load(string modelConfig)
+    {
+        if (modelConfig is null)
+            throw new ArgumentNullException(nameof(modelConfig));
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Tokenizer_load(modelConfig, out var ptr));
+        if (ptr == IntPtr.Zero)
+            throw new OpenCvSharpException($"Failed to load {nameof(Tokenizer)}");
+        return new Tokenizer(ptr);
+    }
+
+    /// <summary>
+    /// Encodes UTF-8 text to token ids.
+    /// </summary>
+    /// <param name="text">UTF-8 input string.</param>
+    /// <returns>The token ids.</returns>
+    public int[] Encode(string text)
+    {
+        if (text is null)
+            throw new ArgumentNullException(nameof(text));
+        ThrowIfDisposed();
+
+        using var vec = new VectorOfInt32();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Tokenizer_encode(CvPtr, text, vec.CvPtr));
+        GC.KeepAlive(this);
+        return vec.ToArray();
+    }
+
+    /// <summary>
+    /// Decodes token ids back to text.
+    /// </summary>
+    /// <param name="tokens">The token ids.</param>
+    /// <returns>The decoded UTF-8 string.</returns>
+    public string Decode(int[] tokens)
+    {
+        if (tokens is null)
+            throw new ArgumentNullException(nameof(tokens));
+        ThrowIfDisposed();
+
+        using var stdString = new StdString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Tokenizer_decode(CvPtr, tokens, tokens.Length, stdString.CvPtr));
+        GC.KeepAlive(this);
+        return stdString.ToString();
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/TracingMode.cs
+++ b/src/OpenCvSharp/Modules/dnn/TracingMode.cs
@@ -1,0 +1,28 @@
+﻿#pragma warning disable CS1591
+
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// Tracing mode for the new DNN engine (OpenCV 5). See Net.TracingMode.
+/// </summary>
+public enum TracingMode
+{
+    /// <summary>
+    /// Don't trace anything.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Print all executed operations along with the output tensors
+    /// (more or less compatible with ONNX Runtime).
+    /// </summary>
+    All = 1,
+
+    /// <summary>
+    /// Print all executed operations. Types and shapes of all inputs and outputs are printed,
+    /// but the content is not.
+    /// </summary>
+    Op = 2
+}

--- a/src/OpenCvSharpExtern/dnn.cpp
+++ b/src/OpenCvSharpExtern/dnn.cpp
@@ -3,3 +3,4 @@
 #include "dnn_Net.h"
 #include "dnn_Model.h"
 #include "dnn_TextModel.h"
+#include "dnn_Tokenizer.h"

--- a/src/OpenCvSharpExtern/dnn_Net.h
+++ b/src/OpenCvSharpExtern/dnn_Net.h
@@ -292,6 +292,48 @@ CVAPI(ExceptionStatus) dnn_Net_printPerfProfile(cv::dnn::Net* net)
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) dnn_Net_finalizeNet(cv::dnn::Net* net)
+{
+    BEGIN_WRAP
+    net->finalizeNet();
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_setTracingMode(cv::dnn::Net* net, int tracingMode)
+{
+    BEGIN_WRAP
+    net->setTracingMode(static_cast<cv::dnn::TracingMode>(tracingMode));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getTracingMode(cv::dnn::Net* net, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = static_cast<int>(net->getTracingMode());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_setProfilingMode(cv::dnn::Net* net, int profilingMode)
+{
+    BEGIN_WRAP
+    net->setProfilingMode(static_cast<cv::dnn::ProfilingMode>(profilingMode));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_getProfilingMode(cv::dnn::Net* net, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = static_cast<int>(net->getProfilingMode());
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Net_registerOutput(cv::dnn::Net* net, const char *outputName, int layerId, int outputPort, int *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = net->registerOutput(cv::String(outputName), layerId, outputPort);
+    END_WRAP
+}
+
 #endif // !#ifndef _WINRT_DLL
 
 #endif // NO_DNN

--- a/src/OpenCvSharpExtern/dnn_Tokenizer.h
+++ b/src/OpenCvSharpExtern/dnn_Tokenizer.h
@@ -1,0 +1,44 @@
+﻿#pragma once
+
+#ifndef NO_DNN
+
+#ifndef _WINRT_DLL
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) dnn_Tokenizer_load(const char *modelConfig, cv::dnn::Tokenizer **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::dnn::Tokenizer(cv::dnn::Tokenizer::load(std::string(modelConfig)));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Tokenizer_delete(cv::dnn::Tokenizer *obj)
+{
+    BEGIN_WRAP
+    delete obj;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Tokenizer_encode(cv::dnn::Tokenizer *obj, const char *text, std::vector<int> *returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = obj->encode(std::string(text));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) dnn_Tokenizer_decode(cv::dnn::Tokenizer *obj, int *tokens, int tokensLength, std::string *returnValue)
+{
+    BEGIN_WRAP
+    const std::vector<int> v(tokens, tokens + tokensLength);
+    returnValue->assign(obj->decode(v));
+    END_WRAP
+}
+
+#endif // !_WINRT_DLL
+
+#endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/DnnTokenizerTracingTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/DnnTokenizerTracingTest.cs
@@ -1,0 +1,68 @@
+﻿using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Tests for the OpenCV 5 DNN additions: Tokenizer and the Net tracing/profiling/finalizeNet/
+// registerOutput methods.
+public class DnnTokenizerTracingTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Theory(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    [InlineData(TracingMode.None)]
+    [InlineData(TracingMode.All)]
+    [InlineData(TracingMode.Op)]
+    public void TracingModeRoundTrip(TracingMode mode)
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+        net!.TracingMode = mode;
+        Assert.Equal(mode, net.TracingMode);
+    }
+
+    [Theory(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    [InlineData(ProfilingMode.None)]
+    [InlineData(ProfilingMode.Summary)]
+    [InlineData(ProfilingMode.Detailed)]
+    public void ProfilingModeRoundTrip(ProfilingMode mode)
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+        net!.ProfilingMode = mode;
+        Assert.Equal(mode, net.ProfilingMode);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void FinalizeNetIsWired()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        // finalizeNet is a new-engine operation; for a classic-engine net it may succeed or raise
+        // an OpenCVException. Either way it must reach OpenCV (not fail in the P/Invoke layer).
+        var ex = Record.Exception(() => net!.FinalizeNet());
+        Assert.True(ex is null or OpenCVException, ex?.ToString());
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void RegisterOutputIsWired()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        var ex = Record.Exception(() => net!.RegisterOutput("___out___", 0, 0));
+        Assert.True(ex is null or OpenCVException, ex?.ToString());
+    }
+
+    [Fact]
+    public void TokenizerLoadWithMissingModelThrows()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"__no_tokenizer_{Guid.NewGuid():N}") + Path.DirectorySeparatorChar;
+        Assert.ThrowsAny<OpenCVException>(() => Tokenizer.Load(missing));
+    }
+}


### PR DESCRIPTION
## Summary

OpenCV 5 new-engine / VLM-oriented DNN additions from #1924.

### New API
- **`Tokenizer`** — LLM/VLM BPE tokenizer with `Load(modelConfig)`, `Encode(text)` → `int[]`, `Decode(int[])` → `string`.
- **`TracingMode`** / **`ProfilingMode`** enums.
- **`Net`** methods/properties: `FinalizeNet()`, `TracingMode` (get/set), `ProfilingMode` (get/set), `RegisterOutput(name, layerId, outputPort)`.

### Native bridge
- New `dnn_Tokenizer.h` plus `dnn_Net_*` entry points. Tokenizer text is marshaled as UTF-8; the model path uses the Windows/NotWindows split.

## Test
`DnnTokenizerTracingTest`:
- `TracingMode` / `ProfilingMode` round-trip on the committed MNIST model.
- `FinalizeNet` / `RegisterOutput` entry-point wiring (reach OpenCV; succeed or raise `OpenCVException`).
- `Tokenizer.Load` error path — a missing model directory raises `OpenCVException` (confirms the tokenizer feature is compiled and reachable).

Rebuilt `OpenCvSharpExtern` locally; full Dnn suite green (54 passed).

## Deferred

The remaining new-engine `Net` surface — `forwardAsync` (AsyncArray), `getMainGraph` + the `Graph` class, and the detailed `getPerfProfile` (vector outputs) — is intentionally left for a follow-up PR, since `Graph`/`AsyncArray` need their own wrapper types. Still tracked in #1924.

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
