### PR TITLE
Add multi-view camera calibration: registerCameras and calibrateMultiview

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -337,6 +337,195 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Registers a pair of cameras (OpenCV 5), estimating the relative pose (R, T) between them.
+    /// The two cameras may use different camera models (pinhole / fisheye).
+    /// </summary>
+    /// <param name="objectPoints1">Object points observed by the first camera.</param>
+    /// <param name="objectPoints2">Object points observed by the second camera.</param>
+    /// <param name="imagePoints1">Image points for the first camera.</param>
+    /// <param name="imagePoints2">Image points for the second camera.</param>
+    /// <param name="cameraMatrix1">Intrinsic matrix of the first camera.</param>
+    /// <param name="distCoeffs1">Distortion coefficients of the first camera.</param>
+    /// <param name="cameraModel1">Camera model of the first camera.</param>
+    /// <param name="cameraMatrix2">Intrinsic matrix of the second camera.</param>
+    /// <param name="distCoeffs2">Distortion coefficients of the second camera.</param>
+    /// <param name="cameraModel2">Camera model of the second camera.</param>
+    /// <param name="r">Input/Output rotation between the first and second camera coordinate systems.</param>
+    /// <param name="t">Input/Output translation between the camera coordinate systems.</param>
+    /// <param name="e">Output essential matrix.</param>
+    /// <param name="f">Output fundamental matrix.</param>
+    /// <param name="perViewErrors">Output per-view RMS reprojection errors.</param>
+    /// <param name="flags">Operation flags.</param>
+    /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+    /// <returns>Overall RMS reprojection error.</returns>
+    public static double RegisterCameras(
+        IEnumerable<Mat> objectPoints1, IEnumerable<Mat> objectPoints2,
+        IEnumerable<Mat> imagePoints1, IEnumerable<Mat> imagePoints2,
+        InputArray cameraMatrix1, InputArray distCoeffs1, CameraModel cameraModel1,
+        InputArray cameraMatrix2, InputArray distCoeffs2, CameraModel cameraModel2,
+        InputOutputArray r, InputOutputArray t, OutputArray e, OutputArray f,
+        OutputArray perViewErrors, int flags = 0, TermCriteria? criteria = null)
+    {
+        if (objectPoints1 is null)
+            throw new ArgumentNullException(nameof(objectPoints1));
+        if (objectPoints2 is null)
+            throw new ArgumentNullException(nameof(objectPoints2));
+        if (imagePoints1 is null)
+            throw new ArgumentNullException(nameof(imagePoints1));
+        if (imagePoints2 is null)
+            throw new ArgumentNullException(nameof(imagePoints2));
+        if (cameraMatrix1 is null)
+            throw new ArgumentNullException(nameof(cameraMatrix1));
+        if (distCoeffs1 is null)
+            throw new ArgumentNullException(nameof(distCoeffs1));
+        if (cameraMatrix2 is null)
+            throw new ArgumentNullException(nameof(cameraMatrix2));
+        if (distCoeffs2 is null)
+            throw new ArgumentNullException(nameof(distCoeffs2));
+        if (r is null)
+            throw new ArgumentNullException(nameof(r));
+        if (t is null)
+            throw new ArgumentNullException(nameof(t));
+        if (e is null)
+            throw new ArgumentNullException(nameof(e));
+        if (f is null)
+            throw new ArgumentNullException(nameof(f));
+        if (perViewErrors is null)
+            throw new ArgumentNullException(nameof(perViewErrors));
+        cameraMatrix1.ThrowIfDisposed();
+        distCoeffs1.ThrowIfDisposed();
+        cameraMatrix2.ThrowIfDisposed();
+        distCoeffs2.ThrowIfDisposed();
+        r.ThrowIfNotReady();
+        t.ThrowIfNotReady();
+        e.ThrowIfNotReady();
+        f.ThrowIfNotReady();
+        perViewErrors.ThrowIfNotReady();
+
+        var criteria0 = criteria.GetValueOrDefault(
+            new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, 1e-6));
+        var op1 = objectPoints1.Select(x => x.CvPtr).ToArray();
+        var op2 = objectPoints2.Select(x => x.CvPtr).ToArray();
+        var ip1 = imagePoints1.Select(x => x.CvPtr).ToArray();
+        var ip2 = imagePoints2.Select(x => x.CvPtr).ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.calib_registerCameras(
+                op1, op1.Length, op2, op2.Length, ip1, ip1.Length, ip2, ip2.Length,
+                cameraMatrix1.CvPtr, distCoeffs1.CvPtr, (int)cameraModel1,
+                cameraMatrix2.CvPtr, distCoeffs2.CvPtr, (int)cameraModel2,
+                r.CvPtr, t.CvPtr, e.CvPtr, f.CvPtr, perViewErrors.CvPtr, flags, criteria0, out var ret));
+
+        r.Fix();
+        t.Fix();
+        e.Fix();
+        f.Fix();
+        perViewErrors.Fix();
+        GC.KeepAlive(cameraMatrix1);
+        GC.KeepAlive(distCoeffs1);
+        GC.KeepAlive(cameraMatrix2);
+        GC.KeepAlive(distCoeffs2);
+        GC.KeepAlive(objectPoints1);
+        GC.KeepAlive(objectPoints2);
+        GC.KeepAlive(imagePoints1);
+        GC.KeepAlive(imagePoints2);
+        return ret;
+    }
+
+    /// <summary>
+    /// Estimates intrinsics and extrinsics (camera poses) for a multi-camera system, a.k.a. multi-view
+    /// calibration (OpenCV 5).
+    /// </summary>
+    /// <remarks>
+    /// The point matrices must use single-channel CV_32F layout: each object-point matrix is
+    /// NUM_POINTS x 3 (CV_32FC1) and each image-point matrix is NUM_POINTS x 2 (CV_32FC1). Partially
+    /// observed patterns are supported by setting the unobserved image points to invalid values
+    /// (e.g. (-1, -1)) and clearing the corresponding entry in <paramref name="detectionMask"/>.
+    /// </remarks>
+    /// <param name="objPoints">Calibration pattern object points per frame (each NUM_POINTS x 3, CV_32FC1).</param>
+    /// <param name="imagePoints">Detected pattern points per camera then per frame
+    /// (NUM_CAMERAS x NUM_FRAMES, each NUM_POINTS x 2, CV_32FC1).</param>
+    /// <param name="imageSize">Image resolution for each camera.</param>
+    /// <param name="detectionMask">Per-camera per-frame detection mask (NUM_CAMERAS x NUM_FRAMES, CV_8U).</param>
+    /// <param name="models">Per-camera camera models (NUM_CAMERAS x 1, CV_8U; see <see cref="CameraModel"/>).</param>
+    /// <param name="ks">Output per-camera intrinsic matrices.</param>
+    /// <param name="distortions">Output per-camera distortion coefficients.</param>
+    /// <param name="rs">Output per-camera rotation matrices relative to camera 0.</param>
+    /// <param name="ts">Output per-camera translation vectors relative to camera 0.</param>
+    /// <param name="flagsForIntrinsics">Optional per-camera intrinsics-calibration flags (NUM_CAMERAS x 1, CV_32S).</param>
+    /// <param name="flags">Common multi-view calibration flags.</param>
+    /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+    /// <returns>Overall RMS reprojection error.</returns>
+    public static double CalibrateMultiview(
+        IEnumerable<Mat> objPoints,
+        IReadOnlyList<IReadOnlyList<Mat>> imagePoints,
+        IEnumerable<Size> imageSize,
+        InputArray detectionMask,
+        InputArray models,
+        out Mat[] ks, out Mat[] distortions, out Mat[] rs, out Mat[] ts,
+        InputArray? flagsForIntrinsics = null,
+        int flags = 0,
+        TermCriteria? criteria = null)
+    {
+        if (objPoints is null)
+            throw new ArgumentNullException(nameof(objPoints));
+        if (imagePoints is null)
+            throw new ArgumentNullException(nameof(imagePoints));
+        if (imageSize is null)
+            throw new ArgumentNullException(nameof(imageSize));
+        if (detectionMask is null)
+            throw new ArgumentNullException(nameof(detectionMask));
+        if (models is null)
+            throw new ArgumentNullException(nameof(models));
+        detectionMask.ThrowIfDisposed();
+        models.ThrowIfDisposed();
+        flagsForIntrinsics?.ThrowIfDisposed();
+
+        var criteria0 = criteria.GetValueOrDefault(
+            new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
+
+        var objPointsPtrs = objPoints.Select(x => x.CvPtr).ToArray();
+
+        var framesPerCamera = new int[imagePoints.Count];
+        var flatImagePoints = new List<IntPtr>();
+        for (var c = 0; c < imagePoints.Count; c++)
+        {
+            var frames = imagePoints[c];
+            framesPerCamera[c] = frames.Count;
+            for (var fr = 0; fr < frames.Count; fr++)
+                flatImagePoints.Add(frames[fr].CvPtr);
+        }
+
+        var imageSizeArray = imageSize as Size[] ?? imageSize.ToArray();
+
+        using var ksVec = new VectorOfMat();
+        using var distVec = new VectorOfMat();
+        using var rsVec = new VectorOfMat();
+        using var tsVec = new VectorOfMat();
+
+        NativeMethods.HandleException(
+            NativeMethods.calib_calibrateMultiview(
+                objPointsPtrs, objPointsPtrs.Length,
+                flatImagePoints.ToArray(), framesPerCamera.Length, framesPerCamera,
+                imageSizeArray, imageSizeArray.Length,
+                detectionMask.CvPtr, models.CvPtr,
+                ksVec.CvPtr, distVec.CvPtr, rsVec.CvPtr, tsVec.CvPtr,
+                ToPtr(flagsForIntrinsics), flags, criteria0, out var ret));
+
+        ks = ksVec.ToArray();
+        distortions = distVec.ToArray();
+        rs = rsVec.ToArray();
+        ts = tsVec.ToArray();
+
+        GC.KeepAlive(objPoints);
+        GC.KeepAlive(imagePoints);
+        GC.KeepAlive(detectionMask);
+        GC.KeepAlive(models);
+        GC.KeepAlive(flagsForIntrinsics);
+        return ret;
+    }
+
+    /// <summary>
     /// finds intrinsic and extrinsic parameters of a stereo camera
     /// </summary>
     /// <param name="objectPoints">Vector of vectors of the calibration pattern points.</param>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
@@ -51,6 +51,28 @@ static partial class NativeMethods
         int flags, TermCriteria criteria,
         out double returnValue);
 
+    // OpenCV 5 multi-view calibration
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus calib_registerCameras(
+        IntPtr[] objectPoints1, int objectPoints1Size,
+        IntPtr[] objectPoints2, int objectPoints2Size,
+        IntPtr[] imagePoints1, int imagePoints1Size,
+        IntPtr[] imagePoints2, int imagePoints2Size,
+        IntPtr cameraMatrix1, IntPtr distCoeffs1, int cameraModel1,
+        IntPtr cameraMatrix2, IntPtr distCoeffs2, int cameraModel2,
+        IntPtr R, IntPtr T, IntPtr E, IntPtr F,
+        IntPtr perViewErrors,
+        int flags, TermCriteria criteria, out double returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus calib_calibrateMultiview(
+        IntPtr[] objPoints, int objPointsSize,
+        IntPtr[] imagePoints, int numCameras, int[] framesPerCamera,
+        Size[] imageSize, int imageSizeSize,
+        IntPtr detectionMask, IntPtr models,
+        IntPtr ks, IntPtr distortions, IntPtr rs, IntPtr ts,
+        IntPtr flagsForIntrinsics, int flags, TermCriteria criteria, out double returnValue);
+
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     public static extern unsafe ExceptionStatus calib_calibrateCamera_vector(
         IntPtr[] objectPoints, int opSize1, int[] opSize2,

--- a/src/OpenCvSharp/Modules/calib/Enum/CameraModel.cs
+++ b/src/OpenCvSharp/Modules/calib/Enum/CameraModel.cs
@@ -1,0 +1,20 @@
+﻿// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Camera model used by the OpenCV 5 multi-view calibration functions
+/// (<see cref="Cv2.RegisterCameras"/> / <see cref="Cv2.CalibrateMultiview"/>).
+/// </summary>
+public enum CameraModel
+{
+    /// <summary>
+    /// Pinhole camera model (CALIB_MODEL_PINHOLE).
+    /// </summary>
+    Pinhole = 0,
+
+    /// <summary>
+    /// Fisheye camera model (CALIB_MODEL_FISHEYE).
+    /// </summary>
+    Fisheye = 1
+}

--- a/src/OpenCvSharpExtern/calib.cpp
+++ b/src/OpenCvSharpExtern/calib.cpp
@@ -1,3 +1,4 @@
 ﻿// ReSharper disable CppUnusedIncludeDirective
 #include "calib.h"
 #include "calib_fisheye.h"
+#include "calib_multiview.h"

--- a/src/OpenCvSharpExtern/calib_multiview.h
+++ b/src/OpenCvSharpExtern/calib_multiview.h
@@ -1,0 +1,78 @@
+﻿#pragma once
+
+#ifndef NO_CALIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+// registerCameras (OpenCV 5): registers a pair of cameras (possibly with different camera models).
+CVAPI(ExceptionStatus) calib_registerCameras(
+    cv::Mat **objectPoints1, int objectPoints1Size,
+    cv::Mat **objectPoints2, int objectPoints2Size,
+    cv::Mat **imagePoints1, int imagePoints1Size,
+    cv::Mat **imagePoints2, int imagePoints2Size,
+    cv::_InputArray *cameraMatrix1, cv::_InputArray *distCoeffs1, int cameraModel1,
+    cv::_InputArray *cameraMatrix2, cv::_InputArray *distCoeffs2, int cameraModel2,
+    cv::_InputOutputArray *R, cv::_InputOutputArray *T,
+    cv::_OutputArray *E, cv::_OutputArray *F,
+    cv::_OutputArray *perViewErrors,
+    int flags, MyCvTermCriteria criteria, double *returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::Mat> op1(objectPoints1Size), op2(objectPoints2Size), ip1(imagePoints1Size), ip2(imagePoints2Size);
+    for (int i = 0; i < objectPoints1Size; i++) op1[i] = *objectPoints1[i];
+    for (int i = 0; i < objectPoints2Size; i++) op2[i] = *objectPoints2[i];
+    for (int i = 0; i < imagePoints1Size; i++) ip1[i] = *imagePoints1[i];
+    for (int i = 0; i < imagePoints2Size; i++) ip2[i] = *imagePoints2[i];
+
+    *returnValue = cv::registerCameras(
+        op1, op2, ip1, ip2,
+        *cameraMatrix1, *distCoeffs1, static_cast<cv::CameraModel>(cameraModel1),
+        *cameraMatrix2, *distCoeffs2, static_cast<cv::CameraModel>(cameraModel2),
+        *R, *T, *E, *F, *perViewErrors, flags, cpp(criteria));
+    END_WRAP
+}
+
+// calibrateMultiview (OpenCV 5): intrinsics + extrinsics for a multi-camera system.
+// imagePoints is a flat array of NUM_CAMERAS x framesPerCamera[i] matrices.
+// Ks / distortions / Rs / Ts are InputOutputArrayOfArrays; pass empty vectors to receive the outputs.
+CVAPI(ExceptionStatus) calib_calibrateMultiview(
+    cv::Mat **objPoints, int objPointsSize,
+    cv::Mat **imagePoints, int numCameras, int *framesPerCamera,
+    MyCvSize *imageSize, int imageSizeSize,
+    cv::_InputArray *detectionMask, cv::_InputArray *models,
+    std::vector<cv::Mat> *Ks, std::vector<cv::Mat> *distortions,
+    std::vector<cv::Mat> *Rs, std::vector<cv::Mat> *Ts,
+    cv::_InputArray *flagsForIntrinsics, int flags,
+    MyCvTermCriteria criteria, double *returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::Mat> objPointsVec(objPointsSize);
+    for (int i = 0; i < objPointsSize; i++)
+        objPointsVec[i] = *objPoints[i];
+
+    std::vector<std::vector<cv::Mat>> imagePointsVec(numCameras);
+    int idx = 0;
+    for (int c = 0; c < numCameras; c++)
+    {
+        imagePointsVec[c].resize(framesPerCamera[c]);
+        for (int f = 0; f < framesPerCamera[c]; f++)
+            imagePointsVec[c][f] = *imagePoints[idx++];
+    }
+
+    std::vector<cv::Size> imageSizeVec(imageSizeSize);
+    for (int i = 0; i < imageSizeSize; i++)
+        imageSizeVec[i] = cpp(imageSize[i]);
+
+    *returnValue = cv::calibrateMultiview(
+        objPointsVec, imagePointsVec, imageSizeVec,
+        *detectionMask, *models,
+        *Ks, *distortions, *Rs, *Ts,
+        entity(flagsForIntrinsics), flags, cpp(criteria));
+    END_WRAP
+}
+
+#endif // NO_CALIB

--- a/test/OpenCvSharp.Tests/calib3d/MultiviewCalibrationTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/MultiviewCalibrationTest.cs
@@ -1,0 +1,155 @@
+﻿using Xunit;
+
+namespace OpenCvSharp.Tests.Calib3D;
+
+// Tests for the OpenCV 5 multi-view calibration functions: RegisterCameras and CalibrateMultiview.
+// A synthetic 2-camera rig is used. The relative pose between the cameras is identity rotation and a
+// pure X translation, so camera 1's view of the board is just camera 0's view with the translation
+// applied (because R10 == I): cam1 board pose = (rvec, tvec + (-baseline, 0, 0)).
+public class MultiviewCalibrationTest : TestBase
+{
+    private const double Baseline = 1.0;
+
+    private static readonly double[,] CameraMatrix =
+    {
+        { 800, 0, 320 },
+        { 0, 800, 240 },
+        { 0, 0, 1 }
+    };
+
+    private static Point3f[] BoardPoints()
+    {
+        var points = new List<Point3f>();
+        for (var y = 0; y < 5; y++)
+            for (var x = 0; x < 7; x++)
+                points.Add(new Point3f(x, y, 0));
+        return points.ToArray();
+    }
+
+    private static (double[] rvec, double[] tvec)[] Frames() => new[]
+    {
+        (new[] { 0.0, 0.0, 0.0 }, new[] { -3.0, -2.0, 12.0 }),
+        (new[] { 0.1, 0.0, 0.0 }, new[] { -3.0, -2.0, 13.0 }),
+        (new[] { 0.0, 0.1, 0.0 }, new[] { -2.5, -2.0, 12.0 }),
+        (new[] { -0.1, 0.05, 0.0 }, new[] { -3.0, -1.5, 14.0 }),
+        (new[] { 0.05, -0.1, 0.02 }, new[] { -3.5, -2.0, 12.0 }),
+        (new[] { 0.0, 0.0, 0.1 }, new[] { -3.0, -2.5, 13.0 }),
+    };
+
+    private static Mat ToMatNx3(Point3f[] points)
+    {
+        var data = new float[points.Length * 3];
+        for (var i = 0; i < points.Length; i++)
+        {
+            data[(i * 3) + 0] = points[i].X;
+            data[(i * 3) + 1] = points[i].Y;
+            data[(i * 3) + 2] = points[i].Z;
+        }
+        return Mat.FromPixelData(points.Length, 3, MatType.CV_32FC1, data);
+    }
+
+    private static Mat ToMatNx2(Point2f[] points)
+    {
+        var data = new float[points.Length * 2];
+        for (var i = 0; i < points.Length; i++)
+        {
+            data[(i * 2) + 0] = points[i].X;
+            data[(i * 2) + 1] = points[i].Y;
+        }
+        return Mat.FromPixelData(points.Length, 2, MatType.CV_32FC1, data);
+    }
+
+    private static (List<Mat> obj, List<Mat> cam0, List<Mat> cam1) BuildScene()
+    {
+        var board = BoardPoints();
+        var dist = new double[5];
+        var objMats = new List<Mat>();
+        var cam0 = new List<Mat>();
+        var cam1 = new List<Mat>();
+
+        foreach (var (rvec, tvec) in Frames())
+        {
+            Cv2.ProjectPoints(board, rvec, tvec, CameraMatrix, dist, out var img0, out _);
+            var tvec1 = new[] { tvec[0] - Baseline, tvec[1], tvec[2] };
+            Cv2.ProjectPoints(board, rvec, tvec1, CameraMatrix, dist, out var img1, out _);
+
+            objMats.Add(ToMatNx3(board));
+            cam0.Add(ToMatNx2(img0));
+            cam1.Add(ToMatNx2(img1));
+        }
+        return (objMats, cam0, cam1);
+    }
+
+    private static void DisposeAll(params IEnumerable<Mat>[] groups)
+    {
+        foreach (var g in groups)
+            foreach (var m in g)
+                m.Dispose();
+    }
+
+    [Fact]
+    public void RegisterCameras()
+    {
+        var (obj, cam0, cam1) = BuildScene();
+        using var k1 = Mat.FromPixelData(3, 3, MatType.CV_64FC1, CameraMatrix);
+        using var k2 = Mat.FromPixelData(3, 3, MatType.CV_64FC1, CameraMatrix);
+        using var d1 = Mat.Zeros(1, 5, MatType.CV_64FC1).ToMat();
+        using var d2 = Mat.Zeros(1, 5, MatType.CV_64FC1).ToMat();
+        using var r = new Mat();
+        using var t = new Mat();
+        using var e = new Mat();
+        using var f = new Mat();
+        using var perViewErrors = new Mat();
+        try
+        {
+            var rms = Cv2.RegisterCameras(
+                obj, obj, cam0, cam1,
+                k1, d1, CameraModel.Pinhole, k2, d2, CameraModel.Pinhole,
+                r, t, e, f, perViewErrors);
+
+            Assert.True(rms >= 0 && rms < 1.0, $"rms={rms}");
+            // Recovered translation should point along -X with unit-ish magnitude (up to scale/sign).
+            using var tD = new Mat();
+            t.ConvertTo(tD, MatType.CV_64F);
+            tD.GetArray(out double[] tv);
+            Assert.Equal(3, tv.Length);
+            Assert.True(Math.Abs(tv[0]) > Math.Abs(tv[1]) && Math.Abs(tv[0]) > Math.Abs(tv[2]), $"t=({tv[0]},{tv[1]},{tv[2]})");
+        }
+        finally
+        {
+            DisposeAll(obj, cam0, cam1);
+        }
+    }
+
+    [Fact]
+    public void CalibrateMultiview()
+    {
+        var (obj, cam0, cam1) = BuildScene();
+        var numFrames = obj.Count;
+
+        using var detectionMask = new Mat(2, numFrames, MatType.CV_8UC1, Scalar.All(1));
+        using var models = new Mat(2, 1, MatType.CV_8UC1, Scalar.All((double)CameraModel.Pinhole));
+        var imagePoints = new IReadOnlyList<Mat>[] { cam0, cam1 };
+        var imageSize = new[] { new Size(640, 480), new Size(640, 480) };
+
+        try
+        {
+            var rms = Cv2.CalibrateMultiview(
+                obj, imagePoints, imageSize, detectionMask, models,
+                out var ks, out var distortions, out var rs, out var ts);
+
+            Assert.True(rms >= 0, $"rms={rms}");
+            Assert.Equal(2, ks.Length);
+            Assert.Equal(2, distortions.Length);
+            Assert.Equal(2, rs.Length);
+            Assert.Equal(2, ts.Length);
+
+            foreach (var m in ks.Concat(distortions).Concat(rs).Concat(ts))
+                m.Dispose();
+        }
+        finally
+        {
+            DisposeAll(obj, cam0, cam1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the OpenCV 5 **multi-view camera calibration** functions — one of the headline new features of the calib module (from #1924).

### API
- **`Cv2.RegisterCameras`** — registers a pair of cameras (the two may use different camera models, pinhole/fisheye), estimating their relative pose `R`/`T` plus the essential/fundamental matrices and per-view errors. Returns the overall RMS.
- **`Cv2.CalibrateMultiview`** — estimates per-camera intrinsics (`Ks`, `distortions`) and extrinsics (`Rs`, `Ts`, relative to camera 0) for a multi-camera rig from per-camera/per-frame detected pattern points, with a detection mask for partial observations. Returns the overall RMS.
- **`CameraModel`** enum (`Pinhole` / `Fisheye`).

### Native bridge
- New `calib_multiview.h`. The jagged per-camera/per-frame `imagePoints` (`vector<vector<Mat>>`) is marshaled as a flat `Mat[]` plus a per-camera frame-count array; the `InputOutputArrayOfArrays` outputs use `VectorOfMat`.

## Test
`MultiviewCalibrationTest` builds a synthetic 2-camera rig whose relative pose is identity rotation + a pure X translation (so camera 1's view is camera 0's view with the baseline applied):
- `RegisterCameras` recovers an X-dominant translation with low RMS.
- `CalibrateMultiview` returns per-camera `Ks` / `distortions` / `Rs` / `Ts` (2 each).

Rebuilt `OpenCvSharpExtern` locally; full Calib3D suite green (31 passed).

> Note: `calibrateMultiview` requires single-channel `CV_32F` point matrices (object points `NUM_POINTS x 3`, image points `NUM_POINTS x 2`); a 3-/2-channel layout crashes the native algorithm. This is documented on the managed method.

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
