### PR TITLE
Skip Bm3dDenoising test (upstream heap-corruption crash) to fix red Windows CI

### DIFF
--- a/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
+++ b/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
@@ -233,7 +233,7 @@ public class XPhotoTest : TestBase
         }
     }
 
-    [Fact]
+    [Fact(Skip = "bm3dDenoising corrupts the heap and crashes the test process (upstream OpenCV bug). See https://github.com/shimat/opencvsharp/issues/1904")]
     public void Bm3dDenoising()
     {
         using var src = LoadImage("lenna.png", ImreadModes.Grayscale);

--- a/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
+++ b/test/OpenCvSharp.Tests/xphoto/XPhotoTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using OpenCvSharp.XPhoto;
 using Xunit;
 
@@ -7,6 +8,8 @@ namespace OpenCvSharp.Tests.XPhoto;
 // ReSharper disable InconsistentNaming
 public class XPhotoTest : TestBase
 {
+    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
     private readonly ITestOutputHelper testOutputHelper;
 
     public XPhotoTest(ITestOutputHelper testOutputHelper)
@@ -233,7 +236,10 @@ public class XPhotoTest : TestBase
         }
     }
 
-    [Fact(Skip = "bm3dDenoising corrupts the heap and crashes the test process (upstream OpenCV bug). See https://github.com/shimat/opencvsharp/issues/1904")]
+    // On Windows, bm3dDenoising corrupts the heap and crashes the whole test
+    // process (BEGIN_WRAP/END_WRAP are no-ops on _WIN32, so it cannot be caught).
+    // It runs fine on Linux/macOS, so only skip on Windows. Upstream bug: #1904.
+    [Fact(Skip = "Crashes the test process on Windows (heap corruption); see https://github.com/shimat/opencvsharp/issues/1904", SkipWhen = nameof(IsWindows))]
     public void Bm3dDenoising()
     {
         using var src = LoadImage("lenna.png", ImreadModes.Grayscale);


### PR DESCRIPTION
## Problem

The `Windows Server 2025` workflow has been red on `main` since 2026-06-22. The `Test` step crashed intermittently with native memory-corruption exit codes (`0xC0000374` heap corruption / `0xC0000005` access violation) at varying points, even though every xUnit assertion passed (`Failed: 0`).

## Root cause

The culprit is **`XPhotoTest.Bm3dDenoising`**, identified with `dotnet test --blame-crash`: it is the only `Completed="False"` entry in the blame sequence file at crash time. `cv::xphoto::bm3dDenoising` corrupts the heap; on Windows `BEGIN_WRAP`/`END_WRAP` are no-ops so the corruption takes down the whole test process. The crash is flaky, so the badge flipped red intermittently.

This is an upstream OpenCV bug, tracked as #1904, and the **same test is already skipped on the `5.x` branch** (#1907).

## Fix

Mark `Bm3dDenoising` with `[Fact(Skip = ...)]`, matching the 5.x treatment, referencing #1904.

The diagnostic PR #1956 (test loop + crash-dump capture) is superseded by this and will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the automated denoising test to be skipped on Windows by default, reducing false failures in test runs due to a known crash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->