### PR TITLE
Add detailed Net.GetPerfProfileDetailed

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
@@ -133,4 +133,7 @@ static partial class NativeMethods
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
     public static extern ExceptionStatus dnn_Net_registerOutput(
         IntPtr net, [MarshalAs(UnmanagedType.LPUTF8Str)] string outputName, int layerId, int outputPort, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus dnn_Net_getPerfProfileDetailed(IntPtr net, IntPtr names, IntPtr timems, IntPtr counts);
 }

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -870,5 +870,26 @@ public class Net : CvObject
         return ret;
     }
 
+    /// <summary>
+    /// Returns the detailed per-layer performance profile (new DNN engine, OpenCV 5): for each
+    /// reported layer, its name, execution time and call count (all as strings).
+    /// </summary>
+    /// <param name="names">Output layer names.</param>
+    /// <param name="timems">Output per-layer execution times (ms), as strings.</param>
+    /// <param name="counts">Output per-layer call counts, as strings.</param>
+    public void GetPerfProfileDetailed(out string[] names, out string[] timems, out string[] counts)
+    {
+        ThrowIfDisposed();
+        using var namesVec = new VectorOfString();
+        using var timemsVec = new VectorOfString();
+        using var countsVec = new VectorOfString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getPerfProfileDetailed(CvPtr, namesVec.CvPtr, timemsVec.CvPtr, countsVec.CvPtr));
+        GC.KeepAlive(this);
+        names = Array.ConvertAll(namesVec.ToArray(), s => s ?? string.Empty);
+        timems = Array.ConvertAll(timemsVec.ToArray(), s => s ?? string.Empty);
+        counts = Array.ConvertAll(countsVec.ToArray(), s => s ?? string.Empty);
+    }
+
     #endregion
 }

--- a/src/OpenCvSharpExtern/dnn_Net.h
+++ b/src/OpenCvSharpExtern/dnn_Net.h
@@ -334,6 +334,14 @@ CVAPI(ExceptionStatus) dnn_Net_registerOutput(cv::dnn::Net* net, const char *out
     END_WRAP
 }
 
+CVAPI(ExceptionStatus) dnn_Net_getPerfProfileDetailed(
+    cv::dnn::Net* net, std::vector<std::string> *names, std::vector<std::string> *timems, std::vector<std::string> *counts)
+{
+    BEGIN_WRAP
+    net->getPerfProfile(*names, *timems, *counts);
+    END_WRAP
+}
+
 #endif // !#ifndef _WINRT_DLL
 
 #endif // NO_DNN

--- a/test/OpenCvSharp.Tests/dnn/PerfProfileDetailedTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/PerfProfileDetailedTest.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// Test for the OpenCV 5 detailed Net.GetPerfProfileDetailed (string-based per-layer profile).
+public class PerfProfileDetailedTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetPerfProfileDetailedIsWired()
+    {
+        using var net = CvDnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        // Must reach OpenCV (the three string arrays come back with matching lengths) rather than
+        // failing in the P/Invoke layer; an OpenCVException is acceptable if profiling is unavailable.
+        var ex = Record.Exception(() =>
+        {
+            net!.GetPerfProfileDetailed(out var names, out var timems, out var counts);
+            Assert.Equal(names.Length, timems.Length);
+            Assert.Equal(names.Length, counts.Length);
+        });
+        Assert.True(ex is null or OpenCVException, ex?.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the OpenCV 5 detailed DNN performance profile (from #1924).

- **`Net.GetPerfProfileDetailed(out string[] names, out string[] timems, out string[] counts)`** — the OpenCV 5 string-based per-layer profile (distinct from the existing `int64 getPerfProfile(out double[] timings)` overload).

Native: `dnn_Net_getPerfProfileDetailed`.

## Scope note (forwardAsync / AsyncArray dropped)

This branch originally also wrapped `Net.ForwardAsync` + `AsyncArray`. Those were **intentionally removed**: `forwardAsync` only works on non-CPU back-ends (e.g. OpenVINO / Inference Engine), which OpenCvSharp's official runtime packages do not ship. On every officially-supported (CPU) configuration the call just throws, so the public API + native code + maintenance would be dead weight. (`AsyncArray` is only produced by `forwardAsync` in the dnn surface, so it was removed too.)

## Test
`PerfProfileDetailedTest`: entry-point wiring on the committed MNIST model — the three string arrays come back with matching lengths (an `OpenCVException` is tolerated if profiling is unavailable). Full Dnn suite green (55 passed).

Refs #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
