### PR TITLE
Support UTF-8 / non-ANSI image file paths on Windows (imgcodecs)

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_imgcodecs.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_imgcodecs.cs
@@ -8,49 +8,23 @@ namespace OpenCvSharp.Internal;
 
 static partial class NativeMethods
 {
-    // imread
+    // imread (UTF-8 everywhere; the native side converts to a wide path on Windows so non-ANSI names work)
 
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imread"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imread_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string fileName, int flags, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgcodecs_imread(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fileName, int flags, out IntPtr returnValue);
 
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imread"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imread_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string fileName, int flags, out IntPtr returnValue);
+    // imreadmulti (UTF-8 everywhere; native reads via a wide path on Windows)
 
-    public static ExceptionStatus imgcodecs_imread(string fileName, int flags, out IntPtr returnValue)
-    {
-        if (IsWindows())
-            return imgcodecs_imread_Windows(fileName, flags, out returnValue);
-        return imgcodecs_imread_NotWindows(fileName, flags, out returnValue);
-    }
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgcodecs_imreadmulti(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fileName, IntPtr mats, int flags, out int returnValue);
 
-    // imreadmulti
-
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imreadmulti"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imreadmulti_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string fileName, IntPtr mats, int flags, out int returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imreadmulti"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imreadmulti_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string fileName, IntPtr mats, int flags, out int returnValue);
-
-    public static ExceptionStatus imgcodecs_imreadmulti(string fileName, IntPtr mats, int flags, out int returnValue)
-    {
-        if (IsWindows())
-            return imgcodecs_imreadmulti_Windows(fileName, mats, flags, out returnValue);
-        return imgcodecs_imreadmulti_NotWindows(fileName, mats, flags, out returnValue);
-    }
-
-    // imwrite
+    // imwrite (UTF-8 everywhere; the native side converts to a wide path on Windows so non-ANSI names work)
 
     [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imwrite"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imwrite_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imwrite"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imwrite_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
+    private static partial ExceptionStatus imgcodecs_imwrite_utf8(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
 
     public static ExceptionStatus imgcodecs_imwrite(string fileName, IntPtr img, int[] @params, int paramsLength, out int returnValue)
     {
@@ -59,27 +33,14 @@ static partial class NativeMethods
             return ExceptionStatus.Occurred;
         }
 
-        if (IsWindows())
-            return imgcodecs_imwrite_Windows(fileName, img, @params, paramsLength, out returnValue);
-        return imgcodecs_imwrite_NotWindows(fileName, img, @params, paramsLength, out returnValue);
+        return imgcodecs_imwrite_utf8(fileName, img, @params, paramsLength, out returnValue);
     }
 
-    // imwrite_multi
+    // imwrite_multi (UTF-8 everywhere; native writes via a wide path on Windows)
 
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imwrite_multi"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imwrite_multi_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_imwrite_multi"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_imwrite_multi_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
-
-    public static ExceptionStatus imgcodecs_imwrite_multi(string fileName, IntPtr img, int[] @params, int paramsLength, out int returnValue)
-    {
-        if (IsWindows())
-            return imgcodecs_imwrite_multi_Windows(fileName, img, @params, paramsLength, out returnValue);
-        return imgcodecs_imwrite_multi_NotWindows(fileName, img, @params, paramsLength, out returnValue);
-    }
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgcodecs_imwrite_multi(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fileName, IntPtr img, [In] int[] @params, int paramsLength, out int returnValue);
 
     // 
 
@@ -100,15 +61,11 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgcodecs_imencode_vector(
         [MarshalAs(UnmanagedType.LPStr)] string ext, IntPtr img, IntPtr buf, [In] int[] @params, int paramsLength, out int returnValue);
 
-    // haveImageReader
+    // haveImageReader (UTF-8 everywhere; native probes via a wide path on Windows)
 
     [LibraryImport(DllExtern, EntryPoint = "imgcodecs_haveImageReader"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_haveImageReader_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string fileName, out int returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "imgcodecs_haveImageReader"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgcodecs_haveImageReader_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string fileName, out int returnValue);
+    private static partial ExceptionStatus imgcodecs_haveImageReader_utf8(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string fileName, out int returnValue);
 
     public static ExceptionStatus imgcodecs_haveImageReader(string fileName, out int returnValue)
     {
@@ -116,10 +73,8 @@ static partial class NativeMethods
             returnValue = default(int);
             return ExceptionStatus.Occurred;
         }
-            
-        if (IsWindows())
-            return imgcodecs_haveImageReader_Windows(fileName, out returnValue);
-        return imgcodecs_haveImageReader_NotWindows(fileName, out returnValue);
+
+        return imgcodecs_haveImageReader_utf8(fileName, out returnValue);
     }
         
     // haveImageWriter

--- a/src/OpenCvSharpExtern/imgcodecs.h
+++ b/src/OpenCvSharpExtern/imgcodecs.h
@@ -6,18 +6,121 @@
 
 #include "include_opencv.h"
 
+// Path handling on Windows (opencv #4242): OpenCV's narrow fopen interprets paths in the active code
+// page, so non-ANSI names fail. We keep behaviour identical for paths the code page CAN represent
+// (call cv::imread/imwrite directly -> streaming, full codec parity); only paths it cannot represent
+// take the wide route below. Reads are decoded from a memory-mapped view (the OS demand-pages, so peak
+// memory stays close to cv::imread instead of slurping the whole file); writes encode in memory then
+// write via a wide stream. Non-Windows keeps the plain OpenCV calls (UTF-8 paths already work there).
+
+#ifdef _WIN32
+// The C++ decode work, kept in its own function so the SEH guard below has no objects to unwind (C2712).
+static bool imgcodecs_decodeImpl(const void *data, int size, int flags, cv::Mat *out)
+{
+    const cv::Mat src(1, size, CV_8UC1, const_cast<void*>(data));
+    *out = cv::imdecode(src, flags);
+    return true;
+}
+static bool imgcodecs_decodeMultiImpl(const void *data, int size, int flags, std::vector<cv::Mat> *mats)
+{
+    const cv::Mat src(1, size, CV_8UC1, const_cast<void*>(data));
+    return cv::imdecodemulti(src, flags, *mats);
+}
+// Touching a mapped view can raise EXCEPTION_IN_PAGE_ERROR (file truncated / network read fails mid
+// decode). Guard it as SEH and let the caller fall back. No C++ unwinding objects here (MSVC C2712).
+static bool imgcodecs_decodeGuarded(const void *data, int size, int flags, cv::Mat *out)
+{
+    __try { return imgcodecs_decodeImpl(data, size, flags, out); }
+    __except (GetExceptionCode() == EXCEPTION_IN_PAGE_ERROR ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
+    { return false; }
+}
+static bool imgcodecs_decodeMultiGuarded(const void *data, int size, int flags, std::vector<cv::Mat> *mats)
+{
+    __try { return imgcodecs_decodeMultiImpl(data, size, flags, mats); }
+    __except (GetExceptionCode() == EXCEPTION_IN_PAGE_ERROR ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
+    { return false; }
+}
+
+// Maps the wide-path file and runs 'decode' over the view; on a 0-byte file, mapping failure, an SEH
+// fault, or a file larger than a single Mat can hold, falls back to reading the whole file.
+template <typename TDecodeGuarded, typename TDecodeBuf>
+static bool imgcodecs_withWideFile(const char *utf8, TDecodeGuarded decodeGuarded, TDecodeBuf decodeBuf)
+{
+    const std::wstring wide = utf8ToWide(utf8);
+    HANDLE hFile = CreateFileW(wide.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile != INVALID_HANDLE_VALUE)
+    {
+        LARGE_INTEGER sz;
+        if (GetFileSizeEx(hFile, &sz) && sz.QuadPart > 0 && sz.QuadPart <= 0x7fffffffLL)
+        {
+            HANDLE hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+            if (hMap != nullptr)
+            {
+                void *view = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+                if (view != nullptr)
+                {
+                    const bool ok = decodeGuarded(view, static_cast<int>(sz.QuadPart));
+                    UnmapViewOfFile(view);
+                    CloseHandle(hMap);
+                    CloseHandle(hFile);
+                    if (ok) return true; // decoded over the mapping (no SEH fault)
+                    // SEH fault -> fall through to the slurp fallback below
+                    std::vector<uchar> buf;
+                    return readAllBytesWide(utf8, buf) && !buf.empty() && decodeBuf(buf);
+                }
+                CloseHandle(hMap);
+            }
+        }
+        CloseHandle(hFile);
+    }
+    std::vector<uchar> buf;
+    return readAllBytesWide(utf8, buf) && !buf.empty() && decodeBuf(buf);
+}
+#endif
+
 CVAPI(ExceptionStatus) imgcodecs_imread(const char *filename, int flags, cv::Mat **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string acp;
+    cv::Mat ret;
+    if (pathRoundTripsAcp(filename, acp))
+    {
+        ret = cv::imread(acp, flags);
+    }
+    else
+    {
+        imgcodecs_withWideFile(filename,
+            [&](const void *d, int n) { return imgcodecs_decodeGuarded(d, n, flags, &ret); },
+            [&](const std::vector<uchar> &b) { ret = cv::imdecode(b, flags); return true; });
+    }
+    *returnValue = new cv::Mat(ret);
+#else
     const auto ret = cv::imread(filename, flags);
     *returnValue = new cv::Mat(ret);
+#endif
     END_WRAP
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imreadmulti(const char *filename, std::vector<cv::Mat> *mats, int flags, int *returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string acp;
+    if (pathRoundTripsAcp(filename, acp))
+    {
+        *returnValue = cv::imreadmulti(acp, *mats, flags) ? 1 : 0;
+    }
+    else
+    {
+        const bool ok = imgcodecs_withWideFile(filename,
+            [&](const void *d, int n) { return imgcodecs_decodeMultiGuarded(d, n, flags, mats); },
+            [&](const std::vector<uchar> &b) { return cv::imdecodemulti(b, flags, *mats); });
+        *returnValue = ok ? 1 : 0;
+    }
+#else
     *returnValue = cv::imreadmulti(filename, *mats, flags) ? 1 : 0;
+#endif
     END_WRAP
 }
 
@@ -26,7 +129,23 @@ CVAPI(ExceptionStatus) imgcodecs_imwrite(const char *filename, cv::Mat *img, int
     BEGIN_WRAP
     std::vector<int> paramsVec;
     paramsVec.assign(params, params + paramsLength);
+#ifdef _WIN32
+    std::string acp;
+    if (pathRoundTripsAcp(filename, acp))
+    {
+        *returnValue = cv::imwrite(acp, *img, paramsVec) ? 1 : 0;
+    }
+    else
+    {
+        const std::string fn(filename ? filename : "");
+        const auto dot = fn.find_last_of('.');
+        std::vector<uchar> buf;
+        *returnValue = (dot != std::string::npos && cv::imencode(fn.substr(dot), *img, buf, paramsVec)
+            && writeAllBytesWide(filename, buf.data(), buf.size())) ? 1 : 0;
+    }
+#else
     *returnValue = cv::imwrite(filename, *img, paramsVec) ? 1 : 0;
+#endif
     END_WRAP
 }
 
@@ -35,7 +154,23 @@ CVAPI(ExceptionStatus) imgcodecs_imwrite_multi(const char *filename, std::vector
     BEGIN_WRAP
     std::vector<int> paramsVec;
     paramsVec.assign(params, params + paramsLength);
+#ifdef _WIN32
+    std::string acp;
+    if (pathRoundTripsAcp(filename, acp))
+    {
+        *returnValue = cv::imwrite(acp, *img, paramsVec) ? 1 : 0;
+    }
+    else
+    {
+        const std::string fn(filename ? filename : "");
+        const auto dot = fn.find_last_of('.');
+        std::vector<uchar> buf;
+        *returnValue = (dot != std::string::npos && cv::imencodemulti(fn.substr(dot), *img, buf, paramsVec)
+            && writeAllBytesWide(filename, buf.data(), buf.size())) ? 1 : 0;
+    }
+#else
     *returnValue = cv::imwrite(filename, *img, paramsVec) ? 1 : 0;
+#endif
     END_WRAP
 }
 
@@ -80,7 +215,24 @@ CVAPI(ExceptionStatus) imgcodecs_imencode_vector(
 CVAPI(ExceptionStatus) imgcodecs_haveImageReader(const char *filename, int *returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string acp;
+    if (pathRoundTripsAcp(filename, acp))
+    {
+        *returnValue = cv::haveImageReader(acp) ? 1 : 0;
+    }
+    else
+    {
+        // No narrow path OpenCV can open; probe decodability over the wide-path file instead.
+        cv::Mat probe;
+        imgcodecs_withWideFile(filename,
+            [&](const void *d, int n) { return imgcodecs_decodeGuarded(d, n, cv::IMREAD_UNCHANGED, &probe); },
+            [&](const std::vector<uchar> &b) { probe = cv::imdecode(b, cv::IMREAD_UNCHANGED); return true; });
+        *returnValue = probe.empty() ? 0 : 1;
+    }
+#else
     *returnValue = cv::haveImageReader(filename) ? 1 : 0;
+#endif
     END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/my_functions.h
+++ b/src/OpenCvSharpExtern/my_functions.h
@@ -45,6 +45,77 @@ static int p(T obj, const std::string &caption = "MessageBox")
 #endif
 
 
+#ifdef _WIN32
+#include <Windows.h>
+
+// Windows narrow file APIs (fopen) interpret paths in the active code page, so OpenCV cannot open
+// UTF-8 / non-ANSI file names. These helpers let the path-taking entry points do their own I/O via
+// wide (UTF-16) streams on Windows, combined with OpenCV's in-memory decode/encode APIs. Fixes opencv #4242.
+static std::wstring utf8ToWide(const char *utf8)
+{
+    if (utf8 == nullptr || utf8[0] == '\0')
+        return std::wstring();
+    const int len = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, nullptr, 0);
+    if (len <= 1)
+        return std::wstring();
+    std::wstring wide(static_cast<size_t>(len - 1), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8, -1, &wide[0], len);
+    return wide;
+}
+
+// True if the UTF-8 path can be represented losslessly in the process active code page (so OpenCV's
+// narrow file APIs can open it directly, preserving streaming). 'acp' receives the narrow path.
+// Returns false only for paths with characters the code page cannot represent (those previously
+// failed on Windows and now need the wide path).
+static bool pathRoundTripsAcp(const char *utf8, std::string &acp)
+{
+    if (utf8 == nullptr || utf8[0] == '\0') { acp.clear(); return true; }
+    // A UTF-8 active code page (Windows 10 1903+) opens UTF-8 narrow paths directly.
+    if (GetACP() == CP_UTF8) { acp = utf8; return true; }
+    // Pure ASCII is representable in every code page.
+    bool ascii = true;
+    for (const char *p = utf8; *p != '\0'; ++p)
+        if (static_cast<unsigned char>(*p) >= 0x80) { ascii = false; break; }
+    if (ascii) { acp = utf8; return true; }
+
+    const std::wstring wide = utf8ToWide(utf8);
+    if (wide.empty()) return false;
+    BOOL usedDefault = FALSE;
+    const int len = WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, wide.c_str(), -1, nullptr, 0, nullptr, &usedDefault);
+    if (len <= 0) return false; // e.g. flag unsupported by the code page -> treat as non-representable
+    std::string buf(static_cast<size_t>(len - 1), '\0');
+    WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, wide.c_str(), -1, len > 1 ? &buf[0] : nullptr, len, nullptr, &usedDefault);
+    if (usedDefault) return false; // a character could not be represented in the code page
+    acp = std::move(buf);
+    return true;
+}
+
+// Reads the whole file at a UTF-8 path. Returns false if it could not be opened.
+static bool readAllBytesWide(const char *utf8Path, std::vector<uchar> &out)
+{
+    std::ifstream file(utf8ToWide(utf8Path), std::ios::binary | std::ios::ate);
+    if (!file)
+        return false;
+    const std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    out.resize(static_cast<size_t>(size < 0 ? 0 : size));
+    if (size > 0)
+        file.read(reinterpret_cast<char*>(out.data()), size);
+    return true;
+}
+
+// Writes bytes to a UTF-8 path. Returns false on failure.
+static bool writeAllBytesWide(const char *utf8Path, const uchar *data, size_t size)
+{
+    std::ofstream file(utf8ToWide(utf8Path), std::ios::binary);
+    if (!file)
+        return false;
+    if (size > 0)
+        file.write(reinterpret_cast<const char*>(data), static_cast<std::streamsize>(size));
+    return file.good();
+}
+#endif
+
 #if defined WIN32 || defined _WIN32
 #  define CV_CDECL __cdecl
 #  define CV_STDCALL __stdcall

--- a/test/OpenCvSharp.Tests/imgcodecs/ImgCodecsTest.cs
+++ b/test/OpenCvSharp.Tests/imgcodecs/ImgCodecsTest.cs
@@ -98,8 +98,8 @@ public class ImgCodecsTest : TestBase
         Assert.False(mat.Empty());
     }
 
-    // TODO Windows not supported?
-    // https://github.com/opencv/opencv/issues/4242
+    // Unicode (incl. non-ANSI) paths now work on every platform: the native side reads via a wide
+    // path on Windows. (Formerly unsupported on Windows; opencv #4242.)
     [Fact]
     public void ImReadUnicodeFileName()
     {
@@ -107,21 +107,82 @@ public class ImgCodecsTest : TestBase
 
         CreateDummyImageFile(fileName);
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        using var image = Cv2.ImRead(fileName);
+        Assert.NotNull(image);
+        Assert.False(image.Empty());
+    }
+
+    // --- Edge cases for the Windows non-ANSI (wide-path) route: gating, mmap decode and its fallbacks ---
+
+    [Fact]
+    public void ImReadWriteUnicodeRoundTripPixels()
+    {
+        // The wide-path encode/write and mmap decode must produce byte-identical pixels (PNG is lossless).
+        const string fileName = "_data/image/roundtrip♥😀.png";
+        try
         {
-            // Source-generated ANSI marshalling substitutes the unmappable characters, so OpenCV
-            // receives a different path and cannot find the file (Unicode paths remain unsupported
-            // on the Windows ANSI path; see opencv #4242). imread then returns an empty Mat.
-            // TODO(Phase 4, #1938): once UTF-8 string marshalling replaces the Windows ANSI path,
-            // this branch should match the non-Windows one (read succeeds, image is not empty).
+            using var src = new Mat(10, 20, MatType.CV_8UC3, Scalar.Blue);
+            src.Set(3, 5, new Vec3b(10, 20, 30));
+            src.Set(9, 19, new Vec3b(200, 100, 50));
+
+            Assert.True(Cv2.ImWrite(fileName, src));
+            Assert.True(File.Exists(fileName), $"File '{fileName}' not found");
+
+            using var dst = Cv2.ImRead(fileName, ImreadModes.Color);
+            Assert.False(dst.Empty());
+            Assert.Equal(src.Rows, dst.Rows);
+            Assert.Equal(src.Cols, dst.Cols);
+            Assert.Equal(src.At<Vec3b>(0, 0), dst.At<Vec3b>(0, 0));
+            Assert.Equal(src.At<Vec3b>(3, 5), dst.At<Vec3b>(3, 5));
+            Assert.Equal(src.At<Vec3b>(9, 19), dst.At<Vec3b>(9, 19));
+        }
+        finally
+        {
+            if (File.Exists(fileName)) File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void ImReadUnicodeEmptyFileReturnsEmpty()
+    {
+        // 0-byte file with a non-ANSI name: mapping is skipped and the fallback yields an empty Mat (no crash).
+        const string fileName = "_data/image/empty♡😄.png";
+        try
+        {
+            File.WriteAllBytes(fileName, Array.Empty<byte>());
+            using var image = Cv2.ImRead(fileName);
+            Assert.NotNull(image);
+            Assert.True(image.Empty());
+        }
+        finally
+        {
+            if (File.Exists(fileName)) File.Delete(fileName);
+        }
+    }
+
+    [Fact]
+    public void ImReadUnicodeMissingFileReturnsEmpty()
+    {
+        using var image = Cv2.ImRead("_data/image/does_not_exist♥😀.png");
+        Assert.NotNull(image);
+        Assert.True(image.Empty());
+    }
+
+    [Fact]
+    public void HaveImageReaderUnicodeNonImageIsFalse()
+    {
+        // Non-ANSI name with a .png extension but non-image content -> not decodable.
+        const string fileName = "_data/image/notimage♥😀.png";
+        try
+        {
+            File.WriteAllText(fileName, "this is not an image");
+            Assert.False(Cv2.HaveImageReader(fileName));
             using var image = Cv2.ImRead(fileName);
             Assert.True(image.Empty());
         }
-        else
+        finally
         {
-            using var image = Cv2.ImRead(fileName);
-            Assert.NotNull(image);
-            Assert.False(image.Empty());
+            if (File.Exists(fileName)) File.Delete(fileName);
         }
     }
 
@@ -171,9 +232,8 @@ public class ImgCodecsTest : TestBase
         Assert.Equal(20, imageInfo.Width);
     }
 
-    // TODO
-    // https://github.com/opencv/opencv/issues/4242
-    //[PlatformSpecificFact("Linux")]
+    // Unicode (incl. non-ANSI) paths now work on every platform: the native side writes via a wide
+    // path on Windows. (Formerly unsupported on Windows; opencv #4242.)
     [Fact]
     public void ImWriteUnicodeFileName()
     {
@@ -185,22 +245,9 @@ public class ImgCodecsTest : TestBase
 
         using (var mat = new Mat(10, 20, MatType.CV_8UC3, Scalar.Blue))
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // ANSI marshalling mangles the unmappable characters, so the requested Unicode file
-                // is not produced (Unicode paths remain unsupported on the Windows ANSI path; opencv #4242).
-                // TODO(Phase 4, #1938): once UTF-8 string marshalling replaces the Windows ANSI path,
-                // this branch should match the non-Windows one (the Unicode file is written successfully).
-                Cv2.ImWrite(fileName, mat);
-                Assert.False(File.Exists(fileName), $"Unexpectedly wrote '{fileName}' via the ANSI path");
-                return;
-            }
-            else
-            {
-                Cv2.ImWrite(fileName, mat);
-            }
+            Cv2.ImWrite(fileName, mat);
         }
-        
+
         var file = new FileInfo(fileName);
         Assert.True(file.Exists, $"File '{fileName}' not found");
         Assert.True(file.Length > 0, $"File size of '{fileName}' == 0");
@@ -290,18 +337,9 @@ public class ImgCodecsTest : TestBase
         {
             CreateDummyImageFile(path);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // ANSI marshalling mangles the unmappable characters, so OpenCV looks for a different
-                // path and reports the reader as unavailable (opencv #4242).
-                // TODO(Phase 4, #1938): once UTF-8 string marshalling replaces the Windows ANSI path,
-                // this branch should match the non-Windows one (HaveImageReader returns true).
-                Assert.False(Cv2.HaveImageReader(path));
-            }
-            else
-            {
-                Assert.True(Cv2.HaveImageReader(path));
-            }
+            // Unicode (incl. non-ANSI) paths now work on every platform (native probes via a wide
+            // path on Windows; formerly unsupported there, opencv #4242).
+            Assert.True(Cv2.HaveImageReader(path));
         }
         finally
         {


### PR DESCRIPTION
OpenCV's imgcodecs uses narrow `fopen`, so `cv::imread`/`imwrite`/`imreadmulti`/`haveImageReader` interpret paths in the active code page and cannot open UTF-8 / non-ANSI file names on Windows ([opencv #4242](https://github.com/opencv/opencv/issues/4242)). This fixes it on Windows **while keeping behaviour identical for everything that already worked**.

### Approach (Windows)
1. **Gate on representability.** If the path round-trips through the active code page (pure ASCII, a UTF-8 ACP, or a losslessly-encodable name) we call `cv::imread`/`imwrite` **directly, exactly as before** → streaming and full codec parity (incl. GDAL, tiled TIFF, `IMREAD_REDUCED_*`) preserved. Only paths the code page **cannot** represent (which previously failed outright) take the wide route.
2. **Wide route — reads:** decode from a **memory-mapped view** of the wide-opened file (`CreateFileW` + `MapViewOfFile` + `cv::imdecode`/`imdecodemulti`). The OS demand-pages, so peak memory stays close to `cv::imread` instead of slurping the whole file into the heap. Touching a mapped view can raise `EXCEPTION_IN_PAGE_ERROR` (truncation / network fault mid-decode), so the decode runs under an **SEH guard** (in a dedicated helper kept free of C++ unwinding objects per MSVC C2712) and **falls back** to reading the file on fault / mapping failure / 0-byte / >2 GB.
3. **Wide route — writes:** `cv::imencode`/`imencodemulti` in memory + write via a wide stream.

Non-Windows keeps the plain `cv::` calls (UTF-8 paths already work there). The wide-path helpers (`utf8ToWide` / `pathRoundTripsAcp` / `readAllBytesWide` / `writeAllBytesWide`) live in `my_functions.h` for reuse by the other path-taking subsystems.

**Managed:** these entry points now marshal the filename as UTF-8 (`LPUTF8Str`) through a single entry point; the per-OS `LPStr`/`LPUTF8Str` split and the OS dispatcher are removed.

### Why this design
- No regression for representable paths (the overwhelming majority, incl. large ASCII files): byte-identical to today, full streaming.
- The wide route only affects paths that **failed before**, and even there avoids a full-file heap copy via mmap.
- SEH/fault risk is confined to the imgcodecs read helpers, Windows-only.

### Tests
Unicode-filename read/write/haveImageReader now assert success on every platform, plus edge cases: **pixel-exact write→read round-trip**, **0-byte file**, **missing file**, **non-image content**. Full managed suite passes (**933 passed, 25 skipped**) against a freshly built `OpenCvSharpExtern`.

### Scope
imgcodecs slice of the UTF-8 path unification (#1938 roadmap). FileStorage, dnn model loading, FontFace, ptcloud follow module by module. **videoio is intentionally excluded**: its string may be an RTSP/HTTP URL or a pipeline, not a local file, so it needs a different (non-slurp) approach.

Part of #1938.