### PR TITLE
CI debug: capture crash dumps for intermittent Windows test crash

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -165,7 +165,27 @@ jobs:
 
       - name: Test
         shell: cmd
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64
+        env:
+          # Capture a full native crash dump in addition to xUnit's blame sequence
+          # file, to diagnose the intermittent test-process crash (0xC0000374 /
+          # 0xC0000005). See debug/windows-test-crashdump.
+          DOTNET_DbgEnableMiniDump: "1"
+          DOTNET_DbgMiniDumpType: "4"
+          DOTNET_DbgMiniDumpName: "${{ github.workspace }}\\crashdumps\\coredump.%d.dmp"
+        run: |
+          mkdir "%GITHUB_WORKSPACE%\crashdumps" 2>nul
+          dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full --results-directory "%GITHUB_WORKSPACE%\TestResults"
+
+      - name: Upload test crash dumps
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-test-crashdumps
+          path: |
+            ${{ github.workspace }}\crashdumps\**
+            ${{ github.workspace }}\TestResults\**
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Test Windows-only functions
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,7 +174,10 @@ jobs:
           DOTNET_DbgMiniDumpName: "${{ github.workspace }}\\crashdumps\\coredump.%d.dmp"
         run: |
           mkdir "%GITHUB_WORKSPACE%\crashdumps" 2>nul
-          dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full --results-directory "%GITHUB_WORKSPACE%\TestResults"
+          for /l %%i in (1,1,8) do (
+            echo === Test attempt %%i / 8 ===
+            dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full --results-directory "%GITHUB_WORKSPACE%\TestResults\attempt%%i" || exit /b 1
+          )
 
       - name: Upload test crash dumps
         if: always()


### PR DESCRIPTION
## Why

The `Windows Server 2025` workflow has been red on `main` since 2026-06-22. The `Test` step crashes intermittently:

| run | tests passed before crash | exit code | meaning |
|---|---|---|---|
| 28276579124 | 675 | `0xC0000374` | heap corruption |
| 28276458829 | 276 | `0xC0000374` | heap corruption |
| 27943750483 | 350 (arm64) | `0xC0000005` | access violation |

All xUnit assertions pass (`Failed: 0`); the **process** dies at varying points with native memory-corruption codes — i.e. a flaky native crash, not a test assertion failure or the recent README badge change.

## What this PR does (diagnostic only)

- Adds `--blame-crash --blame-crash-dump-type full` to capture the xUnit sequence file (which test was executing at crash time).
- Sets `DOTNET_DbgEnableMiniDump=1` / full dump type to capture a native crash dump.
- Uploads `crashdumps/` + `TestResults/` as an artifact (`windows-test-crashdumps`) for offline SOS analysis.

Not for merge as-is — once the offending native call is identified, this will be reverted and replaced with the real fix (or a targeted `Assert.Skip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows test runs to capture full crash dumps when a .NET test process fails.
  * Updated test execution to enable crash-dump blame and run with enhanced reliability via retries.
  * Added automatic artifact uploads for both crash dumps and full test results (with a 7-day retention window) to simplify post-failure diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->