### PR TITLE
CI: platform-explicit job names + trim macOS PR checks

### DIFF
--- a/.github/workflows/docker-test-ubuntu.yml
+++ b/.github/workflows/docker-test-ubuntu.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build_full:
+    name: Docker (full)
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -37,6 +38,7 @@ jobs:
           cache-to: type=gha,mode=min,scope=full-${{ github.ref_name }}
 
   build_slim:
+    name: Docker (slim)
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build:
+    name: Linux (arm64)
 
     runs-on: ubuntu-24.04-arm
     

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,7 @@ jobs:
   # Uses vcpkg for static image libs + Tesseract + Leptonica.
   # ---------------------------------------------------------------------------
   build_x64:
+    name: macOS (x64)
     runs-on: macos-26-intel
 
     steps:
@@ -175,6 +176,7 @@ jobs:
   # Build libOpenCvSharpExtern.dylib for macOS arm64 (Apple Silicon).
   # ---------------------------------------------------------------------------
   build_arm64:
+    name: macOS (arm64)
     runs-on: macos-26
 
     steps:
@@ -324,24 +326,9 @@ jobs:
           name: libOpenCvSharpExtern-osx-arm64
           path: libOpenCvSharpExtern.dylib
 
-  # ---------------------------------------------------------------------------
-  # Integration test on arm64 (the native runner arch).
-  # ---------------------------------------------------------------------------
-  test:
-    needs: [build_arm64]
-    runs-on: macos-26
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: false
-
-      - name: Download arm64 artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: libOpenCvSharpExtern-osx-arm64
-          path: nuget/
-
+      # -- Integration test on arm64 (the native runner arch) ------------------
+      # Folded into this job: runs against the just-built dylib, avoiding a
+      # separate runner and an artifact upload/download round-trip.
       - name: Install .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -351,10 +338,10 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
           dotnet build -c Release -f net10.0
-          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib bin/Release/net10.0/
-          cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib ./
+          cp ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.dylib bin/Release/net10.0/
+          cp ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.dylib ./
           sudo mkdir -p /usr/local/lib
-          sudo cp ${GITHUB_WORKSPACE}/nuget/libOpenCvSharpExtern.dylib /usr/local/lib/
+          sudo cp ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.dylib /usr/local/lib/
           DYLD_LIBRARY_PATH=/usr/local/lib:${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime osx-arm64 \
             --logger "trx;LogFileName=test-results.trx" < /dev/null
 
@@ -367,7 +354,9 @@ jobs:
   # Create NuGet packages from the macOS-built binaries.
   # ---------------------------------------------------------------------------
   nuget:
-    needs: [build_x64, build_arm64, test]
+    name: macOS (nuget)
+    needs: [build_x64, build_arm64]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -19,6 +19,7 @@ jobs:
   # The resulting .so depends only on glibc / libstdc++ system libraries.
   # ---------------------------------------------------------------------------
   build_full:
+    name: Linux (x64, full)
     runs-on: ubuntu-24.04
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
@@ -199,6 +200,7 @@ jobs:
   # jpeg/png/tiff/webp/zlib internally.
   # ---------------------------------------------------------------------------
   build_slim:
+    name: Linux (x64, slim)
     runs-on: ubuntu-24.04
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
@@ -286,6 +288,7 @@ jobs:
   # This validates that a glibc 2.28-built binary works on a newer distro.
   # ---------------------------------------------------------------------------
   test:
+    name: Linux (test)
     needs: [build_full, build_slim]
     runs-on: ubuntu-24.04
 
@@ -339,6 +342,7 @@ jobs:
   # Only runs on push to main.
   # ---------------------------------------------------------------------------
   nuget:
+    name: Linux (nuget)
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    name: Wasm
 
     runs-on: ubuntu-24.04
     

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   build:
+    name: Windows (x64)
 
     runs-on: windows-2025
 
@@ -261,6 +262,7 @@ jobs:
           path: ${{ github.workspace }}\artifacts
 
   build-arm64:
+    name: Windows (arm64)
 
     runs-on: windows-11-arm
 


### PR DESCRIPTION
CI: platform-explicit job names + trim macOS PR checks

Reduce PR check clutter without cutting test coverage.

Naming (all workflows):
Give every job a platform-explicit `name:` so the PR check list reads
"macOS (x64)", "Windows (arm64)", "Linux (x64, full)", "Wasm", ... instead
of three indistinguishable "build" rows plus bare job ids.

macOS:
- Fold the separate `test` job into `build_arm64`. Build and test share the
  same macos-26 runner, so testing the just-built dylib in-job removes a
  runner spin-up and a redundant artifact upload/download round-trip.
- Gate the `nuget` job with `if: github.event_name == 'push' && github.ref
  == 'refs/heads/main'`, matching manylinux. macOS was the only workflow
  packing NuGet on every PR; now it only packs on push to main like the
  others. publish_nuget.yml is unchanged (it pulls the same
  nuget-packages-macos artifact from the main-branch run).

Net effect on a PR: macOS shows 2 active checks (was 4).

manylinux is intentionally left as-is: its `test` job runs on bare
ubuntu-24.04 (outside the manylinux_2_28 container) to verify the glibc
2.28 binary works on a newer distro. Folding it into the container build
would defeat that cross-distro check.

Windows is left as a single build job: splitting it would add rows and each
split job would re-restore the large OpenCV cache, so wall-clock would not
meaningfully improve.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
