### PR TITLE
Internal 1b: unify CvPtrObject on the owned SafeHandle (+ CLAHE pilot)

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2.cs
+++ b/src/OpenCvSharp/Cv2/Cv2.cs
@@ -25,10 +25,8 @@ public static partial class Cv2
     public const int FILLED = -1;
         
     /// <summary>
-    /// 引数がnullの時はIntPtr.Zeroに変換する
+    /// Returns the object's native pointer, or <see cref="IntPtr.Zero"/> when the object is null
+    /// (for optional native arguments such as mask / noArray).
     /// </summary>
     internal static IntPtr ToPtr(CvObject? obj) => obj?.CvPtr ?? IntPtr.Zero;
-
-    /// <inheritdoc cref="ToPtr(CvObject?)"/>
-    internal static IntPtr ToPtr(CvPtrObject? obj) => obj?.RawPtr ?? IntPtr.Zero;
 }

--- a/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
+++ b/src/OpenCvSharp/Fundamentals/CvPtrObject.cs
@@ -1,15 +1,15 @@
-﻿namespace OpenCvSharp;
+namespace OpenCvSharp;
 
 /// <summary>
 /// Base class for OpenCV Algorithm-hierarchy objects.
-/// Stores both the smart pointer (cv::Ptr&lt;T&gt;*) for lifetime management
-/// and the raw T* for P/Invoke calls, so that <see cref="RawPtr"/> always
-/// returns the raw pointer without ambiguity.
+/// The owned <see cref="OpenCvSafeHandle"/> (in <see cref="CvObject"/>) wraps the raw <c>T*</c> used
+/// for P/Invoke, so <see cref="RawPtr"/>, <see cref="CvObject.CvPtr"/> and <see cref="CvObject.Handle"/>
+/// all yield that pointer. When the object is owned through a <c>cv::Ptr&lt;T&gt;*</c> smart pointer,
+/// that smart pointer (kept in <see cref="smartPtr"/>) is what gets released on disposal.
 /// </summary>
 public abstract class CvPtrObject : CvObject
 {
-    private volatile OpenCvSafeHandle? lifecycleHandle;
-    private readonly IntPtr rawPtr;
+    private readonly IntPtr smartPtr;
 
     /// <summary>
     /// Factory-pattern constructor.
@@ -18,10 +18,10 @@ public abstract class CvPtrObject : CvObject
     /// </summary>
     protected CvPtrObject(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> releaseSmartPtr)
     {
-        this.rawPtr = rawPtr;
-        lifecycleHandle = new OpenCvPtrSafeHandle(
-            smartPtr, ownsHandle: true,
-            releaseAction: _ => releaseSmartPtr(smartPtr));
+        this.smartPtr = smartPtr;
+        // The handle is the raw T* (so it marshals correctly to P/Invoke), but releasing it must
+        // delete the smart pointer that actually owns the lifetime.
+        SetSafeHandle(new OpenCvPtrSafeHandle(rawPtr, ownsHandle: true, releaseAction: _ => releaseSmartPtr(smartPtr)));
     }
 
     /// <summary>
@@ -30,10 +30,8 @@ public abstract class CvPtrObject : CvObject
     /// </summary>
     protected CvPtrObject(IntPtr rawPtr, Action<IntPtr> releaseRawPtr)
     {
-        this.rawPtr = rawPtr;
-        lifecycleHandle = new OpenCvPtrSafeHandle(
-            rawPtr, ownsHandle: true,
-            releaseAction: _ => releaseRawPtr(rawPtr));
+        smartPtr = IntPtr.Zero;
+        SetSafeHandle(new OpenCvPtrSafeHandle(rawPtr, ownsHandle: true, releaseAction: releaseRawPtr));
     }
 
     /// <summary>
@@ -44,33 +42,21 @@ public abstract class CvPtrObject : CvObject
         get
         {
             ThrowIfDisposed();
-            return rawPtr;
+            return CvPtr;
         }
     }
 
     /// <summary>
     /// Returns the cv::Ptr&lt;T&gt;* smart pointer for P/Invoke calls that require it
-    /// (e.g. functions that take ownership of the pointer).
+    /// (e.g. functions that take ownership of the pointer). Falls back to the raw pointer
+    /// for directly-allocated objects that have no smart pointer.
     /// </summary>
     internal IntPtr SmartPtr
     {
         get
         {
             ThrowIfDisposed();
-            return lifecycleHandle?.DangerousGetHandle() ?? IntPtr.Zero;
+            return smartPtr != IntPtr.Zero ? smartPtr : CvPtr;
         }
-    }
-
-    /// <inheritdoc />
-    protected override void DisposeManaged()
-    {
-        lifecycleHandle?.Dispose();
-    }
-
-    /// <inheritdoc />
-    protected override void DisposeUnmanaged()
-    {
-        lifecycleHandle = null;
-        base.DisposeUnmanaged();
     }
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Algorithm.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Algorithm.cs
@@ -9,18 +9,20 @@ namespace OpenCvSharp.Internal;
 
 static partial class NativeMethods
 {
+    // The Algorithm object handle is an OpenCvSafeHandle, so the marshaller keeps the managed object
+    // alive for the call and callers drop GC.KeepAlive(this). Shared by all Algorithm-derived types.
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Algorithm_write(IntPtr obj, IntPtr fs);
+    public static partial ExceptionStatus core_Algorithm_write(OpenCvSafeHandle obj, IntPtr fs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Algorithm_read(IntPtr obj, IntPtr fn);
+    public static partial ExceptionStatus core_Algorithm_read(OpenCvSafeHandle obj, IntPtr fn);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Algorithm_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_Algorithm_empty(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Algorithm_save(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
+    public static partial ExceptionStatus core_Algorithm_save(OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Algorithm_getDefaultName(IntPtr obj, IntPtr buf);
+    public static partial ExceptionStatus core_Algorithm_getDefaultName(OpenCvSafeHandle obj, IntPtr buf);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
@@ -13,45 +13,47 @@ static partial class NativeMethods
 {
     // ReSharper disable InconsistentNaming
 
+    // Feature2D base entry points take the object as an OpenCvSafeHandle (callers pass Handle and drop
+    // GC.KeepAlive(this)). Image / keypoint / mask arguments stay IntPtr until those classes are swept.
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_detect_Mat1(
-        IntPtr detector, IntPtr image, IntPtr keypoints, IntPtr mask);
+        OpenCvSafeHandle detector, IntPtr image, IntPtr keypoints, IntPtr mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_detect_Mat2(
-        IntPtr detector, IntPtr[] images, int imageLength, IntPtr keypoints, IntPtr[]? mask);
+        OpenCvSafeHandle detector, IntPtr[] images, int imageLength, IntPtr keypoints, IntPtr[]? mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_detect_InputArray(
-        IntPtr detector, IntPtr image, IntPtr keypoints, IntPtr mask);
-        
+        OpenCvSafeHandle detector, IntPtr image, IntPtr keypoints, IntPtr mask);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_compute1(IntPtr obj, IntPtr image, IntPtr keypoints, IntPtr descriptors);
+    public static partial ExceptionStatus features_Feature2D_compute1(OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, IntPtr descriptors);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_compute2(
-        IntPtr detector, IntPtr[] images, int imageLength,
+        OpenCvSafeHandle detector, IntPtr[] images, int imageLength,
         IntPtr keypoints, IntPtr[] descriptors, int descriptorsLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_detectAndCompute(
-        IntPtr detector, IntPtr image, IntPtr mask,
+        OpenCvSafeHandle detector, IntPtr image, IntPtr mask,
         IntPtr keypoints, IntPtr descriptors, int useProvidedKeypoints);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_descriptorSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_Feature2D_descriptorSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_descriptorType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_Feature2D_descriptorType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_defaultNorm(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_Feature2D_defaultNorm(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_Feature2D_empty(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_write(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string fileName);
+    public static partial ExceptionStatus features_Feature2D_write(OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string fileName);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_read(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string fileName);
+    public static partial ExceptionStatus features_Feature2D_read(OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string fileName);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_getDefaultName(IntPtr obj, IntPtr returnValue);
+    public static partial ExceptionStatus features_Feature2D_getDefaultName(OpenCvSafeHandle obj, IntPtr returnValue);
         
     #region SIFT
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_CLAHE.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_CLAHE.cs
@@ -22,22 +22,24 @@ static partial class NativeMethods
 
 
 
+    // The object handle is passed as an OpenCvSafeHandle so the marshaller keeps the managed CLAHE
+    // alive for the duration of the call; callers no longer need GC.KeepAlive(this).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_apply(IntPtr obj, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus imgproc_CLAHE_apply(OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_setClipLimit(IntPtr obj, double clipLimit);
+    public static partial ExceptionStatus imgproc_CLAHE_setClipLimit(OpenCvSafeHandle obj, double clipLimit);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_getClipLimit(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_CLAHE_getClipLimit(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_setTilesGridSize(IntPtr obj, Size tileGridSize);
+    public static partial ExceptionStatus imgproc_CLAHE_setTilesGridSize(OpenCvSafeHandle obj, Size tileGridSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_getTilesGridSize(IntPtr obj, out Size returnValue);
+    public static partial ExceptionStatus imgproc_CLAHE_getTilesGridSize(OpenCvSafeHandle obj, out Size returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_CLAHE_collectGarbage(IntPtr obj);
+    public static partial ExceptionStatus imgproc_CLAHE_collectGarbage(OpenCvSafeHandle obj);
 
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
@@ -10,25 +10,25 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_clear(IntPtr obj);
+    public static partial ExceptionStatus ml_StatModel_clear(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_getVarCount(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_StatModel_getVarCount(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_StatModel_empty(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_isTrained(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_StatModel_isTrained(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_isClassifier(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_StatModel_isClassifier(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_StatModel_train2(
-        IntPtr obj, IntPtr samples, int layout, IntPtr responses, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr samples, int layout, IntPtr responses, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_StatModel_predict(
-        IntPtr obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
+        OpenCvSafeHandle obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_BackgroundSubtractor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_BackgroundSubtractor.cs
@@ -12,9 +12,9 @@ static partial class NativeMethods
     #region BackgroundSubtractor
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractor_getBackgroundImage(IntPtr self, IntPtr backgroundImage);
+    public static partial ExceptionStatus video_BackgroundSubtractor_getBackgroundImage(OpenCvSafeHandle self, IntPtr backgroundImage);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractor_apply(IntPtr self, IntPtr image, IntPtr fgmask, double learningRate);
+    public static partial ExceptionStatus video_BackgroundSubtractor_apply(OpenCvSafeHandle self, IntPtr image, IntPtr fgmask, double learningRate);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus video_Ptr_BackgroundSubtractor_delete(IntPtr ptr);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
@@ -112,10 +112,10 @@ static partial class NativeMethods
     // Tracker
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_Tracker_init(IntPtr obj, IntPtr image, Rect boundingBox);
+    public static partial ExceptionStatus video_Tracker_init(OpenCvSafeHandle obj, IntPtr image, Rect boundingBox);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_Tracker_update(IntPtr obj, IntPtr image, ref Rect boundingBox, out int returnValue);
+    public static partial ExceptionStatus video_Tracker_update(OpenCvSafeHandle obj, IntPtr image, ref Rect boundingBox, out int returnValue);
         
 
     // TrackerMIL

--- a/src/OpenCvSharp/Modules/core/Algorithm.cs
+++ b/src/OpenCvSharp/Modules/core/Algorithm.cs
@@ -34,8 +34,7 @@ public abstract class Algorithm : CvPtrObject
             throw new ArgumentNullException(nameof(fs));
 
         NativeMethods.HandleException(
-            NativeMethods.core_Algorithm_write(RawPtr, fs.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_Algorithm_write(Handle, fs.CvPtr));
         GC.KeepAlive(fs);
     }
 
@@ -50,8 +49,7 @@ public abstract class Algorithm : CvPtrObject
             throw new ArgumentNullException(nameof(fn));
 
         NativeMethods.HandleException(
-            NativeMethods.core_Algorithm_read(RawPtr, fn.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_Algorithm_read(Handle, fn.CvPtr));
         GC.KeepAlive(fn);
     }
 
@@ -65,8 +63,7 @@ public abstract class Algorithm : CvPtrObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_Algorithm_empty(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_Algorithm_empty(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -84,8 +81,7 @@ public abstract class Algorithm : CvPtrObject
             throw new ArgumentNullException(nameof(fileName));
 
         NativeMethods.HandleException(
-            NativeMethods.core_Algorithm_save(RawPtr, fileName));
-        GC.KeepAlive(this);
+            NativeMethods.core_Algorithm_save(Handle, fileName));
     }
 
     /// <summary>
@@ -100,8 +96,7 @@ public abstract class Algorithm : CvPtrObject
 
         using var buf = new StdString();
         NativeMethods.HandleException(
-            NativeMethods.core_Algorithm_getDefaultName(RawPtr, buf.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_Algorithm_getDefaultName(Handle, buf.CvPtr));
         return buf.ToString();
     }
 }

--- a/src/OpenCvSharp/Modules/features/Feature2D.cs
+++ b/src/OpenCvSharp/Modules/features/Feature2D.cs
@@ -32,8 +32,7 @@ public class Feature2D : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_descriptorSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_Feature2D_descriptorSize(Handle, out var ret));
             return ret;
         }
     }
@@ -47,8 +46,7 @@ public class Feature2D : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_descriptorType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_Feature2D_descriptorType(Handle, out var ret));
             return ret;
         }
     }
@@ -62,8 +60,7 @@ public class Feature2D : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_defaultNorm(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_Feature2D_defaultNorm(Handle, out var ret));
             return ret;
         }
     }
@@ -80,8 +77,7 @@ public class Feature2D : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_Feature2D_empty(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.features_Feature2D_empty(Handle, out var ret));
         return ret != 0;
     }
 
@@ -103,12 +99,11 @@ public class Feature2D : Algorithm
         {
             using var keyPoints = new StdVector<KeyPoint>();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_detect_Mat1(RawPtr, image.CvPtr, keyPoints.CvPtr, Cv2.ToPtr(mask)));
+                NativeMethods.features_Feature2D_detect_Mat1(Handle, image.CvPtr, keyPoints.CvPtr, Cv2.ToPtr(mask)));
             return keyPoints.ToArray();
         }
         finally
         {
-            GC.KeepAlive(this);
             GC.KeepAlive(image);
             GC.KeepAlive(mask);
         }
@@ -132,12 +127,11 @@ public class Feature2D : Algorithm
         {
             using var keypoints = new StdVector<KeyPoint>();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_detect_InputArray(RawPtr, image.CvPtr, keypoints.CvPtr, Cv2.ToPtr(mask)));
+                NativeMethods.features_Feature2D_detect_InputArray(Handle, image.CvPtr, keypoints.CvPtr, Cv2.ToPtr(mask)));
             return keypoints.ToArray();
         }
         finally
         {
-            GC.KeepAlive(this);
             GC.KeepAlive(image);
             GC.KeepAlive(mask);
         }
@@ -171,10 +165,9 @@ public class Feature2D : Algorithm
 
         NativeMethods.HandleException(
         NativeMethods.features_Feature2D_detect_Mat2(
-            RawPtr, imagesPtr, imagesArray.Length, keypoints.CvPtr, masksPtr));
+            Handle, imagesPtr, imagesArray.Length, keypoints.CvPtr, masksPtr));
         GC.KeepAlive(masks);
 
-        GC.KeepAlive(this);
         GC.KeepAlive(imagesArray);
         return keypoints.ToArray();
     }
@@ -195,10 +188,9 @@ public class Feature2D : Algorithm
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
-        NativeMethods.features_Feature2D_compute1(RawPtr, image.CvPtr, keypointsVec.CvPtr, descriptors.CvPtr));
+        NativeMethods.features_Feature2D_compute1(Handle, image.CvPtr, keypointsVec.CvPtr, descriptors.CvPtr));
         keypoints = keypointsVec.ToArray();
 
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(descriptors);
     }
@@ -225,11 +217,10 @@ public class Feature2D : Algorithm
 
         NativeMethods.HandleException(
         NativeMethods.features_Feature2D_compute2(
-            RawPtr, imagesPtrs, imagesPtrs.Length, keypointsVec.CvPtr,
+            Handle, imagesPtrs, imagesPtrs.Length, keypointsVec.CvPtr,
             descriptorsPtrs, descriptorsPtrs.Length));
         keypoints = keypointsVec.ToArray();
 
-        GC.KeepAlive(this);
         GC.KeepAlive(images);
         GC.KeepAlive(descriptors);
     }
@@ -261,11 +252,10 @@ public class Feature2D : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.features_Feature2D_detectAndCompute(
-                RawPtr, image.CvPtr, Cv2.ToPtr(mask), keypointsVec.CvPtr, descriptors.CvPtr,
+                Handle, image.CvPtr, Cv2.ToPtr(mask), keypointsVec.CvPtr, descriptors.CvPtr,
                 useProvidedKeypoints ? 1 : 0));
         keypoints = keypointsVec.ToArray();
 
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(mask);
         descriptors.Fix();
@@ -283,8 +273,7 @@ public class Feature2D : Algorithm
             throw new ArgumentNullException(nameof(fileName));
 
         NativeMethods.HandleException(
-        NativeMethods.features_Feature2D_write(RawPtr, fileName));
-        GC.KeepAlive(this);
+        NativeMethods.features_Feature2D_write(Handle, fileName));
     }
 
     /// <summary>
@@ -298,8 +287,7 @@ public class Feature2D : Algorithm
             throw new ArgumentNullException(nameof(fileName));
 
         NativeMethods.HandleException(
-        NativeMethods.features_Feature2D_read(RawPtr, fileName));
-        GC.KeepAlive(this);
+        NativeMethods.features_Feature2D_read(Handle, fileName));
     }
         
     /// <summary>
@@ -312,8 +300,7 @@ public class Feature2D : Algorithm
 
         using var returnValue = new StdString();
         NativeMethods.HandleException(
-        NativeMethods.features_Feature2D_getDefaultName(RawPtr, returnValue.CvPtr));
-        GC.KeepAlive(this);
+        NativeMethods.features_Feature2D_getDefaultName(Handle, returnValue.CvPtr));
         return returnValue.ToString();
     }
 

--- a/src/OpenCvSharp/Modules/imgproc/CLAHE.cs
+++ b/src/OpenCvSharp/Modules/imgproc/CLAHE.cs
@@ -53,10 +53,10 @@ public sealed class CLAHE : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_CLAHE_apply(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.imgproc_CLAHE_apply(Handle, src.CvPtr, dst.CvPtr));
 
         dst.Fix();
-        GC.KeepAlive(this);
+        // Handle (a SafeHandle) keeps this alive across the call, so no GC.KeepAlive(this) is needed.
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
     }
@@ -70,16 +70,14 @@ public sealed class CLAHE : Algorithm
         { 
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_CLAHE_getClipLimit(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_CLAHE_getClipLimit(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_CLAHE_setClipLimit(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_CLAHE_setClipLimit(Handle, value));
         }
     }
 
@@ -92,16 +90,14 @@ public sealed class CLAHE : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_CLAHE_getTilesGridSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_CLAHE_getTilesGridSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_CLAHE_setTilesGridSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_CLAHE_setTilesGridSize(Handle, value));
         }
     }
 
@@ -112,7 +108,6 @@ public sealed class CLAHE : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_CLAHE_collectGarbage(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.imgproc_CLAHE_collectGarbage(Handle));
     }
 }

--- a/src/OpenCvSharp/Modules/ml/StatModel.cs
+++ b/src/OpenCvSharp/Modules/ml/StatModel.cs
@@ -20,8 +20,7 @@ public abstract class StatModel : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_getVarCount(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_StatModel_getVarCount(Handle, out var ret));
         return ret;
     }
 
@@ -33,8 +32,7 @@ public abstract class StatModel : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_empty(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_StatModel_empty(Handle, out var ret));
         return ret != 0;
     }
 
@@ -46,8 +44,7 @@ public abstract class StatModel : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_isTrained(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_StatModel_isTrained(Handle, out var ret));
         return ret != 0;
     }
 
@@ -59,8 +56,7 @@ public abstract class StatModel : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_isClassifier(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_StatModel_isClassifier(Handle, out var ret));
         return ret != 0;
     }
 
@@ -95,8 +91,7 @@ public abstract class StatModel : Algorithm
         responses.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_train2(RawPtr, samples.CvPtr, (int)layout, responses.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_StatModel_train2(Handle, samples.CvPtr, (int)layout, responses.CvPtr, out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(responses);
         return ret != 0;
@@ -136,8 +131,7 @@ public abstract class StatModel : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ml_StatModel_predict(
-                RawPtr, samples.CvPtr, Cv2.ToPtr(results), (int) flags, out var ret));
-        GC.KeepAlive(this);
+                Handle, samples.CvPtr, Cv2.ToPtr(results), (int) flags, out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(results);
         results?.Fix();

--- a/src/OpenCvSharp/Modules/video/BackgroundSubtractor.cs
+++ b/src/OpenCvSharp/Modules/video/BackgroundSubtractor.cs
@@ -29,10 +29,9 @@ public abstract class BackgroundSubtractor : Algorithm
         fgmask.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.video_BackgroundSubtractor_apply(RawPtr, image.CvPtr, fgmask.CvPtr, learningRate));
+            NativeMethods.video_BackgroundSubtractor_apply(Handle, image.CvPtr, fgmask.CvPtr, learningRate));
             
         fgmask.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(fgmask);
     }
@@ -48,8 +47,7 @@ public abstract class BackgroundSubtractor : Algorithm
         backgroundImage.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.video_BackgroundSubtractor_getBackgroundImage(RawPtr, backgroundImage.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.video_BackgroundSubtractor_getBackgroundImage(Handle, backgroundImage.CvPtr));
         GC.KeepAlive(backgroundImage);
         backgroundImage.Fix();
     }

--- a/src/OpenCvSharp/Modules/video/Tracker.cs
+++ b/src/OpenCvSharp/Modules/video/Tracker.cs
@@ -26,8 +26,7 @@ public abstract class Tracker : Algorithm
 
         image.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.video_Tracker_init(RawPtr, image.CvPtr, boundingBox));
-        GC.KeepAlive(this);
+            NativeMethods.video_Tracker_init(Handle, image.CvPtr, boundingBox));
         GC.KeepAlive(image);
     }
 
@@ -48,8 +47,7 @@ public abstract class Tracker : Algorithm
 
         image.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.video_Tracker_update(RawPtr, image.CvPtr, ref boundingBox, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.video_Tracker_update(Handle, image.CvPtr, ref boundingBox, out var ret));
         GC.KeepAlive(image);
 
         return ret != 0;

--- a/tools/sh_classfile.py
+++ b/tools/sh_classfile.py
@@ -1,0 +1,31 @@
+"""Phase 1b helper: in a wrapper class file, pass the SafeHandle and drop GC.KeepAlive(this).
+
+Usage: python sh_classfile.py <file.cs> [accessor]
+  - replaces the this-handle accessor (default 'RawPtr', word-boundary) with 'Handle'
+  - removes lines that are exactly 'GC.KeepAlive(this);' (any indentation)
+
+ONLY safe for methods that do NOT return an interior pointer dereferenced after the call
+(data / c_str / getPointer / etc.) -- the caller must confirm the file has no such method.
+"""
+import re
+import sys
+import pathlib
+
+path = pathlib.Path(sys.argv[1]).resolve()
+accessor = sys.argv[2] if len(sys.argv) > 2 else "RawPtr"
+
+text = path.read_text(encoding="utf-8-sig")
+nl = "\r\n" if "\r\n" in text else "\n"
+lines = text.replace("\r\n", "\n").split("\n")
+
+out = []
+removed = 0
+for line in lines:
+    if line.strip() == "GC.KeepAlive(this);":
+        removed += 1
+        continue
+    out.append(re.sub(rf"\b{re.escape(accessor)}\b", "Handle", line))
+
+new = nl.join(out)
+path.write_text(new, encoding="utf-8-sig", newline="")
+print(f"{path.name}: accessor {accessor}->Handle, removed {removed} KeepAlive(this)")

--- a/tools/sh_extern.py
+++ b/tools/sh_extern.py
@@ -1,0 +1,47 @@
+"""Phase 1b helper: change the object handle param (first `IntPtr <name>`) of a module's base
+P/Invoke entry points to OpenCvSafeHandle, so callers can pass Handle.
+
+Usage: python sh_extern.py <NativeMethods_file.cs> <prefix> [extra-excludes...]
+
+Acts on `public static partial ... <name>(...)` whose <name> starts with <prefix> and is NOT a
+factory/lifetime function (name containing _new/_create/_delete/_get/_Ptr_). Replaces the FIRST
+`IntPtr <ident>` in the parameter list with `OpenCvSafeHandle <ident>` (skips `IntPtr[]`). Any
+mistake surfaces as a compile-time type mismatch, so the build is the oracle.
+"""
+import re
+import sys
+import pathlib
+
+path = pathlib.Path(sys.argv[1]).resolve()
+prefix = sys.argv[2]
+# Note: do NOT exclude "_get" broadly -- it would skip legitimate getters (getVarCount, ...).
+# The factory get-pointer functions are named *_Ptr_*_get and are covered by "_Ptr_".
+EXCLUDE = ("_new", "_create", "_delete", "_Ptr_") + tuple(sys.argv[3:])
+
+text = path.read_text(encoding="utf-8-sig")
+nl = "\r\n" if "\r\n" in text else "\n"
+lines = text.replace("\r\n", "\n").split("\n")
+
+decl_re = re.compile(r"public static (?:unsafe )?partial ExceptionStatus (" + re.escape(prefix) + r"\w*)\s*\(")
+out = []
+i = 0
+changed = 0
+while i < len(lines):
+    m = decl_re.search(lines[i])
+    if not m or any(x in m.group(1) for x in EXCLUDE):
+        out.append(lines[i])
+        i += 1
+        continue
+    # collect the declaration up to the first ';'
+    j = i
+    while ";" not in lines[j]:
+        j += 1
+    block = "\n".join(lines[i:j + 1])
+    new_block, n = re.subn(r"\bIntPtr (?=[A-Za-z_])", "OpenCvSafeHandle ", block, count=1)
+    if n:
+        changed += 1
+    out.extend(new_block.split("\n"))
+    i = j + 1
+
+path.write_text(nl.join(out), encoding="utf-8-sig", newline="")
+print(f"{path.name}: converted {changed} entry points (prefix {prefix})")


### PR DESCRIPTION
Foundation + first pilot for Phase 1b of #1938 (eliminating manual `GC.KeepAlive` by passing `OpenCvSafeHandle` arguments).

### 1. Unify CvPtrObject on the owned SafeHandle
`CvPtrObject` (the Algorithm hierarchy) now stores its native pointer in the **inherited `CvObject` SafeHandle**: the handle wraps the raw `T*` (so `RawPtr`, `CvPtr` and `Handle` all yield it) while disposal releases the owning `cv::Ptr<T>*` smart pointer, kept in a separate field.

Previously it held its own `lifecycleHandle` wrapping the smart pointer, which left `CvObject.CvPtr` returning `Zero` for Algorithm objects and made `Handle` unusable for them. Now `Handle` works for Algorithm types (so they can pass a SafeHandle argument and drop `GC.KeepAlive`) and `CvPtr` is correct.

Knock-on: `CvPtr == RawPtr` now, so the redundant `ToPtr(CvPtrObject?)` overload is removed (Algorithm args resolve to `ToPtr(CvObject?)`); its doc comment is also translated to English. `ToPtr` itself stays — it's the null-safe optional-pointer helper used in ~170 sites.

### 2. CLAHE pilot
First consumer: `CLAHE`'s instance entry points take the object as an `OpenCvSafeHandle` and the wrapper passes `Handle`, so the marshaller keeps the object alive for the call and `GC.KeepAlive(this)` is dropped (6 sites). Input/output arguments stay `IntPtr` until their classes are swept (their `GC.KeepAlive` remains). **Native is unchanged** — the SafeHandle marshals to the same pointer.

This validates the Phase 1b mechanism end-to-end for an Algorithm-derived type; the per-module rollout follows.

### Tests
Build green; full managed suite passes (**933 passed, 25 skipped**) — Algorithm disposal and CLAHE are exercised.

Part of #1938 (Phase 1b).