### PR TITLE
Fix Windows NuGet pack: FFmpeg DLL path moved to vc18

### DIFF
--- a/nuget/OpenCvSharp4.runtime.win.csproj
+++ b/nuget/OpenCvSharp4.runtime.win.csproj
@@ -23,7 +23,7 @@
   
   <ItemGroup>
     <None Include="../src/build/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
-    <None Include="../opencv_artifacts/x64/vc17/bin/opencv_videoio_ffmpeg4130_64.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
+    <None Include="../opencv_artifacts/x64/vc18/bin/opencv_videoio_ffmpeg4130_64.dll" Pack="true" PackagePath="runtimes/win-x64/native" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netstandard" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/netcoreapp" />
     <None Include="OpenCvSharp4.runtime.win.props" Pack="true" PackagePath="build/net8.0" />


### PR DESCRIPTION
## Problem

The Windows CI `build` job fails at the **Pack NuGet packages** step:

```
error : Could not find a part of the path '...\opencv_artifacts\x64\vc17\bin'.
[nuget/OpenCvSharp4.runtime.win.csproj]
```

## Cause

`windows.yml` was updated to the `Visual Studio 18 2026` generator (commits `dc77c4d9`, `bb2da29c`). OpenCV's install layout is toolset-versioned, so it now installs under `opencv_artifacts/x64/**vc18**/` instead of `vc17/`. Confirmed from the CI build log:

```
-- Installing: .../opencv_artifacts/x64/vc18/bin/opencv_videoio_ffmpeg4130_64.dll
```

`OpenCvSharp4.runtime.win.csproj` still referenced the stale `vc17` path for the FFmpeg DLL, so pack failed.

## Fix

Update the FFmpeg DLL path in `OpenCvSharp4.runtime.win.csproj` from `vc17` → `vc18` to match the new install layout.

Scope notes:
- UWP packages and `ReleaseMaker` keep `vc17` — those use a separately distributed prebuilt OpenCV (`opencv_world490`, built with VS 2022), unrelated to this from-source build.
- The Windows ARM64 job keeps the VS 2022 generator (`a3fb3bf7`) and already passes.
- The slim package disables `videoio`, so it does not ship the FFmpeg DLL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Windows x64 runtime package to include the correct FFmpeg DLL from the newer runtime artifact path, helping ensure smoother video I/O support on Windows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->