### PR TITLE
Internal 1b: sweep wrapper classes to SafeHandle args (drop GC.KeepAlive(this))

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_bgsegm.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_bgsegm.cs
@@ -22,34 +22,34 @@ static partial class NativeMethods
     public static partial ExceptionStatus bgsegm_Ptr_BackgroundSubtractorMOG_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getHistory(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getHistory(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setHistory(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setHistory(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getNMixtures(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getNMixtures(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setNMixtures(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setNMixtures(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getBackgroundRatio(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getBackgroundRatio(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setBackgroundRatio(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setBackgroundRatio(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getNoiseSigma(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getNoiseSigma(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setNoiseSigma(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_setNoiseSigma(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_apply(IntPtr ptr, IntPtr image, IntPtr fgmask, double learningRate);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_apply(OpenCvSafeHandle ptr, IntPtr image, IntPtr fgmask, double learningRate);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getBackgroundImage(IntPtr ptr, IntPtr backgroundImage);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorMOG_getBackgroundImage(OpenCvSafeHandle ptr, IntPtr backgroundImage);
 
     #endregion
 
@@ -66,70 +66,70 @@ static partial class NativeMethods
     public static partial ExceptionStatus bgsegm_Ptr_BackgroundSubtractorGMG_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMaxFeatures(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMaxFeatures(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMaxFeatures(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMaxFeatures(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getDefaultLearningRate(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getDefaultLearningRate(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setDefaultLearningRate(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setDefaultLearningRate(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getNumFrames(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getNumFrames(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setNumFrames(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setNumFrames(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getQuantizationLevels(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getQuantizationLevels(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setQuantizationLevels(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setQuantizationLevels(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getBackgroundPrior(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getBackgroundPrior(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setBackgroundPrior(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setBackgroundPrior(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getSmoothingRadius(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getSmoothingRadius(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setSmoothingRadius(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setSmoothingRadius(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getDecisionThreshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getDecisionThreshold(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setDecisionThreshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setDecisionThreshold(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getUpdateBackgroundModel(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getUpdateBackgroundModel(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setUpdateBackgroundModel(IntPtr ptr, int value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setUpdateBackgroundModel(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMinVal(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMinVal(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMinVal(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMinVal(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMaxVal(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getMaxVal(OpenCvSafeHandle ptr, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMaxVal(IntPtr ptr, double value);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_setMaxVal(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_apply(IntPtr ptr, IntPtr image, IntPtr fgmask, double learningRate);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_apply(OpenCvSafeHandle ptr, IntPtr image, IntPtr fgmask, double learningRate);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getBackgroundImage(IntPtr ptr, IntPtr backgroundImage);
+    public static partial ExceptionStatus bgsegm_BackgroundSubtractorGMG_getBackgroundImage(OpenCvSafeHandle ptr, IntPtr backgroundImage);
 
     #endregion
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_img_hash.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_img_hash.cs
@@ -10,10 +10,10 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_ImgHashBase_compute(IntPtr obj, IntPtr inputArr, IntPtr outputArr);
+    public static partial ExceptionStatus img_hash_ImgHashBase_compute(OpenCvSafeHandle obj, IntPtr inputArr, IntPtr outputArr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_ImgHashBase_compare(IntPtr obj, IntPtr hashOne, IntPtr hashTwo, out double returnValue);
+    public static partial ExceptionStatus img_hash_ImgHashBase_compare(OpenCvSafeHandle obj, IntPtr hashOne, IntPtr hashTwo, out double returnValue);
 
 
     // AverageHash
@@ -39,10 +39,10 @@ static partial class NativeMethods
     public static partial ExceptionStatus img_hash_Ptr_BlockMeanHash_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_BlockMeanHash_setMode(IntPtr obj, int mode);
+    public static partial ExceptionStatus img_hash_BlockMeanHash_setMode(OpenCvSafeHandle obj, int mode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_BlockMeanHash_getMean(IntPtr obj, IntPtr outVec);
+    public static partial ExceptionStatus img_hash_BlockMeanHash_getMean(OpenCvSafeHandle obj, IntPtr outVec);
 
     // ColorMomentHash
 
@@ -67,13 +67,13 @@ static partial class NativeMethods
     public static partial ExceptionStatus img_hash_Ptr_MarrHildrethHash_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_MarrHildrethHash_setKernelParam(IntPtr obj, float alpha, float scale);
+    public static partial ExceptionStatus img_hash_MarrHildrethHash_setKernelParam(OpenCvSafeHandle obj, float alpha, float scale);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_MarrHildrethHash_getAlpha(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus img_hash_MarrHildrethHash_getAlpha(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_MarrHildrethHash_getScale(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus img_hash_MarrHildrethHash_getScale(OpenCvSafeHandle obj, out float returnValue);
 
     // PHash
 
@@ -98,14 +98,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus img_hash_Ptr_RadialVarianceHash_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_RadialVarianceHash_setNumOfAngleLine(IntPtr obj, int value);
+    public static partial ExceptionStatus img_hash_RadialVarianceHash_setNumOfAngleLine(OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_RadialVarianceHash_setSigma(IntPtr obj, double value);
+    public static partial ExceptionStatus img_hash_RadialVarianceHash_setSigma(OpenCvSafeHandle obj, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_RadialVarianceHash_getNumOfAngleLine(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus img_hash_RadialVarianceHash_getNumOfAngleLine(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus img_hash_RadialVarianceHash_getSigma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus img_hash_RadialVarianceHash_getSigma(OpenCvSafeHandle obj, out double returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_quality.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_quality.cs
@@ -13,16 +13,16 @@ static partial class NativeMethods
     #region QualityBase
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityBase_compute(IntPtr obj, IntPtr img, out Scalar returnValue);
+    public static partial ExceptionStatus quality_QualityBase_compute(OpenCvSafeHandle obj, IntPtr img, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityBase_getQualityMap(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus quality_QualityBase_getQualityMap(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityBase_clear(IntPtr obj);
+    public static partial ExceptionStatus quality_QualityBase_clear(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityBase_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus quality_QualityBase_empty(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 
@@ -39,10 +39,10 @@ static partial class NativeMethods
         IntPtr @ref, IntPtr cmp, IntPtr qualityMap, double maxPixelValue, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityPSNR_getMaxPixelValue(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus quality_QualityPSNR_getMaxPixelValue(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus quality_QualityPSNR_setMaxPixelValue(IntPtr obj, double val);
+    public static partial ExceptionStatus quality_QualityPSNR_setMaxPixelValue(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus quality_Ptr_QualityPSNR_get(IntPtr ptr, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
@@ -99,24 +99,24 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_Ptr_SURF_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_getHessianThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus xfeatures2d_SURF_getHessianThreshold(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_getNOctaves(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_SURF_getNOctaves(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_getNOctaveLayers(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_SURF_getNOctaveLayers(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_getExtended(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_SURF_getExtended(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_getUpright(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_SURF_getUpright(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_setHessianThreshold(IntPtr obj, double value);
+    public static partial ExceptionStatus xfeatures2d_SURF_setHessianThreshold(OpenCvSafeHandle obj, double value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_setNOctaves(IntPtr obj, int value);
+    public static partial ExceptionStatus xfeatures2d_SURF_setNOctaves(OpenCvSafeHandle obj, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_setNOctaveLayers(IntPtr obj, int value);
+    public static partial ExceptionStatus xfeatures2d_SURF_setNOctaveLayers(OpenCvSafeHandle obj, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_setExtended(IntPtr obj, int value);
+    public static partial ExceptionStatus xfeatures2d_SURF_setExtended(OpenCvSafeHandle obj, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_SURF_setUpright(IntPtr obj, int value);
+    public static partial ExceptionStatus xfeatures2d_SURF_setUpright(OpenCvSafeHandle obj, int value);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_BOW.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_BOW.cs
@@ -14,16 +14,16 @@ static partial class NativeMethods
     // BOWTrainer
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWTrainer_add(IntPtr obj, IntPtr descriptors);
+    public static partial ExceptionStatus xfeatures2d_BOWTrainer_add(OpenCvSafeHandle obj, IntPtr descriptors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWTrainer_getDescriptors(IntPtr obj, IntPtr descriptors);
+    public static partial ExceptionStatus xfeatures2d_BOWTrainer_getDescriptors(OpenCvSafeHandle obj, IntPtr descriptors);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 
-    public static partial ExceptionStatus xfeatures2d_BOWTrainer_descriptorsCount(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_BOWTrainer_descriptorsCount(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWTrainer_clear(IntPtr obj);
+    public static partial ExceptionStatus xfeatures2d_BOWTrainer_clear(OpenCvSafeHandle obj);
 
 
     // BOWKMeansTrainer
@@ -37,10 +37,10 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_BOWKMeansTrainer_cluster1(
-        IntPtr obj, out IntPtr returnValue);
+        OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_BOWKMeansTrainer_cluster2(
-        IntPtr obj, IntPtr descriptors, out IntPtr returnValue);
+        OpenCvSafeHandle obj, IntPtr descriptors, out IntPtr returnValue);
 
 
     // BOWImgDescriptorExtractor
@@ -63,26 +63,26 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(IntPtr obj, IntPtr vocabulary);
+    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(OpenCvSafeHandle obj, IntPtr vocabulary);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_getVocabulary(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_getVocabulary(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_compute11(
-        IntPtr obj, IntPtr image, IntPtr keypoints, IntPtr imgDescriptor,
+        OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, IntPtr imgDescriptor,
         IntPtr pointIdxsOfClusters, IntPtr descriptors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_compute12(
-        IntPtr obj, IntPtr keypointDescriptors,
+        OpenCvSafeHandle obj, IntPtr keypointDescriptors,
         IntPtr imgDescriptor, IntPtr pointIdxsOfClusters);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_compute2(
-        IntPtr obj, IntPtr image, IntPtr keypoints, IntPtr imgDescriptor);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, IntPtr imgDescriptor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_descriptorSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_descriptorSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_descriptorType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_BOWImgDescriptorExtractor_descriptorType(OpenCvSafeHandle obj, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_FeatureDetectors.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_FeatureDetectors.cs
@@ -53,19 +53,19 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_Ptr_AgastFeatureDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setThreshold(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setThreshold(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getThreshold(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getThreshold(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setNonmaxSuppression(IntPtr obj,int val);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setNonmaxSuppression(OpenCvSafeHandle obj,int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getNonmaxSuppression(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getNonmaxSuppression(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setType(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_setType(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AgastFeatureDetector_getType(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
     #region KAZE
@@ -79,34 +79,34 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_Ptr_KAZE_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setDiffusivity(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setDiffusivity(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getDiffusivity(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getDiffusivity(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setExtended(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setExtended(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getExtended(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getExtended(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setNOctaveLayers(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setNOctaveLayers(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getNOctaveLayers(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getNOctaveLayers(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setNOctaves(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setNOctaves(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getNOctaves(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getNOctaves(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setThreshold(IntPtr obj, double val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setThreshold(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getThreshold(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_setUpright(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_KAZE_setUpright(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_KAZE_getUpright(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_KAZE_getUpright(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 
@@ -121,39 +121,39 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_Ptr_AKAZE_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorType(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorType(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorType(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorSize(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorSize(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorSize(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorChannels(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setDescriptorChannels(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorChannels(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getDescriptorChannels(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setThreshold(IntPtr obj, double val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setThreshold(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getThreshold(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setNOctaves(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setNOctaves(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getNOctaves(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getNOctaves(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setNOctaveLayers(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setNOctaveLayers(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getNOctaveLayers(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getNOctaveLayers(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_setDiffusivity(IntPtr obj, int val);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_setDiffusivity(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_AKAZE_getDiffusivity(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus xfeatures2d_AKAZE_getDiffusivity(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xphoto.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xphoto.cs
@@ -73,28 +73,28 @@ static partial class NativeMethods
     #region tonemap.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_getSaturation(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus xphoto_TonemapDurand_getSaturation(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_setSaturation(IntPtr obj, float saturation);
+    public static partial ExceptionStatus xphoto_TonemapDurand_setSaturation(OpenCvSafeHandle obj, float saturation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_getContrast(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus xphoto_TonemapDurand_getContrast(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_setContrast(IntPtr obj, float contrast);
+    public static partial ExceptionStatus xphoto_TonemapDurand_setContrast(OpenCvSafeHandle obj, float contrast);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_getSigmaSpace(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus xphoto_TonemapDurand_getSigmaSpace(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_setSigmaSpace(IntPtr obj, float saturation);
+    public static partial ExceptionStatus xphoto_TonemapDurand_setSigmaSpace(OpenCvSafeHandle obj, float saturation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_getSigmaColor(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus xphoto_TonemapDurand_getSigmaColor(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_TonemapDurand_setSigmaColor(IntPtr obj, float saturation);
+    public static partial ExceptionStatus xphoto_TonemapDurand_setSigmaColor(OpenCvSafeHandle obj, float saturation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xphoto_createTonemapDurand(
@@ -124,13 +124,13 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_GrayworldWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_GrayworldWB_balanceWhite(IntPtr prt, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus xphoto_GrayworldWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_GrayworldWB_SaturationThreshold_get(IntPtr ptr, out float returnValue);
+    public static partial ExceptionStatus xphoto_GrayworldWB_SaturationThreshold_get(OpenCvSafeHandle ptr, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_GrayworldWB_SaturationThreshold_set(IntPtr ptr, float val);
+    public static partial ExceptionStatus xphoto_GrayworldWB_SaturationThreshold_set(OpenCvSafeHandle ptr, float val);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -143,28 +143,28 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_LearningBasedWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_balanceWhite(IntPtr prt, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_extractSimpleFeatures(IntPtr prt, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_extractSimpleFeatures(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_HistBinNum_set(IntPtr prt, int value);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_HistBinNum_set(OpenCvSafeHandle prt, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_RangeMaxVal_set(IntPtr prt, int value);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_RangeMaxVal_set(OpenCvSafeHandle prt, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_SaturationThreshold_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_SaturationThreshold_set(OpenCvSafeHandle prt, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_HistBinNum_get(IntPtr prt, out int returnValue);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_HistBinNum_get(OpenCvSafeHandle prt, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_RangeMaxVal_get(IntPtr prt, out int returnValue);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_RangeMaxVal_get(OpenCvSafeHandle prt, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_SaturationThreshold_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_LearningBasedWB_SaturationThreshold_get(OpenCvSafeHandle prt, out float returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -177,37 +177,37 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_SimpleWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_balanceWhite(IntPtr prt, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus xphoto_SimpleWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_InputMax_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_SimpleWB_InputMax_get(OpenCvSafeHandle prt, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_InputMax_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_SimpleWB_InputMax_set(OpenCvSafeHandle prt, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_InputMin_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_SimpleWB_InputMin_get(OpenCvSafeHandle prt, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_InputMin_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_SimpleWB_InputMin_set(OpenCvSafeHandle prt, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_OutputMax_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_SimpleWB_OutputMax_get(OpenCvSafeHandle prt, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_OutputMax_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_SimpleWB_OutputMax_set(OpenCvSafeHandle prt, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_OutputMin_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_SimpleWB_OutputMin_get(OpenCvSafeHandle prt, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_OutputMin_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_SimpleWB_OutputMin_set(OpenCvSafeHandle prt, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_P_get(IntPtr prt, out float returnValue);
+    public static partial ExceptionStatus xphoto_SimpleWB_P_get(OpenCvSafeHandle prt, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_P_set(IntPtr prt, float value);
+    public static partial ExceptionStatus xphoto_SimpleWB_P_set(OpenCvSafeHandle prt, float value);
 
     #endregion
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
@@ -26,34 +26,34 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_PCA_operatorThis(
-        IntPtr obj, IntPtr data, IntPtr mean, int flags, int maxComponents);
+        OpenCvSafeHandle obj, IntPtr data, IntPtr mean, int flags, int maxComponents);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_PCA_computeVar(
-        IntPtr obj, IntPtr data, IntPtr mean, int flags, double retainedVariance);
+        OpenCvSafeHandle obj, IntPtr data, IntPtr mean, int flags, double retainedVariance);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_project1(IntPtr obj, IntPtr vec, out IntPtr returnValue);
+    public static partial ExceptionStatus core_PCA_project1(OpenCvSafeHandle obj, IntPtr vec, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_project2(IntPtr obj, IntPtr vec, IntPtr result);
+    public static partial ExceptionStatus core_PCA_project2(OpenCvSafeHandle obj, IntPtr vec, IntPtr result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_backProject1(IntPtr obj, IntPtr vec, out IntPtr returnValue);
+    public static partial ExceptionStatus core_PCA_backProject1(OpenCvSafeHandle obj, IntPtr vec, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_backProject2(IntPtr obj, IntPtr vec, IntPtr result);
+    public static partial ExceptionStatus core_PCA_backProject2(OpenCvSafeHandle obj, IntPtr vec, IntPtr result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_eigenvectors(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_PCA_eigenvectors(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_eigenvalues(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_PCA_eigenvalues(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_mean(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_PCA_mean(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_write(IntPtr obj, IntPtr fs);
+    public static partial ExceptionStatus core_PCA_write(OpenCvSafeHandle obj, IntPtr fs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCA_read(IntPtr obj, IntPtr fn);
+    public static partial ExceptionStatus core_PCA_read(OpenCvSafeHandle obj, IntPtr fn);
 
     #endregion
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
@@ -77,9 +77,9 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_SVD_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVD_operatorThis(IntPtr obj, IntPtr src, int flags);
+    public static partial ExceptionStatus core_SVD_operatorThis(OpenCvSafeHandle obj, IntPtr src, int flags);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVD_backSubst(IntPtr obj, IntPtr rhs, IntPtr dst);
+    public static partial ExceptionStatus core_SVD_backSubst(OpenCvSafeHandle obj, IntPtr rhs, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_SVD_static_compute1(IntPtr src, IntPtr w, IntPtr u, IntPtr vt, int flags);
@@ -93,11 +93,11 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_SVD_static_solveZ(IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVD_u(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_SVD_u(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVD_w(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_SVD_w(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVD_vt(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_SVD_vt(OpenCvSafeHandle obj, out IntPtr returnValue);
     #endregion
 
     #region LDA
@@ -112,31 +112,31 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_LDA_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_save_String(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
+    public static partial ExceptionStatus core_LDA_save_String(OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_load_String(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
+    public static partial ExceptionStatus core_LDA_load_String(OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_save_FileStorage(IntPtr obj, IntPtr fs);
+    public static partial ExceptionStatus core_LDA_save_FileStorage(OpenCvSafeHandle obj, IntPtr fs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_load_FileStorage(IntPtr obj, IntPtr node);
+    public static partial ExceptionStatus core_LDA_load_FileStorage(OpenCvSafeHandle obj, IntPtr node);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_compute(IntPtr obj, IntPtr src, IntPtr labels);
+    public static partial ExceptionStatus core_LDA_compute(OpenCvSafeHandle obj, IntPtr src, IntPtr labels);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_project(IntPtr obj, IntPtr src, out IntPtr returnValue);
+    public static partial ExceptionStatus core_LDA_project(OpenCvSafeHandle obj, IntPtr src, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_reconstruct(IntPtr obj, IntPtr src, out IntPtr returnValue);
+    public static partial ExceptionStatus core_LDA_reconstruct(OpenCvSafeHandle obj, IntPtr src, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_eigenvectors(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_LDA_eigenvectors(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LDA_eigenvalues(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_LDA_eigenvalues(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_LDA_subspaceProject(IntPtr w, IntPtr mean, IntPtr src, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
@@ -18,160 +18,160 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_operatorThis_byString(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string nodeName, out IntPtr returnValue);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string nodeName, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_operatorThis_byInt(IntPtr obj, int i, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNode_operatorThis_byInt(OpenCvSafeHandle obj, int i, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_type(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_type(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_empty(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isNone(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isNone(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isSeq(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isSeq(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isMap(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isMap(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isInt(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isInt(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isReal(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isReal(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isString(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isString(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_isNamed(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_isNamed(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_name(IntPtr obj, IntPtr buf);
+    public static partial ExceptionStatus core_FileNode_name(OpenCvSafeHandle obj, IntPtr buf);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_size(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNode_size(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_toInt(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNode_toInt(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_toFloat(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus core_FileNode_toFloat(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_toDouble(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus core_FileNode_toDouble(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_toString(IntPtr obj, IntPtr buf);
+    public static partial ExceptionStatus core_FileNode_toString(OpenCvSafeHandle obj, IntPtr buf);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_toMat(IntPtr obj, IntPtr m);
+    public static partial ExceptionStatus core_FileNode_toMat(OpenCvSafeHandle obj, IntPtr m);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_begin(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNode_begin(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_end(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNode_end(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_readRaw(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr len);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr len);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_int(IntPtr node, out int value, int defaultValue);
+    public static partial ExceptionStatus core_FileNode_read_int(OpenCvSafeHandle node, out int value, int defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_float(IntPtr node, out float value, float defaultValue);
+    public static partial ExceptionStatus core_FileNode_read_float(OpenCvSafeHandle node, out float value, float defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_double(IntPtr node, out double value, double defaultValue);
+    public static partial ExceptionStatus core_FileNode_read_double(OpenCvSafeHandle node, out double value, double defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_String(IntPtr node, IntPtr value, [MarshalAs(UnmanagedType.LPStr)] string? defaultValue);
+    public static partial ExceptionStatus core_FileNode_read_String(OpenCvSafeHandle node, IntPtr value, [MarshalAs(UnmanagedType.LPStr)] string? defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Mat(IntPtr node, IntPtr mat, IntPtr defaultMat);
+    public static partial ExceptionStatus core_FileNode_read_Mat(OpenCvSafeHandle node, IntPtr mat, IntPtr defaultMat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_SparseMat(IntPtr node, IntPtr mat, IntPtr defaultMat);
+    public static partial ExceptionStatus core_FileNode_read_SparseMat(OpenCvSafeHandle node, IntPtr mat, IntPtr defaultMat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_vectorOfKeyPoint(IntPtr node, IntPtr keypoints);
+    public static partial ExceptionStatus core_FileNode_read_vectorOfKeyPoint(OpenCvSafeHandle node, IntPtr keypoints);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_vectorOfDMatch(IntPtr node, IntPtr matches);
+    public static partial ExceptionStatus core_FileNode_read_vectorOfDMatch(OpenCvSafeHandle node, IntPtr matches);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Range(IntPtr node, out Range returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Range(OpenCvSafeHandle node, out Range returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_KeyPoint(IntPtr node, out KeyPoint returnValue);
+    public static partial ExceptionStatus core_FileNode_read_KeyPoint(OpenCvSafeHandle node, out KeyPoint returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_DMatch(IntPtr node, out DMatch returnValue);
+    public static partial ExceptionStatus core_FileNode_read_DMatch(OpenCvSafeHandle node, out DMatch returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point2i(IntPtr node, out Point returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point2i(OpenCvSafeHandle node, out Point returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point2f(IntPtr node, out Point2f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point2f(OpenCvSafeHandle node, out Point2f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point2d(IntPtr node, out Point2d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point2d(OpenCvSafeHandle node, out Point2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point3i(IntPtr nod, out Point3i returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point3i(OpenCvSafeHandle nod, out Point3i returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point3f(IntPtr node, out Point3f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point3f(OpenCvSafeHandle node, out Point3f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Point3d(IntPtr node, out Point3d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Point3d(OpenCvSafeHandle node, out Point3d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Size2i(IntPtr node, out Size returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Size2i(OpenCvSafeHandle node, out Size returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Size2f(IntPtr node, out Size2f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Size2f(OpenCvSafeHandle node, out Size2f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Size2d(IntPtr node, out Size2d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Size2d(OpenCvSafeHandle node, out Size2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Rect2i(IntPtr node, out Rect returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Rect2i(OpenCvSafeHandle node, out Rect returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Rect2f(IntPtr node, out Rect2f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Rect2f(OpenCvSafeHandle node, out Rect2f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Rect2d(IntPtr node, out Rect2d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Rect2d(OpenCvSafeHandle node, out Rect2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Scalar(IntPtr node, out Scalar returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Scalar(OpenCvSafeHandle node, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2i(IntPtr node, out Vec2i returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2i(OpenCvSafeHandle node, out Vec2i returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3i(IntPtr node, out Vec3i returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3i(OpenCvSafeHandle node, out Vec3i returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4i(IntPtr node, out Vec4i returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4i(OpenCvSafeHandle node, out Vec4i returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6i(IntPtr node, out Vec6i returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6i(OpenCvSafeHandle node, out Vec6i returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2d(IntPtr node, out Vec2d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2d(OpenCvSafeHandle node, out Vec2d returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3d(IntPtr node, out Vec3d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3d(OpenCvSafeHandle node, out Vec3d returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4d(IntPtr node, out Vec4d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4d(OpenCvSafeHandle node, out Vec4d returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6d(IntPtr node, out Vec6d returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6d(OpenCvSafeHandle node, out Vec6d returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2f(IntPtr node, out Vec2f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2f(OpenCvSafeHandle node, out Vec2f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3f(IntPtr node, out Vec3f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3f(OpenCvSafeHandle node, out Vec3f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4f(IntPtr node, out Vec4f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4f(OpenCvSafeHandle node, out Vec4f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6f(IntPtr node, out Vec6f returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6f(OpenCvSafeHandle node, out Vec6f returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2b(IntPtr node, out Vec2b returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2b(OpenCvSafeHandle node, out Vec2b returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3b(IntPtr node, out Vec3b returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3b(OpenCvSafeHandle node, out Vec3b returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4b(IntPtr node, out Vec4b returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4b(OpenCvSafeHandle node, out Vec4b returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6b(IntPtr node, out Vec6b returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6b(OpenCvSafeHandle node, out Vec6b returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2s(IntPtr node, out Vec2s returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2s(OpenCvSafeHandle node, out Vec2s returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3s(IntPtr node, out Vec3s returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3s(OpenCvSafeHandle node, out Vec3s returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4s(IntPtr node, out Vec4s returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4s(OpenCvSafeHandle node, out Vec4s returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6s(IntPtr node, out Vec6s returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6s(OpenCvSafeHandle node, out Vec6s returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec2w(IntPtr node, out Vec2w returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec2w(OpenCvSafeHandle node, out Vec2w returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec3w(IntPtr node, out Vec3w returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec3w(OpenCvSafeHandle node, out Vec3w returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec4w(IntPtr node, out Vec4w returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec4w(OpenCvSafeHandle node, out Vec4w returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Vec6w(IntPtr node, out Vec6w returnValue);
+    public static partial ExceptionStatus core_FileNode_read_Vec6w(OpenCvSafeHandle node, out Vec6w returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNodeIterator.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNodeIterator.cs
@@ -17,24 +17,24 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_FileNodeIterator_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorAsterisk(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorAsterisk(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorIncrement(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorIncrement(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorPlusEqual(IntPtr obj, int ofs, out int returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorPlusEqual(OpenCvSafeHandle obj, int ofs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNodeIterator_readRaw(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr maxCount);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr maxCount);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorEqual(IntPtr it1, IntPtr it2, out int returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorEqual(OpenCvSafeHandle it1, IntPtr it2, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorMinus(IntPtr it1, IntPtr it2, out IntPtr returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorMinus(OpenCvSafeHandle it1, IntPtr it2, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNodeIterator_operatorLessThan(IntPtr it1, IntPtr it2, out int returnValue);
+    public static partial ExceptionStatus core_FileNodeIterator_operatorLessThan(OpenCvSafeHandle it1, IntPtr it2, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
@@ -25,235 +25,235 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_open(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename, 
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename, 
         int flags, [MarshalAs(UnmanagedType.LPStr)] string? encoding, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_isOpened(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileStorage_isOpened(OpenCvSafeHandle obj, out int returnValue);
 
     //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     //public static extern ExceptionStatus core_FileStorage_release(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_releaseAndGetString(
-        IntPtr obj, IntPtr outString);
+        OpenCvSafeHandle obj, IntPtr outString);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_getFirstTopLevelNode(
-        IntPtr obj, out IntPtr returnValue);
+        OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_root(
-        IntPtr obj, int streamIdx, out IntPtr returnValue);
+        OpenCvSafeHandle obj, int streamIdx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_indexer(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string nodeName, out IntPtr returnValue);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string nodeName, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_writeRaw(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr len);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string fmt, IntPtr vec, IntPtr len);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_writeComment(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string comment, int append);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string comment, int append);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_getDefaultObjectName(
         [MarshalAs(UnmanagedType.LPStr)] string filename, IntPtr buf);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_elname(IntPtr obj, IntPtr returnValue);
+    public static partial ExceptionStatus core_FileStorage_elname(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_startWriteStruct(
-        IntPtr obj,
+        OpenCvSafeHandle obj,
         [MarshalAs(UnmanagedType.LPStr)] string name,
         int flags,
         [MarshalAs(UnmanagedType.LPStr)] string typeName);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_endWriteStruct(IntPtr obj);
+    public static partial ExceptionStatus core_FileStorage_endWriteStruct(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_state(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus core_FileStorage_state(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_int(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, int value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_float(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, float value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_double(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, double value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, double value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_String(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, [MarshalAs(UnmanagedType.LPStr)] string value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, [MarshalAs(UnmanagedType.LPStr)] string value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_Mat(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_SparseMat(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_vectorOfKeyPoint(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_vectorOfDMatch(
-        IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_writeScalar_int(IntPtr fs, int value);
+    public static partial ExceptionStatus core_FileStorage_writeScalar_int(OpenCvSafeHandle fs, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_writeScalar_float(IntPtr fs, float value);
+    public static partial ExceptionStatus core_FileStorage_writeScalar_float(OpenCvSafeHandle fs, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_writeScalar_double(IntPtr fs, double value);
+    public static partial ExceptionStatus core_FileStorage_writeScalar_double(OpenCvSafeHandle fs, double value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_writeScalar_String(IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string value);
+    public static partial ExceptionStatus core_FileStorage_writeScalar_String(OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string value);
         
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_String(IntPtr fs, [MarshalAs(UnmanagedType.LPStr)] string val);
+    public static partial ExceptionStatus core_FileStorage_shift_String(OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_int(IntPtr fs, int val);
+    public static partial ExceptionStatus core_FileStorage_shift_int(OpenCvSafeHandle fs, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_float(IntPtr fs, float val);
+    public static partial ExceptionStatus core_FileStorage_shift_float(OpenCvSafeHandle fs, float val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_double(IntPtr fs, double val);
+    public static partial ExceptionStatus core_FileStorage_shift_double(OpenCvSafeHandle fs, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Mat(IntPtr fs, IntPtr val);
+    public static partial ExceptionStatus core_FileStorage_shift_Mat(OpenCvSafeHandle fs, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_SparseMat(IntPtr fs, IntPtr val);
+    public static partial ExceptionStatus core_FileStorage_shift_SparseMat(OpenCvSafeHandle fs, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Range(IntPtr fs, Range val);
+    public static partial ExceptionStatus core_FileStorage_shift_Range(OpenCvSafeHandle fs, Range val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_KeyPoint(IntPtr fs, KeyPoint val);
+    public static partial ExceptionStatus core_FileStorage_shift_KeyPoint(OpenCvSafeHandle fs, KeyPoint val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_DMatch(IntPtr fs, DMatch val);
+    public static partial ExceptionStatus core_FileStorage_shift_DMatch(OpenCvSafeHandle fs, DMatch val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_vectorOfKeyPoint(IntPtr fs, IntPtr val);
+    public static partial ExceptionStatus core_FileStorage_shift_vectorOfKeyPoint(OpenCvSafeHandle fs, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_vectorOfDMatch(IntPtr fs, IntPtr val);
+    public static partial ExceptionStatus core_FileStorage_shift_vectorOfDMatch(OpenCvSafeHandle fs, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point2i(IntPtr fs, Point val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point2i(OpenCvSafeHandle fs, Point val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point2f(IntPtr fs, Point2f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point2f(OpenCvSafeHandle fs, Point2f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point2d(IntPtr fs, Point2d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point2d(OpenCvSafeHandle fs, Point2d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point3i(IntPtr fs, Point3i val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point3i(OpenCvSafeHandle fs, Point3i val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point3f(IntPtr fs, Point3f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point3f(OpenCvSafeHandle fs, Point3f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Point3d(IntPtr fs, Point3d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Point3d(OpenCvSafeHandle fs, Point3d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Size2i(IntPtr fs, Size val);
+    public static partial ExceptionStatus core_FileStorage_shift_Size2i(OpenCvSafeHandle fs, Size val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Size2f(IntPtr fs, Size2f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Size2f(OpenCvSafeHandle fs, Size2f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Size2d(IntPtr fs, Size2d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Size2d(OpenCvSafeHandle fs, Size2d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Rect2i(IntPtr fs, Rect val);
+    public static partial ExceptionStatus core_FileStorage_shift_Rect2i(OpenCvSafeHandle fs, Rect val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Rect2f(IntPtr fs, Rect2f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Rect2f(OpenCvSafeHandle fs, Rect2f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Rect2d(IntPtr fs, Rect2d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Rect2d(OpenCvSafeHandle fs, Rect2d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Scalar(IntPtr fs, Scalar val);
+    public static partial ExceptionStatus core_FileStorage_shift_Scalar(OpenCvSafeHandle fs, Scalar val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2i(IntPtr fs, Vec2i val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2i(OpenCvSafeHandle fs, Vec2i val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3i(IntPtr fs, Vec3i val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3i(OpenCvSafeHandle fs, Vec3i val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4i(IntPtr fs, Vec4i val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4i(OpenCvSafeHandle fs, Vec4i val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6i(IntPtr fs, Vec6i val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6i(OpenCvSafeHandle fs, Vec6i val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2d(IntPtr fs, Vec2d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2d(OpenCvSafeHandle fs, Vec2d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3d(IntPtr fs, Vec3d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3d(OpenCvSafeHandle fs, Vec3d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4d(IntPtr fs, Vec4d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4d(OpenCvSafeHandle fs, Vec4d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6d(IntPtr fs, Vec6d val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6d(OpenCvSafeHandle fs, Vec6d val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2f(IntPtr fs, Vec2f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2f(OpenCvSafeHandle fs, Vec2f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3f(IntPtr fs, Vec3f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3f(OpenCvSafeHandle fs, Vec3f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4f(IntPtr fs, Vec4f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4f(OpenCvSafeHandle fs, Vec4f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6f(IntPtr fs, Vec6f val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6f(OpenCvSafeHandle fs, Vec6f val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2b(IntPtr fs, Vec2b val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2b(OpenCvSafeHandle fs, Vec2b val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3b(IntPtr fs, Vec3b val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3b(OpenCvSafeHandle fs, Vec3b val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4b(IntPtr fs, Vec4b val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4b(OpenCvSafeHandle fs, Vec4b val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6b(IntPtr fs, Vec6b val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6b(OpenCvSafeHandle fs, Vec6b val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2s(IntPtr fs, Vec2s val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2s(OpenCvSafeHandle fs, Vec2s val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3s(IntPtr fs, Vec3s val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3s(OpenCvSafeHandle fs, Vec3s val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4s(IntPtr fs, Vec4s val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4s(OpenCvSafeHandle fs, Vec4s val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6s(IntPtr fs, Vec6s val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6s(OpenCvSafeHandle fs, Vec6s val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec2w(IntPtr fs, Vec2w val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec2w(OpenCvSafeHandle fs, Vec2w val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec3w(IntPtr fs, Vec3w val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec3w(OpenCvSafeHandle fs, Vec3w val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec4w(IntPtr fs, Vec4w val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec4w(OpenCvSafeHandle fs, Vec4w val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileStorage_shift_Vec6w(IntPtr fs, Vec6w val);
+    public static partial ExceptionStatus core_FileStorage_shift_Vec6w(OpenCvSafeHandle fs, Vec6w val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_InputArray.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_InputArray.cs
@@ -41,74 +41,74 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_InputArray_delete_withScalar(IntPtr ia, IntPtr handle);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getMat(IntPtr ia, int idx, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_getMat(OpenCvSafeHandle ia, int idx, out IntPtr returnValue);
     //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     //public static extern ExceptionStatus core_InputArray_getMat_(IntPtr ia, int idx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getUMat(IntPtr ia, int idx, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_getUMat(OpenCvSafeHandle ia, int idx, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getMatVector(IntPtr ia, IntPtr mv);
+    public static partial ExceptionStatus core_InputArray_getMatVector(OpenCvSafeHandle ia, IntPtr mv);
     //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     //public static extern void core_InputArray_getUMatVector(IntPtr ia, IntPtr umv);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getFlags(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_getFlags(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getObj(IntPtr ia, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_getObj(OpenCvSafeHandle ia, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_getSz(IntPtr ia, out Size returnValue);
+    public static partial ExceptionStatus core_InputArray_getSz(OpenCvSafeHandle ia, out Size returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_kind(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_kind(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_dims(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_dims(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_cols(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_cols(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_rows(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_rows(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_size(IntPtr ia, int i, out Size returnValue);
+    public static partial ExceptionStatus core_InputArray_size(OpenCvSafeHandle ia, int i, out Size returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_sizend(IntPtr ia, int[] sz, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_sizend(OpenCvSafeHandle ia, int[] sz, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_sameSize(IntPtr self, IntPtr target, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_sameSize(OpenCvSafeHandle self, IntPtr target, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_total(IntPtr ia, int i, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_total(OpenCvSafeHandle ia, int i, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_type(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_type(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_depth(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_depth(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_channels(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_channels(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isContinuous(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isContinuous(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isSubmatrix(IntPtr ia, int i, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isSubmatrix(OpenCvSafeHandle ia, int i, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_empty(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_empty(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_copyTo1(IntPtr ia, IntPtr arr);
+    public static partial ExceptionStatus core_InputArray_copyTo1(OpenCvSafeHandle ia, IntPtr arr);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_copyTo2(IntPtr ia, IntPtr arr, IntPtr mask);
+    public static partial ExceptionStatus core_InputArray_copyTo2(OpenCvSafeHandle ia, IntPtr arr, IntPtr mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_offset(IntPtr ia, int i, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_offset(OpenCvSafeHandle ia, int i, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_step(IntPtr ia, int i, out IntPtr returnValue);
+    public static partial ExceptionStatus core_InputArray_step(OpenCvSafeHandle ia, int i, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isMat(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isMat(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isUMat(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isUMat(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isMatVector(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isMatVector(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isUMatVector(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isUMatVector(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isMatx(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isMatx(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isVector(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isVector(OpenCvSafeHandle ia, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_InputArray_isGpuMatVector(IntPtr ia, out int returnValue);
+    public static partial ExceptionStatus core_InputArray_isGpuMatVector(OpenCvSafeHandle ia, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_MatExpr.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_MatExpr.cs
@@ -18,42 +18,42 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_MatExpr_delete(IntPtr expr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_toMat(IntPtr expr, IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_toMat(OpenCvSafeHandle expr, IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_row(IntPtr self, int y, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_row(OpenCvSafeHandle self, int y, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_col(IntPtr self, int x, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_col(OpenCvSafeHandle self, int x, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_diag(IntPtr self, int d, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_diag(OpenCvSafeHandle self, int d, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_MatExpr_submat(
-        IntPtr self, int rowStart, int rowEnd, int colStart, int colEnd, out IntPtr returnValue);
+        OpenCvSafeHandle self, int rowStart, int rowEnd, int colStart, int colEnd, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_t(IntPtr self, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_t(OpenCvSafeHandle self, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_inv(IntPtr self, int method, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_inv(OpenCvSafeHandle self, int method, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_mul_toMatExpr(IntPtr self, IntPtr e, double scale, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_mul_toMatExpr(OpenCvSafeHandle self, IntPtr e, double scale, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_mul_toMat(IntPtr self, IntPtr m, double scale, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_mul_toMat(OpenCvSafeHandle self, IntPtr m, double scale, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_cross(IntPtr self, IntPtr m, out IntPtr returnValue);
+    public static partial ExceptionStatus core_MatExpr_cross(OpenCvSafeHandle self, IntPtr m, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_dot(IntPtr self, IntPtr m, out double returnValue);
+    public static partial ExceptionStatus core_MatExpr_dot(OpenCvSafeHandle self, IntPtr m, out double returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_size(IntPtr self, out Size returnValue);
+    public static partial ExceptionStatus core_MatExpr_size(OpenCvSafeHandle self, out Size returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_MatExpr_type(IntPtr self, out int returnValue);
+    public static partial ExceptionStatus core_MatExpr_type(OpenCvSafeHandle self, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_operatorUnaryMinus_MatExpr(IntPtr e, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/FacemarkParamsData.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/FacemarkParamsData.cs
@@ -1,0 +1,42 @@
+using System.Runtime.InteropServices;
+
+namespace OpenCvSharp.Internal;
+
+/// <summary>
+/// Blittable view of the scalar fields of cv::face::FacemarkLBF::Params.
+/// The std::string / std::vector members are marshalled separately.
+/// Field order must match the native FacemarkLBFParamsData struct.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct FacemarkLBFParamsData
+{
+    public double ShapeOffset;
+    public int Verbose;
+    public int NLandmarks;
+    public int InitShapeN;
+    public int StagesN;
+    public int TreeN;
+    public int TreeDepth;
+    public double BaggingOverlap;
+    public int SaveModel;
+    public uint Seed;
+    public Rect DetectROI;
+}
+
+/// <summary>
+/// Blittable view of the scalar fields of cv::face::FacemarkAAM::Params.
+/// The model_filename / scales members are marshalled separately.
+/// Field order must match the native FacemarkAAMParamsData struct.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct FacemarkAAMParamsData
+{
+    public int M;
+    public int N;
+    public int NIter;
+    public int Verbose;
+    public int SaveModel;
+    public int MaxM;
+    public int MaxN;
+    public int TextureMaxM;
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_FaceRecognizer.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_FaceRecognizer.cs
@@ -16,75 +16,75 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_train(
-        IntPtr obj, IntPtr[] src, int srcLength, int[] labels, int labelsLength);
+        OpenCvSafeHandle obj, IntPtr[] src, int srcLength, int[] labels, int labelsLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_update(
-        IntPtr obj, IntPtr[] src, int srcLength, int[] labels, int labelsLength);
+        OpenCvSafeHandle obj, IntPtr[] src, int srcLength, int[] labels, int labelsLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_predict1(IntPtr obj, IntPtr src, out int returnValue);
+    public static partial ExceptionStatus face_FaceRecognizer_predict1(OpenCvSafeHandle obj, IntPtr src, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_predict2(
-        IntPtr obj, IntPtr src, out int label, out double confidence);
+        OpenCvSafeHandle obj, IntPtr src, out int label, out double confidence);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_write1(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_read1(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string filename);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_write2(IntPtr obj, IntPtr fs);
+    public static partial ExceptionStatus face_FaceRecognizer_write2(OpenCvSafeHandle obj, IntPtr fs);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_read2(IntPtr obj, IntPtr fs);
+    public static partial ExceptionStatus face_FaceRecognizer_read2(OpenCvSafeHandle obj, IntPtr fs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_setLabelInfo(
-        IntPtr obj, int label, [MarshalAs(UnmanagedType.LPStr)] string strInfo);
+        OpenCvSafeHandle obj, int label, [MarshalAs(UnmanagedType.LPStr)] string strInfo);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_getLabelInfo(IntPtr obj, int label, IntPtr dst);
+    public static partial ExceptionStatus face_FaceRecognizer_getLabelInfo(OpenCvSafeHandle obj, int label, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_getLabelsByString(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string str, IntPtr dst);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string str, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_getThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus face_FaceRecognizer_getThreshold(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FaceRecognizer_setThreshold(IntPtr obj, double val);
+    public static partial ExceptionStatus face_FaceRecognizer_setThreshold(OpenCvSafeHandle obj, double val);
 
     #endregion
 
     #region BasicFaceRecognizer
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getNumComponents(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getNumComponents(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_setNumComponents(IntPtr obj, int val);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_setNumComponents(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getThreshold(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_setThreshold(IntPtr obj, double val);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_setThreshold(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getProjections(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getProjections(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getLabels(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getLabels(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getEigenValues(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getEigenValues(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getEigenVectors(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getEigenVectors(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_BasicFaceRecognizer_getMean(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_BasicFaceRecognizer_getMean(OpenCvSafeHandle obj, IntPtr dst);
 
     #endregion
 
@@ -121,40 +121,40 @@ static partial class NativeMethods
         int radius, int neighbors, int gridX, int gridY, double threshold, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getGridX(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getGridX(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_setGridX(IntPtr obj, int val);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_setGridX(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getGridY(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getGridY(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_setGridY(IntPtr obj, int val);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_setGridY(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getRadius(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getRadius(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_setRadius(IntPtr obj, int val);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_setRadius(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getNeighbors(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getNeighbors(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_setNeighbors(IntPtr obj, int val);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_setNeighbors(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getThreshold(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getThreshold(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_setThreshold(IntPtr obj, double val);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_setThreshold(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getHistograms(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getHistograms(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_LBPHFaceRecognizer_getLabels(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus face_LBPHFaceRecognizer_getLabels(OpenCvSafeHandle obj, IntPtr dst);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
@@ -16,11 +16,11 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_Facemark_loadModel(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string model);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string model);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_Facemark_fit(
-        IntPtr obj, IntPtr image, IntPtr faces, IntPtr landmarks, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr faces, IntPtr landmarks, out int returnValue);
 
     #endregion
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
@@ -44,108 +44,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus face_FacemarkLBF_Params_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_shape_offset_get(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus face_FacemarkLBF_Params_getAll(
+        IntPtr obj, out FacemarkLBFParamsData data, IntPtr cascadeFace, IntPtr modelFilename,
+        IntPtr featsM, IntPtr radiusM, IntPtr pupils0, IntPtr pupils1);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_shape_offset_set(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_cascade_face_get(IntPtr obj, IntPtr s);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_cascade_face_set(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_verbose_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_verbose_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_n_landmarks_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_n_landmarks_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_initShape_n_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_initShape_n_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_stages_n_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_stages_n_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_tree_n_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_tree_n_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_tree_depth_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_tree_depth_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_bagging_overlap_get(IntPtr obj, out double returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_bagging_overlap_set(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_model_filename_get(IntPtr obj, IntPtr s);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_model_filename_set(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_save_model_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_save_model_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_seed_get(IntPtr obj, out uint returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_seed_set(IntPtr obj, uint val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_feats_m_get(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_feats_m_set(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_radius_m_get(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_radius_m_set(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_pupils0_get(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_pupils0_set(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_pupils1_get(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_pupils1_set(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_detectROI_get(IntPtr obj, out Rect returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkLBF_Params_detectROI_set(IntPtr obj, Rect val);
+    public static partial ExceptionStatus face_FacemarkLBF_Params_setAll(
+        IntPtr obj, FacemarkLBFParamsData data, [MarshalAs(UnmanagedType.LPStr)] string cascadeFace,
+        [MarshalAs(UnmanagedType.LPStr)] string modelFilename, IntPtr featsM, IntPtr radiusM, IntPtr pupils0, IntPtr pupils1);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FacemarkLBF_Params_read(IntPtr obj, IntPtr fn);
@@ -177,65 +83,12 @@ static partial class NativeMethods
     public static partial ExceptionStatus face_FacemarkAAM_Params_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_model_filename_get(IntPtr obj, IntPtr s);
+    public static partial ExceptionStatus face_FacemarkAAM_Params_getAll(
+        IntPtr obj, out FacemarkAAMParamsData data, IntPtr modelFilename, IntPtr scales);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_model_filename_set(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_m_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_m_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_n_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_n_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_n_iter_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_n_iter_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_verbose_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_verbose_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_save_model_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_save_model_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_max_m_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_max_m_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_max_n_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_max_n_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_texture_max_m_get(IntPtr obj, out int returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_texture_max_m_set(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_scales_get(IntPtr obj, IntPtr v);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus face_FacemarkAAM_Params_scales_set(IntPtr obj, IntPtr v);
+    public static partial ExceptionStatus face_FacemarkAAM_Params_setAll(
+        IntPtr obj, FacemarkAAMParamsData data, [MarshalAs(UnmanagedType.LPStr)] string modelFilename, IntPtr scales);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FacemarkAAM_Params_read(IntPtr obj, IntPtr fn);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
@@ -22,60 +22,60 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_ANNIndex_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_addItems(IntPtr obj, IntPtr features);
+    public static partial ExceptionStatus features_ANNIndex_addItems(OpenCvSafeHandle obj, IntPtr features);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_build(IntPtr obj, int trees);
+    public static partial ExceptionStatus features_ANNIndex_build(OpenCvSafeHandle obj, int trees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_knnSearch(
-        IntPtr obj, IntPtr query, IntPtr indices, IntPtr dists, int knn, int search_k);
+        OpenCvSafeHandle obj, IntPtr query, IntPtr indices, IntPtr dists, int knn, int search_k);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_save"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_save_NotWindows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_save"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_save_Windows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
 
-    public static ExceptionStatus features_ANNIndex_save(IntPtr obj, string filename, int prefault)
+    public static ExceptionStatus features_ANNIndex_save(OpenCvSafeHandle obj, string filename, int prefault)
         => IsWindows()
             ? features_ANNIndex_save_Windows(obj, filename, prefault)
             : features_ANNIndex_save_NotWindows(obj, filename, prefault);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_load"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_load_NotWindows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, int prefault);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_load"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_load_Windows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, int prefault);
 
-    public static ExceptionStatus features_ANNIndex_load(IntPtr obj, string filename, int prefault)
+    public static ExceptionStatus features_ANNIndex_load(OpenCvSafeHandle obj, string filename, int prefault)
         => IsWindows()
             ? features_ANNIndex_load_Windows(obj, filename, prefault)
             : features_ANNIndex_load_NotWindows(obj, filename, prefault);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_getTreeNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ANNIndex_getTreeNumber(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_getItemNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ANNIndex_getItemNumber(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_setOnDiskBuild"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_setOnDiskBuild_NotWindows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, out int returnValue);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, out int returnValue);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_setOnDiskBuild"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_setOnDiskBuild_Windows(
-        IntPtr obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, out int returnValue);
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeWindows)] string filename, out int returnValue);
 
-    public static ExceptionStatus features_ANNIndex_setOnDiskBuild(IntPtr obj, string filename, out int returnValue)
+    public static ExceptionStatus features_ANNIndex_setOnDiskBuild(OpenCvSafeHandle obj, string filename, out int returnValue)
         => IsWindows()
             ? features_ANNIndex_setOnDiskBuild_Windows(obj, filename, out returnValue)
             : features_ANNIndex_setOnDiskBuild_NotWindows(obj, filename, out returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_setSeed(IntPtr obj, int seed);
+    public static partial ExceptionStatus features_ANNIndex_setSeed(OpenCvSafeHandle obj, int seed);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
@@ -15,50 +15,50 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_add(
-        IntPtr obj, IntPtr[] descriptors, int descriptorLength);
+        OpenCvSafeHandle obj, IntPtr[] descriptors, int descriptorLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DescriptorMatcher_getTrainDescriptors(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus features_DescriptorMatcher_getTrainDescriptors(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DescriptorMatcher_clear(IntPtr obj);
+    public static partial ExceptionStatus features_DescriptorMatcher_clear(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DescriptorMatcher_empty(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_DescriptorMatcher_empty(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DescriptorMatcher_isMaskSupported(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_DescriptorMatcher_isMaskSupported(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DescriptorMatcher_train(IntPtr obj);
+    public static partial ExceptionStatus features_DescriptorMatcher_train(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_match1(
-        IntPtr obj, IntPtr queryDescriptors, IntPtr trainDescriptors, IntPtr matches, IntPtr mask);
+        OpenCvSafeHandle obj, IntPtr queryDescriptors, IntPtr trainDescriptors, IntPtr matches, IntPtr mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_knnMatch1(
-        IntPtr obj, IntPtr queryDescriptors, IntPtr trainDescriptors, IntPtr matches, int k,
+        OpenCvSafeHandle obj, IntPtr queryDescriptors, IntPtr trainDescriptors, IntPtr matches, int k,
         IntPtr mask, int compactResult);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_radiusMatch1(
-        IntPtr obj, IntPtr queryDescriptors,IntPtr trainDescriptors, IntPtr matches, float maxDistance,
+        OpenCvSafeHandle obj, IntPtr queryDescriptors,IntPtr trainDescriptors, IntPtr matches, float maxDistance,
         IntPtr mask, int compactResult);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_match2(
-        IntPtr obj, IntPtr queryDescriptors, IntPtr matches,
+        OpenCvSafeHandle obj, IntPtr queryDescriptors, IntPtr matches,
         IntPtr[] masks, int masksSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_knnMatch2(
-        IntPtr obj, IntPtr queryDescriptors, IntPtr matches,
+        OpenCvSafeHandle obj, IntPtr queryDescriptors, IntPtr matches,
         int k, IntPtr[] masks, int masksSize, int compactResult);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_DescriptorMatcher_radiusMatch2(
-        IntPtr obj, IntPtr queryDescriptors, IntPtr matches,
+        OpenCvSafeHandle obj, IntPtr queryDescriptors, IntPtr matches,
         float maxDistance, IntPtr[] masks, int masksSize, int compactResult);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -81,7 +81,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_BFMatcher_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_BFMatcher_isMaskSupported(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_BFMatcher_isMaskSupported(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_BFMatcher_get(IntPtr ptr, out IntPtr returnValue);
@@ -101,16 +101,16 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_FlannBasedMatcher_add(
-        IntPtr obj, IntPtr[] descriptors, int descriptorsSize);
+        OpenCvSafeHandle obj, IntPtr[] descriptors, int descriptorsSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FlannBasedMatcher_clear(IntPtr obj);
+    public static partial ExceptionStatus features_FlannBasedMatcher_clear(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FlannBasedMatcher_train(IntPtr obj);
+    public static partial ExceptionStatus features_FlannBasedMatcher_train(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FlannBasedMatcher_isMaskSupported(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_FlannBasedMatcher_isMaskSupported(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_FlannBasedMatcher_get(IntPtr ptr, out IntPtr returnValue);
@@ -139,10 +139,10 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_LightGlueMatcher_setPairInfo(
-        IntPtr obj, IntPtr queryKpts, IntPtr trainKpts, Size queryImageSize, Size trainImageSize);
+        OpenCvSafeHandle obj, IntPtr queryKpts, IntPtr trainKpts, Size queryImageSize, Size trainImageSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_LightGlueMatcher_clearPairInfo(IntPtr obj);
+    public static partial ExceptionStatus features_LightGlueMatcher_clearPairInfo(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_LightGlueMatcher_get(IntPtr ptr, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
@@ -79,49 +79,49 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_ORB_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setMaxFeatures(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setMaxFeatures(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getMaxFeatures(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getMaxFeatures(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setScaleFactor(IntPtr obj, double val);
+    public static partial ExceptionStatus features_ORB_setScaleFactor(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getScaleFactor(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus features_ORB_getScaleFactor(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setNLevels(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setNLevels(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getNLevels(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getNLevels(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setEdgeThreshold(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setEdgeThreshold(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getEdgeThreshold(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getEdgeThreshold(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setFirstLevel(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setFirstLevel(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getFirstLevel(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getFirstLevel(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setWTA_K(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setWTA_K(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getWTA_K(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getWTA_K(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setScoreType(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setScoreType(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getScoreType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getScoreType(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setPatchSize(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setPatchSize(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getPatchSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getPatchSize(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_setFastThreshold(IntPtr obj, int val);
+    public static partial ExceptionStatus features_ORB_setFastThreshold(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ORB_getFastThreshold(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_ORB_getFastThreshold(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 
@@ -138,27 +138,27 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_MSER_detectRegions(
-        IntPtr obj, IntPtr image, IntPtr msers, IntPtr bboxes);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr msers, IntPtr bboxes);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_setDelta(IntPtr obj, int delta);
+    public static partial ExceptionStatus features_MSER_setDelta(OpenCvSafeHandle obj, int delta);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_getDelta(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_MSER_getDelta(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_setMinArea(IntPtr obj, int minArea);
+    public static partial ExceptionStatus features_MSER_setMinArea(OpenCvSafeHandle obj, int minArea);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_getMinArea(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_MSER_getMinArea(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_setMaxArea(IntPtr obj, int maxArea);
+    public static partial ExceptionStatus features_MSER_setMaxArea(OpenCvSafeHandle obj, int maxArea);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_getMaxArea(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_MSER_getMaxArea(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_setPass2Only(IntPtr obj, int f);
+    public static partial ExceptionStatus features_MSER_setPass2Only(OpenCvSafeHandle obj, int f);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_getPass2Only(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_MSER_getPass2Only(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 
@@ -175,19 +175,19 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_FastFeatureDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_setThreshold(IntPtr obj, int threshold);
+    public static partial ExceptionStatus features_FastFeatureDetector_setThreshold(OpenCvSafeHandle obj, int threshold);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_getThreshold(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_FastFeatureDetector_getThreshold(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_setNonmaxSuppression(IntPtr obj, int f);
+    public static partial ExceptionStatus features_FastFeatureDetector_setNonmaxSuppression(OpenCvSafeHandle obj, int f);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_getNonmaxSuppression(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_FastFeatureDetector_getNonmaxSuppression(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_setType(IntPtr obj, int type);
+    public static partial ExceptionStatus features_FastFeatureDetector_setType(OpenCvSafeHandle obj, int type);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FastFeatureDetector_getType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_FastFeatureDetector_getType(OpenCvSafeHandle obj, out int returnValue);
 
     #endregion
 
@@ -202,34 +202,34 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_GFTTDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setMaxFeatures(IntPtr obj, int maxFeatures);
+    public static partial ExceptionStatus features_GFTTDetector_setMaxFeatures(OpenCvSafeHandle obj, int maxFeatures);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getMaxFeatures(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getMaxFeatures(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setQualityLevel(IntPtr obj, double qLevel);
+    public static partial ExceptionStatus features_GFTTDetector_setQualityLevel(OpenCvSafeHandle obj, double qLevel);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getQualityLevel(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getQualityLevel(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setMinDistance(IntPtr obj, double minDistance);
+    public static partial ExceptionStatus features_GFTTDetector_setMinDistance(OpenCvSafeHandle obj, double minDistance);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getMinDistance(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getMinDistance(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setBlockSize(IntPtr obj, int blockSize);
+    public static partial ExceptionStatus features_GFTTDetector_setBlockSize(OpenCvSafeHandle obj, int blockSize);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getBlockSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getBlockSize(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setHarrisDetector(IntPtr obj, int val);
+    public static partial ExceptionStatus features_GFTTDetector_setHarrisDetector(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getHarrisDetector(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getHarrisDetector(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_setK(IntPtr obj, double k);
+    public static partial ExceptionStatus features_GFTTDetector_setK(OpenCvSafeHandle obj, double k);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_GFTTDetector_getK(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus features_GFTTDetector_getK(OpenCvSafeHandle obj, out double returnValue);
 
     #endregion
 
@@ -256,10 +256,10 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_AffineFeature_setViewParams(
-        IntPtr obj, float[] tilts, int tiltsLength, float[] rolls, int rollsLength);
+        OpenCvSafeHandle obj, float[] tilts, int tiltsLength, float[] rolls, int rollsLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_AffineFeature_getViewParams(IntPtr obj, IntPtr tilts, IntPtr rolls);
+    public static partial ExceptionStatus features_AffineFeature_getViewParams(OpenCvSafeHandle obj, IntPtr tilts, IntPtr rolls);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_AffineFeature_delete(IntPtr ptr);
@@ -286,17 +286,17 @@ static partial class NativeMethods
         byte[] bufferModel, IntPtr bufferModelLength, int maxKeypoints, float scoreThreshold, Size imageSize, int backendId, int targetId, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_setMaxKeypoints(IntPtr obj, int maxKeypoints);
+    public static partial ExceptionStatus features_DISK_setMaxKeypoints(OpenCvSafeHandle obj, int maxKeypoints);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_getMaxKeypoints(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus features_DISK_getMaxKeypoints(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_setScoreThreshold(IntPtr obj, float threshold);
+    public static partial ExceptionStatus features_DISK_setScoreThreshold(OpenCvSafeHandle obj, float threshold);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_getScoreThreshold(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus features_DISK_getScoreThreshold(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_setImageSize(IntPtr obj, Size size);
+    public static partial ExceptionStatus features_DISK_setImageSize(OpenCvSafeHandle obj, Size size);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_DISK_getImageSize(IntPtr obj, out Size returnValue);
+    public static partial ExceptionStatus features_DISK_getImageSize(OpenCvSafeHandle obj, out Size returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_DISK_delete(IntPtr ptr);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_GeneralizedHough.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_GeneralizedHough.cs
@@ -14,54 +14,54 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_GeneralizedHough_setTemplate1(
-        IntPtr obj, IntPtr templ, Point templCenter);
+        OpenCvSafeHandle obj, IntPtr templ, Point templCenter);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_GeneralizedHough_setTemplate2(
-        IntPtr obj, IntPtr edges, IntPtr dx, IntPtr dy, Point templCenter);
+        OpenCvSafeHandle obj, IntPtr edges, IntPtr dx, IntPtr dy, Point templCenter);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_GeneralizedHough_detect1(
-        IntPtr obj, IntPtr image, IntPtr positions, IntPtr votes);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr positions, IntPtr votes);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_GeneralizedHough_detect2(
-        IntPtr obj, IntPtr edges, IntPtr dx, IntPtr dy, IntPtr positions, IntPtr votes);
+        OpenCvSafeHandle obj, IntPtr edges, IntPtr dx, IntPtr dy, IntPtr positions, IntPtr votes);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_setCannyLowThresh(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_setCannyLowThresh(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_getCannyLowThresh(IntPtr obj, out int returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_setCannyHighThresh(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_getCannyHighThresh(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_getCannyLowThresh(OpenCvSafeHandle obj, out int returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_setMinDist(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_setCannyHighThresh(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_getMinDist(IntPtr obj, out double returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_setDp(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_getDp(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_getCannyHighThresh(OpenCvSafeHandle obj, out int returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_setMaxBufferSize(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_setMinDist(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHough_getMaxBufferSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHough_getMinDist(OpenCvSafeHandle obj, out double returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHough_setDp(OpenCvSafeHandle obj, double val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHough_getDp(OpenCvSafeHandle obj, out double returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHough_setMaxBufferSize(OpenCvSafeHandle obj, int val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHough_getMaxBufferSize(OpenCvSafeHandle obj, out int returnValue);
 
 
 
@@ -78,17 +78,17 @@ static partial class NativeMethods
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_setLevels(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_setLevels(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_getLevels(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_getLevels(OpenCvSafeHandle obj, out int returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_setVotesThreshold(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_setVotesThreshold(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_getVotesThreshold(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughBallard_getVotesThreshold(OpenCvSafeHandle obj, out int returnValue);
 
 
 
@@ -105,83 +105,83 @@ static partial class NativeMethods
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setXi(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setXi(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getXi(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getXi(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setLevels(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setLevels(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getLevels(IntPtr obj, out int returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleEpsilon(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleEpsilon(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getLevels(OpenCvSafeHandle obj, out int returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMinAngle(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleEpsilon(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMinAngle(IntPtr obj, out double returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMaxAngle(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMaxAngle(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleEpsilon(OpenCvSafeHandle obj, out double returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleStep(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMinAngle(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleStep(IntPtr obj, out double returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleThresh(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleThresh(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMinAngle(OpenCvSafeHandle obj, out double returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMinScale(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMaxAngle(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMinScale(IntPtr obj, out double returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMaxScale(IntPtr obj, double val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMaxScale(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMaxAngle(OpenCvSafeHandle obj, out double returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setScaleStep(IntPtr obj, double val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleStep(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getScaleStep(IntPtr obj, out double returnValue);
-
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setScaleThresh(IntPtr obj, int val);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getScaleThresh(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleStep(OpenCvSafeHandle obj, out double returnValue);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setPosThresh(IntPtr obj, int val);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setAngleThresh(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getPosThresh(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getAngleThresh(OpenCvSafeHandle obj, out int returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMinScale(OpenCvSafeHandle obj, double val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMinScale(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setMaxScale(OpenCvSafeHandle obj, double val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getMaxScale(OpenCvSafeHandle obj, out double returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setScaleStep(OpenCvSafeHandle obj, double val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getScaleStep(OpenCvSafeHandle obj, out double returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setScaleThresh(OpenCvSafeHandle obj, int val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getScaleThresh(OpenCvSafeHandle obj, out int returnValue);
+
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_setPosThresh(OpenCvSafeHandle obj, int val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_GeneralizedHoughGuil_getPosThresh(OpenCvSafeHandle obj, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_LineSegmentDetector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_LineSegmentDetector.cs
@@ -11,18 +11,18 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial void imgproc_LineSegmentDetector_detect_OutputArray(IntPtr obj, IntPtr image, IntPtr lines,
+    public static partial void imgproc_LineSegmentDetector_detect_OutputArray(OpenCvSafeHandle obj, IntPtr image, IntPtr lines,
         IntPtr width, IntPtr prec, IntPtr nfa);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial void imgproc_LineSegmentDetector_detect_vector(IntPtr obj, IntPtr image, IntPtr lines,
+    public static partial void imgproc_LineSegmentDetector_detect_vector(OpenCvSafeHandle obj, IntPtr image, IntPtr lines,
         IntPtr width, IntPtr prec, IntPtr nfa);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial void imgproc_LineSegmentDetector_drawSegments(IntPtr obj, IntPtr image, IntPtr lines);
+    public static partial void imgproc_LineSegmentDetector_drawSegments(OpenCvSafeHandle obj, IntPtr image, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int imgproc_LineSegmentDetector_compareSegments(IntPtr obj, Size size,
+    public static partial int imgproc_LineSegmentDetector_compareSegments(OpenCvSafeHandle obj, Size size,
         IntPtr lines1, IntPtr lines2, IntPtr image);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_ANN_MLP.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_ANN_MLP.cs
@@ -11,61 +11,61 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setTrainMethod(IntPtr obj, int method, double param1, double param2);
+    public static partial ExceptionStatus ml_ANN_MLP_setTrainMethod(OpenCvSafeHandle obj, int method, double param1, double param2);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getTrainMethod(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getTrainMethod(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setActivationFunction(IntPtr obj, int type, double param1, double param2);
+    public static partial ExceptionStatus ml_ANN_MLP_setActivationFunction(OpenCvSafeHandle obj, int type, double param1, double param2);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setLayerSizes(IntPtr obj, IntPtr layerSizes);
+    public static partial ExceptionStatus ml_ANN_MLP_setLayerSizes(OpenCvSafeHandle obj, IntPtr layerSizes);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getLayerSizes(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getLayerSizes(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getTermCriteria(IntPtr obj, out TermCriteria returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setTermCriteria(IntPtr obj, TermCriteria val);
+    public static partial ExceptionStatus ml_ANN_MLP_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getBackpropWeightScale(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getBackpropWeightScale(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setBackpropWeightScale(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setBackpropWeightScale(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getBackpropMomentumScale(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getBackpropMomentumScale(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setBackpropMomentumScale(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setBackpropMomentumScale(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getRpropDW0(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getRpropDW0(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setRpropDW0(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setRpropDW0(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWPlus(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWPlus(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWPlus(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWPlus(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMinus(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMinus(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMinus(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMinus(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMin(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMin(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMin(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMin(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMax(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getRpropDWMax(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMax(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_ANN_MLP_setRpropDWMax(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_getWeights(IntPtr obj, int layerIdx, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_ANN_MLP_getWeights(OpenCvSafeHandle obj, int layerIdx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_ANN_MLP_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_Boost.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_Boost.cs
@@ -11,19 +11,19 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_getBoostType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_Boost_getBoostType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_setBoostType(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_Boost_setBoostType(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_getWeakCount(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_Boost_getWeakCount(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_setWeakCount(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_Boost_setWeakCount(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_getWeightTrimRate(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_Boost_getWeightTrimRate(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_Boost_setWeightTrimRate(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_Boost_setWeightTrimRate(OpenCvSafeHandle obj, double val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_Boost_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_DTrees.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_DTrees.cs
@@ -11,58 +11,58 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getMaxCategories(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getMaxCategories(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setMaxCategories(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setMaxCategories(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getMaxDepth(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getMaxDepth(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setMaxDepth(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setMaxDepth(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getMinSampleCount(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getMinSampleCount(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setMinSampleCount(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setMinSampleCount(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getCVFolds(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getCVFolds(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setCVFolds(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setCVFolds(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getUseSurrogates(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getUseSurrogates(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setUseSurrogates(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setUseSurrogates(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getUse1SERule(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getUse1SERule(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setUse1SERule(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setUse1SERule(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getTruncatePrunedTree(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_DTrees_getTruncatePrunedTree(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setTruncatePrunedTree(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_DTrees_setTruncatePrunedTree(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getRegressionAccuracy(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ml_DTrees_getRegressionAccuracy(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setRegressionAccuracy(IntPtr obj, float val);
+    public static partial ExceptionStatus ml_DTrees_setRegressionAccuracy(OpenCvSafeHandle obj, float val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getPriors(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_DTrees_getPriors(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_setPriors(IntPtr obj, IntPtr val);
+    public static partial ExceptionStatus ml_DTrees_setPriors(OpenCvSafeHandle obj, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getRoots(IntPtr obj, IntPtr result);
+    public static partial ExceptionStatus ml_DTrees_getRoots(OpenCvSafeHandle obj, IntPtr result);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getNodes(IntPtr obj, IntPtr result);
+    public static partial ExceptionStatus ml_DTrees_getNodes(OpenCvSafeHandle obj, IntPtr result);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getSplits(IntPtr obj, IntPtr result);
+    public static partial ExceptionStatus ml_DTrees_getSplits(OpenCvSafeHandle obj, IntPtr result);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_DTrees_getSubsets(IntPtr obj, IntPtr result);
+    public static partial ExceptionStatus ml_DTrees_getSubsets(OpenCvSafeHandle obj, IntPtr result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_DTrees_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_EM.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_EM.cs
@@ -12,43 +12,43 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getClustersNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_EM_getClustersNumber(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_setClustersNumber(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_EM_setClustersNumber(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getCovarianceMatrixType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_EM_getCovarianceMatrixType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_setCovarianceMatrixType(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_EM_setCovarianceMatrixType(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getTermCriteria(IntPtr obj, out TermCriteria returnValue);
+    public static partial ExceptionStatus ml_EM_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_setTermCriteria(IntPtr obj, TermCriteria val);
+    public static partial ExceptionStatus ml_EM_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getWeights(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_EM_getWeights(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getMeans(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_EM_getMeans(OpenCvSafeHandle obj, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_getCovs(IntPtr obj, IntPtr covs);
+    public static partial ExceptionStatus ml_EM_getCovs(OpenCvSafeHandle obj, IntPtr covs);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_predict2(IntPtr model, IntPtr sample, IntPtr probs, out Vec2d returnValue);
+    public static partial ExceptionStatus ml_EM_predict2(OpenCvSafeHandle model, IntPtr sample, IntPtr probs, out Vec2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_EM_trainEM(
-        IntPtr obj, IntPtr samples, IntPtr logLikelihoods, IntPtr labels, IntPtr probs, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr samples, IntPtr logLikelihoods, IntPtr labels, IntPtr probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_EM_trainE(
-        IntPtr model, IntPtr samples, IntPtr means0, IntPtr covs0, IntPtr weights0,
+        OpenCvSafeHandle model, IntPtr samples, IntPtr means0, IntPtr covs0, IntPtr weights0,
         IntPtr logLikelihoods, IntPtr labels, IntPtr probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_EM_trainM(
-        IntPtr model, IntPtr samples, IntPtr probs0, IntPtr logLikelihoods, 
+        OpenCvSafeHandle model, IntPtr samples, IntPtr probs0, IntPtr logLikelihoods, 
         IntPtr labels, IntPtr probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_KNearest.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_KNearest.cs
@@ -11,27 +11,27 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_getDefaultK(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_KNearest_getDefaultK(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_setDefaultK(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_KNearest_setDefaultK(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_getIsClassifier(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_KNearest_getIsClassifier(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_setIsClassifier(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_KNearest_setIsClassifier(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_getEmax(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_KNearest_getEmax(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_setEmax(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_KNearest_setEmax(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_getAlgorithmType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_KNearest_getAlgorithmType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_setAlgorithmType(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_KNearest_setAlgorithmType(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_findNearest(IntPtr obj, IntPtr samples, int k,
+    public static partial ExceptionStatus ml_KNearest_findNearest(OpenCvSafeHandle obj, IntPtr samples, int k,
         IntPtr results, IntPtr neighborResponses, IntPtr dist, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_LogisticRegression.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_LogisticRegression.cs
@@ -11,41 +11,41 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getLearningRate(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getLearningRate(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setLearningRate(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_LogisticRegression_setLearningRate(OpenCvSafeHandle obj, double val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_LogisticRegression_setIterations(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getRegularization(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getRegularization(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setRegularization(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_LogisticRegression_setRegularization(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getTrainMethod(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getTrainMethod(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setTrainMethod(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_LogisticRegression_setTrainMethod(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getMiniBatchSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getMiniBatchSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setMiniBatchSize(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_LogisticRegression_setMiniBatchSize(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_getTermCriteria(IntPtr obj, out TermCriteria returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_setTermCriteria(IntPtr obj, TermCriteria val);
+    public static partial ExceptionStatus ml_LogisticRegression_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_LogisticRegression_predict(
-        IntPtr obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
+        OpenCvSafeHandle obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_get_learnt_thetas(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_LogisticRegression_get_learnt_thetas(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_LogisticRegression_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_NormalBayesClassifier.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_NormalBayesClassifier.cs
@@ -12,7 +12,7 @@ static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_NormalBayesClassifier_predictProb(
-        IntPtr obj, IntPtr inputs,
+        OpenCvSafeHandle obj, IntPtr inputs,
         IntPtr samples, IntPtr outputProbs, int flags, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_RTrees.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_RTrees.cs
@@ -11,22 +11,22 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_getCalculateVarImportance(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_RTrees_getCalculateVarImportance(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_setCalculateVarImportance(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_RTrees_setCalculateVarImportance(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_getActiveVarCount(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_RTrees_getActiveVarCount(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_setActiveVarCount(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_RTrees_setActiveVarCount(OpenCvSafeHandle obj, int val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_getTermCriteria(IntPtr obj, out TermCriteria returnValue);
+    public static partial ExceptionStatus ml_RTrees_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_setTermCriteria(IntPtr obj, TermCriteria val);
+    public static partial ExceptionStatus ml_RTrees_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_RTrees_getVarImportance(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_RTrees_getVarImportance(OpenCvSafeHandle obj, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_RTrees_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
@@ -12,61 +12,61 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_SVM_getType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setType(IntPtr obj, int val);
+    public static partial ExceptionStatus ml_SVM_setType(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getGamma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getGamma(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setGamma(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setGamma(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getCoef0(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getCoef0(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setCoef0(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setCoef0(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getDegree(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getDegree(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setDegree(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setDegree(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getC(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getC(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setC(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setC(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getP(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getP(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setP(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setP(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getNu(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ml_SVM_getNu(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setNu(IntPtr obj, double val);
+    public static partial ExceptionStatus ml_SVM_setNu(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getClassWeights(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_SVM_getClassWeights(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setClassWeights(IntPtr obj, IntPtr val);
+    public static partial ExceptionStatus ml_SVM_setClassWeights(OpenCvSafeHandle obj, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getTermCriteria(IntPtr obj, out TermCriteria returnValue);
+    public static partial ExceptionStatus ml_SVM_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setTermCriteria(IntPtr obj, TermCriteria val);
+    public static partial ExceptionStatus ml_SVM_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getKernelType(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ml_SVM_getKernelType(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_setKernel(IntPtr obj, int kernelType);
+    public static partial ExceptionStatus ml_SVM_setKernel(OpenCvSafeHandle obj, int kernelType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getSupportVectors(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus ml_SVM_getSupportVectors(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_SVM_getDecisionFunction(
-        IntPtr obj, int i, IntPtr alpha, IntPtr svidx, out double returnValue);
+        OpenCvSafeHandle obj, int i, IntPtr alpha, IntPtr svidx, out double returnValue);
 
     // static
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/objdetect/NativeMethods_objdetect_FaceDetectorYN.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/objdetect/NativeMethods_objdetect_FaceDetectorYN.cs
@@ -30,5 +30,5 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus objdetect_FaceDetectorYN_detect(
-        IntPtr obj, IntPtr image, IntPtr faces, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr faces, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_HDR.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_HDR.cs
@@ -22,22 +22,22 @@ static partial class NativeMethods
     public static partial ExceptionStatus photo_Ptr_CalibrateDebevec_get(IntPtr obj, out IntPtr returnValue);
                 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_getLambda(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_CalibrateDebevec_getLambda(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_setLambda(IntPtr obj, float value);
+    public static partial ExceptionStatus photo_CalibrateDebevec_setLambda(OpenCvSafeHandle obj, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_getSamples(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_CalibrateDebevec_getSamples(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_setSamples(IntPtr obj, float value);
+    public static partial ExceptionStatus photo_CalibrateDebevec_setSamples(OpenCvSafeHandle obj, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_getRandom(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus photo_CalibrateDebevec_getRandom(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateDebevec_setRandom(IntPtr obj, int value);
+    public static partial ExceptionStatus photo_CalibrateDebevec_setRandom(OpenCvSafeHandle obj, int value);
 
     // CalibrateRobertson
 
@@ -51,23 +51,23 @@ static partial class NativeMethods
     public static partial ExceptionStatus photo_Ptr_CalibrateRobertson_get(IntPtr obj, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateRobertson_getMaxIter(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus photo_CalibrateRobertson_getMaxIter(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateRobertson_setMaxIter(IntPtr obj, int value);
+    public static partial ExceptionStatus photo_CalibrateRobertson_setMaxIter(OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateRobertson_getThreshold(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_CalibrateRobertson_getThreshold(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateRobertson_setThreshold(IntPtr obj, float value);
+    public static partial ExceptionStatus photo_CalibrateRobertson_setThreshold(OpenCvSafeHandle obj, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_CalibrateRobertson_getRadiance(IntPtr obj, IntPtr returnValue);
+    public static partial ExceptionStatus photo_CalibrateRobertson_getRadiance(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_CalibrateCRF_process(
-        IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times);
+        OpenCvSafeHandle obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_createMergeDebevec(out IntPtr returnValue);
@@ -85,8 +85,8 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_MergeExposures_process(
-        IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times, IntPtr response);
+        OpenCvSafeHandle obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst, [In, MarshalAs(UnmanagedType.LPArray)] float[] times, IntPtr response);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_MergeMertens_process(IntPtr obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst);
+    public static partial ExceptionStatus photo_MergeMertens_process(OpenCvSafeHandle obj, IntPtr[] srcImgs, int srcImgsLength, IntPtr dst);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_Tonemap.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo_Tonemap.cs
@@ -13,13 +13,13 @@ static partial class NativeMethods
     #region Tonemap
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_Tonemap_process(IntPtr obj, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus photo_Tonemap_process(OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_Tonemap_getGamma(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_Tonemap_getGamma(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_Tonemap_setGamma(IntPtr obj, float gamma);
+    public static partial ExceptionStatus photo_Tonemap_setGamma(OpenCvSafeHandle obj, float gamma);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_createTonemap(float gamma, out IntPtr returnValue);
@@ -35,16 +35,16 @@ static partial class NativeMethods
     #region TonemapDrago
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapDrago_getSaturation(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_TonemapDrago_getSaturation(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapDrago_setSaturation(IntPtr obj, float saturation);
+    public static partial ExceptionStatus photo_TonemapDrago_setSaturation(OpenCvSafeHandle obj, float saturation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapDrago_getBias(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_TonemapDrago_getBias(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapDrago_setBias(IntPtr obj, float bias);
+    public static partial ExceptionStatus photo_TonemapDrago_setBias(OpenCvSafeHandle obj, float bias);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_createTonemapDrago(
@@ -62,27 +62,27 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_getIntensity(
-        IntPtr obj, out float returnValue);
+        OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_setIntensity(
-        IntPtr obj, float intensity);
+        OpenCvSafeHandle obj, float intensity);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_getLightAdaptation(
-        IntPtr obj, out float returnValue);
+        OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_setLightAdaptation(
-        IntPtr obj, float light_adapt);
+        OpenCvSafeHandle obj, float light_adapt);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_getColorAdaptation(
-        IntPtr obj, out float returnValue);
+        OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_TonemapReinhard_setColorAdaptation(
-        IntPtr obj, float color_adapt);
+        OpenCvSafeHandle obj, float color_adapt);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_createTonemapReinhard(
@@ -101,16 +101,16 @@ static partial class NativeMethods
     #region TonemapMantiuk
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapMantiuk_getScale(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_TonemapMantiuk_getScale(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapMantiuk_setScale(IntPtr obj, float scale);
+    public static partial ExceptionStatus photo_TonemapMantiuk_setScale(OpenCvSafeHandle obj, float scale);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapMantiuk_getSaturation(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus photo_TonemapMantiuk_getSaturation(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_TonemapMantiuk_setSaturation(IntPtr obj, float saturation);
+    public static partial ExceptionStatus photo_TonemapMantiuk_setSaturation(OpenCvSafeHandle obj, float saturation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus photo_createTonemapMantiuk(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_MotionSaliencyBinWangApr2014.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_MotionSaliencyBinWangApr2014.cs
@@ -22,29 +22,29 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_computeSaliency(
-        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImagesize(
-        IntPtr obj, int W, int H);
+        OpenCvSafeHandle obj, int W, int H);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_init(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_getImageWidth(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImageWidth(
-        IntPtr obj, int val);
+        OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_getImageHeight(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_MotionSaliencyBinWangApr2014_setImageHeight(
-        IntPtr obj, int val);
+        OpenCvSafeHandle obj, int val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_ObjectnessBING.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_ObjectnessBING.cs
@@ -21,38 +21,38 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_computeSaliency(
-        IntPtr obj, IntPtr image, IntPtr objectnessBoundingBox, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr objectnessBoundingBox, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_getobjectnessValues(
-        IntPtr obj, IntPtr returnValue);
+        OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_setTrainingPath(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string trainingPath);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string trainingPath);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_setBBResDir(
-        IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string resultsDir);
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string resultsDir);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_getBase(
-        IntPtr obj, out double returnValue);
+        OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus saliency_ObjectnessBING_setBase(IntPtr obj, double val);
+    public static partial ExceptionStatus saliency_ObjectnessBING_setBase(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_getNSS(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus saliency_ObjectnessBING_setNSS(IntPtr obj, int val);
+    public static partial ExceptionStatus saliency_ObjectnessBING_setNSS(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_ObjectnessBING_getW(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus saliency_ObjectnessBING_setW(IntPtr obj, int val);
+    public static partial ExceptionStatus saliency_ObjectnessBING_setW(OpenCvSafeHandle obj, int val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencyFineGrained.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencyFineGrained.cs
@@ -22,9 +22,9 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencyFineGrained_computeSaliency(
-        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencyFineGrained_computeBinaryMap(
-        IntPtr obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencySpectralResidual.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/saliency/NativeMethods_saliency_StaticSaliencySpectralResidual.cs
@@ -22,25 +22,25 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_computeSaliency(
-        IntPtr obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr saliencyMap, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_computeBinaryMap(
-        IntPtr obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
+        OpenCvSafeHandle obj, IntPtr saliencyMap, IntPtr binaryMap, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_getImageWidth(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_setImageWidth(
-        IntPtr obj, int val);
+        OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_getImageHeight(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus saliency_StaticSaliencySpectralResidual_setImageHeight(
-        IntPtr obj, int val);
+        OpenCvSafeHandle obj, int val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_HistogramCostExtractor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_HistogramCostExtractor.cs
@@ -13,19 +13,19 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_HistogramCostExtractor_buildCostMatrix(
-        IntPtr obj, IntPtr descriptors1, IntPtr descriptors2, IntPtr costMatrix);
+        OpenCvSafeHandle obj, IntPtr descriptors1, IntPtr descriptors2, IntPtr costMatrix);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HistogramCostExtractor_setNDummies(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_HistogramCostExtractor_setNDummies(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HistogramCostExtractor_getNDummies(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_HistogramCostExtractor_getNDummies(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HistogramCostExtractor_setDefaultCost(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_HistogramCostExtractor_setDefaultCost(OpenCvSafeHandle obj, float val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HistogramCostExtractor_getDefaultCost(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_HistogramCostExtractor_getDefaultCost(OpenCvSafeHandle obj, out float returnValue);
 
     // Ptr<HistogramCostExtractor> lifetime management (shared across all subclasses)
 
@@ -42,10 +42,10 @@ static partial class NativeMethods
         int flag, int nDummies, float defaultCost, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_NormHistogramCostExtractor_setNormFlag(IntPtr obj, int flag);
+    public static partial ExceptionStatus shape_NormHistogramCostExtractor_setNormFlag(OpenCvSafeHandle obj, int flag);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_NormHistogramCostExtractor_getNormFlag(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_NormHistogramCostExtractor_getNormFlag(OpenCvSafeHandle obj, out int returnValue);
 
     // EMDHistogramCostExtractor
 
@@ -54,10 +54,10 @@ static partial class NativeMethods
         int flag, int nDummies, float defaultCost, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_EMDHistogramCostExtractor_setNormFlag(IntPtr obj, int flag);
+    public static partial ExceptionStatus shape_EMDHistogramCostExtractor_setNormFlag(OpenCvSafeHandle obj, int flag);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_EMDHistogramCostExtractor_getNormFlag(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_EMDHistogramCostExtractor_getNormFlag(OpenCvSafeHandle obj, out int returnValue);
 
     // ChiHistogramCostExtractor
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_ShapeDistanceExtractor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_ShapeDistanceExtractor.cs
@@ -13,7 +13,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeDistanceExtractor_computeDistance(
-        IntPtr obj, IntPtr contour1, IntPtr contour2, out float returnValue);
+        OpenCvSafeHandle obj, IntPtr contour1, IntPtr contour2, out float returnValue);
 
     // ShapeContextDistanceExtractor
 
@@ -24,59 +24,59 @@ static partial class NativeMethods
     public static partial ExceptionStatus shape_Ptr_ShapeContextDistanceExtractor_get(IntPtr obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setAngularBins(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setAngularBins(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getAngularBins(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getAngularBins(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setRadialBins(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setRadialBins(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getRadialBins(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getRadialBins(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setInnerRadius(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setInnerRadius(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getInnerRadius(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getInnerRadius(OpenCvSafeHandle obj, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setOuterRadius(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setOuterRadius(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getOuterRadius(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getOuterRadius(OpenCvSafeHandle obj, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setRotationInvariant(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setRotationInvariant(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getRotationInvariant(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getRotationInvariant(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setShapeContextWeight(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setShapeContextWeight(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getShapeContextWeight(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getShapeContextWeight(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setImageAppearanceWeight(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setImageAppearanceWeight(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getImageAppearanceWeight(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getImageAppearanceWeight(OpenCvSafeHandle obj, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setBendingEnergyWeight(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setBendingEnergyWeight(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getBendingEnergyWeight(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getBendingEnergyWeight(OpenCvSafeHandle obj, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setImages(IntPtr obj, IntPtr image1, IntPtr image2);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setImages(OpenCvSafeHandle obj, IntPtr image1, IntPtr image2);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getImages(IntPtr obj, IntPtr image1, IntPtr image2);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getImages(OpenCvSafeHandle obj, IntPtr image1, IntPtr image2);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setIterations(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getIterations(OpenCvSafeHandle obj, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setStdDev(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setStdDev(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getStdDev(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_getStdDev(OpenCvSafeHandle obj, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_createShapeContextDistanceExtractor(
@@ -95,14 +95,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus shape_Ptr_HausdorffDistanceExtractor_get(IntPtr obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_setDistanceFlag(IntPtr obj, int val);
+    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_setDistanceFlag(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_getDistanceFlag(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_getDistanceFlag(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_setRankProportion(IntPtr obj, float val);
+    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_setRankProportion(OpenCvSafeHandle obj, float val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_getRankProportion(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus shape_HausdorffDistanceExtractor_getRankProportion(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_createHausdorffDistanceExtractor(int distanceFlag, float rankProp, out IntPtr returnValue);
@@ -111,5 +111,5 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setCostExtractor(
-        IntPtr obj, IntPtr comparer);
+        OpenCvSafeHandle obj, IntPtr comparer);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_ShapeTransformer.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/shape/NativeMethods_shape_ShapeTransformer.cs
@@ -13,15 +13,15 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeTransformer_estimateTransformation(
-        IntPtr obj, IntPtr transformingShape, IntPtr targetShape, IntPtr matches);
+        OpenCvSafeHandle obj, IntPtr transformingShape, IntPtr targetShape, IntPtr matches);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeTransformer_applyTransformation(
-        IntPtr obj, IntPtr input, IntPtr output, out float returnValue);
+        OpenCvSafeHandle obj, IntPtr input, IntPtr output, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeTransformer_warpImage(
-        IntPtr obj, IntPtr transformingImage, IntPtr output,
+        OpenCvSafeHandle obj, IntPtr transformingImage, IntPtr output,
         int flags, int borderMode, Scalar borderValue);
 
     // ThinPlateSplineShapeTransformer
@@ -39,11 +39,11 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ThinPlateSplineShapeTransformer_setRegularizationParameter(
-        IntPtr obj, double beta);
+        OpenCvSafeHandle obj, double beta);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ThinPlateSplineShapeTransformer_getRegularizationParameter(
-        IntPtr obj, out double returnValue);
+        OpenCvSafeHandle obj, out double returnValue);
 
     // AffineTransformer
 
@@ -59,11 +59,11 @@ static partial class NativeMethods
         int fullAffine, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus shape_AffineTransformer_setFullAffine(IntPtr obj, int value);
+    public static partial ExceptionStatus shape_AffineTransformer_setFullAffine(OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_AffineTransformer_getFullAffine(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     // Upcast helpers: Ptr<Derived> → Ptr<ShapeTransformer>
 
@@ -80,5 +80,5 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus shape_ShapeContextDistanceExtractor_setTransformAlgorithm(
-        IntPtr obj, IntPtr transformer);
+        OpenCvSafeHandle obj, IntPtr transformer);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stereo/NativeMethods_stereo_StereoMatcher.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stereo/NativeMethods_stereo_StereoMatcher.cs
@@ -15,55 +15,55 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_compute(
-        IntPtr obj, IntPtr left, IntPtr right, IntPtr disparity);
+        OpenCvSafeHandle obj, IntPtr left, IntPtr right, IntPtr disparity);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getMinDisparity(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setMinDisparity(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getNumDisparities(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setNumDisparities(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getBlockSize(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setBlockSize(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getSpeckleWindowSize(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setSpeckleWindowSize(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getSpeckleRange(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setSpeckleRange(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_getDisp12MaxDiff(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoMatcher_setDisp12MaxDiff(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     #endregion
 
@@ -84,67 +84,67 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getPreFilterType(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setPreFilterType(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getPreFilterSize(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setPreFilterSize(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getPreFilterCap(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setPreFilterCap(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getTextureThreshold(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setTextureThreshold(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getUniquenessRatio(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setUniquenessRatio(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getSmallerBlockSize(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setSmallerBlockSize(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getROI1(
-        IntPtr obj, out Rect returnValue);
+        OpenCvSafeHandle obj, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setROI1(
-        IntPtr obj, Rect value);
+        OpenCvSafeHandle obj, Rect value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_getROI2(
-        IntPtr obj, out Rect returnValue);
+        OpenCvSafeHandle obj, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoBM_setROI2(
-        IntPtr obj, Rect value);
+        OpenCvSafeHandle obj, Rect value);
 
     #endregion
 
@@ -168,43 +168,43 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_getPreFilterCap(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_setPreFilterCap(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_getUniquenessRatio(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_setUniquenessRatio(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_getP1(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_setP1(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_getP2(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_setP2(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_getMode(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stereo_StereoSGBM_setMode(
-        IntPtr obj, int value);
+        OpenCvSafeHandle obj, int value);
 
     #endregion
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_DenseOpticalFlowExt.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_DenseOpticalFlowExt.cs
@@ -11,9 +11,9 @@ static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus superres_DenseOpticalFlowExt_calc(
-        IntPtr obj, IntPtr frame0, IntPtr frame1, IntPtr flow1, IntPtr flow2);
+        OpenCvSafeHandle obj, IntPtr frame0, IntPtr frame1, IntPtr flow1, IntPtr flow2);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DenseOpticalFlowExt_collectGarbage(IntPtr obj);
+    public static partial ExceptionStatus superres_DenseOpticalFlowExt_collectGarbage(OpenCvSafeHandle obj);
         
     #region FarnebackOpticalFlow
 
@@ -28,33 +28,33 @@ static partial class NativeMethods
     public static partial ExceptionStatus superres_Ptr_FarnebackOpticalFlow_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPyrScale(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPyrScale(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPyrScale(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPyrScale(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getLevelsNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getLevelsNumber(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setLevelsNumber(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setLevelsNumber(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getWindowSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getWindowSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setWindowSize(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setWindowSize(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setIterations(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPolyN(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPolyN(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPolyN(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPolyN(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPolySigma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getPolySigma(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPolySigma(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setPolySigma(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getFlags(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_getFlags(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setFlags(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_FarnebackOpticalFlow_setFlags(OpenCvSafeHandle obj, int val);
 
     #endregion
 
@@ -71,37 +71,37 @@ static partial class NativeMethods
     public static partial ExceptionStatus superres_Ptr_DualTVL1OpticalFlow_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getTau(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getTau(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setTau(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setTau(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getLambda(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getLambda(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setLambda(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setLambda(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getTheta(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getTheta(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setTheta(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setTheta(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getScalesNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getScalesNumber(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setScalesNumber(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setScalesNumber(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getWarpingsNumber(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getWarpingsNumber(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setWarpingsNumber(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setWarpingsNumber(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getEpsilon(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getEpsilon(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setEpsilon(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setEpsilon(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setIterations(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getUseInitialFlow(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_getUseInitialFlow(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setUseInitialFlow(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_DualTVL1OpticalFlow_setUseInitialFlow(OpenCvSafeHandle obj, int val);
 
     #endregion
 
@@ -117,29 +117,29 @@ static partial class NativeMethods
     public static partial ExceptionStatus superres_Ptr_BroxOpticalFlow_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getAlpha(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getAlpha(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setAlpha(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setAlpha(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getGamma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getGamma(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setGamma(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setGamma(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getScaleFactor(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getScaleFactor(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setScaleFactor(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setScaleFactor(OpenCvSafeHandle obj, double val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getInnerIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getInnerIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setInnerIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setInnerIterations(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getOuterIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getOuterIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setOuterIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setOuterIterations(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_getSolverIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_getSolverIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_BroxOpticalFlow_setSolverIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_BroxOpticalFlow_setSolverIterations(OpenCvSafeHandle obj, int val);
 
     #endregion
 
@@ -154,17 +154,17 @@ static partial class NativeMethods
     public static partial ExceptionStatus superres_Ptr_PyrLKOpticalFlow_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getWindowSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getWindowSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setWindowSize(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setWindowSize(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getMaxLevel(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getMaxLevel(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setMaxLevel(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setMaxLevel(OpenCvSafeHandle obj, int val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_getIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_PyrLKOpticalFlow_setIterations(OpenCvSafeHandle obj, int val);
 
     #endregion
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_FrameSource.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_FrameSource.cs
@@ -11,10 +11,10 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FrameSource_nextFrame(IntPtr obj, IntPtr frame);
+    public static partial ExceptionStatus superres_FrameSource_nextFrame(OpenCvSafeHandle obj, IntPtr frame);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_FrameSource_reset(IntPtr obj);
+    public static partial ExceptionStatus superres_FrameSource_reset(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus superres_createFrameSource_Empty(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_SuperResolution.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/superres/NativeMethods_superres_SuperResolution.cs
@@ -10,13 +10,13 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setInput(IntPtr obj, IntPtr frameSource);
+    public static partial ExceptionStatus superres_SuperResolution_setInput(OpenCvSafeHandle obj, IntPtr frameSource);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_nextFrame(IntPtr obj, IntPtr frame);
+    public static partial ExceptionStatus superres_SuperResolution_nextFrame(OpenCvSafeHandle obj, IntPtr frame);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_reset(IntPtr obj);
+    public static partial ExceptionStatus superres_SuperResolution_reset(OpenCvSafeHandle obj);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_collectGarbage(IntPtr obj);
+    public static partial ExceptionStatus superres_SuperResolution_collectGarbage(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus superres_createSuperResolution_BTVL1(out IntPtr returnValue);
@@ -29,54 +29,54 @@ static partial class NativeMethods
     public static partial ExceptionStatus superres_Ptr_SuperResolution_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getScale(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getScale(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setScale(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_SuperResolution_setScale(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getIterations(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_SuperResolution_setIterations(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getTau(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getTau(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setTau(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_SuperResolution_setTau(OpenCvSafeHandle obj, double val);
         
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getLambda(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getLambda(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setLambda(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_SuperResolution_setLambda(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getAlpha(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getAlpha(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setAlpha(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_SuperResolution_setAlpha(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getKernelSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getKernelSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setKernelSize(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_SuperResolution_setKernelSize(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getBlurKernelSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getBlurKernelSize(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setBlurKernelSize(IntPtr obj, int val);
+    public static partial ExceptionStatus superres_SuperResolution_setBlurKernelSize(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getBlurSigma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getBlurSigma(OpenCvSafeHandle obj, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setBlurSigma(IntPtr obj, double val);
+    public static partial ExceptionStatus superres_SuperResolution_setBlurSigma(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getTemporalAreaRadius(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getTemporalAreaRadius(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setTemporalAreaRadius(IntPtr obj,int val);
+    public static partial ExceptionStatus superres_SuperResolution_setTemporalAreaRadius(OpenCvSafeHandle obj,int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_getOpticalFlow(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus superres_SuperResolution_getOpticalFlow(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus superres_SuperResolution_setOpticalFlow(IntPtr obj, IntPtr val);
+    public static partial ExceptionStatus superres_SuperResolution_setOpticalFlow(OpenCvSafeHandle obj, IntPtr val);
 
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_BackgroundSubtractor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_BackgroundSubtractor.cs
@@ -33,64 +33,64 @@ static partial class NativeMethods
     public static partial ExceptionStatus video_Ptr_BackgroundSubtractorMOG2_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getHistory(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getHistory(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setHistory(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setHistory(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getNMixtures(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getNMixtures(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setNMixtures(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setNMixtures(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getBackgroundRatio(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getBackgroundRatio(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setBackgroundRatio(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setBackgroundRatio(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarThreshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarThreshold(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarThreshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarThreshold(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarThresholdGen(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarThresholdGen(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarThresholdGen(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarThresholdGen(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarInit(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarInit(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarInit(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarInit(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarMin(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarMin(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarMin(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarMin(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarMax(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getVarMax(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarMax(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setVarMax(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getComplexityReductionThreshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getComplexityReductionThreshold(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setComplexityReductionThreshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setComplexityReductionThreshold(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getDetectShadows(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getDetectShadows(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setDetectShadows(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setDetectShadows(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getShadowValue(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getShadowValue(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setShadowValue(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setShadowValue(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getShadowThreshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_getShadowThreshold(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setShadowThreshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorMOG2_setShadowThreshold(OpenCvSafeHandle ptr, double value);
 
     #endregion
 
@@ -107,39 +107,39 @@ static partial class NativeMethods
     public static partial ExceptionStatus video_Ptr_BackgroundSubtractorKNN_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getHistory(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getHistory(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setHistory(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setHistory(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getNSamples(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getNSamples(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setNSamples(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setNSamples(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getDist2Threshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getDist2Threshold(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setDist2Threshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setDist2Threshold(OpenCvSafeHandle ptr, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getkNNSamples(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getkNNSamples(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setkNNSamples(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setkNNSamples(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getDetectShadows(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getDetectShadows(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setDetectShadows(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setDetectShadows(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getShadowValue(IntPtr ptr, out int returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getShadowValue(OpenCvSafeHandle ptr, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setShadowValue(IntPtr ptr, int value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setShadowValue(OpenCvSafeHandle ptr, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getShadowThreshold(IntPtr ptr, out double returnValue);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_getShadowThreshold(OpenCvSafeHandle ptr, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setShadowThreshold(IntPtr ptr, double value);
+    public static partial ExceptionStatus video_BackgroundSubtractorKNN_setShadowThreshold(OpenCvSafeHandle ptr, double value);
 
     #endregion
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
@@ -73,37 +73,37 @@ static partial class NativeMethods
     public static partial ExceptionStatus video_KalmanFilter_new2(
         int dynamParams, int measureParams, int controlParams, int type, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_init(IntPtr obj, int dynamParams, int measureParams,
+    public static partial ExceptionStatus video_KalmanFilter_init(OpenCvSafeHandle obj, int dynamParams, int measureParams,
         int controlParams, int type);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus video_KalmanFilter_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_predict(IntPtr obj, IntPtr control, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_predict(OpenCvSafeHandle obj, IntPtr control, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_correct(IntPtr obj, IntPtr measurement, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_correct(OpenCvSafeHandle obj, IntPtr measurement, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_statePre(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_statePre(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_statePost(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_statePost(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_transitionMatrix(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_transitionMatrix(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_controlMatrix(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_controlMatrix(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_measurementMatrix(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_measurementMatrix(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_processNoiseCov(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_processNoiseCov(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_measurementNoiseCov(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_measurementNoiseCov(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_errorCovPre(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_errorCovPre(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_gain(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_gain(OpenCvSafeHandle obj, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_errorCovPost(IntPtr obj, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_errorCovPost(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     #endregion
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeBoxes.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeBoxes.cs
@@ -13,56 +13,56 @@ static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeBoxes_getBoundingBoxes(
-        IntPtr obj, IntPtr edgeMap, IntPtr orientationMap, IntPtr boxes);
+        OpenCvSafeHandle obj, IntPtr edgeMap, IntPtr orientationMap, IntPtr boxes);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getAlpha(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getAlpha(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setAlpha(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setAlpha(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getBeta(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getBeta(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setBeta(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setBeta(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEta(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEta(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEta(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEta(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMinScore(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMinScore(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMinScore(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMinScore(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMaxBoxes(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMaxBoxes(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMaxBoxes(IntPtr obj, int value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMaxBoxes(OpenCvSafeHandle obj, int value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEdgeMinMag(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEdgeMinMag(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEdgeMinMag(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEdgeMinMag(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEdgeMergeThr(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getEdgeMergeThr(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEdgeMergeThr(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setEdgeMergeThr(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getClusterMinMag(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getClusterMinMag(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setClusterMinMag(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setClusterMinMag(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMaxAspectRatio(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMaxAspectRatio(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMaxAspectRatio(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMaxAspectRatio(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMinBoxArea(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getMinBoxArea(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMinBoxArea(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setMinBoxArea(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getGamma(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getGamma(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setGamma(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setGamma(OpenCvSafeHandle obj, float value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getKappa(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_getKappa(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_setKappa(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_EdgeBoxes_setKappa(OpenCvSafeHandle obj, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createEdgeBoxes(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeDrawing.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeDrawing.cs
@@ -44,38 +44,38 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_createEdgeDrawing(out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEdges(IntPtr obj, IntPtr src);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEdges(OpenCvSafeHandle obj, IntPtr src);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getEdgeImage(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_getEdgeImage(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getGradientImage(IntPtr obj, IntPtr dst);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_getGradientImage(OpenCvSafeHandle obj, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegments(IntPtr obj, IntPtr returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegments(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegmentIndicesOfLines(IntPtr obj, IntPtr returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegmentIndicesOfLines(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines(IntPtr obj, IntPtr lines);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines(OpenCvSafeHandle obj, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines_vector(IntPtr obj, IntPtr lines);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines_vector(OpenCvSafeHandle obj, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses(IntPtr obj, IntPtr ellipses);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses(OpenCvSafeHandle obj, IntPtr ellipses);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses_vector(IntPtr obj, IntPtr ellipses);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses_vector(OpenCvSafeHandle obj, IntPtr ellipses);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeDrawing_Params_default(out CvEdgeDrawingParams returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getParams(IntPtr obj, out CvEdgeDrawingParams returnValue);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_getParams(OpenCvSafeHandle obj, out CvEdgeDrawingParams returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_setParams(IntPtr obj, ref CvEdgeDrawingParams parameters);
+    public static partial ExceptionStatus ximgproc_EdgeDrawing_setParams(OpenCvSafeHandle obj, ref CvEdgeDrawingParams parameters);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeFilter.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeFilter.cs
@@ -23,7 +23,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_DTFilter_filter(
-        IntPtr obj, IntPtr src, IntPtr dst, int dDepth);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, int dDepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createDTFilter(
@@ -46,7 +46,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_GuidedFilter_filter(
-        IntPtr obj, IntPtr src, IntPtr dst, int dDepth);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, int dDepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createGuidedFilter(
@@ -69,47 +69,47 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_filter(
-        IntPtr obj, IntPtr src, IntPtr dst, IntPtr joint);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, IntPtr joint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_collectGarbage(
-        IntPtr obj);
+        OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getSigmaS(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getSigmaS(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setSigmaS(IntPtr obj, double val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setSigmaS(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getSigmaR(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getSigmaR(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setSigmaR(IntPtr obj, double val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setSigmaR(OpenCvSafeHandle obj, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getTreeHeight(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getTreeHeight(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setTreeHeight(IntPtr obj, int val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setTreeHeight(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getPCAIterations(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getPCAIterations(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setPCAIterations(IntPtr obj, int val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setPCAIterations(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getAdjustOutliers(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getAdjustOutliers(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setAdjustOutliers(IntPtr obj, int val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setAdjustOutliers(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getUseRNG(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_getUseRNG(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setUseRNG(IntPtr obj, int val);
+    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_setUseRNG(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createAMFilter(
@@ -146,7 +146,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_FastBilateralSolverFilter_filter(
-        IntPtr obj, IntPtr src, IntPtr confidence, IntPtr dst);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr confidence, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createFastBilateralSolverFilter(
@@ -171,7 +171,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_FastGlobalSmootherFilter_filter(
-        IntPtr obj, IntPtr src, IntPtr dst);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createFastGlobalSmootherFilter(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_FastLineDetector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_FastLineDetector.cs
@@ -19,16 +19,16 @@ static partial class NativeMethods
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_OutputArray(IntPtr obj, IntPtr image, IntPtr lines);
+    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_OutputArray(OpenCvSafeHandle obj, IntPtr image, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_vector(IntPtr obj, IntPtr image, IntPtr lines);
+    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_vector(OpenCvSafeHandle obj, IntPtr image, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_InputArray(IntPtr obj, IntPtr image, IntPtr lines, int draw_arrow);
+    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_InputArray(OpenCvSafeHandle obj, IntPtr image, IntPtr lines, int draw_arrow);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_vector(IntPtr obj, IntPtr image, IntPtr lines, int draw_arrow);
+    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_vector(OpenCvSafeHandle obj, IntPtr image, IntPtr lines, int draw_arrow);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createFastLineDetector(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_RidgeDetectionFilter.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_RidgeDetectionFilter.cs
@@ -18,7 +18,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(
-        IntPtr obj, IntPtr _img, IntPtr @out);
+        OpenCvSafeHandle obj, IntPtr _img, IntPtr @out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_Ptr_RidgeDetectionFilter_delete(IntPtr obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Segmentation.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Segmentation.cs
@@ -23,38 +23,38 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_segmentation_Ptr_GraphSegmentation_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_processImage(IntPtr obj, IntPtr src, IntPtr dst);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_processImage(OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setSigma(IntPtr obj, double value);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setSigma(OpenCvSafeHandle obj, double value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getSigma(IntPtr obj, out double returnValue);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getSigma(OpenCvSafeHandle obj, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setK(IntPtr obj, float value);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setK(OpenCvSafeHandle obj, float value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getK(IntPtr obj, out float returnValue);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getK(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setMinSize(IntPtr obj, int value);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setMinSize(OpenCvSafeHandle obj, int value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getMinSize(IntPtr obj, out int returnValue);
+    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_getMinSize(OpenCvSafeHandle obj, out int returnValue);
 
 
     // SelectiveSearchSegmentationStrategy
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(IntPtr obj,
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(OpenCvSafeHandle obj,
         IntPtr img, IntPtr regions, IntPtr sizes, int image_id);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(IntPtr obj, int r1, int r2, out float returnValue);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(OpenCvSafeHandle obj, int r1, int r2, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(IntPtr obj, int r1, int r2);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(OpenCvSafeHandle obj, int r1, int r2);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_createSelectiveSearchSegmentationStrategyColor(out IntPtr returnValue);
@@ -131,40 +131,40 @@ static partial class NativeMethods
     // SelectiveSearchSegmentation
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(IntPtr obj, IntPtr img);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(OpenCvSafeHandle obj, IntPtr img);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(IntPtr obj,
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(OpenCvSafeHandle obj,
         int k, float sigma);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchFast(
-        IntPtr obj, int base_k, int inc_k, float sigma);
+        OpenCvSafeHandle obj, int base_k, int inc_k, float sigma);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchQuality(
-        IntPtr obj, int base_k, int inc_k, float sigma);
+        OpenCvSafeHandle obj, int base_k, int inc_k, float sigma);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addImage(IntPtr obj, IntPtr img);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addImage(OpenCvSafeHandle obj, IntPtr img);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(IntPtr obj);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(IntPtr obj, IntPtr g);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(OpenCvSafeHandle obj, IntPtr g);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearGraphSegmentations(IntPtr obj);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearGraphSegmentations(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(IntPtr obj, IntPtr s);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(OpenCvSafeHandle obj, IntPtr s);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(IntPtr obj);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(OpenCvSafeHandle obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_process(IntPtr obj, IntPtr rects);
+    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_process(OpenCvSafeHandle obj, IntPtr rects);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_createSelectiveSearchSegmentation(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_StructuredEdgeDetection.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_StructuredEdgeDetection.cs
@@ -25,7 +25,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_RFFeatureGetter_getFeatures(
-        IntPtr obj, IntPtr src, IntPtr features,
+        OpenCvSafeHandle obj, IntPtr src, IntPtr features,
         int gnrmRad, int gsmthRad, int shrink, int outNum, int gradNum);
 
 
@@ -43,15 +43,15 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_detectEdges(
-        IntPtr obj, IntPtr src, IntPtr dst);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_computeOrientation(
-        IntPtr obj, IntPtr src, IntPtr dst);
+        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_edgesNms(
-        IntPtr obj, IntPtr edge_image, IntPtr orientation_image, IntPtr dst,
+        OpenCvSafeHandle obj, IntPtr edge_image, IntPtr orientation_image, IntPtr dst,
         int r, int s, float m, int isParallel);
 
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Superpixel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Superpixel.cs
@@ -23,23 +23,23 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_getNumberOfSuperpixels(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_iterate(
-        IntPtr obj, int num_iterations);
+        OpenCvSafeHandle obj, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabels(
-        IntPtr obj, IntPtr labels_out);
+        OpenCvSafeHandle obj, IntPtr labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabelContourMask(
-        IntPtr obj, IntPtr image, int thick_line);
+        OpenCvSafeHandle obj, IntPtr image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_enforceLabelConnectivity(
-        IntPtr obj, int min_element_size);
+        OpenCvSafeHandle obj, int min_element_size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createSuperpixelLSC(
@@ -58,19 +58,19 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_iterate(
-        IntPtr obj, IntPtr img, int num_iterations);
+        OpenCvSafeHandle obj, IntPtr img, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabels(
-        IntPtr obj, IntPtr labels_out);
+        OpenCvSafeHandle obj, IntPtr labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabelContourMask(
-        IntPtr obj, IntPtr image, int thick_line);
+        OpenCvSafeHandle obj, IntPtr image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createSuperpixelSEEDS(
@@ -92,23 +92,23 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_getNumberOfSuperpixels(
-        IntPtr obj, out int returnValue);
+        OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_iterate(
-        IntPtr obj, int num_iterations);
+        OpenCvSafeHandle obj, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabels(
-        IntPtr obj, IntPtr labels_out);
+        OpenCvSafeHandle obj, IntPtr labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabelContourMask(
-        IntPtr obj, IntPtr image, int thick_line);
+        OpenCvSafeHandle obj, IntPtr image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
-        IntPtr obj, int min_element_size);
+        OpenCvSafeHandle obj, int min_element_size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createSuperpixelSLIC(

--- a/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorGMG.cs
+++ b/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorGMG.cs
@@ -40,16 +40,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMaxFeatures(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMaxFeatures(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMaxFeatures(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMaxFeatures(Handle, value));
         }
     }
 
@@ -62,16 +60,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getDefaultLearningRate(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getDefaultLearningRate(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setDefaultLearningRate(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setDefaultLearningRate(Handle, value));
         }
     }
 
@@ -84,16 +80,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getNumFrames(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getNumFrames(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setNumFrames(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setNumFrames(Handle, value));
         }
     }
 
@@ -106,16 +100,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getQuantizationLevels(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getQuantizationLevels(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setQuantizationLevels(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setQuantizationLevels(Handle, value));
         }
     }
 
@@ -128,16 +120,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getBackgroundPrior(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getBackgroundPrior(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setBackgroundPrior(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setBackgroundPrior(Handle, value));
         }
     }
 
@@ -150,16 +140,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getSmoothingRadius(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getSmoothingRadius(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setSmoothingRadius(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setSmoothingRadius(Handle, value));
         }
     }
 
@@ -172,16 +160,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getDecisionThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getDecisionThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setDecisionThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setDecisionThreshold(Handle, value));
         }
     }
 
@@ -194,16 +180,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getUpdateBackgroundModel(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getUpdateBackgroundModel(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setUpdateBackgroundModel(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setUpdateBackgroundModel(Handle, value ? 1 : 0));
         }
     }
 
@@ -216,16 +200,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMinVal(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMinVal(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMinVal(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMinVal(Handle, value));
         }
     }
 
@@ -238,16 +220,14 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMaxVal(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_getMaxVal(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMaxVal(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorGMG_setMaxVal(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorMOG.cs
+++ b/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorMOG.cs
@@ -39,16 +39,14 @@ public class BackgroundSubtractorMOG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_getHistory(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_getHistory(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_setHistory(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_setHistory(Handle, value));
         }
     }
 
@@ -61,16 +59,14 @@ public class BackgroundSubtractorMOG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_getNMixtures(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_getNMixtures(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_setNMixtures(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_setNMixtures(Handle, value));
         }
     }
 
@@ -83,16 +79,14 @@ public class BackgroundSubtractorMOG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_getBackgroundRatio(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_getBackgroundRatio(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_setBackgroundRatio(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_setBackgroundRatio(Handle, value));
         }
     }
 
@@ -105,16 +99,14 @@ public class BackgroundSubtractorMOG : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_getNoiseSigma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_getNoiseSigma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.bgsegm_BackgroundSubtractorMOG_setNoiseSigma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.bgsegm_BackgroundSubtractorMOG_setNoiseSigma(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/core/FileNode.cs
+++ b/src/OpenCvSharp/Modules/core/FileNode.cs
@@ -70,9 +70,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_toInt(CvPtr, out var ret));
+            NativeMethods.core_FileNode_toInt(Handle, out var ret));
 
-        GC.KeepAlive(this);
         return ret;
     }
 
@@ -97,9 +96,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_toFloat(CvPtr, out var ret));
+            NativeMethods.core_FileNode_toFloat(Handle, out var ret));
 
-        GC.KeepAlive(this);
         return ret;
     }
 
@@ -124,9 +122,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_toDouble(CvPtr, out var ret));
+            NativeMethods.core_FileNode_toDouble(Handle, out var ret));
 
-        GC.KeepAlive(this);
         return ret;
     }
 
@@ -152,9 +149,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
 
         using var buf = new StdString();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_toString(CvPtr, buf.CvPtr));
+            NativeMethods.core_FileNode_toString(Handle, buf.CvPtr));
 
-        GC.KeepAlive(this);
         return buf.ToString();
     }
         
@@ -180,9 +176,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
 
         var matrix = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_toMat(CvPtr, matrix.CvPtr));
+            NativeMethods.core_FileNode_toMat(Handle, matrix.CvPtr));
 
-        GC.KeepAlive(this);
         return matrix;
     }
 
@@ -202,9 +197,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
                 throw new ArgumentNullException(nameof(nodeName));
 
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_operatorThis_byString(CvPtr, nodeName, out var node));
+                NativeMethods.core_FileNode_operatorThis_byString(Handle, nodeName, out var node));
 
-            GC.KeepAlive(this);
             if (node == IntPtr.Zero)
                 return null;
             return new FileNode(node);
@@ -221,9 +215,8 @@ public class FileNode : CvObject, IEnumerable<FileNode>
             ThrowIfDisposed();
 
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_operatorThis_byInt(CvPtr, i, out var node));
+                NativeMethods.core_FileNode_operatorThis_byInt(Handle, i, out var node));
 
-            GC.KeepAlive(this);
             if (node == IntPtr.Zero)
                 return null;
             return new FileNode(node);
@@ -240,8 +233,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_empty(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_empty(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -256,8 +248,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_isNone(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isNone(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -272,8 +263,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_isSeq(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isSeq(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -288,8 +278,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_isMap(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isMap(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -304,8 +293,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_isInt(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isInt(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -320,8 +308,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_isReal(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isReal(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -336,8 +323,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException( 
-                NativeMethods.core_FileNode_isString(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isString(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -352,8 +338,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_isNamed(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_isNamed(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -369,8 +354,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
             ThrowIfDisposed();
             using var buf = new StdString();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_name(CvPtr, buf.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_name(Handle, buf.CvPtr));
             return buf.ToString();
         }
     }
@@ -385,8 +369,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_size(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_size(Handle, out var ret));
             return ret.ToInt64();
         }
     }
@@ -401,8 +384,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_type(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_type(Handle, out var ret));
             return (Types)ret;
         }
     }
@@ -419,8 +401,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_begin(CvPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_begin(Handle, out var p));
         return new FileNodeIterator(p);
     }
 
@@ -432,8 +413,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_end(CvPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_end(Handle, out var p));
         return new FileNodeIterator(p);
     }
         
@@ -467,8 +447,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         if (fmt is null)
             throw new ArgumentNullException(nameof(fmt));
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_readRaw(CvPtr, fmt, vec, new IntPtr(len)));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_readRaw(Handle, fmt, vec, new IntPtr(len)));
     }
 
     #region Read
@@ -481,8 +460,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public int ReadInt(int defaultValue = default)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_int(CvPtr, out var value, defaultValue));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_int(Handle, out var value, defaultValue));
         return value;
     }
 
@@ -494,8 +472,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public float ReadFloat(float defaultValue = default)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_float(CvPtr, out var value, defaultValue));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_float(Handle, out var value, defaultValue));
         return value;
     }
 
@@ -507,8 +484,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public double ReadDouble(double defaultValue = default)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_double(CvPtr, out var value, defaultValue));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_double(Handle, out var value, defaultValue));
         return value;
     }
 
@@ -521,8 +497,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         using var value = new StdString();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_String(CvPtr, value.CvPtr, defaultValue));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_String(Handle, value.CvPtr, defaultValue));
         return value.ToString();
     }
 
@@ -537,8 +512,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         try
         {
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_read_Mat(CvPtr, value.CvPtr, Cv2.ToPtr(defaultMat)));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_read_Mat(Handle, value.CvPtr, Cv2.ToPtr(defaultMat)));
             GC.KeepAlive(defaultMat);
         }
         catch
@@ -560,8 +534,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         try
         {
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_read_SparseMat(CvPtr, value.CvPtr, Cv2.ToPtr(defaultMat)));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNode_read_SparseMat(Handle, value.CvPtr, Cv2.ToPtr(defaultMat)));
             GC.KeepAlive(defaultMat);
         }
         catch
@@ -580,8 +553,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         using var valueVector = new StdVector<KeyPoint>();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_vectorOfKeyPoint(CvPtr, valueVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_vectorOfKeyPoint(Handle, valueVector.CvPtr));
         return valueVector.ToArray();
     }
 
@@ -593,8 +565,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         using var valueVector = new StdVector<DMatch>();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_vectorOfDMatch(CvPtr, valueVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_vectorOfDMatch(Handle, valueVector.CvPtr));
         return valueVector.ToArray();
     }
 
@@ -606,8 +577,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Range(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Range(Handle, out var ret));
         return ret;
     }
 
@@ -618,8 +588,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public KeyPoint ReadKeyPoint()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException( NativeMethods.core_FileNode_read_KeyPoint(CvPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException( NativeMethods.core_FileNode_read_KeyPoint(Handle, out var ret));
         return ret;
     }
 
@@ -630,8 +599,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public DMatch ReadDMatch()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.core_FileNode_read_DMatch(CvPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.core_FileNode_read_DMatch(Handle, out var ret));
         return ret;
     }
 
@@ -642,8 +610,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public Point ReadPoint()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2i(Handle, out var ret));
         return ret;
     }
 
@@ -654,8 +621,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public Point2f ReadPoint2f()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2f(Handle, out var ret));
         return ret;
     }
 
@@ -666,8 +632,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public Point2d ReadPoint2d()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException( NativeMethods.core_FileNode_read_Point2d(Handle, out var ret));
         return ret;
     }
 
@@ -679,8 +644,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Point3i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Point3i(Handle, out var ret));
         return ret;
     }
 
@@ -692,8 +656,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Point3f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Point3f(Handle, out var ret));
         return ret;
     }
 
@@ -705,8 +668,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Point3d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Point3d(Handle, out var ret));
         return ret;
     }
 
@@ -718,8 +680,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Size2i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Size2i(Handle, out var ret));
         return ret;
     }
 
@@ -731,8 +692,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Size2f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Size2f(Handle, out var ret));
         return ret;
     }
 
@@ -744,8 +704,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Size2d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Size2d(Handle, out var ret));
         return ret;
     }
 
@@ -757,8 +716,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Rect2i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Rect2i(Handle, out var ret));
         return ret;
     }
 
@@ -770,8 +728,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Rect2f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Rect2f(Handle, out var ret));
         return ret;
     }
 
@@ -783,8 +740,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Rect2d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Rect2d(Handle, out var ret));
         return ret;
     }
 
@@ -796,8 +752,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Scalar(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Scalar(Handle, out var ret));
         return ret;
     }
 
@@ -809,8 +764,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec2i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2i(Handle, out var ret));
         return ret;
     }
 
@@ -822,8 +776,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec3i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3i(Handle, out var ret));
         return ret;
     }
 
@@ -835,8 +788,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec4i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4i(Handle, out var ret));
         return ret;
     }
 
@@ -848,8 +800,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec6i(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6i(Handle, out var ret));
         return ret;
     }
 
@@ -861,8 +812,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec2d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2d(Handle, out var ret));
         return ret;
     }
 
@@ -874,8 +824,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec3d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3d(Handle, out var ret));
         return ret;
     }
 
@@ -887,8 +836,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec4d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4d(Handle, out var ret));
         return ret;
     }
 
@@ -900,8 +848,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec6d(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6d(Handle, out var ret));
         return ret;
     }
 
@@ -913,8 +860,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec2f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2f(Handle, out var ret));
         return ret;
     }
 
@@ -926,8 +872,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec3f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3f(Handle, out var ret));
         return ret;
     }
 
@@ -939,8 +884,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec4f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4f(Handle, out var ret));
         return ret;
     }
 
@@ -952,8 +896,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec6f(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6f(Handle, out var ret));
         return ret;
     }
         
@@ -965,8 +908,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec2b(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2b(Handle, out var ret));
         return ret;
     }
 
@@ -978,8 +920,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec3b(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3b(Handle, out var ret));
         return ret;
     }
 
@@ -991,8 +932,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec4b(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4b(Handle, out var ret));
         return ret;
     }
 
@@ -1004,8 +944,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec6b(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6b(Handle, out var ret));
         return ret;
     }
 
@@ -1018,8 +957,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec2s(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2s(Handle, out var ret));
         return ret;
     }
 
@@ -1031,8 +969,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec3s(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3s(Handle, out var ret));
         return ret;
     }
 
@@ -1044,8 +981,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec4s(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4s(Handle, out var ret));
         return ret;
     }
 
@@ -1057,8 +993,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec6s(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6s(Handle, out var ret));
         return ret;
     }
         
@@ -1070,8 +1005,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec2w(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec2w(Handle, out var ret));
         return ret;
     }
 
@@ -1083,8 +1017,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec3w(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec3w(Handle, out var ret));
         return ret;
     }
 
@@ -1096,8 +1029,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileNode_read_Vec4w(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec4w(Handle, out var ret));
         return ret;
     }
 
@@ -1109,8 +1041,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNode_read_Vec6w(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNode_read_Vec6w(Handle, out var ret));
         return ret;
     }
 

--- a/src/OpenCvSharp/Modules/core/FileNodeIterator.cs
+++ b/src/OpenCvSharp/Modules/core/FileNodeIterator.cs
@@ -53,8 +53,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         if (fmt is null)
             throw new ArgumentNullException(nameof(fmt));
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_readRaw(CvPtr, fmt, vec, new IntPtr(maxCount)));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNodeIterator_readRaw(Handle, fmt, vec, new IntPtr(maxCount)));
         return this;
     }      
 
@@ -67,8 +66,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileNodeIterator_operatorAsterisk(CvPtr, out var p));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileNodeIterator_operatorAsterisk(Handle, out var p));
             return new FileNode(p);
         }
     }
@@ -88,8 +86,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_operatorIncrement(CvPtr, out var changed));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNodeIterator_operatorIncrement(Handle, out var changed));
         return changed != 0;
     }
 
@@ -102,8 +99,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_operatorPlusEqual(CvPtr, ofs, out var changed));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileNodeIterator_operatorPlusEqual(Handle, ofs, out var changed));
         return changed != 0;
     }
 
@@ -126,10 +122,9 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
             fixed (byte* vecPtr = vec)
             {
                 NativeMethods.HandleException(
-                    NativeMethods.core_FileNodeIterator_readRaw(CvPtr, fmt, new IntPtr(vecPtr), new IntPtr(maxCount)));
+                    NativeMethods.core_FileNodeIterator_readRaw(Handle, fmt, new IntPtr(vecPtr), new IntPtr(maxCount)));
             }
         }
-        GC.KeepAlive(this);
         return this;
     }
         
@@ -149,9 +144,8 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         other.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_operatorEqual(CvPtr, other.CvPtr, out var ret));
+            NativeMethods.core_FileNodeIterator_operatorEqual(Handle, other.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(other);
 
         return ret != 0;
@@ -167,9 +161,8 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         it.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_operatorMinus(CvPtr, it.CvPtr, out var ret));
+            NativeMethods.core_FileNodeIterator_operatorMinus(Handle, it.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(it);
 
         return ret.ToInt64();
@@ -183,9 +176,8 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         it.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileNodeIterator_operatorLessThan(CvPtr, it.CvPtr, out var ret));
+            NativeMethods.core_FileNodeIterator_operatorLessThan(Handle, it.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(it);
 
         return ret != 0;

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -74,9 +74,8 @@ public class FileStorage : CvObject
                 throw new ArgumentNullException(nameof(nodeName));
 
             NativeMethods.HandleException(
-                NativeMethods.core_FileStorage_indexer(CvPtr, nodeName, out var node));
+                NativeMethods.core_FileStorage_indexer(Handle, nodeName, out var node));
 
-            GC.KeepAlive(this);
             if (node == IntPtr.Zero)
                 return null;
             return new FileNode(node);
@@ -93,8 +92,7 @@ public class FileStorage : CvObject
             ThrowIfDisposed();
             using var buf = new StdString();
             NativeMethods.HandleException(
-                NativeMethods.core_FileStorage_elname(CvPtr, buf.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileStorage_elname(Handle, buf.CvPtr));
             return buf.ToString();
         }
     }
@@ -108,8 +106,7 @@ public class FileStorage : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_FileStorage_state(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_FileStorage_state(Handle, out var ret));
             return (States)ret;
         }
     }
@@ -137,8 +134,7 @@ public class FileStorage : CvObject
         if (fileName is null)
             throw new ArgumentNullException(nameof(fileName));
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_open(CvPtr, fileName, (int)flags, encoding, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_open(Handle, fileName, (int)flags, encoding, out var ret));
         return ret != 0;
     }
 
@@ -150,8 +146,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_isOpened(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_isOpened(Handle, out var ret));
         return ret != 0;
     }
 
@@ -176,7 +171,7 @@ public class FileStorage : CvObject
         {
             using var stdString = new StdString();
             NativeMethods.HandleException(
-                NativeMethods.core_FileStorage_releaseAndGetString(CvPtr, stdString.CvPtr));
+                NativeMethods.core_FileStorage_releaseAndGetString(Handle, stdString.CvPtr));
             return stdString.ToString();
         }
         finally
@@ -194,9 +189,8 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_getFirstTopLevelNode(CvPtr, out var node));
+            NativeMethods.core_FileStorage_getFirstTopLevelNode(Handle, out var node));
 
-        GC.KeepAlive(this);
         if (node == IntPtr.Zero)
             return null;
         return new FileNode(node);
@@ -213,9 +207,8 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_root(CvPtr, streamIdx, out var node));
+            NativeMethods.core_FileStorage_root(Handle, streamIdx, out var node));
 
-        GC.KeepAlive(this);
         if (node == IntPtr.Zero)
             return null;
         return new FileNode(node);
@@ -236,9 +229,8 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeRaw(CvPtr, fmt, vec, new IntPtr(len)));
+            NativeMethods.core_FileStorage_writeRaw(Handle, fmt, vec, new IntPtr(len)));
 
-        GC.KeepAlive(this);
     }
 
     /// <summary>
@@ -255,9 +247,8 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeComment(CvPtr, comment, append ? 1 : 0));
+            NativeMethods.core_FileStorage_writeComment(Handle, comment, append ? 1 : 0));
 
-        GC.KeepAlive(this);
     }
 
     /// <summary>
@@ -270,8 +261,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_startWriteStruct(CvPtr, name, flags, typeName));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_startWriteStruct(Handle, name, flags, typeName));
     }
 
     /// <summary>
@@ -281,8 +271,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_endWriteStruct(CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_endWriteStruct(Handle));
     }
 
     /// <summary>
@@ -315,8 +304,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(name));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_int(CvPtr, name, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_int(Handle, name, value));
     }
 
     /// <summary>
@@ -331,8 +319,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(name));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_float(CvPtr, name, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_float(Handle, name, value));
     }
 
     /// <summary>
@@ -347,8 +334,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(name));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_double(CvPtr, name, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_double(Handle, name, value));
     }
 
     /// <summary>
@@ -365,8 +351,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(value));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_String(CvPtr, name, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_String(Handle, name, value));
     }
 
     /// <summary>
@@ -383,8 +368,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(value));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_Mat(CvPtr, name, value.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_Mat(Handle, name, value.CvPtr));
         GC.KeepAlive(value);
     }
 
@@ -402,8 +386,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(value));
 
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_SparseMat(CvPtr, name, value.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_SparseMat(Handle, name, value.CvPtr));
         GC.KeepAlive(value);
     }
 
@@ -422,8 +405,7 @@ public class FileStorage : CvObject
 
         using var valueVector = new StdVector<KeyPoint>(value);
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_vectorOfKeyPoint(CvPtr, name, valueVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_vectorOfKeyPoint(Handle, name, valueVector.CvPtr));
     }
 
     /// <summary>
@@ -441,8 +423,7 @@ public class FileStorage : CvObject
 
         using var valueVector = new StdVector<DMatch>(value);
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_write_vectorOfDMatch(CvPtr, name, valueVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_write_vectorOfDMatch(Handle, name, valueVector.CvPtr));
     }
 
     /// <summary>
@@ -453,8 +434,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeScalar_int(CvPtr, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_writeScalar_int(Handle, value));
     }
 
     /// <summary>
@@ -465,8 +445,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeScalar_float(CvPtr, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_writeScalar_float(Handle, value));
     }
 
     /// <summary>
@@ -477,8 +456,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeScalar_double(CvPtr, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_writeScalar_double(Handle, value));
     }
 
     /// <summary>
@@ -491,8 +469,7 @@ public class FileStorage : CvObject
         if (value is null)
             throw new ArgumentNullException(nameof(value));
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeScalar_String(CvPtr, value));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_writeScalar_String(Handle, value));
     }
 
     #endregion
@@ -509,8 +486,7 @@ public class FileStorage : CvObject
             throw new ArgumentNullException(nameof(val));
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_String(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_String(Handle, val));
         return this;
     }
 
@@ -522,8 +498,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_int(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_int(Handle, val));
         return this;
     }
 
@@ -535,8 +510,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_float(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_float(Handle, val));
         return this;
     }
 
@@ -548,8 +522,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_double(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_double(Handle, val));
         return this;
     }
 
@@ -564,8 +537,7 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_Mat(CvPtr, val.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Mat(Handle, val.CvPtr));
         return this;
     }
 
@@ -580,8 +552,7 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
         val.ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_SparseMat(CvPtr, val.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_SparseMat(Handle, val.CvPtr));
         return this;
     }
 
@@ -593,8 +564,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_Range(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Range(Handle, val));
         return this;
     }
 
@@ -606,8 +576,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_KeyPoint(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_KeyPoint(Handle, val));
         return this;
     }
 
@@ -619,8 +588,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_DMatch(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_DMatch(Handle, val));
         return this;
     }
 
@@ -636,9 +604,8 @@ public class FileStorage : CvObject
         using (var valVec = new StdVector<KeyPoint>(val))
         {
             NativeMethods.HandleException( 
-                NativeMethods.core_FileStorage_shift_vectorOfKeyPoint(CvPtr, valVec.CvPtr));
+                NativeMethods.core_FileStorage_shift_vectorOfKeyPoint(Handle, valVec.CvPtr));
         }
-        GC.KeepAlive(this);
         return this;
     }
 
@@ -654,9 +621,8 @@ public class FileStorage : CvObject
         using (var valVec = new StdVector<DMatch>(val))
         {
             NativeMethods.HandleException( 
-                NativeMethods.core_FileStorage_shift_vectorOfDMatch(CvPtr, valVec.CvPtr));
+                NativeMethods.core_FileStorage_shift_vectorOfDMatch(Handle, valVec.CvPtr));
         }
-        GC.KeepAlive(this);
         return this;
     }
 
@@ -668,8 +634,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Point2i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point2i(Handle, val));
         return this;
     }
 
@@ -681,8 +646,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Point2f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point2f(Handle, val));
         return this;
     }
 
@@ -694,8 +658,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Point2d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point2d(Handle, val));
         return this;
     }
 
@@ -707,8 +670,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Point3i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point3i(Handle, val));
         return this;
     }
 
@@ -720,8 +682,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Point3f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point3f(Handle, val));
         return this;
     }
 
@@ -733,8 +694,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Point3d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Point3d(Handle, val));
         return this;
     }
 
@@ -746,8 +706,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Size2i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Size2i(Handle, val));
         return this;
     }
 
@@ -759,8 +718,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Size2f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Size2f(Handle, val));
         return this;
     }
 
@@ -772,8 +730,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_Size2d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Size2d(Handle, val));
         return this;
     }
 
@@ -785,8 +742,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Rect2i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Rect2i(Handle, val));
         return this;
     }
 
@@ -798,8 +754,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Rect2f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Rect2f(Handle, val));
         return this;
     }
 
@@ -811,8 +766,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Rect2d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Rect2d(Handle, val));
         return this;
     }
 
@@ -824,8 +778,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Scalar(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Scalar(Handle, val));
         return this;
     }
 
@@ -837,8 +790,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(   
-            NativeMethods.core_FileStorage_shift_Vec2i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2i(Handle, val));
         return this;
     }
 
@@ -850,8 +802,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec3i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3i(Handle, val));
         return this;
     }
 
@@ -863,8 +814,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec4i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4i(Handle, val));
         return this;
     }
 
@@ -876,8 +826,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6i(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6i(Handle, val));
         return this;
     }
 
@@ -889,8 +838,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec2d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2d(Handle, val));
         return this;
     }
 
@@ -902,8 +850,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec3d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3d(Handle, val));
         return this;
     }
 
@@ -915,8 +862,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec4d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4d(Handle, val));
         return this;
     }
 
@@ -928,8 +874,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6d(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6d(Handle, val));
         return this;
     }
 
@@ -941,8 +886,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec2f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2f(Handle, val));
         return this;
     }
 
@@ -954,8 +898,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec3f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3f(Handle, val));
         return this;
     }
 
@@ -967,8 +910,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec4f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4f(Handle, val));
         return this;
     }
 
@@ -980,8 +922,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6f(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6f(Handle, val));
         return this;
     }
 
@@ -993,8 +934,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec2b(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2b(Handle, val));
         return this;
     }
 
@@ -1006,8 +946,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec3b(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3b(Handle, val));
         return this;
     }
 
@@ -1019,8 +958,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec4b(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4b(Handle, val));
         return this;
     }
 
@@ -1032,8 +970,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6b(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6b(Handle, val));
         return this;
     }
 
@@ -1045,8 +982,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec2s(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2s(Handle, val));
         return this;
     }
 
@@ -1058,8 +994,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec3s(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3s(Handle, val));
         return this;
     }
 
@@ -1071,8 +1006,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec4s(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4s(Handle, val));
         return this;
     }
 
@@ -1084,8 +1018,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6s(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6s(Handle, val));
         return this;
     }
 
@@ -1097,8 +1030,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_shift_Vec2w(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec2w(Handle, val));
         return this;
     }
 
@@ -1110,8 +1042,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec3w(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec3w(Handle, val));
         return this;
     }
 
@@ -1123,8 +1054,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(  
-            NativeMethods.core_FileStorage_shift_Vec4w(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec4w(Handle, val));
         return this;
     }
 
@@ -1136,8 +1066,7 @@ public class FileStorage : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException( 
-            NativeMethods.core_FileStorage_shift_Vec6w(CvPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.core_FileStorage_shift_Vec6w(Handle, val));
         return this;
     }
 

--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -633,8 +633,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getMat(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getMat(Handle, i, out var ret));
         return new Mat(ret);
     }
         
@@ -647,8 +646,7 @@ public class InputArray : CvObject
         ThrowIfDisposed();
         using var vec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getMatVector(CvPtr, vec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getMatVector(Handle, vec.CvPtr));
         return vec.ToArray();
     }
 
@@ -661,8 +659,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getUMat(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getUMat(Handle, i, out var ret));
         return new UMat(ret);
     }
 
@@ -674,8 +671,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getFlags(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getFlags(Handle, out var ret));
         return ret;
     }
 
@@ -687,8 +683,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getObj(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getObj(Handle, out var ret));
         return ret;
     }
 
@@ -700,8 +695,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_getSz(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_getSz(Handle, out var ret));
         return ret;
     }
 
@@ -712,8 +706,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_kind(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_kind(Handle, out var ret));
         return (InOutArrayKind)ret;
     }
 
@@ -726,8 +719,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_dims(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_dims(Handle, i, out var ret));
         return ret;
     }
 
@@ -740,8 +732,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_cols(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_cols(Handle, i, out var ret));
         return ret;
     }
 
@@ -754,8 +745,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_rows(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_rows(Handle, i, out var ret));
         return ret;
     }
 
@@ -768,8 +758,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_size(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_size(Handle, i, out var ret));
         return ret;
     }
 
@@ -784,8 +773,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_sizend(CvPtr, sz, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_sizend(Handle, sz, i, out var ret));
         return ret;
     }
 
@@ -801,8 +789,7 @@ public class InputArray : CvObject
         arr.ThrowIfDisposed();
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_sameSize(CvPtr, arr.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_sameSize(Handle, arr.CvPtr, out var ret));
         GC.KeepAlive(arr);
         return ret != 0;
     }
@@ -816,8 +803,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_total(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_total(Handle, i, out var ret));
         return ret.ToInt64();
     }
 
@@ -830,8 +816,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_type(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_type(Handle, i, out var ret));
         return ret;
     }
 
@@ -844,8 +829,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_depth(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_depth(Handle, i, out var ret));
         return ret;
     }
 
@@ -858,8 +842,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_channels(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_channels(Handle, i, out var ret));
         return ret;
     }
 
@@ -872,8 +855,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isContinuous(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isContinuous(Handle, i, out var ret));
         return ret != 0;
     }
 
@@ -886,8 +868,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isSubmatrix(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isSubmatrix(Handle, i, out var ret));
         return ret != 0;
     }
 
@@ -900,8 +881,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_empty(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_empty(Handle, out var ret));
         return ret != 0;
     }
 
@@ -917,9 +897,8 @@ public class InputArray : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_copyTo1(CvPtr, arr.CvPtr));
+            NativeMethods.core_InputArray_copyTo1(Handle, arr.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(arr);
     }
 
@@ -939,10 +918,9 @@ public class InputArray : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_copyTo2(CvPtr, arr.CvPtr, mask.CvPtr));
+            NativeMethods.core_InputArray_copyTo2(Handle, arr.CvPtr, mask.CvPtr));
 
         arr.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(arr);
         GC.KeepAlive(mask);
     }
@@ -956,8 +934,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_offset(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_offset(Handle, i, out var ret));
         return ret.ToInt64();
     }
 
@@ -970,8 +947,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_step(CvPtr, i, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_step(Handle, i, out var ret));
         return ret.ToInt64();
     }
 
@@ -983,8 +959,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isMat(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isMat(Handle, out var ret));
         return ret != 0;
     }
 
@@ -996,8 +971,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isUMat(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isUMat(Handle, out var ret));
         return ret != 0;
     }
 
@@ -1009,8 +983,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isMatVector(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isMatVector(Handle, out var ret));
         return ret != 0;
     }
 
@@ -1022,8 +995,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isUMatVector(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isUMatVector(Handle, out var ret));
         return ret != 0;
     }
 
@@ -1035,8 +1007,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isMatx(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isMatx(Handle, out var ret));
         return ret != 0;
     }
 
@@ -1048,8 +1019,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isVector(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isVector(Handle, out var ret));
         return ret != 0;
     }
 
@@ -1061,8 +1031,7 @@ public class InputArray : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_InputArray_isGpuMatVector(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_InputArray_isGpuMatVector(Handle, out var ret));
         return ret != 0;
     }
 

--- a/src/OpenCvSharp/Modules/core/LDA.cs
+++ b/src/OpenCvSharp/Modules/core/LDA.cs
@@ -59,8 +59,7 @@ public class LDA : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_eigenvectors(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_LDA_eigenvectors(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -71,8 +70,7 @@ public class LDA : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_eigenvalues(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_LDA_eigenvalues(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -86,8 +84,7 @@ public class LDA : CvObject
         if (fileName is null)
             throw new ArgumentNullException(nameof(fileName));
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_save_String(CvPtr, fileName));
-        GC.KeepAlive(this);
+            NativeMethods.core_LDA_save_String(Handle, fileName));
     }
 
     /// <summary>
@@ -100,8 +97,7 @@ public class LDA : CvObject
         if (fileName is null)
             throw new ArgumentNullException(nameof(fileName));
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_load_String(CvPtr, fileName));
-        GC.KeepAlive(this);
+            NativeMethods.core_LDA_load_String(Handle, fileName));
     }
 
     /// <summary>
@@ -116,9 +112,8 @@ public class LDA : CvObject
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_save_FileStorage(CvPtr, fs.CvPtr));
+            NativeMethods.core_LDA_save_FileStorage(Handle, fs.CvPtr));
             
-        GC.KeepAlive(this);
         GC.KeepAlive(fs);
     }
 
@@ -134,9 +129,8 @@ public class LDA : CvObject
         node.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_load_FileStorage(CvPtr, node.CvPtr));
+            NativeMethods.core_LDA_load_FileStorage(Handle, node.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(node);
     }
 
@@ -156,9 +150,8 @@ public class LDA : CvObject
         labels.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_compute(CvPtr, src.CvPtr, labels.CvPtr));
+            NativeMethods.core_LDA_compute(Handle, src.CvPtr, labels.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(labels);
     }
@@ -177,9 +170,8 @@ public class LDA : CvObject
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_project(CvPtr, src.CvPtr, out var ret));
+            NativeMethods.core_LDA_project(Handle, src.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
 
         return new Mat(ret);
@@ -199,9 +191,8 @@ public class LDA : CvObject
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LDA_reconstruct(CvPtr, src.CvPtr, out var ret));
+            NativeMethods.core_LDA_reconstruct(Handle, src.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
 
         return new Mat(ret);

--- a/src/OpenCvSharp/Modules/core/MatExpr.cs
+++ b/src/OpenCvSharp/Modules/core/MatExpr.cs
@@ -71,8 +71,7 @@ public sealed partial class MatExpr : CvObject
         {
             mat = new Mat();
             NativeMethods.HandleException(
-                NativeMethods.core_MatExpr_toMat(CvPtr, mat.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.core_MatExpr_toMat(Handle, mat.CvPtr));
             return mat;
         }
         catch
@@ -506,8 +505,7 @@ public sealed partial class MatExpr : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_row(CvPtr, y, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_row(Handle, y, out var ret));
         return new MatExpr(ret);
     }
 
@@ -520,8 +518,7 @@ public sealed partial class MatExpr : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_col(CvPtr, x, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_col(Handle, x, out var ret));
         return new MatExpr(ret);
     }
 
@@ -538,8 +535,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_diag(CvPtr, (int) d, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_diag(Handle, (int) d, out var ret));
         var retVal = new MatExpr(ret);
         return retVal;
     }
@@ -557,8 +553,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_submat(CvPtr, rowStart, rowEnd, colStart, colEnd, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_submat(Handle, rowStart, rowEnd, colStart, colEnd, out var ret));
         var retVal = new MatExpr(ret);
         return retVal;
     }
@@ -593,8 +588,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_t(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_t(Handle, out var ret));
         var retVal = new MatExpr(ret);
         return retVal;
     }
@@ -609,8 +603,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_inv(CvPtr, (int) method, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_inv(Handle, (int) method, out var ret));
         var retVal = new MatExpr(ret);
         return retVal;
     }
@@ -629,9 +622,8 @@ public sealed partial class MatExpr : CvObject
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_mul_toMatExpr(CvPtr, e.CvPtr, scale, out var ret));
+            NativeMethods.core_MatExpr_mul_toMatExpr(Handle, e.CvPtr, scale, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(e);
         var retVal = new MatExpr(ret);
         return retVal;
@@ -652,9 +644,8 @@ public sealed partial class MatExpr : CvObject
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_mul_toMat(CvPtr, m.CvPtr, scale, out var ret));
+            NativeMethods.core_MatExpr_mul_toMat(Handle, m.CvPtr, scale, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(m);
         var retVal = new MatExpr(ret);
         return retVal;
@@ -674,9 +665,8 @@ public sealed partial class MatExpr : CvObject
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_cross(CvPtr, m.CvPtr, out var ret));
+            NativeMethods.core_MatExpr_cross(Handle, m.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(m);
         var retVal = new Mat(ret);
         return retVal;
@@ -695,9 +685,8 @@ public sealed partial class MatExpr : CvObject
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_dot(CvPtr, m.CvPtr, out var ret));
+            NativeMethods.core_MatExpr_dot(Handle, m.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(m);
         return ret;
     }
@@ -710,8 +699,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_size(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_size(Handle, out var ret));
         return ret;
     }
 
@@ -723,8 +711,7 @@ public sealed partial class MatExpr : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_MatExpr_type(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_MatExpr_type(Handle, out var ret));
         return (MatType) ret;
     }
 

--- a/src/OpenCvSharp/Modules/core/PCA.cs
+++ b/src/OpenCvSharp/Modules/core/PCA.cs
@@ -85,8 +85,7 @@ public class PCA : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_PCA_eigenvectors(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_PCA_eigenvectors(Handle, out var ret));
             return Mat.FromNativePointer(ret);
         }
     }
@@ -100,8 +99,7 @@ public class PCA : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_PCA_eigenvalues(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_PCA_eigenvalues(Handle, out var ret));
             return Mat.FromNativePointer(ret);
         }
     }
@@ -115,8 +113,7 @@ public class PCA : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.core_PCA_mean(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.core_PCA_mean(Handle, out var ret));
             return Mat.FromNativePointer(ret);
         }
     }
@@ -149,7 +146,7 @@ public class PCA : CvObject
         data.ThrowIfDisposed();
         mean.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_operatorThis(CvPtr, data.CvPtr, mean.CvPtr, (int)flags, maxComponents));
+            NativeMethods.core_PCA_operatorThis(Handle, data.CvPtr, mean.CvPtr, (int)flags, maxComponents));
         GC.KeepAlive(data);
         GC.KeepAlive(mean);
         return this;
@@ -186,7 +183,7 @@ public class PCA : CvObject
         data.ThrowIfDisposed();
         mean.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_computeVar(CvPtr, data.CvPtr, mean.CvPtr, (int)flags, retainedVariance));
+            NativeMethods.core_PCA_computeVar(Handle, data.CvPtr, mean.CvPtr, (int)flags, retainedVariance));
         GC.KeepAlive(data);
         GC.KeepAlive(mean);
         return this;
@@ -215,8 +212,7 @@ public class PCA : CvObject
             throw new ArgumentNullException(nameof(vec));
         vec.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_project1(CvPtr, vec.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_PCA_project1(Handle, vec.CvPtr, out var ret));
         GC.KeepAlive(vec);
         return Mat.FromNativePointer(ret);
     }
@@ -243,9 +239,8 @@ public class PCA : CvObject
         vec.ThrowIfDisposed();
         result.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_project2(CvPtr, vec.CvPtr, result.CvPtr));
+            NativeMethods.core_PCA_project2(Handle, vec.CvPtr, result.CvPtr));
         result.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(vec);
         GC.KeepAlive(result);
     }
@@ -270,8 +265,7 @@ public class PCA : CvObject
             throw new ArgumentNullException(nameof(vec));
         vec.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_backProject1(CvPtr, vec.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_PCA_backProject1(Handle, vec.CvPtr, out var ret));
         GC.KeepAlive(vec);
         return new Mat(ret);
     }
@@ -300,9 +294,8 @@ public class PCA : CvObject
         vec.ThrowIfDisposed();
         result.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_backProject2(CvPtr, vec.CvPtr, result.CvPtr));
+            NativeMethods.core_PCA_backProject2(Handle, vec.CvPtr, result.CvPtr));
         result.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(vec);
         GC.KeepAlive(result);
     }
@@ -319,9 +312,8 @@ public class PCA : CvObject
         fs.ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_write(CvPtr, fs.CvPtr));
+            NativeMethods.core_PCA_write(Handle, fs.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(fs);
     }
 
@@ -337,9 +329,8 @@ public class PCA : CvObject
         fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCA_read(CvPtr, fn.CvPtr));
+            NativeMethods.core_PCA_read(Handle, fn.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(fn);
     }
 

--- a/src/OpenCvSharp/Modules/core/SVD.cs
+++ b/src/OpenCvSharp/Modules/core/SVD.cs
@@ -51,8 +51,7 @@ public class SVD : CvObject
 
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_SVD_u(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_SVD_u(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -63,8 +62,7 @@ public class SVD : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_SVD_w(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_SVD_w(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -75,8 +73,7 @@ public class SVD : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_SVD_vt(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.core_SVD_vt(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -93,7 +90,7 @@ public class SVD : CvObject
             throw new ArgumentNullException(nameof(src));
         src.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.core_SVD_operatorThis(CvPtr, src.CvPtr, (int)flags));
+            NativeMethods.core_SVD_operatorThis(Handle, src.CvPtr, (int)flags));
         GC.KeepAlive(src);
         return this;
     }
@@ -114,8 +111,7 @@ public class SVD : CvObject
         rhs.ThrowIfDisposed();
         dst.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.core_SVD_backSubst(CvPtr, rhs.CvPtr, dst.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.core_SVD_backSubst(Handle, rhs.CvPtr, dst.CvPtr));
         GC.KeepAlive(rhs);
         GC.KeepAlive(dst);
     }

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/BasicFaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/BasicFaceRecognizer.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp.Face;
@@ -22,8 +22,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getNumComponents(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getNumComponents(Handle, out var ret));
         return ret;
     }
 
@@ -35,8 +34,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_setNumComponents(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_setNumComponents(Handle, val));
     }
 
     /// <summary>
@@ -47,8 +45,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getThreshold(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getThreshold(Handle, out var ret));
         return ret;
     }
 
@@ -60,8 +57,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_setThreshold(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_setThreshold(Handle, val));
     }
 
     /// <summary>
@@ -73,8 +69,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         using var resultVector = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getProjections(RawPtr, resultVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getProjections(Handle, resultVector.CvPtr));
         return resultVector.ToArray();
     }
 
@@ -87,8 +82,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         var result = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getLabels(RawPtr, result.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getLabels(Handle, result.CvPtr));
         return result;
     }
 
@@ -101,8 +95,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         var result = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getEigenValues(RawPtr, result.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getEigenValues(Handle, result.CvPtr));
         return result;
     }
 
@@ -115,8 +108,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         var result = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getEigenVectors(RawPtr, result.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getEigenVectors(Handle, result.CvPtr));
         return result;
     }
 
@@ -129,8 +121,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         var result = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.face_BasicFaceRecognizer_getMean(RawPtr, result.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_BasicFaceRecognizer_getMean(Handle, result.CvPtr));
         return result;
     }
 }

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
@@ -33,9 +33,8 @@ public abstract class FaceRecognizer : Algorithm
         var labelsArray = labels.ToArray();
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_train(
-                RawPtr, srcArray, srcArray.Length, labelsArray, labelsArray.Length));
+                Handle, srcArray, srcArray.Length, labelsArray, labelsArray.Length));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
     }
 
@@ -56,8 +55,7 @@ public abstract class FaceRecognizer : Algorithm
         var labelsArray = labels.ToArray();
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_update(
-                RawPtr, srcArray, srcArray.Length, labelsArray, labelsArray.Length));
-        GC.KeepAlive(this);
+                Handle, srcArray, srcArray.Length, labelsArray, labelsArray.Length));
         GC.KeepAlive(src);
     }
 
@@ -74,8 +72,7 @@ public abstract class FaceRecognizer : Algorithm
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_predict1(RawPtr, src.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_predict1(Handle, src.CvPtr, out var ret));
         GC.KeepAlive(src);
         return ret;
     }
@@ -94,8 +91,7 @@ public abstract class FaceRecognizer : Algorithm
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_predict2(RawPtr, src.CvPtr, out label, out confidence));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_predict2(Handle, src.CvPtr, out label, out confidence));
         GC.KeepAlive(src);
     }
 
@@ -110,7 +106,7 @@ public abstract class FaceRecognizer : Algorithm
             throw new ArgumentNullException(nameof(fileName));
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_write1(RawPtr, fileName));
+            NativeMethods.face_FaceRecognizer_write1(Handle, fileName));
     }
 
     /// <summary>
@@ -124,7 +120,7 @@ public abstract class FaceRecognizer : Algorithm
             throw new ArgumentNullException(nameof(fileName));
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_read1(RawPtr, fileName));
+            NativeMethods.face_FaceRecognizer_read1(Handle, fileName));
     }
 
     /// <inheritdoc />
@@ -136,8 +132,7 @@ public abstract class FaceRecognizer : Algorithm
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_write2(RawPtr, fs.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_write2(Handle, fs.CvPtr));
         GC.KeepAlive(fs);
     }
 
@@ -150,8 +145,7 @@ public abstract class FaceRecognizer : Algorithm
         fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_read2(RawPtr, fn.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_read2(Handle, fn.CvPtr));
         GC.KeepAlive(fn);
     }
 
@@ -168,8 +162,7 @@ public abstract class FaceRecognizer : Algorithm
             throw new ArgumentNullException(nameof(strInfo));
 
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_setLabelInfo(RawPtr, label, strInfo));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_setLabelInfo(Handle, label, strInfo));
     }
 
     /// <summary>
@@ -185,8 +178,7 @@ public abstract class FaceRecognizer : Algorithm
 
         using var resultString = new StdString();
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_getLabelInfo(RawPtr, label, resultString.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_getLabelInfo(Handle, label, resultString.CvPtr));
         return resultString.ToString();
     }
 
@@ -203,8 +195,7 @@ public abstract class FaceRecognizer : Algorithm
             throw new ArgumentNullException(nameof(str));
         using var resultVector = new StdVector<int>();
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_getLabelsByString(RawPtr, str, resultVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_getLabelsByString(Handle, str, resultVector.CvPtr));
         return resultVector.ToArray();
     }
 
@@ -216,8 +207,7 @@ public abstract class FaceRecognizer : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_getThreshold(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_getThreshold(Handle, out var ret));
         return ret;
     }
 
@@ -229,7 +219,6 @@ public abstract class FaceRecognizer : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_FaceRecognizer_setThreshold(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_FaceRecognizer_setThreshold(Handle, val));
     }
 }

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/LBPHFaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/LBPHFaceRecognizer.cs
@@ -54,8 +54,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getGridX(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getGridX(Handle, out var ret));
         return ret;
     }
 
@@ -67,8 +66,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_setGridX(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_setGridX(Handle, val));
     }
 
     /// <summary>
@@ -79,8 +77,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getGridY(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getGridY(Handle, out var ret));
         return ret;
     }
 
@@ -92,8 +89,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_setGridY(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_setGridY(Handle, val));
     }
 
     /// <summary>
@@ -104,8 +100,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getRadius(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getRadius(Handle, out var ret));
         return ret;
     }
 
@@ -117,8 +112,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_setRadius(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_setRadius(Handle, val));
     }
 
     /// <summary>
@@ -129,8 +123,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getNeighbors(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getNeighbors(Handle, out var ret));
         return ret;
     }
 
@@ -142,8 +135,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_setNeighbors(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_setNeighbors(Handle, val));
     }
 
     /// <summary>
@@ -154,8 +146,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getThreshold(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getThreshold(Handle, out var ret));
         return ret;
     }
 
@@ -167,8 +158,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_setThreshold(RawPtr, val));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_setThreshold(Handle, val));
     }
 
     /// <summary>
@@ -180,8 +170,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         using var resultVector = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getHistograms(RawPtr, resultVector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getHistograms(Handle, resultVector.CvPtr));
         return resultVector.ToArray();
     }
 
@@ -194,8 +183,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
         ThrowIfDisposed();
         var result = new Mat();
         NativeMethods.HandleException(
-            NativeMethods.face_LBPHFaceRecognizer_getLabels(RawPtr, result.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.face_LBPHFaceRecognizer_getLabels(Handle, result.CvPtr));
         return result;
     }
 }

--- a/src/OpenCvSharp/Modules/face/Facemark/Facemark.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/Facemark.cs
@@ -28,8 +28,7 @@ public abstract class Facemark : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.face_Facemark_loadModel(RawPtr, model));
-        GC.KeepAlive(this);
+            NativeMethods.face_Facemark_loadModel(Handle, model));
     }
 
     /// <summary>
@@ -56,11 +55,10 @@ public abstract class Facemark : Algorithm
         using (var landmarx = new VectorOfVectorPoint2f())
         {
             NativeMethods.HandleException(
-                NativeMethods.face_Facemark_fit(RawPtr, image.CvPtr, faces.CvPtr, landmarx.CvPtr, out ret));
+                NativeMethods.face_Facemark_fit(Handle, image.CvPtr, faces.CvPtr, landmarx.CvPtr, out ret));
             landmarks = landmarx.ToArray();
         }
 
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
 
         return ret != 0;

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -1,11 +1,11 @@
-﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp.Face;
 
 /// <inheritdoc />
 /// <summary>
-/// 
+///
 /// </summary>
 // ReSharper disable once InconsistentNaming
 public sealed class FacemarkAAM : Facemark
@@ -15,14 +15,32 @@ public sealed class FacemarkAAM : Facemark
     { }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="parameters"></param>
     /// <returns></returns>
     public static FacemarkAAM Create(Params? parameters = null)
     {
-        NativeMethods.HandleException(
-            NativeMethods.face_FacemarkAAM_create(parameters?.CvPtr ?? IntPtr.Zero, out var smartPtr));
+        IntPtr smartPtr;
+        if (parameters is null)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkAAM_create(IntPtr.Zero, out smartPtr));
+        }
+        else
+        {
+            var p = parameters.ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkAAM_create(p, out smartPtr));
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(p));
+            }
+        }
+
         if (smartPtr == IntPtr.Zero)
             throw new OpenCvSharpException($"Invalid cv::Ptr<{nameof(FacemarkAAM)}> pointer");
         NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkAAM_get(smartPtr, out var rawPtr));
@@ -30,202 +48,181 @@ public sealed class FacemarkAAM : Facemark
     }
 
 #pragma warning disable CA1034
-    /// <inheritdoc />
     /// <summary>
+    /// Parameters for the FacemarkAAM model.
+    /// This is a plain managed value holder; it is materialised into a native
+    /// cv::face::FacemarkAAM::Params only at the moment of Create / Read / Write.
     /// </summary>
-    public sealed class Params : CvObject
+    public sealed class Params
     {
         /// <summary>
-        /// Constructor
+        /// Constructs a parameter set initialised with the OpenCV default values.
         /// </summary>
         public Params()
         {
             NativeMethods.HandleException(
                 NativeMethods.face_FacemarkAAM_Params_new(out var p));
             if (p == IntPtr.Zero)
-                throw new OpenCvSharpException($"Invalid {GetType().Name} pointer");
-            InitSafeHandle(p);
-        }
-
-        /// <summary>
-        /// Releases managed resources
-        /// </summary>
-
-        private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
-        {
-            SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
-                static h => NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(h))));
+                throw new OpenCvSharpException($"Invalid {nameof(Params)} pointer");
+            try
+            {
+                LoadFrom(p);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(p));
+            }
         }
 
         /// <summary>
         /// filename of the model
         /// </summary>
-        public string ModelFilename
-        {
-            get
-            {
-                using var s = new StdString();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_model_filename_get(CvPtr, s.CvPtr));
-                GC.KeepAlive(this);
-                return s.ToString();
-            }
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_model_filename_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public string ModelFilename { get; set; } = "";
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public int M
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_m_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_m_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int M { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public int N
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_n_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_n_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int N { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public int NIter
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_n_iter_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_n_iter_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int NIter { get; set; }
 
         /// <summary>
         /// show the training print-out
         /// </summary>
-        public bool Verbose
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_verbose_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret != 0;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_verbose_set(CvPtr, value ? 1 : 0));
-                GC.KeepAlive(this);
-            }
-        }
+        public bool Verbose { get; set; }
+
         /// <summary>
         /// flag to save the trained model or not
         /// </summary>
-        public bool SaveModel
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_save_model_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret != 0;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_save_model_set(CvPtr, value ? 1 : 0));
-                GC.KeepAlive(this);
-            }
-        }
+        public bool SaveModel { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public IReadOnlyList<float> Scales
-        {
-            get
-            {
-                using var vec = new StdVector<float>();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_scales_get(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-                return vec.ToArray();
-            }
-            set
-            {
-                using var vec = new StdVector<float>(value);
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkAAM_Params_scales_set(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-            }
-        }
-            
+        public int MaxM { get; set; }
+
         /// <summary>
-        /// 
+        ///
+        /// </summary>
+        public int MaxN { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public int TextureMaxM { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public IReadOnlyList<float> Scales { get; set; } = [];
+
+        /// <summary>
+        /// Reads the parameters from a file node.
         /// </summary>
         /// <param name="fn"></param>
         public void Read(FileNode fn)
         {
             if (fn is null)
                 throw new ArgumentNullException(nameof(fn));
-            NativeMethods.HandleException(
-                NativeMethods.face_FacemarkAAM_Params_write(CvPtr, fn.CvPtr));
-            GC.KeepAlive(this);
+            var p = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkAAM_Params_read(p, fn.CvPtr));
+                GC.KeepAlive(fn);
+                LoadFrom(p);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(p));
+            }
         }
 
         /// <summary>
-        /// 
+        /// Writes the parameters to a file storage.
         /// </summary>
         /// <param name="fs"></param>
         public void Write(FileStorage fs)
         {
             if (fs is null)
                 throw new ArgumentNullException(nameof(fs));
+            var p = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkAAM_Params_write(p, fs.CvPtr));
+                GC.KeepAlive(fs);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(p));
+            }
+        }
+
+        /// <summary>
+        /// Copies every field of a native Params into this managed instance.
+        /// </summary>
+        private void LoadFrom(IntPtr nativeParams)
+        {
+            using var modelFilename = new StdString();
+            using var scales = new StdVector<float>();
             NativeMethods.HandleException(
-                NativeMethods.face_FacemarkAAM_Params_write(CvPtr, fs.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.face_FacemarkAAM_Params_getAll(
+                    nativeParams, out var data, modelFilename.CvPtr, scales.CvPtr));
+            M = data.M;
+            N = data.N;
+            NIter = data.NIter;
+            Verbose = data.Verbose != 0;
+            SaveModel = data.SaveModel != 0;
+            MaxM = data.MaxM;
+            MaxN = data.MaxN;
+            TextureMaxM = data.TextureMaxM;
+            ModelFilename = modelFilename.ToString();
+            Scales = scales.ToArray();
+        }
+
+        /// <summary>
+        /// Builds a native cv::face::FacemarkAAM::Params from this managed instance.
+        /// The caller is responsible for deleting the returned pointer.
+        /// </summary>
+        internal IntPtr ToNative()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkAAM_Params_new(out var p));
+            if (p == IntPtr.Zero)
+                throw new OpenCvSharpException($"Invalid {nameof(Params)} pointer");
+            try
+            {
+                var data = new FacemarkAAMParamsData
+                {
+                    M = M,
+                    N = N,
+                    NIter = NIter,
+                    Verbose = Verbose ? 1 : 0,
+                    SaveModel = SaveModel ? 1 : 0,
+                    MaxM = MaxM,
+                    MaxN = MaxN,
+                    TextureMaxM = TextureMaxM,
+                };
+                using var scales = new StdVector<float>(Scales);
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkAAM_Params_setAll(
+                        p, data, ModelFilename, scales.CvPtr));
+                return p;
+            }
+            catch
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_Params_delete(p));
+                throw;
+            }
         }
     }
-
-    }
+}

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -1,11 +1,11 @@
-﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp.Face;
 
 /// <inheritdoc />
 /// <summary>
-/// 
+///
 /// </summary>
 // ReSharper disable once InconsistentNaming
 public sealed class FacemarkLBF : Facemark
@@ -15,14 +15,32 @@ public sealed class FacemarkLBF : Facemark
     { }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="parameters"></param>
     /// <returns></returns>
     public static FacemarkLBF Create(Params? parameters = null)
     {
-        NativeMethods.HandleException(
-            NativeMethods.face_FacemarkLBF_create(parameters?.CvPtr ?? IntPtr.Zero, out var smartPtr));
+        IntPtr smartPtr;
+        if (parameters is null)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkLBF_create(IntPtr.Zero, out smartPtr));
+        }
+        else
+        {
+            var p = parameters.ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkLBF_create(p, out smartPtr));
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(p));
+            }
+        }
+
         if (smartPtr == IntPtr.Zero)
             throw new OpenCvSharpException($"Invalid cv::Ptr<{nameof(FacemarkLBF)}> pointer");
         NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkLBF_get(smartPtr, out var rawPtr));
@@ -30,413 +48,236 @@ public sealed class FacemarkLBF : Facemark
     }
 
 #pragma warning disable CA1034
-    /// <inheritdoc />
     /// <summary>
+    /// Parameters for the FacemarkLBF model.
+    /// This is a plain managed value holder; it is materialised into a native
+    /// cv::face::FacemarkLBF::Params only at the moment of Create / Read / Write.
     /// </summary>
-    public sealed class Params : CvObject
+    public sealed class Params
     {
         /// <summary>
-        /// Constructor
+        /// Constructs a parameter set initialised with the OpenCV default values.
         /// </summary>
         public Params()
         {
             NativeMethods.HandleException(
                 NativeMethods.face_FacemarkLBF_Params_new(out var p));
             if (p == IntPtr.Zero)
-                throw new OpenCvSharpException($"Invalid {GetType().Name} pointer");
-            InitSafeHandle(p);
-        }
-
-        /// <summary>
-        /// Releases managed resources
-        /// </summary>
-
-        private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
-        {
-            SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
-                static h => NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(h))));
+                throw new OpenCvSharpException($"Invalid {nameof(Params)} pointer");
+            try
+            {
+                LoadFrom(p);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(p));
+            }
         }
 
         /// <summary>
         /// offset for the loaded face landmark points
         /// </summary>
-        public double ShapeOffset
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_shape_offset_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_shape_offset_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public double ShapeOffset { get; set; }
 
         /// <summary>
         /// filename of the face detector model
         /// </summary>
-        public string CascadeFace
-        {
-            get
-            {
-                using var s = new StdString();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_cascade_face_get(CvPtr, s.CvPtr));
-                GC.KeepAlive(this);
-                return s.ToString();
-            }
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_cascade_face_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public string CascadeFace { get; set; } = "";
 
         /// <summary>
         /// show the training print-out
         /// </summary>
-        public bool Verbose
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_verbose_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret != 0;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_verbose_set(CvPtr, value ? 1 : 0));
-                GC.KeepAlive(this);
-            }
-        }
+        public bool Verbose { get; set; }
 
         /// <summary>
         /// number of landmark points
         /// </summary>
-        public int NLandmarks
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_n_landmarks_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_n_landmarks_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int NLandmarks { get; set; }
 
         /// <summary>
         /// multiplier for augment the training data
         /// </summary>
-        public int InitShapeN
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_initShape_n_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_initShape_n_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int InitShapeN { get; set; }
 
         /// <summary>
         /// number of refinement stages
         /// </summary>
-        public int StagesN
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_stages_n_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_stages_n_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int StagesN { get; set; }
 
         /// <summary>
         /// number of tree in the model for each landmark point refinement
         /// </summary>
-        public int TreeN
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_tree_n_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_tree_n_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int TreeN { get; set; }
 
         /// <summary>
         /// the depth of decision tree, defines the size of feature
         /// </summary>
-        public int TreeDepth
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_tree_depth_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_tree_depth_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public int TreeDepth { get; set; }
 
         /// <summary>
         /// overlap ratio for training the LBF feature
         /// </summary>
-        public double BaggingOverlap
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_bagging_overlap_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_bagging_overlap_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public double BaggingOverlap { get; set; }
 
         /// <summary>
         /// filename where the trained model will be saved
         /// </summary>
-        public string ModelFilename
-        {
-            get
-            {
-                using var s = new StdString();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_model_filename_get(CvPtr, s.CvPtr));
-                GC.KeepAlive(this);
-                return s.ToString();
-            }
-            set
-            {
-                if (value is null)
-                    throw new ArgumentNullException(nameof(value));
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_model_filename_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public string ModelFilename { get; set; } = "";
 
         /// <summary>
         /// flag to save the trained model or not
         /// </summary>
-        public bool SaveModel
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_save_model_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret != 0;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_save_model_set(CvPtr, value ? 1 : 0));
-                GC.KeepAlive(this);
-            }
-        }
+        public bool SaveModel { get; set; }
 
         /// <summary>
         /// seed for shuffling the training data
         /// </summary>
-        public uint Seed
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_seed_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_seed_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public uint Seed { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public IReadOnlyList<int> FeatsM
-        {
-            get
-            {
-                using var vec = new StdVector<int>();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_feats_m_get(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-                return vec.ToArray();
-            }
-            set
-            {
-                using var vec = new StdVector<int>(value);
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_feats_m_set(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-            }
-        }
+        public IReadOnlyList<int> FeatsM { get; set; } = [];
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
-        public IReadOnlyList<double> RadiusM
-        {
-            get
-            {
-                using var vec = new StdVector<double>();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_radius_m_get(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-                return vec.ToArray();
-            }
-            set
-            {
-                using var vec = new StdVector<double>(value);
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_radius_m_set(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-            }
-        }
+        public IReadOnlyList<double> RadiusM { get; set; } = [];
 
         /// <summary>
         /// index of facemark points on pupils of left and right eye
         /// </summary>
-        public IReadOnlyList<int> Pupils0
-        {
-            get
-            {
-                using var vec = new StdVector<int>();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_pupils0_get(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-                return vec.ToArray();
-            }
-            set
-            {
-                using var vec = new StdVector<int>(value);
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_pupils0_set(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-            }
-        }
+        public IReadOnlyList<int> Pupils0 { get; set; } = [];
 
         /// <summary>
         /// index of facemark points on pupils of left and right eye
         /// </summary>
-        public IReadOnlyList<int> Pupils1
-        {
-            get
-            {
-                using var vec = new StdVector<int>();
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_pupils1_get(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-                return vec.ToArray();
-            }
-            set
-            {
-                using var vec = new StdVector<int>(value);
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_pupils1_set(CvPtr, vec.CvPtr));
-                GC.KeepAlive(this);
-            }
-        }
-            
+        public IReadOnlyList<int> Pupils1 { get; set; } = [];
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         // ReSharper disable once InconsistentNaming
-        public Rect DetectROI
-        {
-            get
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_detectROI_get(CvPtr, out var ret));
-                GC.KeepAlive(this);
-                return ret;
-            }
-            set
-            {
-                NativeMethods.HandleException(
-                    NativeMethods.face_FacemarkLBF_Params_detectROI_set(CvPtr, value));
-                GC.KeepAlive(this);
-            }
-        }
+        public Rect DetectROI { get; set; }
 
         /// <summary>
-        /// 
+        /// Reads the parameters from a file node.
         /// </summary>
         /// <param name="fn"></param>
         public void Read(FileNode fn)
         {
             if (fn is null)
                 throw new ArgumentNullException(nameof(fn));
-            NativeMethods.HandleException(
-                NativeMethods.face_FacemarkLBF_Params_write(CvPtr, fn.CvPtr));
-            GC.KeepAlive(this);
+            var p = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkLBF_Params_read(p, fn.CvPtr));
+                GC.KeepAlive(fn);
+                LoadFrom(p);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(p));
+            }
         }
 
         /// <summary>
-        /// 
+        /// Writes the parameters to a file storage.
         /// </summary>
         /// <param name="fs"></param>
         public void Write(FileStorage fs)
         {
             if (fs is null)
                 throw new ArgumentNullException(nameof(fs));
+            var p = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkLBF_Params_write(p, fs.CvPtr));
+                GC.KeepAlive(fs);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(p));
+            }
+        }
+
+        /// <summary>
+        /// Copies every field of a native Params into this managed instance.
+        /// </summary>
+        private void LoadFrom(IntPtr nativeParams)
+        {
+            using var cascadeFace = new StdString();
+            using var modelFilename = new StdString();
+            using var featsM = new StdVector<int>();
+            using var radiusM = new StdVector<double>();
+            using var pupils0 = new StdVector<int>();
+            using var pupils1 = new StdVector<int>();
             NativeMethods.HandleException(
-                NativeMethods.face_FacemarkLBF_Params_write(CvPtr, fs.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.face_FacemarkLBF_Params_getAll(
+                    nativeParams, out var data, cascadeFace.CvPtr, modelFilename.CvPtr,
+                    featsM.CvPtr, radiusM.CvPtr, pupils0.CvPtr, pupils1.CvPtr));
+            ShapeOffset = data.ShapeOffset;
+            Verbose = data.Verbose != 0;
+            NLandmarks = data.NLandmarks;
+            InitShapeN = data.InitShapeN;
+            StagesN = data.StagesN;
+            TreeN = data.TreeN;
+            TreeDepth = data.TreeDepth;
+            BaggingOverlap = data.BaggingOverlap;
+            SaveModel = data.SaveModel != 0;
+            Seed = data.Seed;
+            DetectROI = data.DetectROI;
+            CascadeFace = cascadeFace.ToString();
+            ModelFilename = modelFilename.ToString();
+            FeatsM = featsM.ToArray();
+            RadiusM = radiusM.ToArray();
+            Pupils0 = pupils0.ToArray();
+            Pupils1 = pupils1.ToArray();
+        }
+
+        /// <summary>
+        /// Builds a native cv::face::FacemarkLBF::Params from this managed instance.
+        /// The caller is responsible for deleting the returned pointer.
+        /// </summary>
+        internal IntPtr ToNative()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkLBF_Params_new(out var p));
+            if (p == IntPtr.Zero)
+                throw new OpenCvSharpException($"Invalid {nameof(Params)} pointer");
+            try
+            {
+                var data = new FacemarkLBFParamsData
+                {
+                    ShapeOffset = ShapeOffset,
+                    Verbose = Verbose ? 1 : 0,
+                    NLandmarks = NLandmarks,
+                    InitShapeN = InitShapeN,
+                    StagesN = StagesN,
+                    TreeN = TreeN,
+                    TreeDepth = TreeDepth,
+                    BaggingOverlap = BaggingOverlap,
+                    SaveModel = SaveModel ? 1 : 0,
+                    Seed = Seed,
+                    DetectROI = DetectROI,
+                };
+                using var featsM = new StdVector<int>(FeatsM);
+                using var radiusM = new StdVector<double>(RadiusM);
+                using var pupils0 = new StdVector<int>(Pupils0);
+                using var pupils1 = new StdVector<int>(Pupils1);
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkLBF_Params_setAll(
+                        p, data, CascadeFace, ModelFilename,
+                        featsM.CvPtr, radiusM.CvPtr, pupils0.CvPtr, pupils1.CvPtr));
+                return p;
+            }
+            catch
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_Params_delete(p));
+                throw;
+            }
         }
     }
-
-    }
+}

--- a/src/OpenCvSharp/Modules/features/ANNIndex.cs
+++ b/src/OpenCvSharp/Modules/features/ANNIndex.cs
@@ -41,8 +41,7 @@ public class ANNIndex : CvPtrObject
             throw new ArgumentNullException(nameof(features));
         features.ThrowIfDisposed();
 
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_addItems(RawPtr, features.CvPtr));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_addItems(Handle, features.CvPtr));
         GC.KeepAlive(features);
     }
 
@@ -53,8 +52,7 @@ public class ANNIndex : CvPtrObject
     public void Build(int trees = -1)
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_build(RawPtr, trees));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_build(Handle, trees));
     }
 
     /// <summary>
@@ -79,8 +77,7 @@ public class ANNIndex : CvPtrObject
         dists.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.features_ANNIndex_knnSearch(RawPtr, query.CvPtr, indices.CvPtr, dists.CvPtr, knn, searchK));
-        GC.KeepAlive(this);
+            NativeMethods.features_ANNIndex_knnSearch(Handle, query.CvPtr, indices.CvPtr, dists.CvPtr, knn, searchK));
         GC.KeepAlive(query);
         indices.Fix();
         dists.Fix();
@@ -97,8 +94,7 @@ public class ANNIndex : CvPtrObject
         if (filename is null)
             throw new ArgumentNullException(nameof(filename));
 
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_save(RawPtr, filename, prefault ? 1 : 0));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_save(Handle, filename, prefault ? 1 : 0));
     }
 
     /// <summary>
@@ -112,8 +108,7 @@ public class ANNIndex : CvPtrObject
         if (filename is null)
             throw new ArgumentNullException(nameof(filename));
 
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_load(RawPtr, filename, prefault ? 1 : 0));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_load(Handle, filename, prefault ? 1 : 0));
     }
 
     /// <summary>
@@ -122,8 +117,7 @@ public class ANNIndex : CvPtrObject
     public int GetTreeNumber()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getTreeNumber(RawPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getTreeNumber(Handle, out var ret));
         return ret;
     }
 
@@ -133,8 +127,7 @@ public class ANNIndex : CvPtrObject
     public int GetItemNumber()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getItemNumber(RawPtr, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_getItemNumber(Handle, out var ret));
         return ret;
     }
 
@@ -150,8 +143,7 @@ public class ANNIndex : CvPtrObject
         if (filename is null)
             throw new ArgumentNullException(nameof(filename));
 
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setOnDiskBuild(RawPtr, filename, out var ret));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setOnDiskBuild(Handle, filename, out var ret));
         return ret != 0;
     }
 
@@ -163,7 +155,6 @@ public class ANNIndex : CvPtrObject
     public void SetSeed(int seed)
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setSeed(RawPtr, seed));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_setSeed(Handle, seed));
     }
 }

--- a/src/OpenCvSharp/Modules/features/AffineFeature.cs
+++ b/src/OpenCvSharp/Modules/features/AffineFeature.cs
@@ -56,8 +56,7 @@ public class AffineFeature : Feature2D
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.features_AffineFeature_setViewParams(RawPtr, tilts, tilts.Length, rolls, rolls.Length));
-        GC.KeepAlive(this);
+            NativeMethods.features_AffineFeature_setViewParams(Handle, tilts, tilts.Length, rolls, rolls.Length));
     }
 
     /// <summary>
@@ -72,8 +71,7 @@ public class AffineFeature : Feature2D
         using var tiltsVec = new StdVector<float>();
         using var rollsVec = new StdVector<float>();
         NativeMethods.HandleException(
-            NativeMethods.features_AffineFeature_getViewParams(RawPtr, tiltsVec.CvPtr, rollsVec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_AffineFeature_getViewParams(Handle, tiltsVec.CvPtr, rollsVec.CvPtr));
         tilts = tiltsVec.ToArray();
         rolls = rollsVec.ToArray();
     }

--- a/src/OpenCvSharp/Modules/features/BFMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/BFMatcher.cs
@@ -51,8 +51,7 @@ public class BFMatcher : DescriptorMatcher
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_BFMatcher_isMaskSupported(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.features_BFMatcher_isMaskSupported(Handle, out var ret));
         return ret != 0;
     }
 }

--- a/src/OpenCvSharp/Modules/features/DISK.cs
+++ b/src/OpenCvSharp/Modules/features/DISK.cs
@@ -75,15 +75,13 @@ public class DISK : Feature2D
         get
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_getMaxKeypoints(RawPtr, out var ret));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_getMaxKeypoints(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_setMaxKeypoints(RawPtr, value));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_setMaxKeypoints(Handle, value));
         }
     }
 
@@ -95,15 +93,13 @@ public class DISK : Feature2D
         get
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_getScoreThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_getScoreThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_setScoreThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_setScoreThreshold(Handle, value));
         }
     }
 
@@ -115,15 +111,13 @@ public class DISK : Feature2D
         get
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_getImageSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_getImageSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
-            NativeMethods.HandleException(NativeMethods.features_DISK_setImageSize(RawPtr, value));
-            GC.KeepAlive(this);
+            NativeMethods.HandleException(NativeMethods.features_DISK_setImageSize(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
@@ -104,8 +104,7 @@ public class DescriptorMatcher : Algorithm
 
         var descriptorsPtrs = descriptorsArray.Select(x => x.CvPtr).ToArray();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_add(RawPtr, descriptorsPtrs, descriptorsPtrs.Length));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_add(Handle, descriptorsPtrs, descriptorsPtrs.Length));
         GC.KeepAlive(descriptorsArray);
     }
 
@@ -118,8 +117,7 @@ public class DescriptorMatcher : Algorithm
         ThrowIfDisposed();
         using var matVec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_getTrainDescriptors(RawPtr, matVec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_getTrainDescriptors(Handle, matVec.CvPtr));
         return matVec.ToArray();
     }
 
@@ -130,8 +128,7 @@ public class DescriptorMatcher : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_clear(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_clear(Handle));
     }
 
     /// <summary>
@@ -142,8 +139,7 @@ public class DescriptorMatcher : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_empty(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_empty(Handle, out var ret));
         return ret != 0;
     }
 
@@ -155,8 +151,7 @@ public class DescriptorMatcher : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_isMaskSupported(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_isMaskSupported(Handle, out var ret));
         return ret != 0;
     }
 
@@ -174,8 +169,7 @@ public class DescriptorMatcher : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_train(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_DescriptorMatcher_train(Handle));
     }
 
     #region *Match
@@ -197,9 +191,8 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new StdVector<DMatch>();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_match1(
-                RawPtr, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
+                Handle, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
                 matchesVec.CvPtr, Cv2.ToPtr(mask)));
-        GC.KeepAlive(this);
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(trainDescriptors);
         GC.KeepAlive(mask);
@@ -229,9 +222,8 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_knnMatch1(
-                RawPtr, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
+                Handle, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
                 matchesVec.CvPtr, k, Cv2.ToPtr(mask), compactResult ? 1 : 0));
-        GC.KeepAlive(this);
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(trainDescriptors);
         GC.KeepAlive(mask);
@@ -260,9 +252,8 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_radiusMatch1(
-                RawPtr, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
+                Handle, queryDescriptors.CvPtr, trainDescriptors.CvPtr,
                 matchesVec.CvPtr, maxDistance, Cv2.ToPtr(mask), compactResult ? 1 : 0));
-        GC.KeepAlive(this);
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(trainDescriptors);
         GC.KeepAlive(mask);
@@ -290,8 +281,7 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new StdVector<DMatch>();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_match2(
-                RawPtr, queryDescriptors.CvPtr, matchesVec.CvPtr, masksPtrs, masksPtrs.Length));
-        GC.KeepAlive(this);
+                Handle, queryDescriptors.CvPtr, matchesVec.CvPtr, masksPtrs, masksPtrs.Length));
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(masks);
         return matchesVec.ToArray();
@@ -323,9 +313,8 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_knnMatch2(
-                RawPtr, queryDescriptors.CvPtr, matchesVec.CvPtr, k,
+                Handle, queryDescriptors.CvPtr, matchesVec.CvPtr, k,
                 masksPtrs, masksPtrs.Length, compactResult ? 1 : 0));
-        GC.KeepAlive(this);
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(masks);
         return matchesVec.ToArray();
@@ -355,9 +344,8 @@ public class DescriptorMatcher : Algorithm
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_radiusMatch2(
-                RawPtr, queryDescriptors.CvPtr, matchesVec.CvPtr, maxDistance,
+                Handle, queryDescriptors.CvPtr, matchesVec.CvPtr, maxDistance,
                 masksPtrs, masksPtrs.Length, compactResult ? 1 : 0));
-        GC.KeepAlive(this);
         GC.KeepAlive(queryDescriptors);
         GC.KeepAlive(masks);
         return matchesVec.ToArray();

--- a/src/OpenCvSharp/Modules/features/FastFeatureDetector.cs
+++ b/src/OpenCvSharp/Modules/features/FastFeatureDetector.cs
@@ -38,16 +38,14 @@ public class FastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_getThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_getThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_setThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_setThreshold(Handle, value));
         }
     }
 
@@ -60,16 +58,14 @@ public class FastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_getNonmaxSuppression(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_getNonmaxSuppression(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_setNonmaxSuppression(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_setNonmaxSuppression(Handle, value ? 1 : 0));
         }
     }
 
@@ -82,16 +78,14 @@ public class FastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_getType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_getType(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_FastFeatureDetector_setType(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_FastFeatureDetector_setType(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/features/FlannBasedMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/FlannBasedMatcher.cs
@@ -71,8 +71,7 @@ public class FlannBasedMatcher : DescriptorMatcher
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_FlannBasedMatcher_isMaskSupported(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.features_FlannBasedMatcher_isMaskSupported(Handle, out var ret));
         return ret != 0;
     }
 
@@ -92,7 +91,7 @@ public class FlannBasedMatcher : DescriptorMatcher
 
         var descriptorsPtrs = descriptorsArray.Select(x => x.CvPtr).ToArray();
         NativeMethods.HandleException(
-            NativeMethods.features_DescriptorMatcher_add(RawPtr, descriptorsPtrs, descriptorsPtrs.Length));
+            NativeMethods.features_DescriptorMatcher_add(Handle, descriptorsPtrs, descriptorsPtrs.Length));
         GC.KeepAlive(descriptorsArray);
     }
 
@@ -103,8 +102,7 @@ public class FlannBasedMatcher : DescriptorMatcher
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_FlannBasedMatcher_clear(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_FlannBasedMatcher_clear(Handle));
     }
 
     /// <summary>
@@ -121,7 +119,6 @@ public class FlannBasedMatcher : DescriptorMatcher
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.features_FlannBasedMatcher_train(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.features_FlannBasedMatcher_train(Handle));
     }
 }

--- a/src/OpenCvSharp/Modules/features/GFTTDetector.cs
+++ b/src/OpenCvSharp/Modules/features/GFTTDetector.cs
@@ -51,16 +51,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getMaxFeatures(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getMaxFeatures(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setMaxFeatures(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setMaxFeatures(Handle, value));
         }
     }
 
@@ -73,16 +71,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getQualityLevel(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getQualityLevel(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setQualityLevel(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setQualityLevel(Handle, value));
         }
     }
 
@@ -95,16 +91,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getMinDistance(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getMinDistance(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setMinDistance(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setMinDistance(Handle, value));
         }
     }
 
@@ -118,16 +112,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getBlockSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getBlockSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setBlockSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setBlockSize(Handle, value));
         }
     }
 
@@ -141,16 +133,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getHarrisDetector(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getHarrisDetector(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setHarrisDetector(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setHarrisDetector(Handle, value ? 1 : 0));
         }
     }
 
@@ -164,16 +154,14 @@ public class GFTTDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_getK(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_getK(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_GFTTDetector_setK(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_GFTTDetector_setK(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
@@ -74,8 +74,7 @@ public class LightGlueMatcher : DescriptorMatcher
         trainKpts.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.features_LightGlueMatcher_setPairInfo(RawPtr, queryKpts.CvPtr, trainKpts.CvPtr, queryImageSize, trainImageSize));
-        GC.KeepAlive(this);
+            NativeMethods.features_LightGlueMatcher_setPairInfo(Handle, queryKpts.CvPtr, trainKpts.CvPtr, queryImageSize, trainImageSize));
         GC.KeepAlive(queryKpts);
         GC.KeepAlive(trainKpts);
     }
@@ -86,7 +85,6 @@ public class LightGlueMatcher : DescriptorMatcher
     public void ClearPairInfo()
     {
         ThrowIfDisposed();
-        NativeMethods.HandleException(NativeMethods.features_LightGlueMatcher_clearPairInfo(RawPtr));
-        GC.KeepAlive(this);
+        NativeMethods.HandleException(NativeMethods.features_LightGlueMatcher_clearPairInfo(Handle));
     }
 }

--- a/src/OpenCvSharp/Modules/features/MSER.cs
+++ b/src/OpenCvSharp/Modules/features/MSER.cs
@@ -60,16 +60,14 @@ public class MSER : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_getDelta(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_getDelta(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_setDelta(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_setDelta(Handle, value));
         }
     }
 
@@ -82,16 +80,14 @@ public class MSER : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_getMinArea(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_getMinArea(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_setMinArea(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_setMinArea(Handle, value));
         }
     }
 
@@ -104,16 +100,14 @@ public class MSER : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_getMaxArea(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_getMaxArea(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_setMaxArea(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_setMaxArea(Handle, value));
         }
     }
 
@@ -126,16 +120,14 @@ public class MSER : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_getPass2Only(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_getPass2Only(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_setPass2Only(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.features_MSER_setPass2Only(Handle, value ? 1 : 0));
         }
     }
 
@@ -162,8 +154,7 @@ public class MSER : Feature2D
         {
             NativeMethods.HandleException(
                 NativeMethods.features_MSER_detectRegions(
-                    RawPtr, image.CvPtr, msersVec.CvPtr, bboxesVec.CvPtr));
-            GC.KeepAlive(this);
+                    Handle, image.CvPtr, msersVec.CvPtr, bboxesVec.CvPtr));
             msers = msersVec.ToArray();
             bboxes = bboxesVec.ToArray();
         }

--- a/src/OpenCvSharp/Modules/features/ORB.cs
+++ b/src/OpenCvSharp/Modules/features/ORB.cs
@@ -77,16 +77,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getMaxFeatures(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getMaxFeatures(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setMaxFeatures(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setMaxFeatures(Handle, value));
         }
     }
 
@@ -99,16 +97,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getScaleFactor(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getScaleFactor(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setScaleFactor(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setScaleFactor(Handle, value));
         }
     }
         
@@ -121,16 +117,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getNLevels(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getNLevels(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setNLevels(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setNLevels(Handle, value));
         }
     }
         
@@ -143,16 +137,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getEdgeThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getEdgeThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setEdgeThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setEdgeThreshold(Handle, value));
         }
     }
 
@@ -165,16 +157,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getFirstLevel(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getFirstLevel(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setFirstLevel(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setFirstLevel(Handle, value));
         }
     }
 
@@ -188,16 +178,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getWTA_K(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getWTA_K(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setWTA_K(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setWTA_K(Handle, value));
         }
     }
 
@@ -210,16 +198,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getScoreType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getScoreType(Handle, out var ret));
             return (ORBScoreType)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setScoreType(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setScoreType(Handle, (int)value));
         }
     }
 
@@ -232,16 +218,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getPatchSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getPatchSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setPatchSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setPatchSize(Handle, value));
         }
     }
 
@@ -254,16 +238,14 @@ public class ORB : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_getFastThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_getFastThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.features_ORB_setFastThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.features_ORB_setFastThreshold(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/img_hash/BlockMeanHash.cs
+++ b/src/OpenCvSharp/Modules/img_hash/BlockMeanHash.cs
@@ -39,8 +39,7 @@ public class BlockMeanHash : ImgHashBase
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.img_hash_BlockMeanHash_setMode(RawPtr, (int)mode));
-        GC.KeepAlive(this);
+            NativeMethods.img_hash_BlockMeanHash_setMode(Handle, (int)mode));
     }
 
     /// <summary>
@@ -52,8 +51,7 @@ public class BlockMeanHash : ImgHashBase
         ThrowIfDisposed();
         using var meanVec = new StdVector<double>();
         NativeMethods.HandleException(
-            NativeMethods.img_hash_BlockMeanHash_getMean(RawPtr, meanVec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.img_hash_BlockMeanHash_getMean(Handle, meanVec.CvPtr));
         return meanVec.ToArray();
     }
         

--- a/src/OpenCvSharp/Modules/img_hash/ImgHashBase.cs
+++ b/src/OpenCvSharp/Modules/img_hash/ImgHashBase.cs
@@ -31,9 +31,8 @@ public abstract class ImgHashBase : Algorithm
         outputArr.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.img_hash_ImgHashBase_compute(RawPtr, inputArr.CvPtr, outputArr.CvPtr));
+            NativeMethods.img_hash_ImgHashBase_compute(Handle, inputArr.CvPtr, outputArr.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(inputArr);
         outputArr.Fix();
     }
@@ -57,8 +56,7 @@ public abstract class ImgHashBase : Algorithm
         hashTwo.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.img_hash_ImgHashBase_compare(RawPtr, hashOne.CvPtr, hashTwo.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.img_hash_ImgHashBase_compare(Handle, hashOne.CvPtr, hashTwo.CvPtr, out var ret));
         GC.KeepAlive(hashOne);
         GC.KeepAlive(hashOne);
         return ret;

--- a/src/OpenCvSharp/Modules/img_hash/MarrHildrethHash.cs
+++ b/src/OpenCvSharp/Modules/img_hash/MarrHildrethHash.cs
@@ -40,8 +40,7 @@ public class MarrHildrethHash : ImgHashBase
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.img_hash_MarrHildrethHash_setKernelParam(RawPtr, alpha, scale));
-        GC.KeepAlive(this);
+            NativeMethods.img_hash_MarrHildrethHash_setKernelParam(Handle, alpha, scale));
     }
 
     /// <summary>
@@ -53,18 +52,16 @@ public class MarrHildrethHash : ImgHashBase
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_getAlpha(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_MarrHildrethHash_getAlpha(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_getScale(RawPtr, out var scale));
+                NativeMethods.img_hash_MarrHildrethHash_getScale(Handle, out var scale));
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_setKernelParam(RawPtr, value, scale));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_MarrHildrethHash_setKernelParam(Handle, value, scale));
         }
     }
 
@@ -77,18 +74,16 @@ public class MarrHildrethHash : ImgHashBase
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_getScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_MarrHildrethHash_getScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_getAlpha(RawPtr, out var alpha));
+                NativeMethods.img_hash_MarrHildrethHash_getAlpha(Handle, out var alpha));
             NativeMethods.HandleException(
-                NativeMethods.img_hash_MarrHildrethHash_setKernelParam(RawPtr, alpha, value));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_MarrHildrethHash_setKernelParam(Handle, alpha, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/img_hash/RadialVarianceHash.cs
+++ b/src/OpenCvSharp/Modules/img_hash/RadialVarianceHash.cs
@@ -42,16 +42,14 @@ public class RadialVarianceHash : ImgHashBase
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_RadialVarianceHash_getSigma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_RadialVarianceHash_getSigma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_RadialVarianceHash_setSigma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_RadialVarianceHash_setSigma(Handle, value));
         }
     }
 
@@ -64,16 +62,14 @@ public class RadialVarianceHash : ImgHashBase
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_RadialVarianceHash_getNumOfAngleLine(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_RadialVarianceHash_getNumOfAngleLine(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.img_hash_RadialVarianceHash_setNumOfAngleLine(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.img_hash_RadialVarianceHash_setNumOfAngleLine(Handle, value));
         }
     }
         

--- a/src/OpenCvSharp/Modules/imgproc/GeneralizedHough.cs
+++ b/src/OpenCvSharp/Modules/imgproc/GeneralizedHough.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -23,16 +23,14 @@ public abstract class GeneralizedHough : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_getCannyLowThresh(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_getCannyLowThresh(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_setCannyLowThresh(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_setCannyLowThresh(Handle, value));
         }
     }
 
@@ -46,16 +44,14 @@ public abstract class GeneralizedHough : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_getCannyHighThresh(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_getCannyHighThresh(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_setCannyHighThresh(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_setCannyHighThresh(Handle, value));
         }
     }
 
@@ -69,16 +65,14 @@ public abstract class GeneralizedHough : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_getMinDist(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_getMinDist(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_setMinDist(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_setMinDist(Handle, value));
         }
     }
 
@@ -92,16 +86,14 @@ public abstract class GeneralizedHough : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_getDp(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_getDp(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_setDp(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_setDp(Handle, value));
         }
     }
 
@@ -115,16 +107,14 @@ public abstract class GeneralizedHough : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_getMaxBufferSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_getMaxBufferSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHough_setMaxBufferSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHough_setMaxBufferSize(Handle, value));
         }
     }
 
@@ -142,8 +132,7 @@ public abstract class GeneralizedHough : Algorithm
         var templCenterValue = templCenter.GetValueOrDefault(new Point(-1, -1));
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_GeneralizedHough_setTemplate1(RawPtr, templ.CvPtr, templCenterValue));
-        GC.KeepAlive(this);
+            NativeMethods.imgproc_GeneralizedHough_setTemplate1(Handle, templ.CvPtr, templCenterValue));
         GC.KeepAlive(templ);
     }
 
@@ -170,9 +159,8 @@ public abstract class GeneralizedHough : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_GeneralizedHough_setTemplate2(
-                RawPtr, edges.CvPtr, dx.CvPtr, dy.CvPtr, templCenterValue));
+                Handle, edges.CvPtr, dx.CvPtr, dy.CvPtr, templCenterValue));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(edges);
         GC.KeepAlive(dx);
         GC.KeepAlive(dy);
@@ -197,9 +185,8 @@ public abstract class GeneralizedHough : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_GeneralizedHough_detect1(
-                RawPtr, image.CvPtr, positions.CvPtr, Cv2.ToPtr(votes)));
+                Handle, image.CvPtr, positions.CvPtr, Cv2.ToPtr(votes)));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(positions);
         GC.KeepAlive(votes);
@@ -234,9 +221,8 @@ public abstract class GeneralizedHough : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_GeneralizedHough_detect2(
-                RawPtr, edges.CvPtr, dx.CvPtr, dy.CvPtr, positions.CvPtr, Cv2.ToPtr(votes)));
+                Handle, edges.CvPtr, dx.CvPtr, dy.CvPtr, positions.CvPtr, Cv2.ToPtr(votes)));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(edges);
         GC.KeepAlive(dx);
         GC.KeepAlive(dy);

--- a/src/OpenCvSharp/Modules/imgproc/GeneralizedHoughBallard.cs
+++ b/src/OpenCvSharp/Modules/imgproc/GeneralizedHoughBallard.cs
@@ -41,16 +41,14 @@ public class GeneralizedHoughBallard : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughBallard_getLevels(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughBallard_getLevels(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughBallard_setLevels(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughBallard_setLevels(Handle, value));
         }
     }
 
@@ -65,16 +63,14 @@ public class GeneralizedHoughBallard : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughBallard_getVotesThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughBallard_getVotesThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughBallard_setVotesThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughBallard_setVotesThreshold(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/imgproc/GeneralizedHoughGuil.cs
+++ b/src/OpenCvSharp/Modules/imgproc/GeneralizedHoughGuil.cs
@@ -42,16 +42,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getXi(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getXi(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setXi(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setXi(Handle, value));
         }
     }
 
@@ -65,16 +63,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getLevels(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getLevels(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setLevels(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setLevels(Handle, value));
         }
     }
 
@@ -88,16 +84,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleEpsilon(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleEpsilon(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleEpsilon(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleEpsilon(Handle, value));
         }
     }
 
@@ -111,16 +105,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getMinAngle(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getMinAngle(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setMinAngle(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setMinAngle(Handle, value));
         }
     }
 
@@ -134,16 +126,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getMaxAngle(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getMaxAngle(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setMaxAngle(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setMaxAngle(Handle, value));
         }
     }
 
@@ -157,16 +147,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleStep(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleStep(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleStep(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleStep(Handle, value));
         }
     }
 
@@ -180,16 +168,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleThresh(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getAngleThresh(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleThresh(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setAngleThresh(Handle, value));
         }
     }
 
@@ -203,16 +189,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getMinScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getMinScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setMinScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setMinScale(Handle, value));
         }
     }
 
@@ -226,16 +210,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getMaxScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getMaxScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setMaxScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setMaxScale(Handle, value));
         }
     }
 
@@ -249,16 +231,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getScaleStep(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getScaleStep(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setScaleStep(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setScaleStep(Handle, value));
         }
     }
 
@@ -272,16 +252,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getScaleThresh(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getScaleThresh(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setScaleThresh(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setScaleThresh(Handle, value));
         }
     }
 
@@ -295,16 +273,14 @@ public class GeneralizedHoughGuil : GeneralizedHough
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_getPosThresh(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_getPosThresh(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.imgproc_GeneralizedHoughGuil_setPosThresh(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.imgproc_GeneralizedHoughGuil_setPosThresh(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/imgproc/LineSegmentDetector.cs
+++ b/src/OpenCvSharp/Modules/imgproc/LineSegmentDetector.cs
@@ -62,9 +62,8 @@ public class LineSegmentDetector : Algorithm
         prec?.ThrowIfNotReady();
         nfa?.ThrowIfNotReady();
 
-        NativeMethods.imgproc_LineSegmentDetector_detect_OutputArray(RawPtr, image.CvPtr, lines.CvPtr,
+        NativeMethods.imgproc_LineSegmentDetector_detect_OutputArray(Handle, image.CvPtr, lines.CvPtr,
             Cv2.ToPtr(width), Cv2.ToPtr(prec), Cv2.ToPtr(nfa));
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(lines);
         GC.KeepAlive(width);
@@ -99,7 +98,7 @@ public class LineSegmentDetector : Algorithm
         using (var precVec = new StdVector<double>())
         using (var nfaVec = new StdVector<double>())
         {
-            NativeMethods.imgproc_LineSegmentDetector_detect_vector(RawPtr, image.CvPtr,
+            NativeMethods.imgproc_LineSegmentDetector_detect_vector(Handle, image.CvPtr,
                 linesVec.CvPtr, widthVec.CvPtr, precVec.CvPtr, nfaVec.CvPtr);
 
             lines = linesVec.ToArray();
@@ -107,7 +106,6 @@ public class LineSegmentDetector : Algorithm
             prec = precVec.ToArray();
             nfa = nfaVec.ToArray();
         }
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
     }
 
@@ -126,8 +124,7 @@ public class LineSegmentDetector : Algorithm
         image.ThrowIfNotReady();
         lines.ThrowIfDisposed();
 
-        NativeMethods.imgproc_LineSegmentDetector_drawSegments(RawPtr, image.CvPtr, lines.CvPtr);
-        GC.KeepAlive(this);
+        NativeMethods.imgproc_LineSegmentDetector_drawSegments(Handle, image.CvPtr, lines.CvPtr);
         GC.KeepAlive(image);
         image.Fix();
         GC.KeepAlive(lines);
@@ -155,8 +152,7 @@ public class LineSegmentDetector : Algorithm
         image?.ThrowIfNotReady();
 
         var ret = NativeMethods.imgproc_LineSegmentDetector_compareSegments(
-            RawPtr, size, lines1.CvPtr, lines2.CvPtr, Cv2.ToPtr(image));
-        GC.KeepAlive(this);
+            Handle, size, lines1.CvPtr, lines2.CvPtr, Cv2.ToPtr(image));
         GC.KeepAlive(lines1);
         GC.KeepAlive(lines2);
         GC.KeepAlive(image);

--- a/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
+++ b/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
@@ -74,15 +74,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getTermCriteria(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getTermCriteria(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setTermCriteria(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setTermCriteria(Handle, value));
         }
     }
 
@@ -96,15 +94,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getBackpropWeightScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getBackpropWeightScale(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setBackpropWeightScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setBackpropWeightScale(Handle, value));
         }
     }
 
@@ -120,15 +116,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getBackpropMomentumScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getBackpropMomentumScale(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setBackpropMomentumScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setBackpropMomentumScale(Handle, value));
         }
     }
 
@@ -142,15 +136,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getRpropDW0(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getRpropDW0(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setRpropDW0(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setRpropDW0(Handle, value));
         }
     }
 
@@ -165,15 +157,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getRpropDWPlus(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getRpropDWPlus(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setRpropDWPlus(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setRpropDWPlus(Handle, value));
         }
     }
 
@@ -188,15 +178,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getRpropDWPlus(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getRpropDWPlus(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setRpropDWPlus(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setRpropDWPlus(Handle, value));
         }
     }
 
@@ -211,15 +199,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getRpropDWMin(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getRpropDWMin(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setRpropDWMin(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setRpropDWMin(Handle, value));
         }
     }
 
@@ -234,15 +220,13 @@ public class ANN_MLP : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_getRpropDWMax(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_getRpropDWMax(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_ANN_MLP_setRpropDWMax(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_ANN_MLP_setRpropDWMax(Handle, value));
         }
     }
 
@@ -262,9 +246,8 @@ public class ANN_MLP : StatModel
             throw new InvalidEnumArgumentException(nameof(method), (int)method, typeof(TrainingMethods));
 
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_setTrainMethod(RawPtr, (int)method, param1, param2));
+            NativeMethods.ml_ANN_MLP_setTrainMethod(Handle, (int)method, param1, param2));
             
-        GC.KeepAlive(this);
     }
 
     /// <summary>
@@ -274,8 +257,7 @@ public class ANN_MLP : StatModel
     public virtual TrainingMethods GetTrainMethod()
     {
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_getTrainMethod(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_ANN_MLP_getTrainMethod(Handle, out var ret));
         return (TrainingMethods) ret;
     }
 
@@ -292,9 +274,8 @@ public class ANN_MLP : StatModel
             throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(ActivationFunctions));
             
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_setActivationFunction(RawPtr, (int)type, param1, param2));
+            NativeMethods.ml_ANN_MLP_setActivationFunction(Handle, (int)type, param1, param2));
 
-        GC.KeepAlive(this);
     }
 
     /// <summary>
@@ -310,9 +291,8 @@ public class ANN_MLP : StatModel
             throw new ArgumentNullException(nameof(layerSizes));
 
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_setLayerSizes(RawPtr, layerSizes.CvPtr));
+            NativeMethods.ml_ANN_MLP_setLayerSizes(Handle, layerSizes.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(layerSizes);
     }
 
@@ -327,9 +307,8 @@ public class ANN_MLP : StatModel
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_getLayerSizes(RawPtr, out var ret));
+            NativeMethods.ml_ANN_MLP_getLayerSizes(Handle, out var ret));
 
-        GC.KeepAlive(this);
         return new Mat(ret);
     }
 

--- a/src/OpenCvSharp/Modules/ml/Boost.cs
+++ b/src/OpenCvSharp/Modules/ml/Boost.cs
@@ -71,16 +71,14 @@ public class Boost : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_getBoostType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_getBoostType(Handle, out var ret));
             return (Types)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_setBoostType(RawPtr, (int) value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_setBoostType(Handle, (int) value));
         }
     }
 
@@ -94,16 +92,14 @@ public class Boost : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_getWeakCount(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_getWeakCount(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_setWeakCount(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_setWeakCount(Handle, value));
         }
     }
 
@@ -119,16 +115,14 @@ public class Boost : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_getWeightTrimRate(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_getWeightTrimRate(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_Boost_setWeightTrimRate(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_Boost_setWeightTrimRate(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/ml/DTrees.cs
+++ b/src/OpenCvSharp/Modules/ml/DTrees.cs
@@ -76,15 +76,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getMaxCategories(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getMaxCategories(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setMaxCategories(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setMaxCategories(Handle, value));
         }
     }
 
@@ -96,15 +94,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getMaxDepth(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getMaxDepth(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setMaxDepth(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setMaxDepth(Handle, value));
         }
     }
 
@@ -117,15 +113,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getMinSampleCount(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getMinSampleCount(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setMinSampleCount(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setMinSampleCount(Handle, value));
         }
     }
 
@@ -139,15 +133,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getCVFolds(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getCVFolds(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setCVFolds(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setCVFolds(Handle, value));
         }
     }
 
@@ -161,15 +153,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getUseSurrogates(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getUseSurrogates(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setUseSurrogates(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setUseSurrogates(Handle, value ? 1 : 0));
         }
     }
 
@@ -184,15 +174,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getUse1SERule(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getUse1SERule(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setUse1SERule(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setUse1SERule(Handle, value ? 1 : 0));
         }
     }
 
@@ -206,15 +194,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getTruncatePrunedTree(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getTruncatePrunedTree(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setTruncatePrunedTree(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setTruncatePrunedTree(Handle, value ? 1 : 0));
         }
     }
 
@@ -229,15 +215,13 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getRegressionAccuracy(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getRegressionAccuracy(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setRegressionAccuracy(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setRegressionAccuracy(Handle, value));
         }
     }
 
@@ -249,8 +233,7 @@ public class DTrees : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_getPriors(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_getPriors(Handle, out var ret));
             return new Mat(ret);
         }
         set
@@ -259,8 +242,7 @@ public class DTrees : StatModel
                 throw new ArgumentNullException(nameof(value));
 
             NativeMethods.HandleException(
-                NativeMethods.ml_DTrees_setPriors(RawPtr, value.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.ml_DTrees_setPriors(Handle, value.CvPtr));
         }
     }
 
@@ -278,8 +260,7 @@ public class DTrees : StatModel
 
         using var vector = new StdVector<int>();
         NativeMethods.HandleException(
-            NativeMethods.ml_DTrees_getRoots(RawPtr, vector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ml_DTrees_getRoots(Handle, vector.CvPtr));
         return vector.ToArray();
     }
 
@@ -293,8 +274,7 @@ public class DTrees : StatModel
 
         using var vector = new VectorOfDTreesNode();
         NativeMethods.HandleException(
-            NativeMethods.ml_DTrees_getNodes(RawPtr, vector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ml_DTrees_getNodes(Handle, vector.CvPtr));
         return vector.ToArray();
     }
 
@@ -309,8 +289,7 @@ public class DTrees : StatModel
 
         using var vector = new VectorOfDTreesSplit();
         NativeMethods.HandleException(
-            NativeMethods.ml_DTrees_getSplits(RawPtr, vector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ml_DTrees_getSplits(Handle, vector.CvPtr));
         return vector.ToArray();
     }
 
@@ -325,8 +304,7 @@ public class DTrees : StatModel
 
         using var vector = new StdVector<int>();
         NativeMethods.HandleException(
-            NativeMethods.ml_DTrees_getSubsets(RawPtr, vector.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ml_DTrees_getSubsets(Handle, vector.CvPtr));
         return vector.ToArray();
     }
 

--- a/src/OpenCvSharp/Modules/ml/EM.cs
+++ b/src/OpenCvSharp/Modules/ml/EM.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp;
@@ -85,15 +85,13 @@ public class EM : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_getClustersNumber(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_getClustersNumber(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_setClustersNumber(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_setClustersNumber(Handle, value));
         }
     }
 
@@ -105,15 +103,13 @@ public class EM : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_getCovarianceMatrixType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_getCovarianceMatrixType(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_setCovarianceMatrixType(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_setCovarianceMatrixType(Handle, value));
         }
     }
 
@@ -129,15 +125,13 @@ public class EM : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_getTermCriteria(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_getTermCriteria(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_EM_setTermCriteria(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_EM_setTermCriteria(Handle, value));
         }
     }
 
@@ -154,8 +148,7 @@ public class EM : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_EM_getWeights(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_EM_getWeights(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -169,8 +162,7 @@ public class EM : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_EM_getMeans(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_EM_getMeans(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -185,8 +177,7 @@ public class EM : Algorithm
 
         using var vec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.ml_EM_getCovs(RawPtr, vec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ml_EM_getCovs(Handle, vec.CvPtr));
         return vec.ToArray();
     }
 
@@ -222,7 +213,7 @@ public class EM : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainEM(
-                RawPtr,
+                Handle,
                 samples.CvPtr,
                 Cv2.ToPtr(logLikelihoods),
                 Cv2.ToPtr(labels),
@@ -232,7 +223,6 @@ public class EM : Algorithm
         logLikelihoods?.Fix();
         labels?.Fix();
         probs?.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(samples);
         GC.KeepAlive(logLikelihoods);
         GC.KeepAlive(labels);
@@ -286,7 +276,7 @@ public class EM : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainE(
-                RawPtr,
+                Handle,
                 samples.CvPtr,
                 means0.CvPtr,
                 Cv2.ToPtr(covs0),
@@ -299,7 +289,6 @@ public class EM : Algorithm
         logLikelihoods?.Fix();
         labels?.Fix();
         probs?.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(samples);
         GC.KeepAlive(means0);
         GC.KeepAlive(covs0);
@@ -345,7 +334,7 @@ public class EM : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainM(
-                RawPtr,
+                Handle,
                 samples.CvPtr,
                 probs0.CvPtr,
                 Cv2.ToPtr(logLikelihoods),
@@ -356,7 +345,6 @@ public class EM : Algorithm
         logLikelihoods?.Fix();
         labels?.Fix();
         probs?.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(samples);
         GC.KeepAlive(probs0);
         GC.KeepAlive(logLikelihoods);
@@ -382,9 +370,8 @@ public class EM : Algorithm
         probs?.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_EM_predict2(RawPtr, sample.CvPtr, Cv2.ToPtr(probs), out var ret));
+            NativeMethods.ml_EM_predict2(Handle, sample.CvPtr, Cv2.ToPtr(probs), out var ret));
         probs?.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(sample);
         GC.KeepAlive(probs);
         return ret;

--- a/src/OpenCvSharp/Modules/ml/KNearest.cs
+++ b/src/OpenCvSharp/Modules/ml/KNearest.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 #pragma warning disable CA1008 // Enums should have zero value
 
@@ -71,15 +71,13 @@ public class KNearest : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_getDefaultK(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_getDefaultK(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_setDefaultK(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_setDefaultK(Handle, value));
         }
     }
 
@@ -91,15 +89,13 @@ public class KNearest : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_getIsClassifier(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_getIsClassifier(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_setIsClassifier(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_setIsClassifier(Handle, value ? 1 : 0));
         }
     }
 
@@ -111,15 +107,13 @@ public class KNearest : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_getEmax(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_getEmax(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_setEmax(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_setEmax(Handle, value));
         }
     }
 
@@ -131,15 +125,13 @@ public class KNearest : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_getAlgorithmType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_getAlgorithmType(Handle, out var ret));
             return (Types)ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_KNearest_setAlgorithmType(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_KNearest_setAlgorithmType(Handle, (int)value));
         }
     }
 
@@ -173,11 +165,10 @@ public class KNearest : StatModel
 
         NativeMethods.HandleException(
             NativeMethods.ml_KNearest_findNearest(
-                RawPtr,
+                Handle,
                 samples.CvPtr, k, results.CvPtr,
                 Cv2.ToPtr(neighborResponses), Cv2.ToPtr(dist), out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(samples);
         GC.KeepAlive(results);
         GC.KeepAlive(neighborResponses);

--- a/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
+++ b/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
@@ -69,15 +69,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getLearningRate(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getLearningRate(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setLearningRate(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setLearningRate(Handle, value));
         }
     }
 
@@ -89,15 +87,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setIterations(Handle, value));
         }
     }
 
@@ -109,15 +105,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getRegularization(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getRegularization(Handle, out var ret));
             return (RegKinds)ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setRegularization(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setRegularization(Handle, (int)value));
         }
     }
 
@@ -129,15 +123,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getTrainMethod(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getTrainMethod(Handle, out var ret));
             return (Methods)ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setTrainMethod(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setTrainMethod(Handle, (int)value));
         }
     }
 
@@ -151,15 +143,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getMiniBatchSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getMiniBatchSize(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setMiniBatchSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setMiniBatchSize(Handle, value));
         }
     }
 
@@ -171,15 +161,13 @@ public class LogisticRegression : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_getTermCriteria(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_getTermCriteria(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_LogisticRegression_setTermCriteria(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_LogisticRegression_setTermCriteria(Handle, value));
         }
     }
 
@@ -205,8 +193,7 @@ public class LogisticRegression : StatModel
         results?.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_LogisticRegression_predict(RawPtr, samples.CvPtr, Cv2.ToPtr(results), flags, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_LogisticRegression_predict(Handle, samples.CvPtr, Cv2.ToPtr(results), flags, out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(results);
         results?.Fix();
@@ -225,8 +212,7 @@ public class LogisticRegression : StatModel
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_LogisticRegression_get_learnt_thetas(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_LogisticRegression_get_learnt_thetas(Handle, out var ret));
         return new Mat(ret);
     }
 

--- a/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
+++ b/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp.ML;
 
@@ -87,10 +87,9 @@ public class NormalBayesClassifier : StatModel
 
         NativeMethods.HandleException(
             NativeMethods.ml_NormalBayesClassifier_predictProb(
-                RawPtr, inputs.CvPtr, outputs.CvPtr, outputProbs.CvPtr, flags, out var ret));
+                Handle, inputs.CvPtr, outputs.CvPtr, outputProbs.CvPtr, flags, out var ret));
         outputs.Fix();
         outputProbs.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(inputs);
         GC.KeepAlive(outputs);
         GC.KeepAlive(outputProbs);

--- a/src/OpenCvSharp/Modules/ml/RTrees.cs
+++ b/src/OpenCvSharp/Modules/ml/RTrees.cs
@@ -71,16 +71,14 @@ public class RTrees : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_getCalculateVarImportance(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_getCalculateVarImportance(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_setCalculateVarImportance(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_setCalculateVarImportance(Handle, value ? 1 : 0));
         }
     }
 
@@ -94,16 +92,14 @@ public class RTrees : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_getActiveVarCount(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_getActiveVarCount(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_setActiveVarCount(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_setActiveVarCount(Handle, value));
         }
     }
 
@@ -116,16 +112,14 @@ public class RTrees : DTrees
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_getTermCriteria(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_getTermCriteria(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ml_RTrees_setTermCriteria(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_RTrees_setTermCriteria(Handle, value));
         }
     }
 
@@ -144,8 +138,7 @@ public class RTrees : DTrees
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_RTrees_getVarImportance(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_RTrees_getVarImportance(Handle, out var ret));
         return new Mat(ret);
     }
 

--- a/src/OpenCvSharp/Modules/ml/SVM.cs
+++ b/src/OpenCvSharp/Modules/ml/SVM.cs
@@ -76,15 +76,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getType(Handle, out var ret));
             return (Types)ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setType(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setType(Handle, (int)value));
         }
     }
 
@@ -97,15 +95,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getGamma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getGamma(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setGamma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setGamma(Handle, value));
         }
     }
 
@@ -118,15 +114,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getCoef0(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getCoef0(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setCoef0(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setCoef0(Handle, value));
         }
     }
 
@@ -139,15 +133,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getDegree(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getDegree(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setDegree(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setDegree(Handle, value));
         }
     }
 
@@ -160,15 +152,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getC(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getC(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setC(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setC(Handle, value));
         }
     }
 
@@ -181,15 +171,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getNu(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getNu(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setNu(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setNu(Handle, value));
         }
     }
 
@@ -202,15 +190,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getP(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getP(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setP(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setP(Handle, value));
         }
     }
 
@@ -228,8 +214,7 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getClassWeights(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getClassWeights(Handle, out var ret));
             return new Mat(ret);
         }
         set
@@ -238,8 +223,7 @@ public class SVM : StatModel
                 throw new ArgumentNullException(nameof(value));
 
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setClassWeights(RawPtr, value.CvPtr));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setClassWeights(Handle, value.CvPtr));
             GC.KeepAlive(value);
         }
     }
@@ -257,15 +241,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getTermCriteria(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getTermCriteria(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setTermCriteria(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setTermCriteria(Handle, value));
         }
     }
 
@@ -277,15 +259,13 @@ public class SVM : StatModel
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_getKernelType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_getKernelType(Handle, out var ret));
             return (KernelTypes)ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.ml_SVM_setKernel(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.ml_SVM_setKernel(Handle, (int)value));
         }
     }
 
@@ -340,8 +320,7 @@ public class SVM : StatModel
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ml_SVM_getSupportVectors(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ml_SVM_getSupportVectors(Handle, out var ret));
         return new Mat(ret);
     }
 
@@ -370,11 +349,10 @@ public class SVM : StatModel
         svidx.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_SVM_getDecisionFunction(RawPtr, i, alpha.CvPtr, svidx.CvPtr, out var ret));
+            NativeMethods.ml_SVM_getDecisionFunction(Handle, i, alpha.CvPtr, svidx.CvPtr, out var ret));
 
         alpha.Fix();
         svidx.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(alpha);
         GC.KeepAlive(svidx);
         return ret;

--- a/src/OpenCvSharp/Modules/objdetect/FaceDetectorYN.cs
+++ b/src/OpenCvSharp/Modules/objdetect/FaceDetectorYN.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Dnn;
+﻿using OpenCvSharp.Dnn;
 using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
@@ -68,8 +68,7 @@ public class FaceDetectorYN : Algorithm
         using InputArray iaImage = new(image);
         using OutputArray oaFaces = new(faces);
         NativeMethods.HandleException(
-            NativeMethods.objdetect_FaceDetectorYN_detect(RawPtr, iaImage.CvPtr, oaFaces.CvPtr, out var result));
-        GC.KeepAlive(this);
+            NativeMethods.objdetect_FaceDetectorYN_detect(Handle, iaImage.CvPtr, oaFaces.CvPtr, out var result));
         return result;
     }
 }

--- a/src/OpenCvSharp/Modules/photo/CalibrateCRF.cs
+++ b/src/OpenCvSharp/Modules/photo/CalibrateCRF.cs
@@ -34,10 +34,9 @@ public abstract class CalibrateCRF : Algorithm
             throw new OpenCvSharpException("src.Count() != times.Count");
 
         NativeMethods.HandleException(
-            NativeMethods.photo_CalibrateCRF_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr, timesArray));
+            NativeMethods.photo_CalibrateCRF_process(Handle, srcArray, srcArray.Length, dst.CvPtr, timesArray));
 
         dst.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
     }

--- a/src/OpenCvSharp/Modules/photo/CalibrateDebevec.cs
+++ b/src/OpenCvSharp/Modules/photo/CalibrateDebevec.cs
@@ -39,12 +39,12 @@ public class CalibrateDebevec : CalibrateCRF
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_getLambda(RawPtr, out var ret));
+                NativeMethods.photo_CalibrateDebevec_getLambda(Handle, out var ret));
             return ret;
         }
         set =>
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_setLambda(RawPtr, value));
+                NativeMethods.photo_CalibrateDebevec_setLambda(Handle, value));
     }
 
     /// <summary>
@@ -55,12 +55,12 @@ public class CalibrateDebevec : CalibrateCRF
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_getSamples(RawPtr, out var ret));
+                NativeMethods.photo_CalibrateDebevec_getSamples(Handle, out var ret));
             return ret;
         }
         set =>
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_setSamples(RawPtr, value));
+                NativeMethods.photo_CalibrateDebevec_setSamples(Handle, value));
     }
         
     /// <summary>
@@ -71,11 +71,11 @@ public class CalibrateDebevec : CalibrateCRF
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_getRandom(RawPtr, out var ret));
+                NativeMethods.photo_CalibrateDebevec_getRandom(Handle, out var ret));
             return ret != 0;
         }
         set =>
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateDebevec_setRandom(RawPtr, value ? 1 : 0));
+                NativeMethods.photo_CalibrateDebevec_setRandom(Handle, value ? 1 : 0));
     }
 }

--- a/src/OpenCvSharp/Modules/photo/CalibrateRobertson.cs
+++ b/src/OpenCvSharp/Modules/photo/CalibrateRobertson.cs
@@ -36,12 +36,12 @@ public class CalibrateRobertson : CalibrateCRF
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateRobertson_getMaxIter(RawPtr, out var ret));
+                NativeMethods.photo_CalibrateRobertson_getMaxIter(Handle, out var ret));
             return ret;
         }
         set =>
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateRobertson_setMaxIter(RawPtr, value));
+                NativeMethods.photo_CalibrateRobertson_setMaxIter(Handle, value));
     }
 
     /// <summary>
@@ -52,12 +52,12 @@ public class CalibrateRobertson : CalibrateCRF
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateRobertson_getThreshold(RawPtr, out var ret));
+                NativeMethods.photo_CalibrateRobertson_getThreshold(Handle, out var ret));
             return ret;
         }
         set =>
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateRobertson_setThreshold(RawPtr, value));
+                NativeMethods.photo_CalibrateRobertson_setThreshold(Handle, value));
     }
         
     /// <summary>
@@ -69,7 +69,7 @@ public class CalibrateRobertson : CalibrateCRF
         {
             var ret = new Mat();
             NativeMethods.HandleException(
-                NativeMethods.photo_CalibrateRobertson_getRadiance(RawPtr, ret.CvPtr));
+                NativeMethods.photo_CalibrateRobertson_getRadiance(Handle, ret.CvPtr));
             return ret;
         }
     }

--- a/src/OpenCvSharp/Modules/photo/MergeDebevec.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeDebevec.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 

--- a/src/OpenCvSharp/Modules/photo/MergeExposures.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeExposures.cs
@@ -36,10 +36,9 @@ public abstract class MergeExposures : Algorithm
             throw new OpenCvSharpException("src.Count() != times.Count");
             
         NativeMethods.HandleException(
-            NativeMethods.photo_MergeExposures_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr, timesArray, response.CvPtr));
+            NativeMethods.photo_MergeExposures_process(Handle, srcArray, srcArray.Length, dst.CvPtr, timesArray, response.CvPtr));
 
         dst.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         GC.KeepAlive(response);

--- a/src/OpenCvSharp/Modules/photo/MergeMertens.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeMertens.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -49,9 +49,8 @@ public sealed class MergeMertens : MergeExposures
         var srcArray = src.Select(s => s.CvPtr).ToArray();
 
         NativeMethods.HandleException(
-            NativeMethods.photo_MergeMertens_process(RawPtr, srcArray, srcArray.Length, dst.CvPtr));
+            NativeMethods.photo_MergeMertens_process(Handle, srcArray, srcArray.Length, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(srcArray);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/photo/Tonemap.cs
+++ b/src/OpenCvSharp/Modules/photo/Tonemap.cs
@@ -51,9 +51,8 @@ public class Tonemap : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.photo_Tonemap_process(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.photo_Tonemap_process(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }
@@ -69,16 +68,14 @@ public class Tonemap : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_Tonemap_getGamma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_Tonemap_getGamma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_Tonemap_setGamma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_Tonemap_setGamma(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/photo/TonemapDrago.cs
+++ b/src/OpenCvSharp/Modules/photo/TonemapDrago.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable UnusedMember.Global
 
@@ -45,16 +45,14 @@ public sealed class TonemapDrago : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapDrago_getSaturation(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapDrago_getSaturation(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapDrago_setSaturation(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapDrago_setSaturation(Handle, value));
         }
     }
 
@@ -68,16 +66,14 @@ public sealed class TonemapDrago : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapDrago_getBias(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapDrago_getBias(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapDrago_setBias(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapDrago_setBias(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/photo/TonemapMantiuk.cs
+++ b/src/OpenCvSharp/Modules/photo/TonemapMantiuk.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable UnusedMember.Global
 
@@ -45,16 +45,14 @@ public sealed class TonemapMantiuk : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapMantiuk_getScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapMantiuk_getScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapMantiuk_setScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapMantiuk_setScale(Handle, value));
         }
     }
 
@@ -68,16 +66,14 @@ public sealed class TonemapMantiuk : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapMantiuk_getSaturation(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapMantiuk_getSaturation(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapMantiuk_setSaturation(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapMantiuk_setSaturation(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/photo/TonemapReinhard.cs
+++ b/src/OpenCvSharp/Modules/photo/TonemapReinhard.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable UnusedMember.Global
 
@@ -45,16 +45,14 @@ public sealed class TonemapReinhard : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_getIntensity(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_getIntensity(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_setIntensity(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_setIntensity(Handle, value));
         }
     }
 
@@ -68,16 +66,14 @@ public sealed class TonemapReinhard : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_getLightAdaptation(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_getLightAdaptation(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_setLightAdaptation(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_setLightAdaptation(Handle, value));
         }
     }
 
@@ -91,16 +87,14 @@ public sealed class TonemapReinhard : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_getColorAdaptation(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_getColorAdaptation(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.photo_TonemapReinhard_setColorAdaptation(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.photo_TonemapReinhard_setColorAdaptation(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/quality/QualityBase.cs
+++ b/src/OpenCvSharp/Modules/quality/QualityBase.cs
@@ -22,8 +22,7 @@ public abstract class QualityBase : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.quality_QualityBase_empty(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.quality_QualityBase_empty(Handle, out var ret));
             return ret != 0;
         }
     }
@@ -38,7 +37,7 @@ public abstract class QualityBase : Algorithm
             throw new ArgumentNullException(nameof(dst));
         dst.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.quality_QualityBase_getQualityMap(RawPtr, dst.CvPtr));
+            NativeMethods.quality_QualityBase_getQualityMap(Handle, dst.CvPtr));
         dst.Fix();
     }
 
@@ -54,8 +53,7 @@ public abstract class QualityBase : Algorithm
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.quality_QualityBase_compute(RawPtr, img.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.quality_QualityBase_compute(Handle, img.CvPtr, out var ret));
         GC.KeepAlive(img);
         return ret;
     }
@@ -67,7 +65,6 @@ public abstract class QualityBase : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.quality_QualityBase_clear(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.quality_QualityBase_clear(Handle));
     }
 }

--- a/src/OpenCvSharp/Modules/quality/QualityPSNR.cs
+++ b/src/OpenCvSharp/Modules/quality/QualityPSNR.cs
@@ -27,16 +27,14 @@ public class QualityPSNR : QualityBase
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.quality_QualityPSNR_getMaxPixelValue(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.quality_QualityPSNR_getMaxPixelValue(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.quality_QualityPSNR_setMaxPixelValue(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.quality_QualityPSNR_setMaxPixelValue(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/saliency/MotionSaliencyBinWangApr2014.cs
+++ b/src/OpenCvSharp/Modules/saliency/MotionSaliencyBinWangApr2014.cs
@@ -44,8 +44,7 @@ public class MotionSaliencyBinWangApr2014 : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.saliency_MotionSaliencyBinWangApr2014_computeSaliency(
-                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, saliencyMap.CvPtr, out var ret));
         GC.KeepAlive(image);
         saliencyMap.Fix();
         return ret != 0;
@@ -61,8 +60,7 @@ public class MotionSaliencyBinWangApr2014 : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImagesize(RawPtr, width, height));
-        GC.KeepAlive(this);
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImagesize(Handle, width, height));
     }
 
     /// <summary>
@@ -74,8 +72,7 @@ public class MotionSaliencyBinWangApr2014 : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.saliency_MotionSaliencyBinWangApr2014_init(RawPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.saliency_MotionSaliencyBinWangApr2014_init(Handle, out var ret));
         return ret != 0;
     }
 
@@ -88,16 +85,14 @@ public class MotionSaliencyBinWangApr2014 : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageWidth(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageWidth(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageWidth(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageWidth(Handle, value));
         }
     }
 
@@ -110,16 +105,14 @@ public class MotionSaliencyBinWangApr2014 : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageHeight(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_getImageHeight(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageHeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_MotionSaliencyBinWangApr2014_setImageHeight(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
+++ b/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
@@ -47,8 +47,7 @@ public class ObjectnessBING : Algorithm
         using var vec = new StdVector<Vec4i>();
         NativeMethods.HandleException(
             NativeMethods.saliency_ObjectnessBING_computeSaliency(
-                RawPtr, image.CvPtr, vec.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, vec.CvPtr, out var ret));
         GC.KeepAlive(image);
         objectnessBoundingBox = vec.ToArray();
         return ret != 0;
@@ -63,8 +62,7 @@ public class ObjectnessBING : Algorithm
         ThrowIfDisposed();
         using var vec = new StdVector<float>();
         NativeMethods.HandleException(
-            NativeMethods.saliency_ObjectnessBING_getobjectnessValues(RawPtr, vec.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.saliency_ObjectnessBING_getobjectnessValues(Handle, vec.CvPtr));
         return vec.ToArray();
     }
 
@@ -77,8 +75,7 @@ public class ObjectnessBING : Algorithm
         if (trainingPath is null)
             throw new ArgumentNullException(nameof(trainingPath));
         NativeMethods.HandleException(
-            NativeMethods.saliency_ObjectnessBING_setTrainingPath(RawPtr, trainingPath));
-        GC.KeepAlive(this);
+            NativeMethods.saliency_ObjectnessBING_setTrainingPath(Handle, trainingPath));
     }
 
     /// <summary>
@@ -90,8 +87,7 @@ public class ObjectnessBING : Algorithm
         if (resultsDir is null)
             throw new ArgumentNullException(nameof(resultsDir));
         NativeMethods.HandleException(
-            NativeMethods.saliency_ObjectnessBING_setBBResDir(RawPtr, resultsDir));
-        GC.KeepAlive(this);
+            NativeMethods.saliency_ObjectnessBING_setBBResDir(Handle, resultsDir));
     }
 
     /// <summary>
@@ -103,16 +99,14 @@ public class ObjectnessBING : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_getBase(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_getBase(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_setBase(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_setBase(Handle, value));
         }
     }
 
@@ -125,16 +119,14 @@ public class ObjectnessBING : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_getNSS(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_getNSS(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_setNSS(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_setNSS(Handle, value));
         }
     }
 
@@ -147,16 +139,14 @@ public class ObjectnessBING : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_getW(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_getW(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_ObjectnessBING_setW(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_ObjectnessBING_setW(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/saliency/StaticSaliencyFineGrained.cs
+++ b/src/OpenCvSharp/Modules/saliency/StaticSaliencyFineGrained.cs
@@ -44,8 +44,7 @@ public class StaticSaliencyFineGrained : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.saliency_StaticSaliencyFineGrained_computeSaliency(
-                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, saliencyMap.CvPtr, out var ret));
         GC.KeepAlive(image);
         saliencyMap.Fix();
         return ret != 0;
@@ -69,8 +68,7 @@ public class StaticSaliencyFineGrained : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.saliency_StaticSaliencyFineGrained_computeBinaryMap(
-                RawPtr, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
         GC.KeepAlive(saliencyMap);
         binaryMap.Fix();
         return ret != 0;

--- a/src/OpenCvSharp/Modules/saliency/StaticSaliencySpectralResidual.cs
+++ b/src/OpenCvSharp/Modules/saliency/StaticSaliencySpectralResidual.cs
@@ -44,8 +44,7 @@ public class StaticSaliencySpectralResidual : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.saliency_StaticSaliencySpectralResidual_computeSaliency(
-                RawPtr, image.CvPtr, saliencyMap.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, saliencyMap.CvPtr, out var ret));
         GC.KeepAlive(image);
         saliencyMap.Fix();
         return ret != 0;
@@ -69,8 +68,7 @@ public class StaticSaliencySpectralResidual : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.saliency_StaticSaliencySpectralResidual_computeBinaryMap(
-                RawPtr, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, saliencyMap.CvPtr, binaryMap.CvPtr, out var ret));
         GC.KeepAlive(saliencyMap);
         binaryMap.Fix();
         return ret != 0;
@@ -85,16 +83,14 @@ public class StaticSaliencySpectralResidual : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageWidth(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageWidth(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageWidth(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageWidth(Handle, value));
         }
     }
 
@@ -107,16 +103,14 @@ public class StaticSaliencySpectralResidual : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageHeight(RawPtr, out var val));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_StaticSaliencySpectralResidual_getImageHeight(Handle, out var val));
             return val;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageHeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.saliency_StaticSaliencySpectralResidual_setImageHeight(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/shape/AffineTransformer.cs
+++ b/src/OpenCvSharp/Modules/shape/AffineTransformer.cs
@@ -43,16 +43,14 @@ public class AffineTransformer : ShapeTransformer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_AffineTransformer_getFullAffine(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_AffineTransformer_getFullAffine(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_AffineTransformer_setFullAffine(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.shape_AffineTransformer_setFullAffine(Handle, value ? 1 : 0));
         }
     }
 
@@ -64,7 +62,6 @@ public class AffineTransformer : ShapeTransformer
     {
         NativeMethods.HandleException(
             NativeMethods.shape_Ptr_AffineTransformer_upcast(SmartPtr, out var basePtr));
-        GC.KeepAlive(this);
         return basePtr;
     }
 

--- a/src/OpenCvSharp/Modules/shape/EMDHistogramCostExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/EMDHistogramCostExtractor.cs
@@ -37,16 +37,14 @@ public class EMDHistogramCostExtractor : HistogramCostExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_EMDHistogramCostExtractor_getNormFlag(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_EMDHistogramCostExtractor_getNormFlag(Handle, out var ret));
             return (DistanceTypes)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_EMDHistogramCostExtractor_setNormFlag(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_EMDHistogramCostExtractor_setNormFlag(Handle, (int)value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/shape/HausdorffDistanceExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/HausdorffDistanceExtractor.cs
@@ -49,16 +49,14 @@ public class HausdorffDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HausdorffDistanceExtractor_getDistanceFlag(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HausdorffDistanceExtractor_getDistanceFlag(Handle, out var ret));
             return (DistanceTypes)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HausdorffDistanceExtractor_setDistanceFlag(RawPtr, (int) value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HausdorffDistanceExtractor_setDistanceFlag(Handle, (int) value));
         }
     }
 
@@ -71,16 +69,14 @@ public class HausdorffDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HausdorffDistanceExtractor_getRankProportion(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HausdorffDistanceExtractor_getRankProportion(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HausdorffDistanceExtractor_setRankProportion(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HausdorffDistanceExtractor_setRankProportion(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/shape/HistogramCostExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/HistogramCostExtractor.cs
@@ -33,9 +33,8 @@ public abstract class HistogramCostExtractor : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.shape_HistogramCostExtractor_buildCostMatrix(
-                RawPtr, descriptors1.CvPtr, descriptors2.CvPtr, costMatrix.CvPtr));
+                Handle, descriptors1.CvPtr, descriptors2.CvPtr, costMatrix.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(descriptors1);
         GC.KeepAlive(descriptors2);
         costMatrix.Fix();
@@ -50,16 +49,14 @@ public abstract class HistogramCostExtractor : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HistogramCostExtractor_getNDummies(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HistogramCostExtractor_getNDummies(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HistogramCostExtractor_setNDummies(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HistogramCostExtractor_setNDummies(Handle, value));
         }
     }
 
@@ -72,16 +69,14 @@ public abstract class HistogramCostExtractor : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HistogramCostExtractor_getDefaultCost(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HistogramCostExtractor_getDefaultCost(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_HistogramCostExtractor_setDefaultCost(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_HistogramCostExtractor_setDefaultCost(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/shape/NormHistogramCostExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/NormHistogramCostExtractor.cs
@@ -37,16 +37,14 @@ public class NormHistogramCostExtractor : HistogramCostExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_NormHistogramCostExtractor_getNormFlag(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_NormHistogramCostExtractor_getNormFlag(Handle, out var ret));
             return (DistanceTypes)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_NormHistogramCostExtractor_setNormFlag(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_NormHistogramCostExtractor_setNormFlag(Handle, (int)value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/shape/ShapeContextDistanceExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/ShapeContextDistanceExtractor.cs
@@ -54,16 +54,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getAngularBins(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getAngularBins(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setAngularBins(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setAngularBins(Handle, value));
         }
     }
 
@@ -76,16 +74,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getRadialBins(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getRadialBins(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setRadialBins(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setRadialBins(Handle, value));
         }
     }
 
@@ -98,16 +94,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getInnerRadius(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getInnerRadius(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setInnerRadius(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setInnerRadius(Handle, value));
         }
     }
 
@@ -120,16 +114,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getOuterRadius(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getOuterRadius(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setOuterRadius(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setOuterRadius(Handle, value));
         }
     }
         
@@ -142,16 +134,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getRotationInvariant(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getRotationInvariant(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setRotationInvariant(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setRotationInvariant(Handle, value ? 1 : 0));
         }
     }
 
@@ -164,16 +154,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getShapeContextWeight(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getShapeContextWeight(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setShapeContextWeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setShapeContextWeight(Handle, value));
         }
     }
 
@@ -186,16 +174,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getImageAppearanceWeight(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getImageAppearanceWeight(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setImageAppearanceWeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setImageAppearanceWeight(Handle, value));
         }
     }
 
@@ -208,16 +194,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getBendingEnergyWeight(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getBendingEnergyWeight(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setBendingEnergyWeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setBendingEnergyWeight(Handle, value));
         }
     }
 
@@ -230,16 +214,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setIterations(Handle, value));
         }
     }
 
@@ -252,16 +234,14 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_getStdDev(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_getStdDev(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.shape_ShapeContextDistanceExtractor_setStdDev(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.shape_ShapeContextDistanceExtractor_setStdDev(Handle, value));
         }
     }
 
@@ -286,9 +266,8 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         image2.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.shape_ShapeContextDistanceExtractor_setImages(RawPtr, image1.CvPtr, image2.CvPtr));
+            NativeMethods.shape_ShapeContextDistanceExtractor_setImages(Handle, image1.CvPtr, image2.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(image1);
         GC.KeepAlive(image2);
     }
@@ -310,11 +289,10 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         image2.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.shape_ShapeContextDistanceExtractor_getImages(RawPtr, image1.CvPtr, image2.CvPtr));
+            NativeMethods.shape_ShapeContextDistanceExtractor_getImages(Handle, image1.CvPtr, image2.CvPtr));
 
         image1.Fix();
         image2.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(image1);
         GC.KeepAlive(image2);
     }
@@ -336,9 +314,8 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
 
         NativeMethods.HandleException(
             NativeMethods.shape_ShapeContextDistanceExtractor_setCostExtractor(
-                RawPtr, comparer.SmartPtr));
+                Handle, comparer.SmartPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(comparer);
     }
 
@@ -358,14 +335,13 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
         {
             NativeMethods.HandleException(
                 NativeMethods.shape_ShapeContextDistanceExtractor_setTransformAlgorithm(
-                    RawPtr, basePtr));
+                    Handle, basePtr));
         }
         finally
         {
             NativeMethods.HandleException(NativeMethods.shape_Ptr_ShapeTransformer_delete(basePtr));
         }
 
-        GC.KeepAlive(this);
         GC.KeepAlive(transformer);
     }
 

--- a/src/OpenCvSharp/Modules/shape/ShapeDistanceExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/ShapeDistanceExtractor.cs
@@ -31,9 +31,8 @@ public abstract class ShapeDistanceExtractor : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.shape_ShapeDistanceExtractor_computeDistance(
-                RawPtr, contour1.CvPtr, contour2.CvPtr, out var ret));
+                Handle, contour1.CvPtr, contour2.CvPtr, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(contour1);
         GC.KeepAlive(contour2);
 

--- a/src/OpenCvSharp/Modules/shape/ShapeTransformer.cs
+++ b/src/OpenCvSharp/Modules/shape/ShapeTransformer.cs
@@ -44,9 +44,8 @@ public abstract class ShapeTransformer : Algorithm
         using var matchesVec = new StdVector<DMatch>(matches);
         NativeMethods.HandleException(
             NativeMethods.shape_ShapeTransformer_estimateTransformation(
-                RawPtr, transformingShape.CvPtr, targetShape.CvPtr, matchesVec.CvPtr));
+                Handle, transformingShape.CvPtr, targetShape.CvPtr, matchesVec.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(transformingShape);
         GC.KeepAlive(targetShape);
     }
@@ -67,9 +66,8 @@ public abstract class ShapeTransformer : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.shape_ShapeTransformer_applyTransformation(
-                RawPtr, input.CvPtr, output?.CvPtr ?? IntPtr.Zero, out var ret));
+                Handle, input.CvPtr, output?.CvPtr ?? IntPtr.Zero, out var ret));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(input);
         output?.Fix();
 
@@ -101,14 +99,13 @@ public abstract class ShapeTransformer : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.shape_ShapeTransformer_warpImage(
-                RawPtr,
+                Handle,
                 transformingImage.CvPtr,
                 output.CvPtr,
                 (int)flags,
                 (int)borderMode,
                 borderValue.GetValueOrDefault(Scalar.All(0))));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(transformingImage);
         output.Fix();
     }

--- a/src/OpenCvSharp/Modules/shape/ThinPlateSplineShapeTransformer.cs
+++ b/src/OpenCvSharp/Modules/shape/ThinPlateSplineShapeTransformer.cs
@@ -45,8 +45,7 @@ public class ThinPlateSplineShapeTransformer : ShapeTransformer
             ThrowIfDisposed();
             NativeMethods.HandleException(
                 NativeMethods.shape_ThinPlateSplineShapeTransformer_getRegularizationParameter(
-                    RawPtr, out var ret));
-            GC.KeepAlive(this);
+                    Handle, out var ret));
             return ret;
         }
         set
@@ -54,8 +53,7 @@ public class ThinPlateSplineShapeTransformer : ShapeTransformer
             ThrowIfDisposed();
             NativeMethods.HandleException(
                 NativeMethods.shape_ThinPlateSplineShapeTransformer_setRegularizationParameter(
-                    RawPtr, value));
-            GC.KeepAlive(this);
+                    Handle, value));
         }
     }
 
@@ -67,7 +65,6 @@ public class ThinPlateSplineShapeTransformer : ShapeTransformer
     {
         NativeMethods.HandleException(
             NativeMethods.shape_Ptr_ThinPlateSplineShapeTransformer_upcast(SmartPtr, out var basePtr));
-        GC.KeepAlive(this);
         return basePtr;
     }
 

--- a/src/OpenCvSharp/Modules/stereo/StereoBM.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoBM.cs
@@ -44,16 +44,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getPreFilterType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getPreFilterType(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setPreFilterType(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setPreFilterType(Handle, value));
         }
     }
 
@@ -66,16 +64,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getPreFilterSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getPreFilterSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setPreFilterSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setPreFilterSize(Handle, value));
         }
     }
 
@@ -88,16 +84,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getPreFilterCap(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getPreFilterCap(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setPreFilterCap(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setPreFilterCap(Handle, value));
         }
     }
 
@@ -110,16 +104,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getTextureThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getTextureThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setTextureThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setTextureThreshold(Handle, value));
         }
     }
 
@@ -132,16 +124,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getUniquenessRatio(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getUniquenessRatio(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setUniquenessRatio(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setUniquenessRatio(Handle, value));
         }
     }
 
@@ -154,16 +144,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getSmallerBlockSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getSmallerBlockSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setSmallerBlockSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setSmallerBlockSize(Handle, value));
         }
     }
 
@@ -176,16 +164,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getROI1(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getROI1(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setROI1(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setROI1(Handle, value));
         }
     }
 
@@ -198,16 +184,14 @@ public class StereoBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_getROI2(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_getROI2(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoBM_setROI2(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoBM_setROI2(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/stereo/StereoMatcher.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoMatcher.cs
@@ -36,9 +36,8 @@ public class StereoMatcher : Algorithm
         disparity.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.stereo_StereoMatcher_compute(RawPtr, left.CvPtr, right.CvPtr, disparity.CvPtr));
+            NativeMethods.stereo_StereoMatcher_compute(Handle, left.CvPtr, right.CvPtr, disparity.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(left);
         GC.KeepAlive(right);
         disparity.Fix();
@@ -52,15 +51,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getMinDisparity(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getMinDisparity(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setMinDisparity(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setMinDisparity(Handle, value));
         }
     }
 
@@ -72,15 +69,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getNumDisparities(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getNumDisparities(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setNumDisparities(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setNumDisparities(Handle, value));
         }
     }
 
@@ -92,15 +87,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getBlockSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getBlockSize(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setBlockSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setBlockSize(Handle, value));
         }
     }
 
@@ -112,15 +105,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getSpeckleWindowSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getSpeckleWindowSize(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setSpeckleWindowSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setSpeckleWindowSize(Handle, value));
         }
     }
 
@@ -132,15 +123,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getSpeckleRange(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getSpeckleRange(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setSpeckleRange(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setSpeckleRange(Handle, value));
         }
     }
 
@@ -152,15 +141,13 @@ public class StereoMatcher : Algorithm
         get
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_getDisp12MaxDiff(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_getDisp12MaxDiff(Handle, out var ret));
             return ret;
         }
         set
         {
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoMatcher_setDisp12MaxDiff(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoMatcher_setDisp12MaxDiff(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
@@ -67,16 +67,14 @@ public class StereoSGBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_getPreFilterCap(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_getPreFilterCap(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_setPreFilterCap(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_setPreFilterCap(Handle, value));
         }
     }
 
@@ -91,16 +89,14 @@ public class StereoSGBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_getUniquenessRatio(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_getUniquenessRatio(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_setUniquenessRatio(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_setUniquenessRatio(Handle, value));
         }
     }
 
@@ -113,16 +109,14 @@ public class StereoSGBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_getP1(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_getP1(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_setP1(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_setP1(Handle, value));
         }
     }
 
@@ -140,16 +134,14 @@ public class StereoSGBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_getP2(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_getP2(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_setP2(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_setP2(Handle, value));
         }
     }
 
@@ -164,16 +156,14 @@ public class StereoSGBM : StereoMatcher
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_getMode(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_getMode(Handle, out var ret));
             return (StereoSGBMMode)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.stereo_StereoSGBM_setMode(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.stereo_StereoSGBM_setMode(Handle, (int)value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/superres/BroxOpticalFlow.cs
+++ b/src/OpenCvSharp/Modules/superres/BroxOpticalFlow.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -45,16 +45,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getAlpha(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getAlpha(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setAlpha(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setAlpha(Handle, value));
         }
     }
 
@@ -67,16 +65,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getGamma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getGamma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setGamma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setGamma(Handle, value));
         }
     }
 
@@ -89,16 +85,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getScaleFactor(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getScaleFactor(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setScaleFactor(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setScaleFactor(Handle, value));
         }
     }
 
@@ -111,16 +105,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getInnerIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getInnerIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setInnerIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setInnerIterations(Handle, value));
         }
     }
 
@@ -133,16 +125,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getOuterIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getOuterIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setOuterIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setOuterIterations(Handle, value));
         }
     }
 
@@ -155,16 +145,14 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_getSolverIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_getSolverIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_BroxOpticalFlow_setSolverIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_BroxOpticalFlow_setSolverIterations(Handle, value));
         }
     }
         

--- a/src/OpenCvSharp/Modules/superres/DenseOpticalFlowExt.cs
+++ b/src/OpenCvSharp/Modules/superres/DenseOpticalFlowExt.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -90,8 +90,7 @@ public abstract class DenseOpticalFlowExt : Algorithm
     public virtual void CollectGarbage()
     {
         NativeMethods.HandleException(
-            NativeMethods.superres_DenseOpticalFlowExt_collectGarbage(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.superres_DenseOpticalFlowExt_collectGarbage(Handle));
     }
 
     /// <summary>
@@ -116,9 +115,8 @@ public abstract class DenseOpticalFlowExt : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.superres_DenseOpticalFlowExt_calc(
-                RawPtr, frame0.CvPtr, frame1.CvPtr, flow1.CvPtr, Cv2.ToPtr(flow2)));
+                Handle, frame0.CvPtr, frame1.CvPtr, flow1.CvPtr, Cv2.ToPtr(flow2)));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(frame0);
         GC.KeepAlive(frame1);
         GC.KeepAlive(flow1);

--- a/src/OpenCvSharp/Modules/superres/DualTVL1OpticalFlow.cs
+++ b/src/OpenCvSharp/Modules/superres/DualTVL1OpticalFlow.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -44,16 +44,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getTau(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getTau(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setTau(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setTau(Handle, value));
         }
     }
 
@@ -66,16 +64,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getLambda(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getLambda(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setLambda(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setLambda(Handle, value));
         }
     }
 
@@ -88,16 +84,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getTheta(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getTheta(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setTheta(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setTheta(Handle, value));
         }
     }
 
@@ -110,16 +104,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getScalesNumber(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getScalesNumber(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setScalesNumber(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setScalesNumber(Handle, value));
         }
     }
 
@@ -133,16 +125,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
             ThrowIfDisposed();
 
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getWarpingsNumber(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getWarpingsNumber(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setWarpingsNumber(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setWarpingsNumber(Handle, value));
         }
     }
 
@@ -155,16 +145,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getEpsilon(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getEpsilon(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setEpsilon(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setEpsilon(Handle, value));
         }
     }
 
@@ -177,16 +165,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setIterations(Handle, value));
         }
     }
 
@@ -200,16 +186,14 @@ public class DualTVL1OpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_getUseInitialFlow(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_getUseInitialFlow(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_DualTVL1OpticalFlow_setUseInitialFlow(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.superres_DualTVL1OpticalFlow_setUseInitialFlow(Handle, value ? 1 : 0));
         }
     }
         

--- a/src/OpenCvSharp/Modules/superres/FarnebackOpticalFlow.cs
+++ b/src/OpenCvSharp/Modules/superres/FarnebackOpticalFlow.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -44,16 +44,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getPyrScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getPyrScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setPyrScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setPyrScale(Handle, value));
         }
     }
 
@@ -66,16 +64,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getLevelsNumber(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getLevelsNumber(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setLevelsNumber(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setLevelsNumber(Handle, value));
         }
     }
 
@@ -88,16 +84,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getWindowSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getWindowSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setWindowSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setWindowSize(Handle, value));
         }
     }
 
@@ -110,16 +104,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setIterations(Handle, value));
         }
     }
 
@@ -132,16 +124,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getPolyN(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getPolyN(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setPolyN(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setPolyN(Handle, value));
         }
     }
 
@@ -154,16 +144,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getPolySigma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getPolySigma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setPolySigma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setPolySigma(Handle, value));
         }
     }
 
@@ -176,16 +164,14 @@ public class FarnebackOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_getFlags(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_getFlags(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_FarnebackOpticalFlow_setFlags(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_FarnebackOpticalFlow_setFlags(Handle, value));
         }
     }
         

--- a/src/OpenCvSharp/Modules/superres/FrameSource.cs
+++ b/src/OpenCvSharp/Modules/superres/FrameSource.cs
@@ -96,10 +96,9 @@ public class FrameSource : CvPtrObject
         frame.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.superres_FrameSource_nextFrame(RawPtr, frame.CvPtr));
+            NativeMethods.superres_FrameSource_nextFrame(Handle, frame.CvPtr));
 
         frame.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(frame);
     }
 
@@ -110,8 +109,7 @@ public class FrameSource : CvPtrObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.superres_FrameSource_reset(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.superres_FrameSource_reset(Handle));
     }
 
     #endregion

--- a/src/OpenCvSharp/Modules/superres/PyrLKOpticalFlow.cs
+++ b/src/OpenCvSharp/Modules/superres/PyrLKOpticalFlow.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -44,16 +44,14 @@ public class PyrLKOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_getWindowSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_getWindowSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_setWindowSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_setWindowSize(Handle, value));
         }
     }
 
@@ -66,16 +64,14 @@ public class PyrLKOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_getMaxLevel(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_getMaxLevel(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_setMaxLevel(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_setMaxLevel(Handle, value));
         }
     }
 
@@ -88,16 +84,14 @@ public class PyrLKOpticalFlow : DenseOpticalFlowExt
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_PyrLKOpticalFlow_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_PyrLKOpticalFlow_setIterations(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/superres/SuperResolution.cs
+++ b/src/OpenCvSharp/Modules/superres/SuperResolution.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
@@ -69,8 +69,7 @@ public class SuperResolution : Algorithm
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.superres_SuperResolution_setInput(RawPtr, fs.SmartPtr));
-        GC.KeepAlive(this);
+            NativeMethods.superres_SuperResolution_setInput(Handle, fs.SmartPtr));
         GC.KeepAlive(fs);
     }
 
@@ -86,9 +85,8 @@ public class SuperResolution : Algorithm
         frame.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.superres_SuperResolution_nextFrame(RawPtr, frame.CvPtr));
+            NativeMethods.superres_SuperResolution_nextFrame(Handle, frame.CvPtr));
         frame.Fix();
-        GC.KeepAlive(this);
         GC.KeepAlive(frame);
     }
         
@@ -98,8 +96,7 @@ public class SuperResolution : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.superres_SuperResolution_reset(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.superres_SuperResolution_reset(Handle));
     }
 
     /// <summary>
@@ -109,8 +106,7 @@ public class SuperResolution : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.superres_SuperResolution_collectGarbage(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.superres_SuperResolution_collectGarbage(Handle));
     }
         
     /// <summary>
@@ -141,16 +137,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getScale(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getScale(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setScale(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setScale(Handle, value));
         }
     }
 
@@ -163,16 +157,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setIterations(Handle, value));
         }
     }
 
@@ -185,16 +177,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getTau(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getTau(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setTau(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setTau(Handle, value));
         }
     }
 
@@ -207,16 +197,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getLambda(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getLambda(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setLambda(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setLambda(Handle, value));
         }
     }
 
@@ -229,16 +217,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getAlpha(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getAlpha(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setAlpha(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setAlpha(Handle, value));
         }
     }
 
@@ -251,16 +237,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getKernelSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getKernelSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setKernelSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setKernelSize(Handle, value));
         }
     }
 
@@ -273,16 +257,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getBlurKernelSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getBlurKernelSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setBlurKernelSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setBlurKernelSize(Handle, value));
         }
     }
 
@@ -295,16 +277,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getBlurSigma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getBlurSigma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setBlurSigma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setBlurSigma(Handle, value));
         }
     }
 
@@ -317,16 +297,14 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_getTemporalAreaRadius(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_getTemporalAreaRadius(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.superres_SuperResolution_setTemporalAreaRadius(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.superres_SuperResolution_setTemporalAreaRadius(Handle, value));
         }
     }
 
@@ -341,13 +319,11 @@ public class SuperResolution : Algorithm
         {
             ThrowIfDisposed();
             var res = NativeMethods.superres_SuperResolution_getOpticalFlow(CvPtr);
-            GC.KeepAlive(this);
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.superres_SuperResolution_setOpticalFlow(CvPtr, value);
-            GC.KeepAlive(this);
         }
     }
     */

--- a/src/OpenCvSharp/Modules/video/BackgroundSubtractorKNN.cs
+++ b/src/OpenCvSharp/Modules/video/BackgroundSubtractorKNN.cs
@@ -45,16 +45,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getHistory(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getHistory(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setHistory(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setHistory(Handle, value));
         }
     }
 
@@ -67,16 +65,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getNSamples(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getNSamples(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setNSamples(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setNSamples(Handle, value));
         }
     }
 
@@ -90,16 +86,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getDist2Threshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getDist2Threshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setDist2Threshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setDist2Threshold(Handle, value));
         }
     }
 
@@ -114,16 +108,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getkNNSamples(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getkNNSamples(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setkNNSamples(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setkNNSamples(Handle, value));
         }
     }
 
@@ -137,16 +129,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getDetectShadows(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getDetectShadows(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setDetectShadows(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setDetectShadows(Handle, value ? 1 : 0));
         }
     }
 
@@ -161,16 +151,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getShadowValue(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getShadowValue(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setShadowValue(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setShadowValue(Handle, value));
         }
     }
 
@@ -187,16 +175,14 @@ public class BackgroundSubtractorKNN : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_getShadowThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_getShadowThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorKNN_setShadowThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorKNN_setShadowThreshold(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/video/BackgroundSubtractorMog2.cs
+++ b/src/OpenCvSharp/Modules/video/BackgroundSubtractorMog2.cs
@@ -47,16 +47,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getHistory(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getHistory(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setHistory(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setHistory(Handle, value));
         }
     }
 
@@ -69,16 +67,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getNMixtures(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getNMixtures(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setNMixtures(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setNMixtures(Handle, value));
         }
     }
 
@@ -94,16 +90,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getBackgroundRatio(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getBackgroundRatio(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setBackgroundRatio(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setBackgroundRatio(Handle, value));
         }
     }
 
@@ -118,16 +112,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getVarThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getVarThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setVarThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setVarThreshold(Handle, value));
         }
     }
 
@@ -144,16 +136,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getVarThresholdGen(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getVarThresholdGen(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setVarThresholdGen(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setVarThresholdGen(Handle, value));
         }
     }
 
@@ -166,16 +156,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getVarInit(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getVarInit(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setVarInit(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setVarInit(Handle, value));
         }
     }
 
@@ -188,16 +176,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getVarMin(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getVarMin(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setVarMin(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setVarMin(Handle, value));
         }
     }
 
@@ -210,16 +196,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getVarMax(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getVarMax(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setVarMax(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setVarMax(Handle, value));
         }
     }
 
@@ -234,16 +218,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getComplexityReductionThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getComplexityReductionThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setComplexityReductionThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setComplexityReductionThreshold(Handle, value));
         }
     }
 
@@ -257,16 +239,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getDetectShadows(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getDetectShadows(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setDetectShadows(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setDetectShadows(Handle, value ? 1 : 0));
         }
     }
 
@@ -281,16 +261,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getShadowValue(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getShadowValue(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setShadowValue(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setShadowValue(Handle, value));
         }
     }
 
@@ -307,16 +285,14 @@ public class BackgroundSubtractorMOG2 : BackgroundSubtractor
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_getShadowThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_getShadowThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_BackgroundSubtractorMOG2_setShadowThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.video_BackgroundSubtractorMOG2_setShadowThreshold(Handle, value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/video/KalmanFilter.cs
+++ b/src/OpenCvSharp/Modules/video/KalmanFilter.cs
@@ -60,8 +60,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_statePre(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_statePre(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -84,8 +83,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_statePost(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_statePost(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -108,8 +106,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_transitionMatrix(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_transitionMatrix(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -132,8 +129,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_controlMatrix(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_controlMatrix(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -156,8 +152,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_measurementMatrix(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_measurementMatrix(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -180,8 +175,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_processNoiseCov(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_processNoiseCov(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -204,8 +198,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_measurementNoiseCov(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_measurementNoiseCov(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -228,8 +221,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_errorCovPre(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_errorCovPre(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -252,8 +244,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_gain(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_gain(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -276,8 +267,7 @@ public class KalmanFilter : CvObject
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.video_KalmanFilter_errorCovPost(CvPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.video_KalmanFilter_errorCovPost(Handle, out var ret));
             return new Mat(ret, ownsHandle: false, owner: this);
         }
         set
@@ -307,8 +297,7 @@ public class KalmanFilter : CvObject
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.video_KalmanFilter_init(
-                CvPtr, dynamParams, measureParams, controlParams, type));
-        GC.KeepAlive(this);
+                Handle, dynamParams, measureParams, controlParams, type));
     }
 
     /// <summary>
@@ -321,8 +310,7 @@ public class KalmanFilter : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_KalmanFilter_predict(CvPtr, Cv2.ToPtr(control), out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.video_KalmanFilter_predict(Handle, Cv2.ToPtr(control), out var ret));
         GC.KeepAlive(control);
         return new Mat(ret);
     }
@@ -340,8 +328,7 @@ public class KalmanFilter : CvObject
         measurement.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_KalmanFilter_correct(CvPtr, measurement.CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.video_KalmanFilter_correct(Handle, measurement.CvPtr, out var ret));
         GC.KeepAlive(measurement);
         return new Mat(ret);
     }

--- a/src/OpenCvSharp/Modules/xfeatures2d/AKAZE.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/AKAZE.cs
@@ -66,16 +66,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getDescriptorType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getDescriptorType(Handle, out var ret));
             return (AKAZEDescriptorType)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setDescriptorType(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setDescriptorType(Handle, (int)value));
         }
     }
 
@@ -89,16 +87,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getDescriptorSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getDescriptorSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setDescriptorSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setDescriptorSize(Handle, value));
         }
     }
 
@@ -112,16 +108,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getDescriptorChannels(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getDescriptorChannels(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setDescriptorChannels(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setDescriptorChannels(Handle, value));
         }
     }
 
@@ -134,16 +128,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setThreshold(Handle, value));
         }
     }
 
@@ -156,16 +148,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getNOctaves(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getNOctaves(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setNOctaves(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setNOctaves(Handle, value));
         }
     }
 
@@ -178,16 +168,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getNOctaveLayers(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getNOctaveLayers(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setNOctaveLayers(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setNOctaveLayers(Handle, value));
         }
     }
 
@@ -200,16 +188,14 @@ public class AKAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_getDiffusivity(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_getDiffusivity(Handle, out var ret));
             return (KAZEDiffusivityType)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AKAZE_setDiffusivity(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AKAZE_setDiffusivity(Handle, (int)value));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/AgastFeatureDetector.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/AgastFeatureDetector.cs
@@ -47,16 +47,14 @@ public class AgastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_getThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_getThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_setThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_setThreshold(Handle, value));
         }
     }
 
@@ -69,16 +67,14 @@ public class AgastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_getNonmaxSuppression(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_getNonmaxSuppression(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_setNonmaxSuppression(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_setNonmaxSuppression(Handle, value));
         }
     }
 
@@ -91,16 +87,14 @@ public class AgastFeatureDetector : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_getType(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_getType(Handle, out var ret));
             return (DetectorType)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_AgastFeatureDetector_setType(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_AgastFeatureDetector_setType(Handle, (int)value));
         }
     }
 

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWImgDescriptorExtractor.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWImgDescriptorExtractor.cs
@@ -66,8 +66,7 @@ public class BOWImgDescriptorExtractor : CvObject
         if (vocabulary is null)
             throw new ArgumentNullException(nameof(vocabulary));
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(CvPtr, vocabulary.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(Handle, vocabulary.CvPtr));
         GC.KeepAlive(vocabulary);
     }
 
@@ -79,8 +78,7 @@ public class BOWImgDescriptorExtractor : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_getVocabulary(CvPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_getVocabulary(Handle, out var p));
         return new Mat(p);
     }
 
@@ -106,12 +104,11 @@ public class BOWImgDescriptorExtractor : CvObject
         using (var pointIdxsOfClustersVec = new VectorOfVectorInt32())
         {
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_compute11(CvPtr, image.CvPtr, keypointsVec.CvPtr, 
+                NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_compute11(Handle, image.CvPtr, keypointsVec.CvPtr, 
                     imgDescriptor.CvPtr, pointIdxsOfClustersVec.CvPtr, Cv2.ToPtr(descriptors)));
             keypoints = keypointsVec.ToArray();
             pointIdxsOfClusters = pointIdxsOfClustersVec.ToArray();
         }
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(imgDescriptor);
         GC.KeepAlive(descriptors);
@@ -136,10 +133,9 @@ public class BOWImgDescriptorExtractor : CvObject
         {
             NativeMethods.HandleException(
                 NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_compute12(
-                    CvPtr, keypointDescriptors.CvPtr, imgDescriptor.CvPtr, pointIdxsOfClustersVec.CvPtr));
+                    Handle, keypointDescriptors.CvPtr, imgDescriptor.CvPtr, pointIdxsOfClustersVec.CvPtr));
             pointIdxsOfClusters = pointIdxsOfClustersVec.ToArray();
         }
-        GC.KeepAlive(this);
         GC.KeepAlive(keypointDescriptors);
         GC.KeepAlive(imgDescriptor);
     }
@@ -162,10 +158,9 @@ public class BOWImgDescriptorExtractor : CvObject
         {
             NativeMethods.HandleException(
                 NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_compute2(
-                    CvPtr, image.CvPtr, keypointsVec.CvPtr, imgDescriptor.CvPtr));
+                    Handle, image.CvPtr, keypointsVec.CvPtr, imgDescriptor.CvPtr));
             keypoints = keypointsVec.ToArray();
         }
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         GC.KeepAlive(imgDescriptor);
     }
@@ -178,8 +173,7 @@ public class BOWImgDescriptorExtractor : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_descriptorSize(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_descriptorSize(Handle, out var ret));
         return ret;
     }
 
@@ -191,8 +185,7 @@ public class BOWImgDescriptorExtractor : CvObject
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_descriptorType(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_descriptorType(Handle, out var ret));
         return ret;
     }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWKMeansTrainer.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWKMeansTrainer.cs
@@ -43,8 +43,7 @@ public class BOWKMeansTrainer : BOWTrainer
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWKMeansTrainer_cluster1(CvPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWKMeansTrainer_cluster1(Handle, out var p));
         return new Mat(p);
     }
 
@@ -63,8 +62,7 @@ public class BOWKMeansTrainer : BOWTrainer
         descriptors.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWKMeansTrainer_cluster2(CvPtr, descriptors.CvPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWKMeansTrainer_cluster2(Handle, descriptors.CvPtr, out var p));
         GC.KeepAlive(descriptors);
         return new Mat(p);
     }

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWTrainer.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWTrainer.cs
@@ -20,8 +20,7 @@ public abstract class BOWTrainer : CvObject
         if (descriptors is null)
             throw new ArgumentNullException(nameof(descriptors));
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWTrainer_add(CvPtr, descriptors.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWTrainer_add(Handle, descriptors.CvPtr));
         GC.KeepAlive(descriptors);
     }
 
@@ -33,8 +32,7 @@ public abstract class BOWTrainer : CvObject
     {
         using var descriptors = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWTrainer_getDescriptors(CvPtr, descriptors.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWTrainer_getDescriptors(Handle, descriptors.CvPtr));
         return descriptors.ToArray();
     }
 
@@ -45,8 +43,7 @@ public abstract class BOWTrainer : CvObject
     public int DescriptorsCount()
     {
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWTrainer_descriptorsCount(CvPtr, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWTrainer_descriptorsCount(Handle, out var ret));
         return ret;
     }
 
@@ -56,8 +53,7 @@ public abstract class BOWTrainer : CvObject
     public virtual void Clear()
     {
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BOWTrainer_clear(CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.xfeatures2d_BOWTrainer_clear(Handle));
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/xfeatures2d/KAZE.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/KAZE.cs
@@ -48,16 +48,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getDiffusivity(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getDiffusivity(Handle, out var ret));
             return (KAZEDiffusivityType)ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setDiffusivity(RawPtr, (int)value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setDiffusivity(Handle, (int)value));
         }
     }
 
@@ -70,16 +68,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getExtended(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getExtended(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setExtended(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setExtended(Handle, value ? 1 : 0));
         }
     }
 
@@ -93,16 +89,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getNOctaveLayers(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getNOctaveLayers(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setNOctaveLayers(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setNOctaveLayers(Handle, value));
         }
     }
 
@@ -116,16 +110,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getNOctaves(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getNOctaves(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setNOctaves(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setNOctaves(Handle, value));
         }
     }
 
@@ -139,16 +131,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setThreshold(Handle, value));
         }
     }
 
@@ -162,16 +152,14 @@ public class KAZE : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_getUpright(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_getUpright(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_KAZE_setUpright(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_KAZE_setUpright(Handle, value ? 1 : 0));
         }
     }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/SURF.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/SURF.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 namespace OpenCvSharp.XFeatures2D;
 
@@ -53,16 +53,14 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_getHessianThreshold(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_getHessianThreshold(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_setHessianThreshold(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_setHessianThreshold(Handle, value));
         }
     }
 
@@ -76,16 +74,14 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_getNOctaves(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_getNOctaves(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_setNOctaves(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_setNOctaves(Handle, value));
         }
     }
 
@@ -98,16 +94,14 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_getNOctaveLayers(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_getNOctaveLayers(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_setNOctaveLayers(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_setNOctaveLayers(Handle, value));
         }
     }
 
@@ -121,16 +115,14 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_getExtended(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_getExtended(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_setExtended(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_setExtended(Handle, value ? 1 : 0));
         }
     }
 
@@ -146,8 +138,7 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_getUpright(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_getUpright(Handle, out var ret));
             return ret != 0;
 
         }
@@ -155,8 +146,7 @@ public class SURF : Feature2D
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xfeatures2d_SURF_setUpright(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.xfeatures2d_SURF_setUpright(Handle, value ? 1 : 0));
         }
     }
 

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeBoxes.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeBoxes.cs
@@ -63,16 +63,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getAlpha(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getAlpha(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setAlpha(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setAlpha(Handle, value));
         }
     }
 
@@ -85,16 +83,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getBeta(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getBeta(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setBeta(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setBeta(Handle, value));
         }
     }
 
@@ -107,16 +103,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getEta(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getEta(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setEta(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setEta(Handle, value));
         }
     }
 
@@ -129,16 +123,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getMinScore(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getMinScore(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setMinScore(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setMinScore(Handle, value));
         }
     }
 
@@ -151,16 +143,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getMaxBoxes(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getMaxBoxes(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setMaxBoxes(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setMaxBoxes(Handle, value));
         }
     }
 
@@ -173,16 +163,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getEdgeMinMag(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getEdgeMinMag(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setEdgeMinMag(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setEdgeMinMag(Handle, value));
         }
     }
 
@@ -195,16 +183,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getEdgeMergeThr(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getEdgeMergeThr(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setEdgeMergeThr(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setEdgeMergeThr(Handle, value));
         }
     }
 
@@ -217,16 +203,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getClusterMinMag(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getClusterMinMag(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setClusterMinMag(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setClusterMinMag(Handle, value));
         }
     }
 
@@ -239,16 +223,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getMaxAspectRatio(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getMaxAspectRatio(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setMaxAspectRatio(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setMaxAspectRatio(Handle, value));
         }
     }
 
@@ -261,16 +243,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getMinBoxArea(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getMinBoxArea(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setMinBoxArea(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setMinBoxArea(Handle, value));
         }
     }
 
@@ -283,16 +263,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getGamma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getGamma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setGamma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setGamma(Handle, value));
         }
     }
 
@@ -305,16 +283,14 @@ public class EdgeBoxes : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_getKappa(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_getKappa(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_EdgeBoxes_setKappa(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_EdgeBoxes_setKappa(Handle, value));
         }
     }
 
@@ -337,10 +313,9 @@ public class EdgeBoxes : Algorithm
         using var boxesVec = new StdVector<Rect>();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(
-                RawPtr, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
+                Handle, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
         boxes = boxesVec.ToArray();
 
-        GC.KeepAlive(this);
         GC.KeepAlive(edgeMap);
         GC.KeepAlive(orientationMap);
     }

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
@@ -135,8 +135,7 @@ public class EdgeDrawing : Algorithm
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectEdges(RawPtr, src.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_detectEdges(Handle, src.CvPtr));
         GC.KeepAlive(src);
     }
 
@@ -152,8 +151,7 @@ public class EdgeDrawing : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getEdgeImage(RawPtr, dst.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_getEdgeImage(Handle, dst.CvPtr));
         dst.Fix();
     }
 
@@ -169,8 +167,7 @@ public class EdgeDrawing : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getGradientImage(RawPtr, dst.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_getGradientImage(Handle, dst.CvPtr));
         dst.Fix();
     }
 
@@ -184,8 +181,7 @@ public class EdgeDrawing : Algorithm
 
         using var segments = new VectorOfVectorPoint();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getSegments(RawPtr, segments.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_getSegments(Handle, segments.CvPtr));
         return segments.ToArray();
     }
 
@@ -200,8 +196,7 @@ public class EdgeDrawing : Algorithm
 
         using var indices = new StdVector<int>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getSegmentIndicesOfLines(RawPtr, indices.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_getSegmentIndicesOfLines(Handle, indices.CvPtr));
         return indices.ToArray();
     }
 
@@ -218,8 +213,7 @@ public class EdgeDrawing : Algorithm
         lines.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectLines(RawPtr, lines.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_detectLines(Handle, lines.CvPtr));
         lines.Fix();
     }
 
@@ -234,8 +228,7 @@ public class EdgeDrawing : Algorithm
 
         using var lines = new StdVector<Vec4f>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectLines_vector(RawPtr, lines.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_detectLines_vector(Handle, lines.CvPtr));
         return lines.ToArray();
     }
 
@@ -255,8 +248,7 @@ public class EdgeDrawing : Algorithm
         ellipses.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectEllipses(RawPtr, ellipses.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_detectEllipses(Handle, ellipses.CvPtr));
         ellipses.Fix();
     }
 
@@ -274,8 +266,7 @@ public class EdgeDrawing : Algorithm
 
         using var ellipses = new StdVector<Vec6d>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectEllipses_vector(RawPtr, ellipses.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_detectEllipses_vector(Handle, ellipses.CvPtr));
         return ellipses.ToArray();
     }
 
@@ -287,8 +278,7 @@ public class EdgeDrawing : Algorithm
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getParams(RawPtr, out var p));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_getParams(Handle, out var p));
         return new EdgeDrawingParams(p);
     }
 
@@ -304,7 +294,6 @@ public class EdgeDrawing : Algorithm
 
         var native = parameters.ToNative();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_setParams(RawPtr, ref native));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_EdgeDrawing_setParams(Handle, ref native));
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/AdaptiveManifoldFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/AdaptiveManifoldFilter.cs
@@ -62,16 +62,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getSigmaS(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getSigmaS(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setSigmaS(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setSigmaS(Handle, value));
         }
     }
 
@@ -84,16 +82,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getSigmaR(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getSigmaR(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setSigmaR(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setSigmaR(Handle, value));
         }
     }
 
@@ -106,16 +102,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getTreeHeight(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getTreeHeight(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setTreeHeight(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setTreeHeight(Handle, value));
         }
     }
 
@@ -128,16 +122,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getPCAIterations(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getPCAIterations(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setPCAIterations(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setPCAIterations(Handle, value));
         }
     }
 
@@ -150,16 +142,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getAdjustOutliers(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getAdjustOutliers(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setAdjustOutliers(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setAdjustOutliers(Handle, value ? 1 : 0));
         }
     }
 
@@ -172,16 +162,14 @@ public class AdaptiveManifoldFilter : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_getUseRNG(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_getUseRNG(Handle, out var ret));
             return ret != 0;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_AdaptiveManifoldFilter_setUseRNG(RawPtr, value ? 1 : 0));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_AdaptiveManifoldFilter_setUseRNG(Handle, value ? 1 : 0));
         }
     }
 
@@ -206,9 +194,8 @@ public class AdaptiveManifoldFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_AdaptiveManifoldFilter_filter(
-                RawPtr, src.CvPtr, dst.CvPtr, joint?.CvPtr ?? IntPtr.Zero));
+                Handle, src.CvPtr, dst.CvPtr, joint?.CvPtr ?? IntPtr.Zero));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
         GC.KeepAlive(joint);

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/DTFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/DTFilter.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -66,9 +66,8 @@ public class DTFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_DTFilter_filter(
-                RawPtr, src.CvPtr, dst.CvPtr, dDepth));
+                Handle, src.CvPtr, dst.CvPtr, dDepth));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastBilateralSolverFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastBilateralSolverFilter.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -66,9 +66,8 @@ public class FastBilateralSolverFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastBilateralSolverFilter_filter(
-                RawPtr, src.CvPtr, confidence.CvPtr, dst.CvPtr));
+                Handle, src.CvPtr, confidence.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(confidence);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastGlobalSmootherFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastGlobalSmootherFilter.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -60,9 +60,8 @@ public class FastGlobalSmootherFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastGlobalSmootherFilter_filter(
-                RawPtr, src.CvPtr, dst.CvPtr));
+                Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/GuidedFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/GuidedFilter.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -60,9 +60,8 @@ public class GuidedFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_GuidedFilter_filter(
-                RawPtr, src.CvPtr, dst.CvPtr, dDepth));
+                Handle, src.CvPtr, dst.CvPtr, dDepth));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }

--- a/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
@@ -59,8 +59,7 @@ public class FastLineDetector : Algorithm
         lines.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_detect_OutputArray(RawPtr, image.CvPtr, lines.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_FastLineDetector_detect_OutputArray(Handle, image.CvPtr, lines.CvPtr));
         GC.KeepAlive(image);
         GC.KeepAlive(lines);
         lines.Fix();
@@ -86,8 +85,7 @@ public class FastLineDetector : Algorithm
 
         using var lines = new StdVector<Vec4f>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_detect_vector(RawPtr, image.CvPtr, lines.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_FastLineDetector_detect_vector(Handle, image.CvPtr, lines.CvPtr));
         GC.KeepAlive(image);
         return lines.ToArray();
     }
@@ -108,8 +106,7 @@ public class FastLineDetector : Algorithm
             throw new ArgumentNullException(nameof(lines));
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_drawSegments_InputArray(RawPtr, image.CvPtr, lines.CvPtr, drawArrow ? 1 : 0));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_FastLineDetector_drawSegments_InputArray(Handle, image.CvPtr, lines.CvPtr, drawArrow ? 1 : 0));
         GC.KeepAlive(image);
         image.Fix();
         GC.KeepAlive(lines);
@@ -132,9 +129,8 @@ public class FastLineDetector : Algorithm
         using var linesVec = new StdVector<Vec4f>(lines);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastLineDetector_drawSegments_vector(
-                RawPtr, image.CvPtr, linesVec.CvPtr, drawArrow ? 1 : 0));
+                Handle, image.CvPtr, linesVec.CvPtr, drawArrow ? 1 : 0));
             
-        GC.KeepAlive(this);
         GC.KeepAlive(image);
         image.Fix();
     }

--- a/src/OpenCvSharp/Modules/ximgproc/RFFeatureGetter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/RFFeatureGetter.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable UnusedMember.Global
 
@@ -64,9 +64,8 @@ public class RFFeatureGetter : Algorithm
             
         NativeMethods.HandleException(
             NativeMethods.ximgproc_RFFeatureGetter_getFeatures(
-                RawPtr, src.CvPtr, features.CvPtr, gnrmRad, gsmthRad, shrink, outNum, gradNum));
+                Handle, src.CvPtr, features.CvPtr, gnrmRad, gsmthRad, shrink, outNum, gradNum));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(features);
     }

--- a/src/OpenCvSharp/Modules/ximgproc/RidgeDetectionFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/RidgeDetectionFilter.cs
@@ -65,7 +65,6 @@ public class RidgeDetectionFilter : Algorithm
             throw new ArgumentNullException(nameof(dst));
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(RawPtr, src.CvPtr, dst.CvPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(Handle, src.CvPtr, dst.CvPtr));
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/GraphSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/GraphSegmentation.cs
@@ -43,16 +43,14 @@ public class GraphSegmentation : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_getSigma(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_getSigma(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_setSigma(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_setSigma(Handle, value));
         }
     }
 
@@ -65,16 +63,14 @@ public class GraphSegmentation : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_getK(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_getK(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_setK(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_setK(Handle, value));
         }
     }
 
@@ -87,16 +83,14 @@ public class GraphSegmentation : Algorithm
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_getMinSize(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_getMinSize(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_segmentation_GraphSegmentation_setMinSize(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.ximgproc_segmentation_GraphSegmentation_setMinSize(Handle, value));
         }
     }
 
@@ -116,9 +110,8 @@ public class GraphSegmentation : Algorithm
         dst.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_GraphSegmentation_processImage(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_segmentation_GraphSegmentation_processImage(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
     }

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
@@ -41,9 +41,8 @@ public class SelectiveSearchSegmentation : Algorithm
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(RawPtr, img.CvPtr));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(Handle, img.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(img);
     }
 
@@ -56,8 +55,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(RawPtr, k, sigma));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(Handle, k, sigma));
     }
 
     /// <summary>
@@ -70,8 +68,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchFast(RawPtr, baseK, incK, sigma));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchFast(Handle, baseK, incK, sigma));
     }
 
     /// <summary>
@@ -84,8 +81,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchQuality(RawPtr, baseK, incK, sigma));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchQuality(Handle, baseK, incK, sigma));
     }
 
     /// <summary>
@@ -100,9 +96,8 @@ public class SelectiveSearchSegmentation : Algorithm
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addImage(RawPtr, img.CvPtr));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addImage(Handle, img.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(img);
     }
 
@@ -113,8 +108,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(Handle));
     }
 
     /// <summary>
@@ -132,9 +126,8 @@ public class SelectiveSearchSegmentation : Algorithm
             throw new ArgumentException("PtrObj is zero", nameof(g));
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(RawPtr, g.PtrObj));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(Handle, g.PtrObj));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(g);
     }
 
@@ -145,8 +138,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearGraphSegmentations(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearGraphSegmentations(Handle));
     }
 
     /// <summary>
@@ -163,9 +155,8 @@ public class SelectiveSearchSegmentation : Algorithm
             throw new ArgumentException("s.PtrObj is zero");
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(RawPtr, s.PtrObj));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(Handle, s.PtrObj));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(s);
     }
 
@@ -176,8 +167,7 @@ public class SelectiveSearchSegmentation : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(RawPtr));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(Handle));
     }
 
     /// <summary>
@@ -190,10 +180,9 @@ public class SelectiveSearchSegmentation : Algorithm
 
         using var rectsVec = new StdVector<Rect>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_process(RawPtr, rectsVec.CvPtr));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_process(Handle, rectsVec.CvPtr));
         rects = rectsVec.ToArray();
 
-        GC.KeepAlive(this);
     }
 
     }

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategy.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategy.cs
@@ -46,9 +46,8 @@ public abstract class SelectiveSearchSegmentationStrategy : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
-                RawPtr, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
+                Handle, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(img);
         GC.KeepAlive(regions);
         GC.KeepAlive(sizes);
@@ -64,8 +63,7 @@ public abstract class SelectiveSearchSegmentationStrategy : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(RawPtr, r1, r2, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(Handle, r1, r2, out var ret));
         return ret;
     }
 
@@ -78,8 +76,7 @@ public abstract class SelectiveSearchSegmentationStrategy : Algorithm
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(RawPtr, r1, r2));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(Handle, r1, r2));
     }
 }
 

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using OpenCvSharp.Internal;
 
 namespace OpenCvSharp.XImgProc.Segmentation;
@@ -38,9 +38,8 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
-                RawPtr, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
+                Handle, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(img);
         GC.KeepAlive(regions);
         GC.KeepAlive(sizes);
@@ -56,8 +55,7 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(RawPtr, r1, r2, out var ret));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(Handle, r1, r2, out var ret));
         return ret;
     }
 
@@ -70,8 +68,7 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     {
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(RawPtr, r1, r2));
-        GC.KeepAlive(this);
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(Handle, r1, r2));
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/ximgproc/StructuredEdgeDetection.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/StructuredEdgeDetection.cs
@@ -51,10 +51,9 @@ public class StructuredEdgeDetection : Algorithm
 
         using var boxesVec = new StdVector<Rect>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(RawPtr, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
+            NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(Handle, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
         boxes = boxesVec.ToArray();
 
-        GC.KeepAlive(this);
         GC.KeepAlive(edgeMap);
         GC.KeepAlive(orientationMap);
     }
@@ -76,9 +75,8 @@ public class StructuredEdgeDetection : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_StructuredEdgeDetection_detectEdges(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_StructuredEdgeDetection_detectEdges(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }
@@ -99,9 +97,8 @@ public class StructuredEdgeDetection : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_StructuredEdgeDetection_computeOrientation(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_StructuredEdgeDetection_computeOrientation(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         dst.Fix();
     }
@@ -132,9 +129,8 @@ public class StructuredEdgeDetection : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_StructuredEdgeDetection_edgesNms(
-                RawPtr, edgeImage.CvPtr, orientationImage.CvPtr, dst.CvPtr, r, s, m, isParallel ? 1 : 0));
+                Handle, edgeImage.CvPtr, orientationImage.CvPtr, dst.CvPtr, r, s, m, isParallel ? 1 : 0));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(edgeImage);
         GC.KeepAlive(orientationImage);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelLSC.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelLSC.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -61,8 +61,7 @@ public class SuperpixelLSC : Algorithm
         ThrowIfDisposed(); 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_getNumberOfSuperpixels(
-                RawPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, out var ret));
         return ret;
     }
 
@@ -84,8 +83,7 @@ public class SuperpixelLSC : Algorithm
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_iterate(
-                RawPtr, numIterations));
-        GC.KeepAlive(this);
+                Handle, numIterations));
     }
 
     /// <summary>
@@ -106,8 +104,7 @@ public class SuperpixelLSC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_getLabels(
-                RawPtr, labelsOut.CvPtr));
-        GC.KeepAlive(this);
+                Handle, labelsOut.CvPtr));
         labelsOut.Fix();
     }
 
@@ -126,8 +123,7 @@ public class SuperpixelLSC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_getLabelContourMask(
-                RawPtr, image.CvPtr, thickLine ? 1 : 0));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, thickLine ? 1 : 0));
         image.Fix();
     }
 
@@ -144,7 +140,6 @@ public class SuperpixelLSC : Algorithm
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_enforceLabelConnectivity(
-                RawPtr, minElementSize));
-        GC.KeepAlive(this);
+                Handle, minElementSize));
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSEEDS.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSEEDS.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -77,8 +77,7 @@ public class SuperpixelSEEDS : Algorithm
         ThrowIfDisposed(); 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(
-                RawPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, out var ret));
         return ret;
     }
 
@@ -100,9 +99,8 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_iterate(
-                RawPtr, img.CvPtr, numIterations));
+                Handle, img.CvPtr, numIterations));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(img);
     }
 
@@ -124,8 +122,7 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_getLabels(
-                RawPtr, labelsOut.CvPtr));
-        GC.KeepAlive(this);
+                Handle, labelsOut.CvPtr));
         labelsOut.Fix();
     }
 
@@ -144,8 +141,7 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_getLabelContourMask(
-                RawPtr, image.CvPtr, thickLine ? 1 : 0));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, thickLine ? 1 : 0));
         image.Fix();
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSLIC.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSLIC.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace OpenCvSharp.XImgProc;
@@ -62,8 +62,7 @@ public class SuperpixelSLIC : Algorithm
         ThrowIfDisposed(); 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_getNumberOfSuperpixels(
-                RawPtr, out var ret));
-        GC.KeepAlive(this);
+                Handle, out var ret));
         return ret;
     }
 
@@ -85,8 +84,7 @@ public class SuperpixelSLIC : Algorithm
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_iterate(
-                RawPtr, numIterations));
-        GC.KeepAlive(this);
+                Handle, numIterations));
     }
 
     /// <summary>
@@ -106,8 +104,7 @@ public class SuperpixelSLIC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_getLabels(
-                RawPtr, labelsOut.CvPtr));
-        GC.KeepAlive(this);
+                Handle, labelsOut.CvPtr));
         labelsOut.Fix();
     }
 
@@ -126,8 +123,7 @@ public class SuperpixelSLIC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_getLabelContourMask(
-                RawPtr, image.CvPtr, thickLine ? 1 : 0));
-        GC.KeepAlive(this);
+                Handle, image.CvPtr, thickLine ? 1 : 0));
         image.Fix();
     }
 
@@ -145,8 +141,7 @@ public class SuperpixelSLIC : Algorithm
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
-                RawPtr, minElementSize));
-        GC.KeepAlive(this);
+                Handle, minElementSize));
     }
 
     }

--- a/src/OpenCvSharp/Modules/xphoto/GrayworldWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/GrayworldWB.cs
@@ -38,16 +38,14 @@ public class GrayworldWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_GrayworldWB_SaturationThreshold_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_GrayworldWB_SaturationThreshold_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_GrayworldWB_SaturationThreshold_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_GrayworldWB_SaturationThreshold_set(Handle, value));
         }
     }
 
@@ -66,9 +64,8 @@ public class GrayworldWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_GrayworldWB_balanceWhite(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_GrayworldWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/xphoto/LearningBasedWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/LearningBasedWB.cs
@@ -36,16 +36,14 @@ public class LearningBasedWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_HistBinNum_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_HistBinNum_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_HistBinNum_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_HistBinNum_set(Handle, value));
         }
     }
 
@@ -58,16 +56,14 @@ public class LearningBasedWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_RangeMaxVal_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_RangeMaxVal_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_RangeMaxVal_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_RangeMaxVal_set(Handle, value));
         }
     }
 
@@ -80,16 +76,14 @@ public class LearningBasedWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_SaturationThreshold_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_SaturationThreshold_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_LearningBasedWB_SaturationThreshold_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_LearningBasedWB_SaturationThreshold_set(Handle, value));
         }
     }
 
@@ -108,9 +102,8 @@ public class LearningBasedWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_LearningBasedWB_balanceWhite(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_LearningBasedWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         dst.Fix();
@@ -131,9 +124,8 @@ public class LearningBasedWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_LearningBasedWB_extractSimpleFeatures(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_LearningBasedWB_extractSimpleFeatures(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/xphoto/SimpleWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/SimpleWB.cs
@@ -36,16 +36,14 @@ public class SimpleWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_InputMax_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_InputMax_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_InputMax_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_InputMax_set(Handle, value));
         }
     }
 
@@ -58,16 +56,14 @@ public class SimpleWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_InputMin_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_InputMin_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_InputMin_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_InputMin_set(Handle, value));
         }
     }
 
@@ -80,16 +76,14 @@ public class SimpleWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_OutputMax_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_OutputMax_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_OutputMax_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_OutputMax_set(Handle, value));
         }
     }
 
@@ -102,16 +96,14 @@ public class SimpleWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_OutputMin_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_OutputMin_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_OutputMin_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_OutputMin_set(Handle, value));
         }
     }
 
@@ -124,16 +116,14 @@ public class SimpleWB : WhiteBalancer
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_P_get(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_P_get(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_SimpleWB_P_set(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_SimpleWB_P_set(Handle, value));
         }
     }
 
@@ -152,9 +142,8 @@ public class SimpleWB : WhiteBalancer
         dst.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.xphoto_SimpleWB_balanceWhite(RawPtr, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_SimpleWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
 
-        GC.KeepAlive(this);
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/xphoto/TonemapDurand.cs
+++ b/src/OpenCvSharp/Modules/xphoto/TonemapDurand.cs
@@ -1,4 +1,4 @@
-using OpenCvSharp.Internal;
+﻿using OpenCvSharp.Internal;
 
 // ReSharper disable UnusedMember.Global
 
@@ -51,16 +51,14 @@ public sealed class TonemapDurand : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_getSaturation(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_getSaturation(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_setSaturation(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_setSaturation(Handle, value));
         }
     }
 
@@ -73,16 +71,14 @@ public sealed class TonemapDurand : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_getContrast(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_getContrast(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_setContrast(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_setContrast(Handle, value));
         }
     }
 
@@ -95,16 +91,14 @@ public sealed class TonemapDurand : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_getSigmaSpace(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_getSigmaSpace(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_setSigmaSpace(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_setSigmaSpace(Handle, value));
         }
     }
 
@@ -117,16 +111,14 @@ public sealed class TonemapDurand : Tonemap
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_getSigmaColor(RawPtr, out var ret));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_getSigmaColor(Handle, out var ret));
             return ret;
         }
         set
         {
             ThrowIfDisposed();
             NativeMethods.HandleException(
-                NativeMethods.xphoto_TonemapDurand_setSigmaColor(RawPtr, value));
-            GC.KeepAlive(this);
+                NativeMethods.xphoto_TonemapDurand_setSigmaColor(Handle, value));
         }
     }
 }

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -9,6 +9,37 @@
 
 #ifndef _WINRT_DLL
 
+// Blittable POD view of the scalar fields of cv::face::FacemarkLBF::Params.
+// The std::string / std::vector members are marshalled separately.
+struct FacemarkLBFParamsData
+{
+    double shape_offset;
+    int verbose;
+    int n_landmarks;
+    int initShape_n;
+    int stages_n;
+    int tree_n;
+    int tree_depth;
+    double bagging_overlap;
+    int save_model;
+    uint32_t seed;
+    MyCvRect detectROI;
+};
+
+// Blittable POD view of the scalar fields of cv::face::FacemarkAAM::Params.
+// The model_filename / scales members are marshalled separately.
+struct FacemarkAAMParamsData
+{
+    int m;
+    int n;
+    int n_iter;
+    int verbose;
+    int save_model;
+    int max_m;
+    int max_n;
+    int texture_max_m;
+};
+
 #pragma region Facemark
 
 CVAPI(ExceptionStatus) face_Facemark_loadModel(cv::face::Facemark *obj, const char *model)
@@ -75,228 +106,65 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_delete(cv::face::FacemarkLBF::Par
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_shape_offset_get(cv::face::FacemarkLBF::Params *obj, double *returnValue)
+CVAPI(ExceptionStatus) face_FacemarkLBF_Params_getAll(
+    cv::face::FacemarkLBF::Params *obj,
+    FacemarkLBFParamsData *data,
+    std::string *cascadeFace,
+    std::string *modelFilename,
+    std::vector<int> *featsM,
+    std::vector<double> *radiusM,
+    std::vector<int> *pupils0,
+    std::vector<int> *pupils1)
 {
     BEGIN_WRAP
-    *returnValue = obj->shape_offset;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_shape_offset_set(cv::face::FacemarkLBF::Params *obj, double val)
-{
-    BEGIN_WRAP
-    obj->shape_offset = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_cascade_face_get(cv::face::FacemarkLBF::Params *obj, std::string *s)
-{
-    BEGIN_WRAP
-    s->assign(obj->cascade_face);
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_cascade_face_set(cv::face::FacemarkLBF::Params *obj, const char *s)
-{
-    BEGIN_WRAP
-     obj->cascade_face = s;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_verbose_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->verbose ? 1 : 0;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_verbose_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->verbose = (val != 0);
+    data->shape_offset = obj->shape_offset;
+    data->verbose = obj->verbose ? 1 : 0;
+    data->n_landmarks = obj->n_landmarks;
+    data->initShape_n = obj->initShape_n;
+    data->stages_n = obj->stages_n;
+    data->tree_n = obj->tree_n;
+    data->tree_depth = obj->tree_depth;
+    data->bagging_overlap = obj->bagging_overlap;
+    data->save_model = obj->save_model ? 1 : 0;
+    data->seed = obj->seed;
+    data->detectROI = c(obj->detectROI);
+    cascadeFace->assign(obj->cascade_face);
+    modelFilename->assign(obj->model_filename);
+    std::copy(obj->feats_m.begin(), obj->feats_m.end(), std::back_inserter(*featsM));
+    std::copy(obj->radius_m.begin(), obj->radius_m.end(), std::back_inserter(*radiusM));
+    std::copy(obj->pupils[0].begin(), obj->pupils[0].end(), std::back_inserter(*pupils0));
+    std::copy(obj->pupils[1].begin(), obj->pupils[1].end(), std::back_inserter(*pupils1));
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_n_landmarks_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
+CVAPI(ExceptionStatus) face_FacemarkLBF_Params_setAll(
+    cv::face::FacemarkLBF::Params *obj,
+    FacemarkLBFParamsData data,
+    const char *cascadeFace,
+    const char *modelFilename,
+    std::vector<int> *featsM,
+    std::vector<double> *radiusM,
+    std::vector<int> *pupils0,
+    std::vector<int> *pupils1)
 {
     BEGIN_WRAP
-    *returnValue = obj->n_landmarks;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_n_landmarks_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->n_landmarks = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_initShape_n_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->initShape_n;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_initShape_n_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->initShape_n = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_stages_n_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->stages_n;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_stages_n_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->stages_n = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_tree_n_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->tree_n;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_tree_n_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->tree_n = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_tree_depth_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->tree_depth;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_tree_depth_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->tree_depth = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_bagging_overlap_get(cv::face::FacemarkLBF::Params *obj, double *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->bagging_overlap;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_bagging_overlap_set(cv::face::FacemarkLBF::Params *obj, double val)
-{
-    BEGIN_WRAP
-    obj->bagging_overlap = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_model_filename_get(cv::face::FacemarkLBF::Params *obj, std::string *s)
-{
-    BEGIN_WRAP
-    s->assign(obj->model_filename);
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_model_filename_set(cv::face::FacemarkLBF::Params *obj, const char *s)
-{
-    BEGIN_WRAP
-    obj->model_filename = s;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_save_model_get(cv::face::FacemarkLBF::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->save_model ? 1 : 0;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_save_model_set(cv::face::FacemarkLBF::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->save_model = (val != 0);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_seed_get(cv::face::FacemarkLBF::Params *obj, unsigned int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->seed;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_seed_set(cv::face::FacemarkLBF::Params *obj, unsigned int val)
-{
-    BEGIN_WRAP
-    obj->seed = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_feats_m_get(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    std::copy(obj->feats_m.begin(), obj->feats_m.end(), std::back_inserter(*v));
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_feats_m_set(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    obj->feats_m.clear();
-    std::copy(v->begin(), v->end(), std::back_inserter(obj->feats_m));
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_radius_m_get(cv::face::FacemarkLBF::Params *obj, std::vector<double> *v)
-{
-    BEGIN_WRAP
-    std::copy(obj->radius_m.begin(), obj->radius_m.end(), std::back_inserter(*v));
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_radius_m_set(cv::face::FacemarkLBF::Params *obj, std::vector<double> *v)
-{
-    BEGIN_WRAP
-    obj->radius_m.clear();
-    std::copy(v->begin(), v->end(), std::back_inserter(obj->radius_m));
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_pupils0_get(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    std::copy(obj->pupils[0].begin(), obj->pupils[0].end(), std::back_inserter(*v));
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_pupils0_set(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    obj->pupils[0].clear();
-    std::copy(v->begin(), v->end(), std::back_inserter(obj->pupils[0]));
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_pupils1_get(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    std::copy(obj->pupils[1].begin(), obj->pupils[1].end(), std::back_inserter(*v));
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_pupils1_set(cv::face::FacemarkLBF::Params *obj, std::vector<int> *v)
-{
-    BEGIN_WRAP
-    obj->pupils[1].clear();
-    std::copy(v->begin(), v->end(), std::back_inserter(obj->pupils[1]));
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_detectROI_get(cv::face::FacemarkLBF::Params *obj, MyCvRect *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = c(obj->detectROI);
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkLBF_Params_detectROI_set(cv::face::FacemarkLBF::Params *obj, MyCvRect val)
-{
-    BEGIN_WRAP
-    obj->detectROI = cpp(val);
+    obj->shape_offset = data.shape_offset;
+    obj->verbose = (data.verbose != 0);
+    obj->n_landmarks = data.n_landmarks;
+    obj->initShape_n = data.initShape_n;
+    obj->stages_n = data.stages_n;
+    obj->tree_n = data.tree_n;
+    obj->tree_depth = data.tree_depth;
+    obj->bagging_overlap = data.bagging_overlap;
+    obj->save_model = (data.save_model != 0);
+    obj->seed = data.seed;
+    obj->detectROI = cpp(data.detectROI);
+    obj->cascade_face = cascadeFace;
+    obj->model_filename = modelFilename;
+    obj->feats_m.assign(featsM->begin(), featsM->end());
+    obj->radius_m.assign(radiusM->begin(), radiusM->end());
+    obj->pupils[0].assign(pupils0->begin(), pupils0->end());
+    obj->pupils[1].assign(pupils1->begin(), pupils1->end());
     END_WRAP
 }
 
@@ -360,134 +228,43 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_delete(cv::face::FacemarkAAM::Par
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_model_filename_get(cv::face::FacemarkAAM::Params *obj, std::string *s)
+CVAPI(ExceptionStatus) face_FacemarkAAM_Params_getAll(
+    cv::face::FacemarkAAM::Params *obj,
+    FacemarkAAMParamsData *data,
+    std::string *modelFilename,
+    std::vector<float> *scales)
 {
     BEGIN_WRAP
-    s->assign(obj->model_filename);
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_model_filename_set(cv::face::FacemarkAAM::Params *obj, const char *s)
-{
-    BEGIN_WRAP
-    obj->model_filename = s;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_m_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->m;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_m_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->m = val;
+    data->m = obj->m;
+    data->n = obj->n;
+    data->n_iter = obj->n_iter;
+    data->verbose = obj->verbose ? 1 : 0;
+    data->save_model = obj->save_model ? 1 : 0;
+    data->max_m = obj->max_m;
+    data->max_n = obj->max_n;
+    data->texture_max_m = obj->texture_max_m;
+    modelFilename->assign(obj->model_filename);
+    std::copy(obj->scales.begin(), obj->scales.end(), std::back_inserter(*scales));
     END_WRAP
 }
 
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_n_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
+CVAPI(ExceptionStatus) face_FacemarkAAM_Params_setAll(
+    cv::face::FacemarkAAM::Params *obj,
+    FacemarkAAMParamsData data,
+    const char *modelFilename,
+    std::vector<float> *scales)
 {
     BEGIN_WRAP
-    *returnValue = obj->n;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_n_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->n = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_n_iter_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->n_iter;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_n_iter_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->n_iter = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_verbose_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->verbose ? 1 : 0;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_verbose_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->verbose = (val != 0);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_save_model_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->save_model ? 1 : 0;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_save_model_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->save_model = (val != 0);
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_max_m_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->max_m;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_max_m_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->max_m = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_max_n_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->max_n;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_max_n_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->max_n = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_texture_max_m_get(cv::face::FacemarkAAM::Params *obj, int *returnValue)
-{
-    BEGIN_WRAP
-    *returnValue = obj->texture_max_m;
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_texture_max_m_set(cv::face::FacemarkAAM::Params *obj, int val)
-{
-    BEGIN_WRAP
-    obj->texture_max_m = val;
-    END_WRAP
-}
-
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_scales_get(cv::face::FacemarkAAM::Params *obj, std::vector<float> *v)
-{
-    BEGIN_WRAP
-    std::copy(obj->scales.begin(), obj->scales.end(), std::back_inserter(*v));
-    END_WRAP
-}
-CVAPI(ExceptionStatus) face_FacemarkAAM_Params_scales_set(cv::face::FacemarkAAM::Params *obj, std::vector<float> *v)
-{
-    BEGIN_WRAP
-    obj->scales.clear();
-    std::copy(v->begin(), v->end(), std::back_inserter(obj->scales));
+    obj->m = data.m;
+    obj->n = data.n;
+    obj->n_iter = data.n_iter;
+    obj->verbose = (data.verbose != 0);
+    obj->save_model = (data.save_model != 0);
+    obj->max_m = data.max_m;
+    obj->max_n = data.max_n;
+    obj->texture_max_m = data.texture_max_m;
+    obj->model_filename = modelFilename;
+    obj->scales.assign(scales->begin(), scales->end());
     END_WRAP
 }
 

--- a/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
@@ -20,11 +20,28 @@ public class FacemarkAAMTest : TestBase
     [Fact]
     public void CreateAndDisposeWithParameter()
     {
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         using (var facemark = FacemarkAAM.Create(parameter))
         {
             GC.KeepAlive(facemark);
         }
+    }
+
+    [Fact]
+    public void ParameterDefaultsFromNative()
+    {
+        // Verifies the managed Params pulls the real OpenCV defaults through the
+        // native getAll bridge (a wrong struct layout would surface as garbage here).
+        var parameter = new FacemarkAAM.Params();
+        Assert.True(parameter.M > 0);
+        Assert.True(parameter.N > 0);
+        Assert.True(parameter.NIter > 0);
+        Assert.True(parameter.MaxM > 0);
+        Assert.True(parameter.MaxN > 0);
+        Assert.True(parameter.TextureMaxM > 0);
+        Assert.True(parameter.Verbose);
+        Assert.True(parameter.SaveModel);
+        Assert.NotEmpty(parameter.Scales);
     }
 
     /*
@@ -34,7 +51,7 @@ public class FacemarkAAMTest : TestBase
     [Fact]
     public void GetFaces()
     {
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.ModelFilename = CascadeFile;
             parameter.Scales = new float[] {2, 4};
@@ -63,7 +80,7 @@ public class FacemarkAAMTest : TestBase
     {
         const string value = "foo";
 
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.ModelFilename = value;
             Assert.Equal(value, parameter.ModelFilename);
@@ -75,7 +92,7 @@ public class FacemarkAAMTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.M = value;
             Assert.Equal(value, parameter.M);
@@ -87,7 +104,7 @@ public class FacemarkAAMTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.N = value;
             Assert.Equal(value, parameter.N);
@@ -99,7 +116,7 @@ public class FacemarkAAMTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.NIter = value;
             Assert.Equal(value, parameter.NIter);
@@ -111,7 +128,7 @@ public class FacemarkAAMTest : TestBase
     {
         float[] value = [1, 2, 3];
 
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.Scales = value;
             Assert.Equal(value, parameter.Scales);
@@ -121,7 +138,7 @@ public class FacemarkAAMTest : TestBase
     [Fact]
     public void ParameterSaveModel()
     {
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.SaveModel = true;
             Assert.True(parameter.SaveModel);
@@ -133,7 +150,7 @@ public class FacemarkAAMTest : TestBase
     [Fact]
     public void ParameterVerbose()
     {
-        using (var parameter = new FacemarkAAM.Params())
+        var parameter = new FacemarkAAM.Params();
         {
             parameter.Verbose = true;
             Assert.True(parameter.Verbose);

--- a/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
@@ -18,7 +18,7 @@ public class FacemarkLBFTest : TestBase
     [Fact]
     public void CreateAndDisposeWithParameter()
     {
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         using (var facemark = FacemarkLBF.Create(parameter))
         {
             GC.KeepAlive(facemark);
@@ -26,11 +26,30 @@ public class FacemarkLBFTest : TestBase
     }
         
     [Fact]
+    public void ParameterDefaultsFromNative()
+    {
+        // Verifies the managed Params pulls the real OpenCV defaults through the
+        // native getAll bridge (a wrong struct layout would surface as garbage here).
+        var parameter = new FacemarkLBF.Params();
+        Assert.Equal(68, parameter.NLandmarks);
+        Assert.Equal(5, parameter.StagesN);
+        Assert.Equal(6, parameter.TreeN);
+        Assert.Equal(5, parameter.TreeDepth);
+        Assert.True(parameter.Verbose);
+        Assert.True(parameter.SaveModel);
+        Assert.Equal(0.4, parameter.BaggingOverlap, 6);
+        Assert.NotEmpty(parameter.FeatsM);
+        Assert.NotEmpty(parameter.RadiusM);
+        Assert.Equal([36, 37, 38, 39, 40, 41], parameter.Pupils0);
+        Assert.Equal([42, 43, 44, 45, 46, 47], parameter.Pupils1);
+    }
+
+    [Fact]
     public void ParameterBaggingOverlap()
     {
         const double value = 3.14;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.BaggingOverlap = value;
             Assert.Equal(value, parameter.BaggingOverlap);
@@ -42,7 +61,7 @@ public class FacemarkLBFTest : TestBase
     {
         const string value = "foo";
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.CascadeFace = value;
             Assert.Equal(value, parameter.CascadeFace);
@@ -55,7 +74,7 @@ public class FacemarkLBFTest : TestBase
     {
         var value = new Rect(1, 2, 3, 4);
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.DetectROI = value;
             Assert.Equal(value, parameter.DetectROI);
@@ -67,7 +86,7 @@ public class FacemarkLBFTest : TestBase
     {
         int[] value = [9, 8, 7, 6, 5];
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.FeatsM = value;
             Assert.Equal(value, parameter.FeatsM);
@@ -79,7 +98,7 @@ public class FacemarkLBFTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.InitShapeN = value;
             Assert.Equal(value, parameter.InitShapeN);
@@ -91,7 +110,7 @@ public class FacemarkLBFTest : TestBase
     {
         const string value = "foo";
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.ModelFilename = value;
             Assert.Equal(value, parameter.ModelFilename);
@@ -103,7 +122,7 @@ public class FacemarkLBFTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.NLandmarks = value;
             Assert.Equal(value, parameter.NLandmarks);
@@ -115,7 +134,7 @@ public class FacemarkLBFTest : TestBase
     {
         int[] value = [9, 8, 7, 6, 5];
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.Pupils0 = value;
             Assert.Equal(value, parameter.Pupils0);
@@ -127,7 +146,7 @@ public class FacemarkLBFTest : TestBase
     {
         int[] value = [9, 8, 7, 6, 5];
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.Pupils1 = value;
             Assert.Equal(value, parameter.Pupils1);
@@ -139,7 +158,7 @@ public class FacemarkLBFTest : TestBase
     {
         double[] value = [1, 2, 3];
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.RadiusM = value;
             Assert.Equal(value, parameter.RadiusM);
@@ -149,7 +168,7 @@ public class FacemarkLBFTest : TestBase
     [Fact]
     public void ParameterSaveModel()
     {
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.SaveModel = true;
             Assert.True(parameter.SaveModel);
@@ -163,7 +182,7 @@ public class FacemarkLBFTest : TestBase
     {
         const uint value = uint.MaxValue;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.Seed = value;
             Assert.Equal(value, parameter.Seed);
@@ -175,7 +194,7 @@ public class FacemarkLBFTest : TestBase
     {
         const double value = 3.14;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.ShapeOffset = value;
             Assert.Equal(value, parameter.ShapeOffset);
@@ -187,7 +206,7 @@ public class FacemarkLBFTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.StagesN = value;
             Assert.Equal(value, parameter.StagesN);
@@ -199,7 +218,7 @@ public class FacemarkLBFTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.TreeDepth = value;
             Assert.Equal(value, parameter.TreeDepth);
@@ -211,7 +230,7 @@ public class FacemarkLBFTest : TestBase
     {
         const int value = 12345;
 
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.TreeN = value;
             Assert.Equal(value, parameter.TreeN);
@@ -221,7 +240,7 @@ public class FacemarkLBFTest : TestBase
     [Fact]
     public void ParameterVerbose()
     {
-        using (var parameter = new FacemarkLBF.Params())
+        var parameter = new FacemarkLBF.Params();
         {
             parameter.Verbose = true;
             Assert.True(parameter.Verbose);

--- a/tools/sh_classfile.py
+++ b/tools/sh_classfile.py
@@ -24,7 +24,8 @@ for line in lines:
     if line.strip() == "GC.KeepAlive(this);":
         removed += 1
         continue
-    out.append(re.sub(rf"\b{re.escape(accessor)}\b", "Handle", line))
+    # Only the bare this-handle accessor (e.g. `CvPtr`), never `other.CvPtr`.
+    out.append(re.sub(rf"(?<!\.)\b{re.escape(accessor)}\b", "Handle", line))
 
 new = nl.join(out)
 path.write_text(new, encoding="utf-8-sig", newline="")

--- a/tools/sh_extern.py
+++ b/tools/sh_extern.py
@@ -37,7 +37,8 @@ while i < len(lines):
     while ";" not in lines[j]:
         j += 1
     block = "\n".join(lines[i:j + 1])
-    new_block, n = re.subn(r"\bIntPtr (?=[A-Za-z_])", "OpenCvSafeHandle ", block, count=1)
+    # Only the (in) object handle param; never an out/ref param such as `out IntPtr returnValue`.
+    new_block, n = re.subn(r"(?<!out )(?<!ref )\bIntPtr (?=[A-Za-z_])", "OpenCvSafeHandle ", block, count=1)
     if n:
         changed += 1
     out.extend(new_block.split("\n"))


### PR DESCRIPTION
Continues the Phase 1b SafeHandle work on top of #1946 (now merged). Each wrapper class passes its own `SafeHandle` (`Handle`) to the native entry points instead of the raw `IntPtr` (`RawPtr`/`CvPtr`), and the now-redundant `GC.KeepAlive(this)` calls are removed. The native marshaller keeps the handle alive across each P/Invoke, so this is equivalent but leaner. `GC.KeepAlive(this)` count: ~1701 → ~643.

Mechanical and managed-only **except** the Facemark Params redesign (see below), which also changes native.

## Swept modules
- **Algorithm-derived**: ml, photo, img_hash, quality, saliency, shape, bgsegm, face (FaceRecognizer + Facemark base), features (Feature2D subclasses, matcher family, ANNIndex), xfeatures2d, ximgproc, stereo, video (BG KNN/MOG2 + KalmanFilter), xphoto, superres, imgproc (GeneralizedHough family, LineSegmentDetector), objdetect (FaceDetectorYN).
- **core (no in-method interior-pointer deref)**: PCA, SVD, LDA, FileNode, FileNodeIterator, FileStorage, MatExpr, InputArray.

## Facemark LBF/AAM Params redesign (native + managed)
The `Params` types were `cv::Object` wrappers exposing each field through its own native getter/setter (~50 entry points), paying a P/Invoke round-trip per property and requiring manual SafeHandle plumbing. They also misrouted `Read(FileNode)` to the `_Params_write` entry point (passing a `FileNode*` where a `FileStorage*` was expected). `Params` is now a plain managed value holder; a native `cv::Params` is materialised only at Create/Read/Write via a single `getAll`/`setAll` pair (blittable POD struct + the string/vector members marshalled alongside). The constructor seeds the OpenCV defaults through `getAll`, and `Read` now correctly calls `_Params_read`. Adds round-trip tests asserting the native defaults survive the bridge.

## What is intentionally left on IntPtr
- Static free functions / static methods whose first argument is a `Mat` (e.g. SVD compute, LDA subspaceProject/Reconstruct, FileStorage getDefaultObjectName, BRISQUE static compute).
- Other-object arguments passed as `obj.CvPtr` (those classes get swept when their own turn comes).
- Interior-pointer returns (`Mat.Data`, `InputArray.GetObj`, etc.) and `_new`/`_delete`/`_Ptr_` lifetime entry points.

## Not yet swept (follow-up stacked PR)
core `Mat`/`UMat`/`SparseMat` and `LineIterator` (their `At<T>`/`Find` etc. dereference an interior pointer in-method, so `GC.KeepAlive(this)` must be retained — needs manual review), `OutputArray`, and the remaining `CvObject` modules (dnn, aruco, ptcloud, objdetect Cascade/HOG/QR, text, stitching, flann, videoio, …).

Native rebuild required (Facemark Params). Full managed test suite green on net10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)