### PR TITLE
SparseMat: non-zero element enumeration + Get/Set and ToString cleanup

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_SparseMat.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_SparseMat.cs
@@ -105,4 +105,8 @@ static partial class NativeMethods
     public static unsafe partial ExceptionStatus core_SparseMat_ptr_nd(
         OpenCvSafeHandle obj, int[] idx, int createMissing, ulong* hashVal, out IntPtr returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_SparseMat_getNodes(
+        OpenCvSafeHandle obj, int dims, IntPtr outIndices, IntPtr outValues, nuint elemSize);
+
 }

--- a/src/OpenCvSharp/Modules/core/SparseMat.cs
+++ b/src/OpenCvSharp/Modules/core/SparseMat.cs
@@ -9,6 +9,26 @@ namespace OpenCvSharp;
 /// </summary>
 public class SparseMat : CvObject
 {
+    // Cached element size in bytes (SparseMat.ElemSize()), used to reject mismatched
+    // element types before they read/write the wrong number of bytes. -1 = not yet queried;
+    // invalidated by the operations that change the matrix type (Create / AssignFrom).
+    private int cachedElementByteSize = -1;
+
+    /// <summary>
+    /// Throws if <typeparamref name="T"/>'s size does not match this matrix's element size.
+    /// Accessing an element with a wrongly sized <typeparamref name="T"/> would otherwise read
+    /// or write past the element and silently corrupt memory.
+    /// </summary>
+    private void ValidateElementType<T>() where T : struct
+    {
+        if (cachedElementByteSize < 0)
+            cachedElementByteSize = ElemSize();
+        var requested = Marshal.SizeOf<T>();
+        if (requested != cachedElementByteSize)
+            throw new OpenCvSharpException(
+                $"Element type '{typeof(T)}' (size {requested}) does not match the matrix element size ({cachedElementByteSize}).");
+    }
+
     #region Init & Disposal
 
     /// <summary>
@@ -115,6 +135,7 @@ public class SparseMat : CvObject
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_operatorAssign_SparseMat(Handle, m.CvPtr));
 
+        cachedElementByteSize = -1;
         GC.KeepAlive(m);
         return this;
     }
@@ -133,6 +154,7 @@ public class SparseMat : CvObject
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_operatorAssign_Mat(Handle, m.CvPtr));
 
+        cachedElementByteSize = -1;
         GC.KeepAlive(m);
         return this;
     }
@@ -256,7 +278,7 @@ public class SparseMat : CvObject
 
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_create(Handle, sizes.Length, sizes, type));
-
+        cachedElementByteSize = -1;
     }
 
     /// <summary>
@@ -583,6 +605,7 @@ public class SparseMat : CvObject
     public T? Find<T>(int i0, long? hashVal = null)
         where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, false, hashVal);
         if (p == IntPtr.Zero)
             return null;
@@ -600,6 +623,7 @@ public class SparseMat : CvObject
     public T? Find<T>(int i0, int i1, long? hashVal = null)
         where T : struct 
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, false, hashVal);
         if (p == IntPtr.Zero)
             return null;
@@ -618,6 +642,7 @@ public class SparseMat : CvObject
     public T? Find<T>(int i0, int i1, int i2, long? hashVal = null)
         where T : struct 
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, i2, false, hashVal);
         if (p == IntPtr.Zero)
             return null;
@@ -634,6 +659,7 @@ public class SparseMat : CvObject
     public T? Find<T>(int[] idx, long? hashVal = null)
         where T : struct 
     {
+        ValidateElementType<T>();
         var p = Ptr(idx, false, hashVal);
         if (p == IntPtr.Zero)
             return null;
@@ -654,6 +680,7 @@ public class SparseMat : CvObject
     public T Value<T>(int i0, long? hashVal = null)
         where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, false, hashVal);
         if (p == IntPtr.Zero)
             return default;
@@ -671,6 +698,7 @@ public class SparseMat : CvObject
     public T Value<T>(int i0, int i1, long? hashVal = null)
         where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, false, hashVal);
         if (p == IntPtr.Zero)
             return default;
@@ -689,6 +717,7 @@ public class SparseMat : CvObject
     public T Value<T>(int i0, int i1, int i2, long? hashVal = null)
         where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, i2, false, hashVal);
         if (p == IntPtr.Zero)
             return default;
@@ -705,6 +734,7 @@ public class SparseMat : CvObject
     public T Value<T>(int[] idx, long? hashVal = null)
         where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(idx, false, hashVal);
         if (p == IntPtr.Zero)
             return default;
@@ -729,10 +759,8 @@ public class SparseMat : CvObject
     public IEnumerable<(int[] Index, T Value)> EnumerateNonZero<T>() where T : unmanaged
     {
         ThrowIfDisposed();
-        var elemSize = ElemSize();
-        if (Marshal.SizeOf<T>() != elemSize)
-            throw new OpenCvSharpException(
-                $"Element type '{typeof(T)}' (size {Marshal.SizeOf<T>()}) does not match the matrix element size ({elemSize}).");
+        ValidateElementType<T>();
+        var elemSize = cachedElementByteSize;
 
         var count = (int)NzCount();
         var dims = Dims();
@@ -781,6 +809,7 @@ public class SparseMat : CvObject
         internal Indexer(SparseMat parent)
             : base(parent)
         {
+            parent.ValidateElementType<T>();
         }
 
         /// <summary>
@@ -885,9 +914,7 @@ public class SparseMat : CvObject
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     public Indexer<T> GetIndexer<T>() where T : struct
-    {
-        return new Indexer<T>(this);
-    }
+        => Ref<T>();
 
     #endregion
 
@@ -902,6 +929,7 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, true, hashVal);
         return Marshal.PtrToStructure<T>(p);
     }
@@ -916,6 +944,7 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, int i1, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, true, hashVal);
         return Marshal.PtrToStructure<T>(p);
     }
@@ -931,6 +960,7 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, int i1, int i2, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, i2, true, hashVal);
         return Marshal.PtrToStructure<T>(p);
     }
@@ -944,6 +974,7 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int[] idx, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(idx, true, hashVal);
         return Marshal.PtrToStructure<T>(p);
     }
@@ -957,6 +988,7 @@ public class SparseMat : CvObject
     /// <param name="hashVal"></param>
     public void Set<T>(int i0, T value, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, true, hashVal);
         Marshal.StructureToPtr(value, p, false);
     }
@@ -971,6 +1003,7 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int i0, int i1, T value, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, true, hashVal);
         Marshal.StructureToPtr(value, p, false);
     }
@@ -986,6 +1019,7 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int i0, int i1, int i2, T value, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(i0, i1, i2, true, hashVal);
         Marshal.StructureToPtr(value, p, false);
     }
@@ -999,6 +1033,7 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int[] idx, T value, long? hashVal = null) where T : struct
     {
+        ValidateElementType<T>();
         var p = Ptr(idx, true, hashVal);
         Marshal.StructureToPtr(value, p, false);
     }

--- a/src/OpenCvSharp/Modules/core/SparseMat.cs
+++ b/src/OpenCvSharp/Modules/core/SparseMat.cs
@@ -714,6 +714,61 @@ public class SparseMat : CvObject
 
     #endregion
 
+    #region EnumerateNonZero
+
+    /// <summary>
+    /// Enumerates every stored (non-zero) element together with its index, mirroring
+    /// cv::SparseMatConstIterator. This is the efficient way to walk a sparse matrix: it
+    /// visits only the stored elements, not the full dense index space.
+    /// </summary>
+    /// <typeparam name="T">Element type; its size must match <see cref="ElemSize"/>.</typeparam>
+    /// <returns>
+    /// A sequence of (index, value) pairs. Each <c>Index</c> is a fresh array of length
+    /// <see cref="Dims"/>. The enumeration is a snapshot taken when the method is called.
+    /// </returns>
+    public IEnumerable<(int[] Index, T Value)> EnumerateNonZero<T>() where T : unmanaged
+    {
+        ThrowIfDisposed();
+        var elemSize = ElemSize();
+        if (Marshal.SizeOf<T>() != elemSize)
+            throw new OpenCvSharpException(
+                $"Element type '{typeof(T)}' (size {Marshal.SizeOf<T>()}) does not match the matrix element size ({elemSize}).");
+
+        var count = (int)NzCount();
+        var dims = Dims();
+        var indices = new int[count * dims];
+        var values = new T[count];
+        if (count > 0)
+        {
+            unsafe
+            {
+                fixed (int* indicesPtr = indices)
+                fixed (T* valuesPtr = values)
+                {
+                    NativeMethods.HandleException(
+                        NativeMethods.core_SparseMat_getNodes(
+                            Handle, dims, (IntPtr)indicesPtr, (IntPtr)valuesPtr, (nuint)elemSize));
+                }
+            }
+            GC.KeepAlive(this);
+        }
+
+        // Native already copied everything into managed arrays, so yielding is allocation-only.
+        return Enumerate(indices, values, count, dims);
+
+        static IEnumerable<(int[], T)> Enumerate(int[] indices, T[] values, int count, int dims)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var index = new int[dims];
+                Array.Copy(indices, i * dims, index, 0, dims);
+                yield return (index, values[i]);
+            }
+        }
+    }
+
+    #endregion
+
     #region Element Indexer
 
 #pragma warning disable CA1034
@@ -847,7 +902,8 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, long? hashVal = null) where T : struct
     {
-        return new Indexer<T>(this)[i0, hashVal];
+        var p = Ptr(i0, true, hashVal);
+        return Marshal.PtrToStructure<T>(p);
     }
 
     /// <summary>
@@ -860,7 +916,8 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, int i1, long? hashVal = null) where T : struct
     {
-        return new Indexer<T>(this)[i0, i1, hashVal];
+        var p = Ptr(i0, i1, true, hashVal);
+        return Marshal.PtrToStructure<T>(p);
     }
 
     /// <summary>
@@ -874,7 +931,8 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int i0, int i1, int i2, long? hashVal = null) where T : struct
     {
-        return new Indexer<T>(this)[i0, i1, i2, hashVal];
+        var p = Ptr(i0, i1, i2, true, hashVal);
+        return Marshal.PtrToStructure<T>(p);
     }
 
     /// <summary>
@@ -886,7 +944,8 @@ public class SparseMat : CvObject
     /// <returns>A value to the specified array element.</returns>
     public T Get<T>(int[] idx, long? hashVal = null) where T : struct
     {
-        return new Indexer<T>(this)[idx, hashVal];
+        var p = Ptr(idx, true, hashVal);
+        return Marshal.PtrToStructure<T>(p);
     }
 
     /// <summary>
@@ -898,7 +957,8 @@ public class SparseMat : CvObject
     /// <param name="hashVal"></param>
     public void Set<T>(int i0, T value, long? hashVal = null) where T : struct
     {
-        (new Indexer<T>(this))[i0, hashVal] = value;
+        var p = Ptr(i0, true, hashVal);
+        Marshal.StructureToPtr(value, p, false);
     }
 
     /// <summary>
@@ -911,7 +971,8 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int i0, int i1, T value, long? hashVal = null) where T : struct
     {
-        (new Indexer<T>(this))[i0, i1, hashVal] = value;
+        var p = Ptr(i0, i1, true, hashVal);
+        Marshal.StructureToPtr(value, p, false);
     }
 
     /// <summary>
@@ -925,7 +986,8 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int i0, int i1, int i2, T value, long? hashVal = null) where T : struct
     {
-        (new Indexer<T>(this)[i0, i1, i2, hashVal]) = value;
+        var p = Ptr(i0, i1, i2, true, hashVal);
+        Marshal.StructureToPtr(value, p, false);
     }
 
     /// <summary>
@@ -937,7 +999,8 @@ public class SparseMat : CvObject
     /// <param name="hashVal">If hashVal is not null, the element hash value is not computed but hashval is taken instead.</param>
     public void Set<T>(int[] idx, T value, long? hashVal = null) where T : struct
     {
-        (new Indexer<T>(this)[idx, hashVal]) = value;
+        var p = Ptr(idx, true, hashVal);
+        Marshal.StructureToPtr(value, p, false);
     }
 
     #endregion
@@ -945,16 +1008,11 @@ public class SparseMat : CvObject
     #region ToString
 
     /// <summary>
-    /// Returns a string that represents this Mat.
+    /// Returns a string that represents this SparseMat.
     /// </summary>
     /// <returns></returns>
     public override string ToString()
-    {
-        return "Mat [ " +
-               "Dims=" + Dims() +
-               "Type=" + Type().ToString() +
-               " ]";
-    }
+        => $"SparseMat [ Dims={Dims()}, Type={Type()}, NzCount={NzCount()} ]";
 
     #endregion
         

--- a/src/OpenCvSharpExtern/core_SparseMat.h
+++ b/src/OpenCvSharpExtern/core_SparseMat.h
@@ -258,3 +258,21 @@ CVAPI(ExceptionStatus) core_SparseMat_ptr_nd(cv::SparseMat *obj, const int* idx,
     }
     END_WRAP
 }
+
+// Copies the indices and values of every stored (non-zero) element into caller-provided buffers.
+// outIndices must hold nzcount()*dims ints, outValues must hold nzcount()*elemSize bytes.
+CVAPI(ExceptionStatus) core_SparseMat_getNodes(cv::SparseMat *obj, int dims, int *outIndices, uchar *outValues, size_t elemSize)
+{
+    BEGIN_WRAP
+    const cv::SparseMat *cobj = obj;
+    cv::SparseMatConstIterator it = cobj->begin();
+    cv::SparseMatConstIterator it_end = cobj->end();
+    for (int i = 0; it != it_end; ++it, ++i)
+    {
+        const cv::SparseMat::Node *node = it.node();
+        for (int d = 0; d < dims; d++)
+            outIndices[static_cast<size_t>(i) * dims + d] = node->idx[d];
+        std::memcpy(outValues + static_cast<size_t>(i) * elemSize, it.ptr, elemSize);
+    }
+    END_WRAP
+}

--- a/test/OpenCvSharp.Tests/core/SparseMatTest.cs
+++ b/test/OpenCvSharp.Tests/core/SparseMatTest.cs
@@ -45,6 +45,16 @@ public class SparseMatTest : TestBase
     }
 
     [Fact]
+    public void ElementTypeMismatchThrows()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_32SC1); // 4-byte elements
+        Assert.Throws<OpenCvSharpException>(() => sm.Set<byte>(0, 0, 1));
+        Assert.Throws<OpenCvSharpException>(() => sm.Get<byte>(0, 0));
+        Assert.Throws<OpenCvSharpException>(() => sm.Find<byte>(0, 0));
+        Assert.Throws<OpenCvSharpException>(() => sm.Ref<byte>());
+    }
+
+    [Fact]
     public void ToStringDescribesSparseMat()
     {
         using var sm = new SparseMat([10, 20], MatType.CV_8UC1);

--- a/test/OpenCvSharp.Tests/core/SparseMatTest.cs
+++ b/test/OpenCvSharp.Tests/core/SparseMatTest.cs
@@ -1,9 +1,58 @@
+using System.Linq;
 using Xunit;
 
 namespace OpenCvSharp.Tests.Core;
 
 public class SparseMatTest : TestBase
 {
+    [Fact]
+    public void GetSetRoundTrip()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_32SC1);
+        sm.Set(3, 7, 42);
+        Assert.Equal(42, sm.Get<int>(3, 7));
+    }
+
+    [Fact]
+    public void EnumerateNonZero()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_32SC1);
+        sm.Ref<int>()[1, 2] = 10;
+        sm.Ref<int>()[5, 6] = 20;
+        sm.Ref<int>()[1, 2] = 11; // overwrite, still one stored element
+
+        var elements = sm.EnumerateNonZero<int>().ToList();
+        Assert.Equal(2, elements.Count);
+
+        var map = elements.ToDictionary(e => (e.Index[0], e.Index[1]), e => e.Value);
+        Assert.Equal(11, map[(1, 2)]);
+        Assert.Equal(20, map[(5, 6)]);
+    }
+
+    [Fact]
+    public void EnumerateNonZeroEmpty()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_32SC1);
+        Assert.Empty(sm.EnumerateNonZero<int>());
+    }
+
+    [Fact]
+    public void EnumerateNonZeroTypeMismatchThrows()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_32SC1);
+        sm.Ref<int>()[0, 0] = 1;
+        Assert.Throws<OpenCvSharpException>(() => sm.EnumerateNonZero<byte>().ToList());
+    }
+
+    [Fact]
+    public void ToStringDescribesSparseMat()
+    {
+        using var sm = new SparseMat([10, 20], MatType.CV_8UC1);
+        var s = sm.ToString();
+        Assert.Contains("SparseMat", s, System.StringComparison.Ordinal);
+        Assert.Contains("NzCount", s, System.StringComparison.Ordinal);
+    }
+
     [Fact]
     public void CreateAndDispose()
     {


### PR DESCRIPTION
Stacked on #1958 (Internal 1b). Review/merge #1958 first; this PR's own diff is
the last two commits.

Improves `SparseMat`, which until now only mirrored the random-access element
API and left the parts that make a sparse matrix useful (and safe) unbuilt.

### 1. Non-zero element enumeration
A `SparseMat` stores only its non-zero elements in a hash table, but there was
no way to iterate them — callers had to probe the full dense index space with
`Find`, throwing away the point of sparse storage.

- **`IEnumerable<(int[] Index, T Value)> EnumerateNonZero<T>()`** — visits only
  the stored elements, mirroring `cv::SparseMatConstIterator`.
- New native **`core_SparseMat_getNodes`** walks the iterator once and copies
  each node's index and value into managed arrays (the native-copy pattern used
  elsewhere), so the managed side never dereferences a live native pointer.

### 2. Element-type safety
Typed access (`Get`/`Set`/`Find`/`Value`, the `Indexer`, `EnumerateNonZero`) now
verifies that `T`'s size matches the matrix element size and throws
`OpenCvSharpException` on mismatch, instead of silently reading/writing the wrong
number of bytes and corrupting memory. The element size is cached and the cache
is invalidated by `Create`/`AssignFrom`. Indexer access is validated once in the
`Indexer<T>` constructor, covering every access through `Ref<T>()`.

### 3. Smaller cleanups
- `Get<T>`/`Set<T>` no longer allocate a throwaway `Indexer<T>` per call; they
  call `Ptr()` directly (same as `Find`/`Value`).
- `GetIndexer<T>` now delegates to `Ref<T>` (both returned an identical indexer).
- `ToString()` now says `SparseMat`, includes `NzCount`, and uses comma
  separators (it previously reported `"Mat [ Dims=2Type=... ]"`).

### Notes
- Touches `OpenCvSharpExtern` (`core_SparseMat_getNodes`), so the native library
  must be rebuilt — CI does this.
- Tests: `GetSetRoundTrip`, `EnumerateNonZero` (+ empty + type-mismatch),
  `ElementTypeMismatchThrows`, and a `ToString` check. SparseMat suite 10/10 on
  net10 against a freshly built native.
- Element-type validation here could later be extended to `Mat` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)