### PR TITLE
Support UTF-8 / non-ANSI model paths on Windows (dnn)

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -28,30 +28,16 @@ static partial class NativeMethods
         int engine,
         out IntPtr returnValue);
 
-    // readNet
+    // readNet (UTF-8 everywhere; non-ANSI paths read via wide + buffer overload on Windows, with the
+    // framework inferred from the model extension when not given)
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNet"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNet_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string config,
+    public static partial ExceptionStatus dnn_readNet(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string config,
         [MarshalAs(UnmanagedType.LPStr)] string framework,
         int engine,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_readNet"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNet_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string config,
-        [MarshalAs(UnmanagedType.LPStr)] string framework,
-        int engine,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_readNet(string model, string config, string framework, int engine, out IntPtr returnValue)
-    {
-        if (IsWindows())
-            return dnn_readNet_Windows(model, config, framework, engine, out returnValue);
-        return dnn_readNet_NotWindows(model, config, framework, engine, out returnValue);
-    }
 
     // readNetFromModelOptimizer (UTF-8 everywhere; non-ANSI paths read via wide + buffer overload on Windows)
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -11,28 +11,15 @@ namespace OpenCvSharp.Internal;
 // ReSharper disable InconsistentNaming
 static partial class NativeMethods
 {
-    // readNetFromTensorflow
+    // readNetFromTensorflow (UTF-8 everywhere; on Windows the native side reads non-ANSI paths via a
+    // wide stream and the in-memory buffer overload)
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTensorflow"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromTensorflow_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_readNetFromTensorflow(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         int engine,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTensorflow"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromTensorflow_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        int engine,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_readNetFromTensorflow(string model, string? config, int engine, out IntPtr returnValue)
-    {
-        if (IsWindows())
-            return dnn_readNetFromTensorflow_Windows(model, config, engine, out returnValue);
-        return dnn_readNetFromTensorflow_NotWindows(model, config, engine, out returnValue);
-    }
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTensorflow_InputArray"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial ExceptionStatus dnn_readNetFromTensorflow(
@@ -66,47 +53,21 @@ static partial class NativeMethods
         return dnn_readNet_NotWindows(model, config, framework, engine, out returnValue);
     }
 
-    // readNetFromModelOptimizer
+    // readNetFromModelOptimizer (UTF-8 everywhere; non-ANSI paths read via wide + buffer overload on Windows)
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromModelOptimizer"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromModelOptimizer_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string xml,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string bin,
+    public static partial ExceptionStatus dnn_readNetFromModelOptimizer(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string xml,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string bin,
         out IntPtr returnValue);
 
-    [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromModelOptimizer"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromModelOptimizer_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string xml,
-        [MarshalAs(StringUnmanagedTypeWindows)] string bin, 
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_readNetFromModelOptimizer(string xml, string bin, out IntPtr returnValue)
-    {
-        if (IsWindows())
-            return dnn_readNetFromModelOptimizer_Windows(xml, bin, out returnValue);
-        return dnn_readNetFromModelOptimizer_NotWindows(xml, bin, out returnValue);
-    }
-
-    // readNetFromONNX
+    // readNetFromONNX (UTF-8 everywhere; non-ANSI paths read via wide + buffer overload on Windows)
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromONNX"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromONNX_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string onnxFile,
+    public static partial ExceptionStatus dnn_readNetFromONNX(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string onnxFile,
         int engine,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromONNX"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromONNX_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string onnxFile,
-        int engine,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_readNetFromONNX(string onnxFile, int engine, out IntPtr returnValue)
-    {
-        if (IsWindows())
-            return dnn_readNetFromONNX_Windows(onnxFile, engine, out returnValue);
-        return dnn_readNetFromONNX_NotWindows(onnxFile, engine, out returnValue);
-    }
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromONNX_InputArray"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial ExceptionStatus dnn_readNetFromONNX(
@@ -184,20 +145,11 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_enableModelDiagnostics(int isDiagnosticsMode);
 
-    // readNetFromTFLite
+    // readNetFromTFLite (UTF-8 everywhere; non-ANSI paths read via wide + buffer overload on Windows)
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTFLite"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromTFLite_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model, int engine, out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTFLite"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_readNetFromTFLite_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model, int engine, out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_readNetFromTFLite(string model, int engine, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_readNetFromTFLite_Windows(model, engine, out returnValue)
-            : dnn_readNetFromTFLite_NotWindows(model, engine, out returnValue);
+    public static partial ExceptionStatus dnn_readNetFromTFLite(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model, int engine, out IntPtr returnValue);
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_readNetFromTFLite_InputArray"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial ExceptionStatus dnn_readNetFromTFLite(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Model.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Model.cs
@@ -16,21 +16,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_Model_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_Model_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_Model_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_Model_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_Model_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_Model_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_Model_new_String_Windows(model, config, out returnValue)
-            : dnn_Model_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_Model_new_Net(IntPtr network, out IntPtr returnValue);
@@ -77,21 +66,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_ClassificationModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_ClassificationModel_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_ClassificationModel_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_ClassificationModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_ClassificationModel_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_ClassificationModel_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_ClassificationModel_new_String_Windows(model, config, out returnValue)
-            : dnn_ClassificationModel_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_ClassificationModel_new_Net(IntPtr network, out IntPtr returnValue);
@@ -113,21 +91,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_DetectionModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_DetectionModel_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_DetectionModel_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_DetectionModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_DetectionModel_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_DetectionModel_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_DetectionModel_new_String_Windows(model, config, out returnValue)
-            : dnn_DetectionModel_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_DetectionModel_new_Net(IntPtr network, out IntPtr returnValue);
@@ -151,21 +118,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_SegmentationModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_SegmentationModel_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_SegmentationModel_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_SegmentationModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_SegmentationModel_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_SegmentationModel_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_SegmentationModel_new_String_Windows(model, config, out returnValue)
-            : dnn_SegmentationModel_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_SegmentationModel_new_Net(IntPtr network, out IntPtr returnValue);
@@ -181,21 +137,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_KeypointsModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_KeypointsModel_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_KeypointsModel_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_KeypointsModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_KeypointsModel_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_KeypointsModel_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_KeypointsModel_new_String_Windows(model, config, out returnValue)
-            : dnn_KeypointsModel_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_KeypointsModel_new_Net(IntPtr network, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
@@ -16,21 +16,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_TextRecognitionModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextRecognitionModel_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_TextRecognitionModel_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_TextRecognitionModel_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextRecognitionModel_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_TextRecognitionModel_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_TextRecognitionModel_new_String_Windows(model, config, out returnValue)
-            : dnn_TextRecognitionModel_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_TextRecognitionModel_new_Net(IntPtr network, out IntPtr returnValue);
@@ -76,21 +65,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_TextDetectionModel_EAST_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextDetectionModel_EAST_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_TextDetectionModel_EAST_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_TextDetectionModel_EAST_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextDetectionModel_EAST_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_TextDetectionModel_EAST_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_TextDetectionModel_EAST_new_String_Windows(model, config, out returnValue)
-            : dnn_TextDetectionModel_EAST_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_TextDetectionModel_EAST_new_Net(IntPtr network, out IntPtr returnValue);
@@ -115,21 +93,10 @@ static partial class NativeMethods
     // ------------------------------------------------------------------------
 
     [LibraryImport(DllExtern, EntryPoint = "dnn_TextDetectionModel_DB_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextDetectionModel_DB_new_String_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string? config,
+    public static partial ExceptionStatus dnn_TextDetectionModel_DB_new_String(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string model,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? config,
         out IntPtr returnValue);
-
-    [LibraryImport(DllExtern, EntryPoint = "dnn_TextDetectionModel_DB_new_String"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus dnn_TextDetectionModel_DB_new_String_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string model,
-        [MarshalAs(StringUnmanagedTypeWindows)] string? config,
-        out IntPtr returnValue);
-
-    public static ExceptionStatus dnn_TextDetectionModel_DB_new_String(string model, string? config, out IntPtr returnValue)
-        => IsWindows()
-            ? dnn_TextDetectionModel_DB_new_String_Windows(model, config, out returnValue)
-            : dnn_TextDetectionModel_DB_new_String_NotWindows(model, config, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_TextDetectionModel_DB_new_Net(IntPtr network, out IntPtr returnValue);

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -10,12 +10,46 @@
 
 #include "include_opencv.h"
 
+// Path handling (opencv #4242): OpenCV reads model files by narrow fopen, so non-ANSI paths fail on
+// Windows. For paths the active code page can represent we call the file-based readNet* directly
+// (streaming, unchanged); only non-representable paths are read via a wide stream and handed to the
+// in-memory buffer overload. Non-Windows keeps the file-based calls (UTF-8 paths already work there).
+#ifdef _WIN32
+static std::vector<uchar> dnn_readFileWideOrThrow(const char *utf8)
+{
+    std::vector<uchar> buf;
+    if (!readAllBytesWide(utf8, buf))
+        CV_Error(cv::Error::StsError, cv::format("Failed to open file: %s", utf8 ? utf8 : "(null)"));
+    return buf;
+}
+#endif
+
 CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    const bool hasConfig = (config != nullptr && config[0] != '\0');
+    std::string modelAcp, configAcp;
+    cv::dnn::Net net;
+    if (pathRoundTripsAcp(model, modelAcp) && (!hasConfig || pathRoundTripsAcp(config, configAcp)))
+    {
+        net = cv::dnn::readNetFromTensorflow(cv::String(modelAcp), hasConfig ? cv::String(configAcp) : cv::String(), engine);
+    }
+    else
+    {
+        const std::vector<uchar> modelBuf = dnn_readFileWideOrThrow(model);
+        const std::vector<uchar> configBuf = hasConfig ? dnn_readFileWideOrThrow(config) : std::vector<uchar>();
+        net = cv::dnn::readNetFromTensorflow(
+            reinterpret_cast<const char*>(modelBuf.data()), modelBuf.size(),
+            hasConfig ? reinterpret_cast<const char*>(configBuf.data()) : nullptr, hasConfig ? configBuf.size() : 0,
+            engine);
+    }
+    *returnValue = new cv::dnn::Net(net);
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     const auto net = cv::dnn::readNetFromTensorflow(model, configStr, engine);
     *returnValue = new cv::dnn::Net(net);
+#endif
     END_WRAP
 }
 
@@ -40,17 +74,48 @@ CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const 
 CVAPI(ExceptionStatus) dnn_readNetFromModelOptimizer(const char *xml, const char *bin, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string xmlAcp, binAcp;
+    cv::dnn::Net net;
+    if (pathRoundTripsAcp(xml, xmlAcp) && pathRoundTripsAcp(bin, binAcp))
+    {
+        net = cv::dnn::readNetFromModelOptimizer(cv::String(xmlAcp), cv::String(binAcp));
+    }
+    else
+    {
+        const std::vector<uchar> xmlBuf = dnn_readFileWideOrThrow(xml);
+        const std::vector<uchar> binBuf = dnn_readFileWideOrThrow(bin);
+        net = cv::dnn::readNetFromModelOptimizer(xmlBuf.data(), xmlBuf.size(), binBuf.data(), binBuf.size());
+    }
+    *returnValue = new cv::dnn::Net(net);
+#else
     const auto net = cv::dnn::readNetFromModelOptimizer(xml, bin);
     *returnValue = new cv::dnn::Net(net);
+#endif
     END_WRAP
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromONNX(const char *onnxFile, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string acp;
+    cv::dnn::Net net;
+    if (pathRoundTripsAcp(onnxFile, acp))
+    {
+        net = cv::dnn::readNetFromONNX(cv::String(acp), engine);
+    }
+    else
+    {
+        const std::vector<uchar> buf = dnn_readFileWideOrThrow(onnxFile);
+        net = cv::dnn::readNetFromONNX(reinterpret_cast<const char*>(buf.data()), buf.size(), engine);
+    }
+    *returnValue = new cv::dnn::Net(net);
+#else
     // Wrap in cv::String to disambiguate from the (const char* buffer, size_t, int) overload.
     const auto net = cv::dnn::readNetFromONNX(cv::String(onnxFile), engine);
     *returnValue = new cv::dnn::Net(net);
+#endif
     END_WRAP
 }
 
@@ -169,9 +234,24 @@ CVAPI(ExceptionStatus) dnn_enableModelDiagnostics(const int isDiagnosticsMode)
 CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    std::string acp;
+    cv::dnn::Net net;
+    if (pathRoundTripsAcp(model, acp))
+    {
+        net = cv::dnn::readNetFromTFLite(cv::String(acp), engine);
+    }
+    else
+    {
+        const std::vector<uchar> buf = dnn_readFileWideOrThrow(model);
+        net = cv::dnn::readNetFromTFLite(reinterpret_cast<const char*>(buf.data()), buf.size(), engine);
+    }
+    *returnValue = new cv::dnn::Net(net);
+#else
     // Wrap in cv::String to disambiguate from the (const char* buffer, size_t, int) overload.
     const auto net = cv::dnn::readNetFromTFLite(cv::String(model), engine);
     *returnValue = new cv::dnn::Net(net);
+#endif
     END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -22,6 +22,25 @@ static std::vector<uchar> dnn_readFileWideOrThrow(const char *utf8)
         CV_Error(cv::Error::StsError, cv::format("Failed to open file: %s", utf8 ? utf8 : "(null)"));
     return buf;
 }
+
+// Mirror cv::dnn::readNet's framework inference from the model file extension. Only used for the
+// buffer overload on non-representable paths (representable paths call file-based readNet, which does
+// OpenCV's own inference). Returns "" for unknown extensions so the buffer call surfaces OpenCV's error.
+static std::string dnn_inferFramework(const char *model)
+{
+    std::string m(model ? model : "");
+    const auto dot = m.find_last_of('.');
+    std::string ext = (dot == std::string::npos) ? "" : m.substr(dot + 1);
+    for (auto &c : ext) c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+    if (ext == "caffemodel") return "caffe";
+    if (ext == "pb") return "tensorflow";
+    if (ext == "t7" || ext == "net") return "torch";
+    if (ext == "weights") return "darknet";
+    if (ext == "bin" || ext == "xml") return "dldt";
+    if (ext == "onnx") return "onnx";
+    if (ext == "tflite") return "tflite";
+    return "";
+}
 #endif
 
 CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, int engine, cv::dnn::Net **returnValue)
@@ -64,10 +83,30 @@ CVAPI(ExceptionStatus) dnn_readNetFromTensorflow_InputArray(const char *model,si
 CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const char *framework, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    const std::string frameworkStr = (framework == nullptr) ? "" : std::string(framework);
+    const bool hasConfig = (config != nullptr && config[0] != '\0');
+    std::string modelAcp, configAcp;
+    cv::dnn::Net net;
+    if (pathRoundTripsAcp(model, modelAcp) && (!hasConfig || pathRoundTripsAcp(config, configAcp)))
+    {
+        net = cv::dnn::readNet(cv::String(modelAcp), hasConfig ? cv::String(configAcp) : cv::String(), frameworkStr, engine);
+    }
+    else
+    {
+        // The buffer overload needs an explicit framework; infer it from the extension when not given.
+        const std::string fw = frameworkStr.empty() ? dnn_inferFramework(model) : frameworkStr;
+        const std::vector<uchar> modelBuf = dnn_readFileWideOrThrow(model);
+        const std::vector<uchar> configBuf = hasConfig ? dnn_readFileWideOrThrow(config) : std::vector<uchar>();
+        net = cv::dnn::readNet(fw, modelBuf, configBuf, engine);
+    }
+    *returnValue = new cv::dnn::Net(net);
+#else
     const auto configStr = (config == nullptr) ? "" : cv::String(config);
     const auto frameworkStr = (framework == nullptr) ? "" : cv::String(framework);
     const auto net = cv::dnn::readNet(model, configStr, frameworkStr, engine);
     *returnValue = new cv::dnn::Net(net);
+#endif
     END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -43,6 +43,29 @@ static std::string dnn_inferFramework(const char *model)
 }
 #endif
 
+// Reads a net from (model, config) file paths, transparently handling non-ANSI paths on Windows
+// (representable -> file-based readNet; otherwise wide-read + framework-explicit buffer overload).
+// Shared by dnn_readNet and the Model constructors.
+static cv::dnn::Net dnn_readNetGated(const char *model, const char *config, const char *framework, int engine)
+{
+#ifdef _WIN32
+    const std::string frameworkStr = (framework == nullptr) ? "" : std::string(framework);
+    const bool hasConfig = (config != nullptr && config[0] != '\0');
+    std::string modelAcp, configAcp;
+    if (pathRoundTripsAcp(model, modelAcp) && (!hasConfig || pathRoundTripsAcp(config, configAcp)))
+        return cv::dnn::readNet(cv::String(modelAcp), hasConfig ? cv::String(configAcp) : cv::String(), frameworkStr, engine);
+
+    const std::string fw = frameworkStr.empty() ? dnn_inferFramework(model) : frameworkStr;
+    const std::vector<uchar> modelBuf = dnn_readFileWideOrThrow(model);
+    const std::vector<uchar> configBuf = hasConfig ? dnn_readFileWideOrThrow(config) : std::vector<uchar>();
+    return cv::dnn::readNet(fw, modelBuf, configBuf, engine);
+#else
+    const std::string configStr = (config == nullptr) ? "" : std::string(config);
+    const std::string frameworkStr = (framework == nullptr) ? "" : std::string(framework);
+    return cv::dnn::readNet(model, configStr, frameworkStr, engine);
+#endif
+}
+
 CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
@@ -83,30 +106,7 @@ CVAPI(ExceptionStatus) dnn_readNetFromTensorflow_InputArray(const char *model,si
 CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const char *framework, int engine, cv::dnn::Net **returnValue)
 {
     BEGIN_WRAP
-#ifdef _WIN32
-    const std::string frameworkStr = (framework == nullptr) ? "" : std::string(framework);
-    const bool hasConfig = (config != nullptr && config[0] != '\0');
-    std::string modelAcp, configAcp;
-    cv::dnn::Net net;
-    if (pathRoundTripsAcp(model, modelAcp) && (!hasConfig || pathRoundTripsAcp(config, configAcp)))
-    {
-        net = cv::dnn::readNet(cv::String(modelAcp), hasConfig ? cv::String(configAcp) : cv::String(), frameworkStr, engine);
-    }
-    else
-    {
-        // The buffer overload needs an explicit framework; infer it from the extension when not given.
-        const std::string fw = frameworkStr.empty() ? dnn_inferFramework(model) : frameworkStr;
-        const std::vector<uchar> modelBuf = dnn_readFileWideOrThrow(model);
-        const std::vector<uchar> configBuf = hasConfig ? dnn_readFileWideOrThrow(config) : std::vector<uchar>();
-        net = cv::dnn::readNet(fw, modelBuf, configBuf, engine);
-    }
-    *returnValue = new cv::dnn::Net(net);
-#else
-    const auto configStr = (config == nullptr) ? "" : cv::String(config);
-    const auto frameworkStr = (framework == nullptr) ? "" : cv::String(framework);
-    const auto net = cv::dnn::readNet(model, configStr, frameworkStr, engine);
-    *returnValue = new cv::dnn::Net(net);
-#endif
+    *returnValue = new cv::dnn::Net(dnn_readNetGated(model, config, framework, engine));
     END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/dnn_Model.h
+++ b/src/OpenCvSharpExtern/dnn_Model.h
@@ -9,6 +9,7 @@
 // ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
 
 #include "include_opencv.h"
+#include "dnn.h" // dnn_readNetGated (UTF-8 / non-ANSI model path handling)
 
 // ----------------------------------------------------------------------------
 // Model (base class)
@@ -17,8 +18,12 @@
 CVAPI(ExceptionStatus) dnn_Model_new_String(const char *model, const char *config, cv::dnn::Model **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::Model(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::Model(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -127,8 +132,12 @@ CVAPI(ExceptionStatus) dnn_ClassificationModel_new_String(
     const char *model, const char *config, cv::dnn::ClassificationModel **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::ClassificationModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::ClassificationModel(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -178,8 +187,12 @@ CVAPI(ExceptionStatus) dnn_DetectionModel_new_String(
     const char *model, const char *config, cv::dnn::DetectionModel **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::DetectionModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::DetectionModel(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -229,8 +242,12 @@ CVAPI(ExceptionStatus) dnn_SegmentationModel_new_String(
     const char *model, const char *config, cv::dnn::SegmentationModel **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::SegmentationModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::SegmentationModel(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -264,8 +281,12 @@ CVAPI(ExceptionStatus) dnn_KeypointsModel_new_String(
     const char *model, const char *config, cv::dnn::KeypointsModel **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::KeypointsModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::KeypointsModel(model, configStr);
+#endif
     END_WRAP
 }
 

--- a/src/OpenCvSharpExtern/dnn_TextModel.h
+++ b/src/OpenCvSharpExtern/dnn_TextModel.h
@@ -9,6 +9,7 @@
 // ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
 
 #include "include_opencv.h"
+#include "dnn.h" // dnn_readNetGated (UTF-8 / non-ANSI model path handling)
 
 // ----------------------------------------------------------------------------
 // TextRecognitionModel
@@ -18,8 +19,12 @@ CVAPI(ExceptionStatus) dnn_TextRecognitionModel_new_String(
     const char *model, const char *config, cv::dnn::TextRecognitionModel **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::TextRecognitionModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextRecognitionModel(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -122,8 +127,12 @@ CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_new_String(
     const char *model, const char *config, cv::dnn::TextDetectionModel_EAST **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::TextDetectionModel_EAST(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextDetectionModel_EAST(model, configStr);
+#endif
     END_WRAP
 }
 
@@ -182,8 +191,12 @@ CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_new_String(
     const char *model, const char *config, cv::dnn::TextDetectionModel_DB **returnValue)
 {
     BEGIN_WRAP
+#ifdef _WIN32
+    *returnValue = new cv::dnn::TextDetectionModel_DB(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
+#else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextDetectionModel_DB(model, configStr);
+#endif
     END_WRAP
 }
 

--- a/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
@@ -58,4 +58,25 @@ public class DnnUnicodePathTest : TestBase
                 File.Delete(unicodePath);
         }
     }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void DetectionModelUnicodePath()
+    {
+        // Model constructors build the net through the same gated reader; verify a non-ANSI path works.
+        Assert.True(File.Exists(MnistModelPath), $"'{MnistModelPath}' not found");
+
+        var unicodePath = Path.Combine("_data", "model", "mnist_model_😀🍀.pb");
+        try
+        {
+            File.Copy(MnistModelPath, unicodePath, true);
+
+            using var model = new DetectionModel(unicodePath);
+            Assert.NotNull(model);
+        }
+        finally
+        {
+            if (File.Exists(unicodePath))
+                File.Delete(unicodePath);
+        }
+    }
 }

--- a/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
@@ -35,4 +35,27 @@ public class DnnUnicodePathTest : TestBase
                 File.Delete(unicodePath);
         }
     }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ReadNetUnicodePath()
+    {
+        // Generic ReadNet infers the framework (tensorflow) from the .pb extension; on Windows the
+        // non-representable path is read via wide + the framework-explicit buffer overload.
+        Assert.True(File.Exists(MnistModelPath), $"'{MnistModelPath}' not found");
+
+        var unicodePath = Path.Combine("_data", "model", "mnist_readnet_😀🍀.pb");
+        try
+        {
+            File.Copy(MnistModelPath, unicodePath, true);
+
+            using var net = CvDnn.ReadNet(unicodePath);
+            Assert.NotNull(net);
+            Assert.False(net!.Empty());
+        }
+        finally
+        {
+            if (File.Exists(unicodePath))
+                File.Delete(unicodePath);
+        }
+    }
 }

--- a/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/DnnUnicodePathTest.cs
@@ -1,0 +1,38 @@
+using System.Runtime.InteropServices;
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+// dnn model files with non-ANSI (UTF-8) paths must load on every platform. On Windows the native side
+// reads such paths via a wide stream + the in-memory buffer overload (OpenCV's narrow fopen cannot
+// open them; opencv #4242).
+public class DnnUnicodePathTest : TestBase
+{
+    public static bool IsWindowsOrLinux =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private static string MnistModelPath => Path.Combine("_data", "model", "MNISTTest_tensorflow.pb");
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ReadNetFromTensorflowUnicodePath()
+    {
+        Assert.True(File.Exists(MnistModelPath), $"'{MnistModelPath}' not found");
+
+        // Emoji cannot be represented in any ANSI code page, so this reliably exercises the Windows wide path.
+        var unicodePath = Path.Combine("_data", "model", "mnist_😀🍀.pb");
+        try
+        {
+            File.Copy(MnistModelPath, unicodePath, true);
+
+            using var net = CvDnn.ReadNetFromTensorflow(unicodePath);
+            Assert.NotNull(net);
+            Assert.False(net!.Empty());
+        }
+        finally
+        {
+            if (File.Exists(unicodePath))
+                File.Delete(unicodePath);
+        }
+    }
+}


### PR DESCRIPTION
Applies the imgcodecs path-handling pattern (#1944) to **all dnn loaders for which OpenCV exposes an in-memory overload**.

`cv::dnn::readNet*` / Model constructors read model files by narrow `fopen`, so non-ANSI model paths fail on Windows ([opencv #4242](https://github.com/opencv/opencv/issues/4242)). Same gating as imgcodecs, centralized in a shared `dnn_readNetGated(model, config, framework, engine)` helper:

- **Representable path** (pure ASCII / UTF-8 ACP / losslessly-encodable) → call the file-based reader directly → unchanged, streaming.
- **Non-representable path** → read the file via a wide stream (`readAllBytesWide`, shared helper from `my_functions.h`) and hand it to the **buffer overload** (framework inferred from the model extension when needed, mirroring `cv::dnn::readNet`).

### Converted
- `readNetFromONNX`, `readNetFromTFLite`, `readNetFromTensorflow`, `readNetFromModelOptimizer`, `readNet` (generic).
- All Model file constructors: `Model`, `ClassificationModel`, `DetectionModel`, `SegmentationModel`, `KeypointsModel`, `TextRecognitionModel`, `TextDetectionModel_EAST`, `TextDetectionModel_DB` (built via `dnn_readNetGated` + the existing `Model(const Net&)` ctor).

Managed collapses all of these from the per-OS `LPStr`/`LPUTF8Str` split to single UTF-8 entry points.

### Not handled (no in-memory overload in OpenCV)
`readTensorFromONNX`, `writeTextGraph` — left on the per-OS split. Other subsystems (FontFace, ptcloud, FLANN index, Tokenizer, DISK/ALIKED/LightGlue) likewise expose no in-memory API, so they cannot be handled this way. videoio is excluded by design (RTSP/HTTP URLs and pipelines are not local files).

### Tests
`ReadNetFromTensorflowUnicodePath`, `ReadNetUnicodePath`, `DetectionModelUnicodePath` load the committed MNIST TF model via an **emoji** path (unrepresentable in any ANSI code page → reliably exercises the Windows wide route). Full managed suite passes (**936 passed, 25 skipped**) against a freshly built `OpenCvSharpExtern`.

> Stacked on #1944 — shares the wide-path helpers in `my_functions.h`. Base retargets to `5.x` once #1944 merges.

Part of #1938.