### PR TITLE
Replace BEGIN_WRAP/END_WRAP macros with a cvTry() wrapper

### DIFF
--- a/src/OpenCvSharpExtern/.clang-format
+++ b/src/OpenCvSharpExtern/.clang-format
@@ -9,9 +9,3 @@ SortIncludes: Never
 AttributeMacros:
   - CVAPI
 BreakAfterAttributes: Never
-
-# Treat BEGIN_WRAP / END_WRAP as self-contained statements so that
-# the formatter does not add an extra indentation level between them.
-StatementMacros:
-  - BEGIN_WRAP
-  - END_WRAP

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -104,7 +104,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 	int* idx, int idxCount,
 	interop::Scalar borderColor)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	std::vector< std::vector<cv::Point2f> > cornerVec(cornerSize1);
 	std::vector<int> idxVec;
 
@@ -114,20 +114,20 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 		idxVec = std::vector<int>(idx, idx + idxCount);
 
 	cv::aruco::drawDetectedMarkers(*image, cornerVec, idxVec, cpp(borderColor));
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_getPredefinedDictionary(int name, cv::aruco::Dictionary** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	const auto dictionary = cv::aruco::getPredefinedDictionary(name);
 	*returnValue = new cv::aruco::Dictionary(dictionary);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_readDictionary(const char* dictionaryFile, cv::aruco::Dictionary** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 
 	auto readMode = cv::FileStorage::READ | cv::FileStorage::FORMAT_YAML;
 	cv::FileStorage storeage(dictionaryFile, readMode);
@@ -140,45 +140,45 @@ CVAPI(ExceptionStatus) aruco_readDictionary(const char* dictionaryFile, cv::aruc
 
 	*returnValue = new cv::aruco::Dictionary(dictionary);
 
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_delete(cv::aruco::Dictionary* ptr)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	delete ptr;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_setMarkerSize(cv::aruco::Dictionary* obj, int value)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	obj->markerSize = value;
-	END_WRAP
+	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_setMaxCorrectionBits(cv::aruco::Dictionary* obj, int value)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	obj->maxCorrectionBits = value;
-	END_WRAP
+	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getBytesList(cv::aruco::Dictionary* obj, cv::Mat** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	* returnValue = new cv::Mat(obj->bytesList);
-	END_WRAP
+	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getMarkerSize(cv::aruco::Dictionary* obj, int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = obj->markerSize;
-	END_WRAP
+	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getMaxCorrectionBits(cv::aruco::Dictionary* obj, int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = obj->maxCorrectionBits;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_identify(
@@ -189,9 +189,9 @@ CVAPI(ExceptionStatus) aruco_Dictionary_identify(
 	double maxCorrectionRate,
 	int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = obj->identify(*onlyBits, *idx, *rotation, maxCorrectionRate) != 0;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_getDistanceToId(
@@ -201,9 +201,9 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getDistanceToId(
 	int allRotations,
 	int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = obj->getDistanceToId(*bits, id, allRotations != 0);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_generateImageMarker(
@@ -213,19 +213,19 @@ CVAPI(ExceptionStatus) aruco_Dictionary_generateImageMarker(
 	cv::_OutputArray *img,
 	int borderBits)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	obj->generateImageMarker(id, sidePixels, *img, borderBits);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_getByteListFromBits(
 	cv::Mat *bits,
 	cv::Mat* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	const auto result = cv::aruco::Dictionary::getByteListFromBits(*bits);
 	result.copyTo(*returnValue);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_getBitsFromByteList(
@@ -233,10 +233,10 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getBitsFromByteList(
 	int markerSize,
 	cv::Mat* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	const auto result = cv::aruco::Dictionary::getBitsFromByteList(*byteList, markerSize);
 	result.copyTo(*returnValue);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
@@ -247,7 +247,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 	std::vector<cv::Vec4i>* ids,
 	interop::Scalar borderColor)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 		std::vector< std::vector<cv::Point2f> > cornerVec(cornerSize1);
 
 	for (int i = 0; i < cornerSize1; i++)
@@ -256,7 +256,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 	const cv::_InputArray idArray = (ids != nullptr) ? *ids : static_cast<cv::_InputArray>(cv::noArray());
 
 	cv::aruco::drawDetectedDiamonds(*image, cornerVec, idArray, cpp(borderColor));
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
@@ -265,11 +265,11 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	std::vector<int>* ids,
 	interop::Scalar cornerColor)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	cv::_InputArray idArray = cv::noArray();
 	if (ids != nullptr) idArray = *ids;
 	cv::aruco::drawDetectedCornersCharuco(*image, *corners, idArray, cpp(cornerColor));
-	END_WRAP
+	});
 }
 
 // ==================== ArucoDetector ====================
@@ -280,18 +280,18 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_create(
 	aruco_RefineParameters* refineParams,
 	cv::aruco::ArucoDetector** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	const auto dp = cpp(*detectorParams);
 	const auto rp = cv::aruco::RefineParameters(refineParams->minRepDistance, refineParams->errorCorrectionRate, refineParams->checkAllOrders);
 	*returnValue = new cv::aruco::ArucoDetector(*dictionary, dp, rp);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_delete(cv::aruco::ArucoDetector* ptr)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	delete ptr;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkers(
@@ -301,9 +301,9 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkers(
 	std::vector<int>* ids,
 	std::vector<std::vector<cv::Point2f>>* rejectedImgPoints)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	detector->detectMarkers(*image, *corners, *ids, *rejectedImgPoints);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
@@ -317,12 +317,12 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
 	cv::_InputArray* distCoeffs,
 	std::vector<int>* recoveredIdxs)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	cv::_OutputArray recoveredIdxsArr = cv::noArray();
 	if (recoveredIdxs != nullptr) recoveredIdxsArr = *recoveredIdxs;
 	detector->refineDetectedMarkers(*image, *board, *detectedCorners, *detectedIds, *rejectedCorners,
 		entity(cameraMatrix), entity(distCoeffs), recoveredIdxsArr);
-	END_WRAP
+	});
 }
 
 // ==================== CharucoBoard ====================
@@ -333,53 +333,53 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_create(
 	cv::aruco::Dictionary* dictionary,
 	cv::aruco::CharucoBoard** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = new cv::aruco::CharucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, *dictionary);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_delete(cv::aruco::CharucoBoard* ptr)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	delete ptr;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getChessboardSize(cv::aruco::CharucoBoard* ptr, interop::Size* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	const auto s = ptr->getChessboardSize();
 	returnValue->width = s.width;
 	returnValue->height = s.height;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getSquareLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = ptr->getSquareLength();
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getMarkerLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = ptr->getMarkerLength();
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_setLegacyPattern(cv::aruco::CharucoBoard* ptr, int value)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	ptr->setLegacyPattern(value != 0);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getLegacyPattern(cv::aruco::CharucoBoard* ptr, int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = ptr->getLegacyPattern() ? 1 : 0;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_generateImage(
@@ -389,9 +389,9 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_generateImage(
 	int marginSize,
 	int borderBits)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	ptr->generateImage(cpp(outSize), *img, marginSize, borderBits);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
@@ -399,9 +399,9 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
 	cv::_InputArray* charucoIds,
 	int* returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	*returnValue = ptr->checkCharucoCornersCollinear(*charucoIds) ? 1 : 0;
-	END_WRAP
+	});
 }
 
 // ==================== CharucoDetector ====================
@@ -417,7 +417,7 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
 	aruco_RefineParameters* refineParams,
 	cv::aruco::CharucoDetector** returnValue)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	cv::aruco::CharucoParameters cp;
 	if (cameraMatrix != nullptr)
 		cp.cameraMatrix = cameraMatrix->getMat();
@@ -429,14 +429,14 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
 	const auto dp = cpp(*detectorParams);
 	const auto rp = cv::aruco::RefineParameters(refineParams->minRepDistance, refineParams->errorCorrectionRate, refineParams->checkAllOrders);
 	*returnValue = new cv::aruco::CharucoDetector(*board, cp, dp, rp);
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_delete(cv::aruco::CharucoDetector* ptr)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	delete ptr;
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
@@ -447,7 +447,7 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 	std::vector<std::vector<cv::Point2f>>* markerCorners,
 	std::vector<int>* markerIds)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	cv::Mat charucoCorners_mat, charucoIds_mat;
 	detector->detectBoard(*image, charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
 	for (int i = 0; i < charucoCorners_mat.rows; ++i)
@@ -455,7 +455,7 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
 		charucoIds->push_back(charucoIds_mat.at<int>(i, 0));
 	}
-	END_WRAP
+	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_detectDiamonds(
@@ -466,9 +466,9 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectDiamonds(
 	std::vector<std::vector<cv::Point2f>>* markerCorners,
 	std::vector<int>* markerIds)
 {
-	BEGIN_WRAP
+	return cvTry([&] {
 	detector->detectDiamonds(*image, *diamondCorners, *diamondIds, *markerCorners, *markerIds);
-	END_WRAP
+	});
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/barcode.h
+++ b/src/OpenCvSharpExtern/barcode.h
@@ -7,57 +7,57 @@
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_create(
     const char *super_resolution_model_path, cv::barcode::BarcodeDetector **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // OpenCV 5: BarcodeDetector takes a single ONNX super-resolution model path (Caffe dropped).
     if (super_resolution_model_path == nullptr || super_resolution_model_path[0] == '\0')
         *returnValue = new cv::barcode::BarcodeDetector();
     else
         *returnValue = new cv::barcode::BarcodeDetector(std::string(super_resolution_model_path));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_delete(cv::barcode::BarcodeDetector *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_setDownsamplingThreshold(cv::barcode::BarcodeDetector *obj, double thresh)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDownsamplingThreshold(thresh);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_setDetectorScales(cv::barcode::BarcodeDetector *obj, std::vector<float> *sizes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDetectorScales(*sizes);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_setGradientThreshold(cv::barcode::BarcodeDetector *obj, double thresh)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGradientThreshold(thresh);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_decodeWithType(cv::barcode::BarcodeDetector *obj, cv::_InputArray *inputImage,
     std::vector<cv::Point2f> *points, std::vector<std::string> *detectorInfos, std::vector<std::string> *detectorTypes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->decodeWithType(*inputImage, *points, *detectorInfos, *detectorTypes);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) barcode_BarcodeDetector_detectAndDecodeWithType(cv::barcode::BarcodeDetector *obj, cv::_InputArray *inputImage,
     std::vector<cv::Point2f> *points, std::vector<std::string> *detectorInfos, std::vector<std::string> *detectorTypes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectAndDecodeWithType(*inputImage, *detectorInfos, *detectorTypes, *points);
-    END_WRAP
+    });
 }
 
 #endif //NO_BARCODE

--- a/src/OpenCvSharpExtern/bgsegm.h
+++ b/src/OpenCvSharpExtern/bgsegm.h
@@ -13,91 +13,91 @@
 CVAPI(ExceptionStatus) bgsegm_createBackgroundSubtractorMOG(
     int history, int nmixtures, double backgroundRatio, double noiseSigma, cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::bgsegm::createBackgroundSubtractorMOG(history, nmixtures, backgroundRatio, noiseSigma);
     *returnValue = new cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG>(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_Ptr_BackgroundSubtractorMOG_get(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *obj, cv::bgsegm::BackgroundSubtractorMOG **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_Ptr_BackgroundSubtractorMOG_delete(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getHistory(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getHistory();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_setHistory(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setHistory(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getNMixtures(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getNMixtures();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_setNMixtures(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setNMixtures(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getBackgroundRatio(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getBackgroundRatio();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_setBackgroundRatio(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setBackgroundRatio(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getNoiseSigma(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getNoiseSigma();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_setNoiseSigma(cv::Ptr<cv::bgsegm::BackgroundSubtractorMOG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setNoiseSigma(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_apply(
     cv::bgsegm::BackgroundSubtractorMOG *obj, cv::_InputArray *image, cv::_OutputArray *fgmask, double learningRate)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->apply(*image, *fgmask, learningRate);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getBackgroundImage(
     cv::bgsegm::BackgroundSubtractorMOG *obj, cv::_OutputArray *backgroundImage)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getBackgroundImage(*backgroundImage);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -107,169 +107,169 @@ CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorMOG_getBackgroundImage(
 CVAPI(ExceptionStatus) bgsegm_createBackgroundSubtractorGMG(
     int initializationFrames, double decisionThreshold, cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::bgsegm::createBackgroundSubtractorGMG(initializationFrames, decisionThreshold);
     *returnValue = new cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG>(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_Ptr_BackgroundSubtractorGMG_get(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *obj, cv::bgsegm::BackgroundSubtractorGMG **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_Ptr_BackgroundSubtractorGMG_delete(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getMaxFeatures(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getMaxFeatures();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setMaxFeatures(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setMaxFeatures(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getDefaultLearningRate(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getDefaultLearningRate();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setDefaultLearningRate(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setDefaultLearningRate(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getNumFrames(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getNumFrames();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setNumFrames(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setNumFrames(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getQuantizationLevels(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getQuantizationLevels();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setQuantizationLevels(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setQuantizationLevels(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getBackgroundPrior(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getBackgroundPrior();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setBackgroundPrior(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setBackgroundPrior(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getSmoothingRadius(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getSmoothingRadius();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setSmoothingRadius(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setSmoothingRadius(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getDecisionThreshold(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getDecisionThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setDecisionThreshold(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setDecisionThreshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getUpdateBackgroundModel(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getUpdateBackgroundModel() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setUpdateBackgroundModel(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setUpdateBackgroundModel(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getMinVal(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getMinVal();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setMinVal(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setMinVal(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getMaxVal(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*ptr)->getMaxVal();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_setMaxVal(cv::Ptr<cv::bgsegm::BackgroundSubtractorGMG> *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*ptr)->setMaxVal(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_apply(
     cv::bgsegm::BackgroundSubtractorGMG *obj, cv::_InputArray *image, cv::_OutputArray *fgmask, double learningRate)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->apply(*image, *fgmask, learningRate);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) bgsegm_BackgroundSubtractorGMG_getBackgroundImage(
     cv::bgsegm::BackgroundSubtractorGMG *obj, cv::_OutputArray *backgroundImage)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getBackgroundImage(*backgroundImage);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/calib.h
+++ b/src/OpenCvSharpExtern/calib.h
@@ -15,7 +15,7 @@ CVAPI(ExceptionStatus) calib_initCameraMatrix2D_Mat(
     interop::Size imageSize, double aspectRatio,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> objectPointsVec(objectPointsLength);
     for (auto i = 0; i < objectPointsLength; i++)
         objectPointsVec[i] = *objectPoints[i];
@@ -25,7 +25,7 @@ CVAPI(ExceptionStatus) calib_initCameraMatrix2D_Mat(
 
     const auto ret = cv::initCameraMatrix2D(objectPointsVec, imagePointsVec, cpp(imageSize), aspectRatio);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_initCameraMatrix2D_array(
@@ -33,7 +33,7 @@ CVAPI(ExceptionStatus) calib_initCameraMatrix2D_array(
     cv::Point2f **imagePoints, int ipSize1, int *ipSize2, interop::Size imageSize, double aspectRatio,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Point3f> > objectPointsVec(opSize1);
     for (auto i = 0; i < opSize1; i++)
         objectPointsVec[i] = std::vector<cv::Point3f>(objectPoints[i], objectPoints[i] + opSize2[i]);
@@ -43,7 +43,7 @@ CVAPI(ExceptionStatus) calib_initCameraMatrix2D_array(
 
     const auto ret = cv::initCameraMatrix2D(objectPointsVec, imagePointsVec, cpp(imageSize), aspectRatio);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 
@@ -52,9 +52,9 @@ CVAPI(ExceptionStatus) calib_findChessboardCorners_InputArray(
     cv::_OutputArray *corners, int flags, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findChessboardCorners(*image, cpp(patternSize), *corners, flags) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_findChessboardCorners_vector(
@@ -62,9 +62,9 @@ CVAPI(ExceptionStatus) calib_findChessboardCorners_vector(
     std::vector<cv::Point2f> *corners, int flags, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findChessboardCorners(*image, cpp(patternSize), *corners, flags) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
@@ -76,7 +76,7 @@ CVAPI(ExceptionStatus) calib_findCirclesGrid_InputArray(
     cv::_OutputArray *centers, int flags, cv::FeatureDetector* blobDetector,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (blobDetector == nullptr)
     {
         *returnValue = cv::findCirclesGrid(*image, cpp(patternSize), *centers, flags) ? 1 : 0;
@@ -86,7 +86,7 @@ CVAPI(ExceptionStatus) calib_findCirclesGrid_InputArray(
         const cv::Ptr<cv::FeatureDetector> detectorPtr(blobDetector, BlobDetectorDeleter); // don't delete
         *returnValue = cv::findCirclesGrid(*image, cpp(patternSize), *centers, flags, detectorPtr) ? 1 : 0;
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_findCirclesGrid_vector(
@@ -94,7 +94,7 @@ CVAPI(ExceptionStatus) calib_findCirclesGrid_vector(
     std::vector<cv::Point2f> *centers, int flags, cv::FeatureDetector* blobDetector,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (blobDetector == nullptr)
     {
         *returnValue = cv::findCirclesGrid(*image, cpp(patternSize), *centers, flags) ? 1 : 0;
@@ -104,7 +104,7 @@ CVAPI(ExceptionStatus) calib_findCirclesGrid_vector(
         const cv::Ptr<cv::FeatureDetector> detectorPtr(blobDetector, BlobDetectorDeleter); // don't delete
         *returnValue = cv::findCirclesGrid(*image, cpp(patternSize), *centers, flags, detectorPtr) ? 1 : 0;
     }
-    END_WRAP
+    });
 }
 
 
@@ -119,7 +119,7 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_InputArray(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> objectPointsVec(objectPointsSize);
     for (auto i = 0; i < objectPointsSize; i++)
         objectPointsVec[i] = *objectPoints[i];
@@ -129,7 +129,7 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_InputArray(
 
     *returnValue = cv::calibrateCamera(objectPointsVec, imagePointsVec, cpp(imageSize),
         *cameraMatrix, *distCoeffs, *rvecs, *tvecs, flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_calibrateCamera_vector(
@@ -143,7 +143,7 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_vector(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Point3f> > objectPointsVec(opSize1);
     for (auto i = 0; i < opSize1; i++)
         objectPointsVec[i] = std::vector<cv::Point3f>(objectPoints[i], objectPoints[i] + opSize2[i]);
@@ -157,7 +157,7 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_vector(
 
     *returnValue = cv::calibrateCamera(objectPointsVec, imagePointsVec, cpp(imageSize),
         cametaMatrixM, distCoeffsM, *rvecs, *tvecs, flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 
@@ -176,7 +176,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_InputArray(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> objectPointsVec(opSize);
     std::vector<cv::Mat> imagePoints1Vec(ip1Size);
     std::vector<cv::Mat> imagePoints2Vec(ip2Size);
@@ -191,7 +191,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_InputArray(
         *cameraMatrix1, *distCoeffs1,
         *cameraMatrix2, *distCoeffs2,
         cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_stereoCalibrate_Mat(
@@ -209,7 +209,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_Mat(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> objectPointsVec(opSize);
     std::vector<cv::Mat> imagePoints1Vec(ip1Size);
     std::vector<cv::Mat> imagePoints2Vec(ip2Size);
@@ -224,7 +224,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_Mat(
         *cameraMatrix1, *distCoeffs1,
         *cameraMatrix2, *distCoeffs2,
         cpp(imageSize), *R, *T, *E, *F, flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_stereoCalibrate_array(
@@ -242,7 +242,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_array(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Point3f> > objectPointsVec(opSize1);
     std::vector<std::vector<cv::Point2f> > imagePoints1Vec(ip1Size1);
     std::vector<std::vector<cv::Point2f> > imagePoints2Vec(ip2Size1);
@@ -265,7 +265,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_array(
         cameraMatrix1M, distCoeffs1M,
         cameraMatrix2M, distCoeffs2M,
         cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 
@@ -278,7 +278,7 @@ CVAPI(ExceptionStatus) calib_calibrateHandEye(
     cv::_OutputArray *t_cam2gripper,
     int32_t method)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> R_gripper2base;
     std::vector<cv::Mat> t_gripper2base;
     std::vector<cv::Mat> R_target2cam;
@@ -292,7 +292,7 @@ CVAPI(ExceptionStatus) calib_calibrateHandEye(
         R_target2cam, t_target2cam, 
         *R_cam2gripper, *t_cam2gripper,
         static_cast<cv::HandEyeCalibrationMethod>(method));
-    END_WRAP    
+    });    
 }
 
 
@@ -313,7 +313,7 @@ CVAPI(ExceptionStatus) calib_calibrateRobotWorldHandEye_OutputArray(
     cv::_OutputArray* R_gripper2cam, cv::_OutputArray* t_gripper2cam,
     int32_t method)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> R_gripper2base;
     std::vector<cv::Mat> t_gripper2base;
     std::vector<cv::Mat> R_target2cam;
@@ -328,7 +328,7 @@ CVAPI(ExceptionStatus) calib_calibrateRobotWorldHandEye_OutputArray(
         *R_base2world, *t_base2world,
         *R_gripper2cam, *t_gripper2cam,
         static_cast<cv::RobotWorldHandEyeCalibrationMethod>(method));
-    END_WRAP
+    });
 }
 
 
@@ -341,7 +341,7 @@ CVAPI(ExceptionStatus) calib_calibrateRobotWorldHandEye_Pointer(
     double* R_gripper2cam, double* t_gripper2cam,
     int32_t method)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> R_gripper2base;
     std::vector<cv::Mat> t_gripper2base;
     std::vector<cv::Mat> R_target2cam;
@@ -366,7 +366,7 @@ CVAPI(ExceptionStatus) calib_calibrateRobotWorldHandEye_Pointer(
     std::memcpy(R_gripper2cam, R_gripper2camM.val, 9 * sizeof(double));
     std::memcpy(t_gripper2cam, t_gripper2camM.val, 3 * sizeof(double));
 
-    END_WRAP
+    });
 }
 
 #endif // NO_CALIB

--- a/src/OpenCvSharpExtern/calib_fisheye.h
+++ b/src/OpenCvSharpExtern/calib_fisheye.h
@@ -12,70 +12,70 @@
     cv::_InputArray *objectPoints, cv::_OutputArray *imagePoints, const cv::Affine3d& affine,
     cv::_InputArray *K, cv::_InputArray *D, double alpha, cv::_OutputArray *jacobian)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::projectPoints(*objectPoints, *imagePoints, affine, *K, *D, alpha, entity(jacobian));
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) calib_fisheye_projectPoints2(
     cv::_InputArray *objectPoints, cv::_OutputArray *imagePoints, cv::_InputArray *rvec, cv::_InputArray *tvec,
     cv::_InputArray *K, cv::_InputArray *D, double alpha, cv::_OutputArray *jacobian)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::projectPoints(*objectPoints, *imagePoints, *rvec, *tvec, *K, *D, alpha, entity(jacobian));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_distortPoints(
     cv::_InputArray *undistorted, cv::_OutputArray *distorted, cv::_InputArray *K, cv::_InputArray *D, double alpha)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::distortPoints(*undistorted, *distorted, *K, *D, alpha);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_distortPoints2(
     cv::_InputArray *undistorted, cv::_OutputArray *distorted, cv::_InputArray *Kundistorted, cv::_InputArray *K, cv::_InputArray *D, double alpha)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::distortPoints(*undistorted, *distorted, *Kundistorted, *K, *D, alpha);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_undistortPoints(
     cv::_InputArray *distorted, cv::_OutputArray *undistorted,
     cv::_InputArray *K, cv::_InputArray *D, cv::_InputArray *R, cv::_InputArray *P)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::undistortPoints(*distorted, *undistorted, *K, *D, entity(R), entity(P));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_initUndistortRectifyMap(
     cv::_InputArray *K, cv::_InputArray *D, cv::_InputArray *R, cv::_InputArray *P,
     interop::Size size, int m1type, cv::_OutputArray *map1, cv::_OutputArray *map2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::initUndistortRectifyMap(*K, *D, *R, *P, cpp(size), m1type, *map1, *map2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_undistortImage(
     cv::_InputArray *distorted, cv::_OutputArray *undistorted,
     cv::_InputArray *K, cv::_InputArray *D, cv::_InputArray *Knew, interop::Size newSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::undistortImage(*distorted, *undistorted, *K, *D, entity(Knew), cpp(newSize));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_estimateNewCameraMatrixForUndistortRectify(
     cv::_InputArray *K, cv::_InputArray *D, interop::Size image_size, cv::_InputArray *R,
     cv::_OutputArray *P, double balance, interop::Size newSize, double fov_scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::estimateNewCameraMatrixForUndistortRectify(*K, *D, cpp(image_size), *R, *P, balance, cpp(newSize), fov_scale);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_calibrate(
@@ -90,11 +90,11 @@ CVAPI(ExceptionStatus) calib_fisheye_calibrate(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::fisheye::calibrate(
         *objectPoints, *imagePoints, cpp(imageSize),
         *K, *D, *rvecs, *tvecs, flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_stereoRectify(
@@ -102,9 +102,9 @@ CVAPI(ExceptionStatus) calib_fisheye_stereoRectify(
     cv::_OutputArray *R1, cv::_OutputArray *R2, cv::_OutputArray *P1, cv::_OutputArray *P2, cv::_OutputArray *Q, int flags, interop::Size newImageSize,
     double balance, double fov_scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fisheye::stereoRectify(*K1, *D1, *K2, *D2, cpp(imageSize), *R, *tvec, *R1, *R2, *P1, *P2, *Q, flags, cpp(newImageSize), balance, fov_scale);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) calib_fisheye_stereoCalibrate(
@@ -122,13 +122,13 @@ CVAPI(ExceptionStatus) calib_fisheye_stereoCalibrate(
     interop::TermCriteria criteria,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::fisheye::stereoCalibrate(
         *objectPoints, *imagePoints1, *imagePoints2,
         *K1, *D1,
         *K2, *D2,
         cpp(imageSize), entity(R), entity(T), flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 #endif // NO_CALIB

--- a/src/OpenCvSharpExtern/calib_multiview.h
+++ b/src/OpenCvSharpExtern/calib_multiview.h
@@ -21,7 +21,7 @@ CVAPI(ExceptionStatus) calib_registerCameras(
     cv::_OutputArray *perViewErrors,
     int flags, interop::TermCriteria criteria, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> op1(objectPoints1Size), op2(objectPoints2Size), ip1(imagePoints1Size), ip2(imagePoints2Size);
     for (int i = 0; i < objectPoints1Size; i++) op1[i] = *objectPoints1[i];
     for (int i = 0; i < objectPoints2Size; i++) op2[i] = *objectPoints2[i];
@@ -33,7 +33,7 @@ CVAPI(ExceptionStatus) calib_registerCameras(
         *cameraMatrix1, *distCoeffs1, static_cast<cv::CameraModel>(cameraModel1),
         *cameraMatrix2, *distCoeffs2, static_cast<cv::CameraModel>(cameraModel2),
         *R, *T, *E, *F, *perViewErrors, flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 // calibrateMultiview (OpenCV 5): intrinsics + extrinsics for a multi-camera system.
@@ -49,7 +49,7 @@ CVAPI(ExceptionStatus) calib_calibrateMultiview(
     cv::_InputArray *flagsForIntrinsics, int flags,
     interop::TermCriteria criteria, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> objPointsVec(objPointsSize);
     for (int i = 0; i < objPointsSize; i++)
         objPointsVec[i] = *objPoints[i];
@@ -72,7 +72,7 @@ CVAPI(ExceptionStatus) calib_calibrateMultiview(
         *detectionMask, *models,
         *Ks, *distortions, *Rs, *Ts,
         entity(flagsForIntrinsics), flags, cpp(criteria));
-    END_WRAP
+    });
 }
 
 #endif // NO_CALIB

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -18,166 +18,166 @@ CVAPI(interop::RotatedRect) core_RotatedRect_byThreeVertexPoints(
 
 CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::borderInterpolate(p, len, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_copyMakeBorder(
     cv::_InputArray* src, cv::_OutputArray* dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cpp(value));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_add(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::add(*src1, *src2, *dst, entity(mask), dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_subtract_InputArray2(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::subtract(*src1, *src2, *dst, entity(mask), dtype);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
     cv::_InputArray *src1, interop::Scalar src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::subtract(*src1, cpp(src2), *dst, entity(mask), dtype);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
     interop::Scalar src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::subtract(cpp(src1), *src2, *dst, entity(mask), dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_multiply(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, double scale, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::multiply(*src1, *src2, *dst, scale, dtype);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_divide1(
     double scale, cv::_InputArray *src2, cv::_OutputArray *dst, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::divide(scale, *src2, *dst, dtype);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_divide2(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, double scale, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::divide(*src1, *src2, *dst, scale, dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_scaleAdd(cv::_InputArray *src1, double alpha, cv::_InputArray *src2, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::scaleAdd(*src1, alpha, *src2, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_addWeighted(cv::_InputArray *src1, double alpha, cv::_InputArray *src2,
                              double beta, double gamma, cv::_OutputArray *dst, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_convertScaleAbs(cv::_InputArray* src, cv::_OutputArray* dst, double alpha, double beta)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convertScaleAbs(*src, *dst, alpha, beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LUT(cv::_InputArray* src, cv::_InputArray* lut, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::LUT(*src, *lut, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_sum(cv::_InputArray* src, interop::Scalar* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::sum(*src));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_countNonZero(cv::_InputArray* src, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::countNonZero(*src);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_findNonZero(cv::_InputArray* src, cv::_OutputArray* idx)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findNonZero(*src, *idx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_mean(cv::_InputArray* src, cv::_InputArray* mask, interop::Scalar* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::mean(*src, entity(mask)));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_meanStdDev_OutputArray(
     cv::_InputArray* src, cv::_OutputArray* mean, cv::_OutputArray* stddev, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::meanStdDev(*src, *mean, *stddev, entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_meanStdDev_Scalar(
     cv::_InputArray* src, interop::Scalar* mean, interop::Scalar* stddev, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar mean0, stddev0;
     cv::meanStdDev(*src, mean0, stddev0, entity(mask));
     *mean = c(mean0);
     *stddev = c(stddev0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_norm1(
     cv::_InputArray* src1, int normType, cv::_InputArray* mask, double *returnValue)
 {
-    BEGIN_WRAP;
+    return cvTry([&] {
     *returnValue = cv::norm(*src1, normType, entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_norm2(
     cv::_InputArray* src1, cv::_InputArray* src2,
     int normType, cv::_InputArray* mask, double* returnValue)
 {
-    BEGIN_WRAP;
+    return cvTry([&] {
     *returnValue = cv::norm(*src1, *src2, normType, entity(mask));
-    END_WRAP;
+    });
 }
 
 CVAPI(ExceptionStatus) core_PSNR(cv::_InputArray* src1, cv::_InputArray* src2, double R, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::PSNR(*src1, *src2, R);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_batchDistance(
@@ -186,96 +186,96 @@ CVAPI(ExceptionStatus) core_batchDistance(
     int normType, int K, cv::_InputArray* mask,
     int update, int crosscheck)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::batchDistance(
         *src1, *src2, *dist, dtype, *nidx, normType, K, entity(mask), update, crosscheck != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_normalize(
     cv::_InputArray* src, cv::_InputOutputArray* dst, double alpha, double beta, int normType, int dtype, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::InputArray maskVal = entity(mask);
     cv::normalize(*src, *dst, alpha, beta, normType, dtype, maskVal);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_reduceArgMax(cv::_InputArray* src, cv::_OutputArray* dst, int axis, bool lastIndex)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::reduceArgMax(*src, *dst, axis, lastIndex);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_reduceArgMin(cv::_InputArray* src, cv::_OutputArray* dst, int axis, bool lastIndex)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::reduceArgMin(*src, *dst, axis, lastIndex);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_minMaxLoc1(cv::_InputArray* src, double* minVal, double* maxVal)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::minMaxLoc(*src, minVal, maxVal);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_minMaxLoc2(cv::_InputArray* src, double* minVal, double* maxVal,
     interop::Point* minLoc, interop::Point* maxLoc, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::InputArray maskVal = entity(mask);
     cv::Point minLoc0, maxLoc0;
     cv::minMaxLoc(*src, minVal, maxVal, &minLoc0, &maxLoc0, maskVal);
     *minLoc = c(minLoc0);
     *maxLoc = c(maxLoc0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_minMaxIdx1(cv::_InputArray* src, double* minVal, double* maxVal)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::minMaxIdx(*src, minVal, maxVal);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_minMaxIdx2(cv::_InputArray* src, double* minVal, double* maxVal,
     int* minIdx, int* maxIdx, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::InputArray maskVal = entity(mask);
     cv::minMaxIdx(*src, minVal, maxVal, minIdx, maxIdx, maskVal);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_reduce(cv::_InputArray* src, cv::_OutputArray* dst, int dim, int rtype, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::reduce(*src, *dst, dim, rtype, dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_merge(cv::Mat** mv, uint32_t count, cv::Mat* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> vec(static_cast<size_t>(count));
     for (uint32_t i = 0; i < count; i++)
         vec[i] = *mv[i];
 
     cv::merge(vec, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_split(cv::Mat* src, std::vector<cv::Mat>* mv)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::split(*src, *mv);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_mixChannels(cv::Mat** src, uint32_t nsrcs, cv::Mat** dst, uint32_t ndsts, int* fromTo, uint32_t npairs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrcs));
     std::vector<cv::Mat> dstVec(static_cast<size_t>(ndsts));
     for (uint32_t i = 0; i < nsrcs; i++)
@@ -284,606 +284,606 @@ CVAPI(ExceptionStatus) core_mixChannels(cv::Mat** src, uint32_t nsrcs, cv::Mat**
         dstVec[i] = *(dst[i]);
 
     cv::mixChannels(srcVec, dstVec, fromTo, npairs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_extractChannel(cv::_InputArray* src, cv::_OutputArray* dst, int coi)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::extractChannel(*src, *dst, coi);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_insertChannel(cv::_InputArray* src, cv::_InputOutputArray* dst, int coi)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::insertChannel(*src, *dst, coi);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_flip(cv::_InputArray* src, cv::_OutputArray* dst, int flipCode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::flip(*src, *dst, flipCode);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_rotate(cv::_InputArray *src, cv::_OutputArray *dst, int rotateCode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rotate(*src, *dst, rotateCode);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_repeat1(cv::_InputArray* src, int ny, int nx, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::repeat(*src, ny, nx, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat ret = cv::repeat(*src, ny, nx);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
     for (uint32_t i = 0; i < nsrc; i++)
         srcVec[i] = *(src[i]);
     cv::hconcat(&srcVec[0], nsrc, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_hconcat2(cv::_InputArray* src1, cv::_InputArray* src2, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::hconcat(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
     for (uint32_t i = 0; i < nsrc; i++)
         srcVec[i] = *(src[i]);
     cv::vconcat(&srcVec[0], nsrc, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_vconcat2(cv::_InputArray* src1, cv::_InputArray* src2, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::vconcat(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_bitwise_and(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::bitwise_and(*src1, *src2, *dst, entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::bitwise_or(*src1, *src2, *dst, entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::bitwise_xor(*src1, *src2, *dst, entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
     cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::bitwise_not(*src, *dst, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_absdiff(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::absdiff(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_copyTo(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::copyTo(*src, *dst, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_inRange_InputArray(
     cv::_InputArray *src, cv::_InputArray *lowerb, cv::_InputArray *upperb, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::inRange(*src, *lowerb, *upperb, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
     cv::_InputArray *src, interop::Scalar lowerb, interop::Scalar upperb, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::inRange(*src, cpp(lowerb), cpp(upperb), *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_compare(
     cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int cmpop)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::compare(*src1, *src2, *dst, cmpop);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_min1(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::min(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_min_MatMat(cv::Mat* src1, cv::Mat* src2, cv::Mat* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::min(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::min(*src1, src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_max1(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::max(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_max_MatMat(cv::Mat *src1, const cv::Mat *src2, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::max(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_max_MatDouble(cv::Mat *src1, double src2, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::max(*src1, src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_sqrt(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::sqrt(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_pow_Mat(cv::_InputArray *src, double power, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::pow(*src, power, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_exp_Mat(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::exp(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_log_Mat(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::log(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_polarToCart(cv::_InputArray* magnitude, cv::_InputArray* angle,
     cv::_OutputArray* x, cv::_OutputArray* y, int angleInDegrees)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::polarToCart(*magnitude, *angle, *x, *y, angleInDegrees != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_cartToPolar(cv::_InputArray* x, cv::_InputArray* y,
     cv::_OutputArray* magnitude, cv::_OutputArray* angle, int angleInDegrees)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cartToPolar(*x, *y, *magnitude, *angle, angleInDegrees != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_phase(cv::_InputArray* x, cv::_InputArray* y, cv::_OutputArray* angle, int angleInDegrees)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::phase(*x, *y, *angle, angleInDegrees != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_magnitude_Mat(cv::_InputArray* x, cv::_InputArray* y, cv::_OutputArray* magnitude)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::magnitude(*x, *y, *magnitude);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_checkRange(cv::_InputArray* a, int quiet, interop::Point* pos, double minVal, double maxVal, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point pos0;
     *returnValue = cv::checkRange(*a, quiet != 0, &pos0, minVal, maxVal);
     *pos = c(pos0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_patchNaNs(cv::_InputOutputArray *a, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::patchNaNs(*a, val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_gemm(cv::_InputArray *src1, cv::_InputArray *src2, double alpha,
                       cv::_InputArray *src3, double gamma, cv::_OutputArray *dst, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::gemm(*src1, *src2, alpha, *src3, gamma, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_mulTransposed(cv::_InputArray *src, cv::_OutputArray *dst, int aTa,
                                cv::_InputArray *delta, double scale, int dtype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::mulTransposed(*src, *dst, aTa != 0, entity(delta), scale, dtype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_transpose(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::transpose(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_transform(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::transform(*src, *dst, *m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_perspectiveTransform(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::perspectiveTransform(*src, *dst, *m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::perspectiveTransform(*src, *dst, *m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2f> srcVector(src, src + srcLength);
     std::vector<cv::Point2f> dstVector(dst, dst + dstLength);
     cv::perspectiveTransform(srcVector, dstVector, *m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2d> srcVector(src, src + srcLength);
     std::vector<cv::Point2d> dstVector(dst, dst + dstLength);
     cv::perspectiveTransform(srcVector, dstVector, *m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point3f> srcVector(src, src + srcLength);
     std::vector<cv::Point3f> dstVector(dst, dst + dstLength);
     cv::perspectiveTransform(srcVector, dstVector, *m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, cv::_InputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point3d> srcVector(src, src + srcLength);
     std::vector<cv::Point3d> dstVector(dst, dst + dstLength);
     cv::perspectiveTransform(srcVector, dstVector, *m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerToUpper)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::completeSymm(*mtx, lowerToUpper != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_setIdentity(cv::_InputOutputArray *mtx, interop::Scalar s)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setIdentity(*mtx, cpp(s));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_determinant(cv::_InputArray *mtx, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::determinant(*mtx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_trace(cv::_InputArray *mtx, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::trace(*mtx));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_invert(cv::_InputArray *src, cv::_OutputArray *dst, int flags, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::invert(*src, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_solve(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int flags, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::solve(*src1, *src2, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_solveLP(cv::_InputArray *Func, cv::_InputArray *Constr, cv::_OutputArray *z, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::solveLP(*Func, *Constr, *z);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_sort(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::sort(*src, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_sortIdx(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::sortIdx(*src, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_solveCubic(cv::_InputArray *coeffs, cv::_OutputArray *roots, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue =  cv::solveCubic(*coeffs, *roots);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_solvePoly(cv::_InputArray *coeffs, cv::_OutputArray *roots, int maxIters, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue =  cv::solvePoly(*coeffs, *roots, maxIters);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_eigen(cv::_InputArray *src, cv::_OutputArray *eigenvalues,    cv::_OutputArray *eigenvectors, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::eigen(*src, *eigenvalues, *eigenvectors) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_eigenNonSymmetric(
     cv::_InputArray *src,  cv::_OutputArray *eigenvalues, cv::_OutputArray *eigenvectors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_calcCovarMatrix_Mat(cv::Mat **samples, int nsamples, cv::Mat *covar, 
                                      cv::Mat *mean, int flags, int ctype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> samplesVec(nsamples);
     for (int i = 0; i < nsamples; i++)    
         samplesVec[i] = *samples[i];
     
     cv::calcCovarMatrix(&samplesVec[0], nsamples, *covar, *mean, flags, ctype);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_calcCovarMatrix_InputArray(cv::_InputArray *samples, cv::_OutputArray *covar, 
                                             cv::_InputOutputArray *mean, int flags, int ctype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCACompute(cv::_InputArray *data, cv::_InputOutputArray *mean,
                             cv::_OutputArray *eigenvectors, int maxComponents)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCACompute(*data, *mean, *eigenvectors, maxComponents);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_PCACompute2(cv::_InputArray *data, cv::_InputOutputArray *mean,
                             cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, int maxComponents)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, maxComponents);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCAComputeVar(cv::_InputArray *data, cv::_InputOutputArray *mean,
                                cv::_OutputArray *eigenvectors, double retainedVariance)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCACompute(*data, *mean, *eigenvectors, retainedVariance);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_PCAComputeVar2(cv::_InputArray *data, cv::_InputOutputArray *mean,
                                cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, double retainedVariance)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, retainedVariance);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCAProject(cv::_InputArray *data, cv::_InputArray *mean,
                             cv::_InputArray *eigenvectors, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCAProject(*data, *mean, *eigenvectors, *result);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_PCABackProject(cv::_InputArray *data, cv::_InputArray *mean,
                                 cv::_InputArray *eigenvectors, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::PCABackProject(*data, *mean, *eigenvectors, *result);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SVDecomp(cv::_InputArray *src, cv::_OutputArray *w,
                           cv::_OutputArray *u, cv::_OutputArray *vt, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVDecomp(*src, *w, *u, *vt, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SVBackSubst(cv::_InputArray *w, cv::_InputArray *u, cv::_InputArray *vt,
                              cv::_InputArray *rhs, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mahalanobis(cv::_InputArray *v1, cv::_InputArray *v2, cv::_InputArray *icovar, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::Mahalanobis(*v1, *v2, *icovar);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_dft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dft(*src, *dst, flags, nonzeroRows);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_idft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::idft(*src, *dst, flags, nonzeroRows);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_dct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dct(*src, *dst, flags); 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_idct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::idct(*src, *dst, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_mulSpectrums(cv::_InputArray *a, cv::_InputArray *b, cv::_OutputArray *c, int flags, int conjB)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::mulSpectrums(*a, *b, *c, flags, conjB != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getOptimalDFTSize(int vecsize, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getOptimalDFTSize(vecsize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_theRNG_get(uint64 *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::RNG &rng = cv::theRNG();
     *returnValue = rng.state;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_theRNG_set(uint64 value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::theRNG().state = value;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_randu_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *low, cv::_InputArray *high)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::randu(*dst, *low, *high);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_randu_Scalar(cv::_InputOutputArray *dst, interop::Scalar low, interop::Scalar high)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::randu(*dst, cpp(low), cpp(high));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_randn_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *mean, cv::_InputArray *stddev)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::randn(*dst, *mean, *stddev);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_randn_Scalar(cv::_InputOutputArray *dst, interop::Scalar mean, interop::Scalar stddev)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::randn(*dst, cpp(mean), cpp(stddev));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_randShuffle(cv::_InputOutputArray *dst, double iterFactor, uint64 *rng)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::RNG rng0;
     cv::randShuffle(*dst, iterFactor, &rng0);
     *rng = rng0.state;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_kmeans(
@@ -891,9 +891,9 @@ CVAPI(ExceptionStatus) core_kmeans(
     interop::TermCriteria criteria, int attempts, int flags, cv::_OutputArray *centers, 
     double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::kmeans(*data, k, *bestLabels, cpp(criteria), attempts, flags, entity(centers));
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -902,15 +902,15 @@ CVAPI(ExceptionStatus) core_kmeans(
 
 CVAPI(ExceptionStatus) core_cubeRoot(float val, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::cubeRoot(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_fastAtan2(float y, float x, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::fastAtan2(y, x);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -929,134 +929,134 @@ CVAPI(cv::ErrorCallback) redirectError(cv::ErrorCallback errCallback, void* user
 
 CVAPI(ExceptionStatus) core_setNumThreads(int nthreads)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setNumThreads(nthreads);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getNumThreads(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getNumThreads();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_getThreadNum(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getThreadNum();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getBuildInformation(std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& str = cv::getBuildInformation();
     buf->assign(str);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getVersionString(char *buf, int bufLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& str = cv::getVersionString();
     copyString(str, buf, bufLength);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getVersionMajor(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getVersionMajor();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getVersionMinor(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getVersionMinor();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getVersionRevision(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getVersionRevision();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getTickCount(int64* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getTickCount();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getTickFrequency(double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getTickFrequency();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getCPUTickCount(int64* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getCPUTickCount();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_checkHardwareSupport(int feature, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::checkHardwareSupport(feature) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getHardwareFeatureName(int feature, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& str = cv::getHardwareFeatureName(feature);
     buf->assign(str);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getCPUFeaturesLine(std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& str = cv::getCPUFeaturesLine();
     buf->assign(str);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_getNumberOfCPUs(int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getNumberOfCPUs();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_setUseOptimized(int onoff)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setUseOptimized(onoff != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_useOptimized(int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::useOptimized() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_format(cv::_InputArray *mtx, int fmt, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto formatted = cv::format(*mtx, static_cast<cv::Formatter::FormatType>(fmt));
 
     std::stringstream s;
     s << formatted;
     buf->assign(s.str());
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -1065,16 +1065,16 @@ CVAPI(ExceptionStatus) core_format(cv::_InputArray *mtx, int fmt, std::string *b
 
 CVAPI(ExceptionStatus) core_logger_setLogLevel(cv::utils::logging::LogLevel logLevel, cv::utils::logging::LogLevel* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::utils::logging::setLogLevel(logLevel);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::utils::logging::getLogLevel();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -1083,20 +1083,20 @@ CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *ret
 
 CVAPI(ExceptionStatus) core_RNG_fill(uint64 *state, cv::_InputOutputArray *mat, int distType, cv::_InputArray *a, cv::_InputArray *b, int saturateRange)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::RNG rng(*state);
     rng.fill(*mat, distType, *a, *b, saturateRange != 0);
     *state = rng.state;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_RNG_gaussian(uint64 *state, double sigma, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::RNG rng(*state);
     *returnValue = rng.gaussian(sigma);
     *state = rng.state;
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/core_Algorithm.h
+++ b/src/OpenCvSharpExtern/core_Algorithm.h
@@ -8,35 +8,35 @@
 
 CVAPI(ExceptionStatus) core_Algorithm_write(cv::Algorithm *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Algorithm_read(cv::Algorithm *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Algorithm_empty(cv::Algorithm *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Algorithm_save(cv::Algorithm *obj, const char *filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->save(filename);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Algorithm_getDefaultName(cv::Algorithm *obj, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     buf->assign(obj->getDefaultName());
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_FileNode.h
+++ b/src/OpenCvSharpExtern/core_FileNode.h
@@ -8,340 +8,340 @@
 
 CVAPI(ExceptionStatus) core_FileNode_new1(cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileNode();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_delete(cv::FileNode *node)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete node;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_operatorThis_byString(cv::FileNode *obj, const char *nodeName, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*obj)[nodeName];
     *returnValue = new cv::FileNode(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_operatorThis_byInt(cv::FileNode *obj, int i, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*obj)[i];
     *returnValue = new cv::FileNode(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_type(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->type();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_empty(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_isNone(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isNone() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isSeq(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isSeq() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isMap(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isMap() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isInt(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isInt() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isReal(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isReal() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isString(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isString() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_isNamed(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isNamed() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_name(cv::FileNode *obj, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     buf->assign(obj->name());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_size(cv::FileNode *obj, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->size();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_toInt(cv::FileNode *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(*obj);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_toFloat(cv::FileNode *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<float>(*obj);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_toDouble(cv::FileNode *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<double>(*obj);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_toString(cv::FileNode *obj, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     buf->assign(*obj);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_toMat(cv::FileNode *obj, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj) >> (*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_begin(cv::FileNode *obj, cv::FileNodeIterator **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileNodeIterator(obj->begin());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_end(cv::FileNode *obj, cv::FileNodeIterator **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileNodeIterator(obj->end());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_readRaw(cv::FileNode *obj, const char *fmt, uchar* vec, size_t len)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->readRaw(fmt, vec, len);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_int(cv::FileNode *node, int *value, int default_value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     int temp;
     cv::read(*node, temp, default_value);
     *value = temp;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_float(cv::FileNode *node, float *value, float default_value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     float temp;
     cv::read(*node, temp, default_value);
     *value = temp;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_double(cv::FileNode *node, double *value, double default_value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     double temp;
     cv::read(*node, temp, default_value);
     *value = temp;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_String(cv::FileNode *node, std::string *value, const char *default_value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::String str;
     cv::read(*node, str, (default_value == nullptr) ? cv::String() : cv::String(default_value));
     value->assign(str);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Mat(cv::FileNode *node, cv::Mat *mat, cv::Mat *default_mat)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::read(*node, *mat, entity(default_mat));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_SparseMat(cv::FileNode *node, cv::SparseMat *mat, cv::SparseMat *default_mat)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::read(*node, *mat, entity(default_mat));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_vectorOfKeyPoint(cv::FileNode *node, std::vector<cv::KeyPoint> *keypoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::read(*node, *keypoints);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_vectorOfDMatch(cv::FileNode *node, std::vector<cv::DMatch> *matches)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::read(*node, *matches);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) core_FileNode_read_Range(cv::FileNode *node, interop::Range *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Range ret;
     (*node) >> ret;
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_KeyPoint(cv::FileNode *node, interop::KeyPoint *returnValue)
 {   
-    BEGIN_WRAP 
+    return cvTry([&] { 
     cv::KeyPoint ret;
     (*node) >> ret;
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_DMatch(cv::FileNode *node, interop::DMatch *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::DMatch ret;
     (*node) >> ret;
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_Point2i(cv::FileNode *node, interop::Point *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2i ret;
     (*node) >> ret;
     *returnValue = interop::Point{ ret.x, ret.y };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Point2f(cv::FileNode *node, interop::Point2f *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2f ret;
     (*node) >> ret;
     *returnValue = interop::Point2f{ ret.x, ret.y };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Point2d(cv::FileNode *node, interop::Point2d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2d ret;
     (*node) >> ret;
     *returnValue = interop::Point2d{ ret.x, ret.y };
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_Point3i(cv::FileNode *node, interop::Point3i *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point3i ret;
     (*node) >> ret;
     *returnValue = interop::Point3i{ ret.x, ret.y, ret.z };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Point3f(cv::FileNode *node, interop::Point3f *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point3f ret;
     (*node) >> ret;
     *returnValue = interop::Point3f{ ret.x, ret.y, ret.z };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Point3d(cv::FileNode *node, interop::Point3d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point3d ret;
     (*node) >> ret;
     *returnValue = interop::Point3d{ ret.x, ret.y, ret.z };
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_Size2i(cv::FileNode *node, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Size2i ret;
     (*node) >> ret;
     *returnValue = interop::Size{ ret.width, ret.height };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Size2f(cv::FileNode *node, interop::Size2f *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Size2f ret;
     (*node) >> ret;
     *returnValue = interop::Size2f{ ret.width, ret.height };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Size2d(cv::FileNode *node, interop::Size2d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Size2d ret;
     (*node) >> ret;
     *returnValue = interop::Size2d{ ret.width, ret.height };
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_Rect2i(cv::FileNode *node, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect2i ret;
     (*node) >> ret;
     *returnValue = interop::Rect{ ret.x, ret.y, ret.width, ret.height };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Rect2f(cv::FileNode *node, interop::Rect2f *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect2f ret;
     (*node) >> ret;
     *returnValue = interop::Rect2f{ ret.x, ret.y, ret.width, ret.height };
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileNode_read_Rect2d(cv::FileNode *node, interop::Rect2d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect2d ret;
     (*node) >> ret;
     *returnValue = interop::Rect2d{ ret.x, ret.y, ret.width, ret.height };
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNode_read_Scalar(cv::FileNode *node, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar s;
     (*node) >> s;
     *returnValue = interop::Scalar{};
@@ -349,103 +349,103 @@ CVAPI(ExceptionStatus) core_FileNode_read_Scalar(cv::FileNode *node, interop::Sc
     returnValue->val[1] = s.val[1];
     returnValue->val[2] = s.val[2];
     returnValue->val[3] = s.val[3];
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2i(cv::FileNode *node, interop::Vec2i *returnValue) { BEGIN_WRAP cv::Vec2i v; (*node) >> v; interop::Vec2i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3i(cv::FileNode *node, interop::Vec3i *returnValue) { BEGIN_WRAP cv::Vec3i v; (*node) >> v; interop::Vec3i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4i(cv::FileNode *node, interop::Vec4i *returnValue) { BEGIN_WRAP cv::Vec4i v; (*node) >> v; interop::Vec4i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6i(cv::FileNode *node, interop::Vec6i *returnValue) { BEGIN_WRAP cv::Vec6i v; (*node) >> v; interop::Vec6i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2d(cv::FileNode *node, interop::Vec2d *returnValue) { BEGIN_WRAP cv::Vec2d v; (*node) >> v; interop::Vec2d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3d(cv::FileNode *node, interop::Vec3d *returnValue) { BEGIN_WRAP cv::Vec3d v; (*node) >> v; interop::Vec3d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4d(cv::FileNode *node, interop::Vec4d *returnValue) { BEGIN_WRAP cv::Vec4d v; (*node) >> v; interop::Vec4d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6d(cv::FileNode *node, interop::Vec6d *returnValue) { BEGIN_WRAP cv::Vec6d v; (*node) >> v; interop::Vec6d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2f(cv::FileNode *node, interop::Vec2f *returnValue) { BEGIN_WRAP cv::Vec2f v; (*node) >> v; interop::Vec2f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3f(cv::FileNode *node, interop::Vec3f *returnValue) { BEGIN_WRAP cv::Vec3f v; (*node) >> v; interop::Vec3f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4f(cv::FileNode *node, interop::Vec4f *returnValue) { BEGIN_WRAP cv::Vec4f v; (*node) >> v; interop::Vec4f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6f(cv::FileNode *node, interop::Vec6f *returnValue) { BEGIN_WRAP cv::Vec6f v; (*node) >> v; interop::Vec6f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2b(cv::FileNode *node, interop::Vec2b *returnValue) { BEGIN_WRAP cv::Vec2b v; (*node) >> v; interop::Vec2b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3b(cv::FileNode *node, interop::Vec3b *returnValue) { BEGIN_WRAP cv::Vec3b v; (*node) >> v; interop::Vec3b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4b(cv::FileNode *node, interop::Vec4b *returnValue) { BEGIN_WRAP cv::Vec4b v; (*node) >> v; interop::Vec4b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6b(cv::FileNode *node, interop::Vec6b *returnValue) { BEGIN_WRAP cv::Vec6b v; (*node) >> v; interop::Vec6b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2s(cv::FileNode *node, interop::Vec2s *returnValue) { BEGIN_WRAP cv::Vec2s v; (*node) >> v; interop::Vec2s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3s(cv::FileNode *node, interop::Vec3s *returnValue) { BEGIN_WRAP cv::Vec3s v; (*node) >> v; interop::Vec3s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4s(cv::FileNode *node, interop::Vec4s *returnValue) { BEGIN_WRAP cv::Vec4s v; (*node) >> v; interop::Vec4s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6s(cv::FileNode *node, interop::Vec6s *returnValue) { BEGIN_WRAP cv::Vec6s v; (*node) >> v; interop::Vec6s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec2w(cv::FileNode *node, interop::Vec2w *returnValue) { BEGIN_WRAP cv::Vec2w v; (*node) >> v; interop::Vec2w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec3w(cv::FileNode *node, interop::Vec3w *returnValue) { BEGIN_WRAP cv::Vec3w v; (*node) >> v; interop::Vec3w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec4w(cv::FileNode *node, interop::Vec4w *returnValue) { BEGIN_WRAP cv::Vec4w v; (*node) >> v; interop::Vec4w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
-CVAPI(ExceptionStatus) core_FileNode_read_Vec6w(cv::FileNode *node, interop::Vec6w *returnValue) { BEGIN_WRAP cv::Vec6w v; (*node) >> v; interop::Vec6w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; END_WRAP }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2i(cv::FileNode *node, interop::Vec2i *returnValue) { return cvTry([&] { cv::Vec2i v; (*node) >> v; interop::Vec2i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3i(cv::FileNode *node, interop::Vec3i *returnValue) { return cvTry([&] { cv::Vec3i v; (*node) >> v; interop::Vec3i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4i(cv::FileNode *node, interop::Vec4i *returnValue) { return cvTry([&] { cv::Vec4i v; (*node) >> v; interop::Vec4i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6i(cv::FileNode *node, interop::Vec6i *returnValue) { return cvTry([&] { cv::Vec6i v; (*node) >> v; interop::Vec6i ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2d(cv::FileNode *node, interop::Vec2d *returnValue) { return cvTry([&] { cv::Vec2d v; (*node) >> v; interop::Vec2d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3d(cv::FileNode *node, interop::Vec3d *returnValue) { return cvTry([&] { cv::Vec3d v; (*node) >> v; interop::Vec3d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4d(cv::FileNode *node, interop::Vec4d *returnValue) { return cvTry([&] { cv::Vec4d v; (*node) >> v; interop::Vec4d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6d(cv::FileNode *node, interop::Vec6d *returnValue) { return cvTry([&] { cv::Vec6d v; (*node) >> v; interop::Vec6d ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2f(cv::FileNode *node, interop::Vec2f *returnValue) { return cvTry([&] { cv::Vec2f v; (*node) >> v; interop::Vec2f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3f(cv::FileNode *node, interop::Vec3f *returnValue) { return cvTry([&] { cv::Vec3f v; (*node) >> v; interop::Vec3f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4f(cv::FileNode *node, interop::Vec4f *returnValue) { return cvTry([&] { cv::Vec4f v; (*node) >> v; interop::Vec4f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6f(cv::FileNode *node, interop::Vec6f *returnValue) { return cvTry([&] { cv::Vec6f v; (*node) >> v; interop::Vec6f ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2b(cv::FileNode *node, interop::Vec2b *returnValue) { return cvTry([&] { cv::Vec2b v; (*node) >> v; interop::Vec2b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3b(cv::FileNode *node, interop::Vec3b *returnValue) { return cvTry([&] { cv::Vec3b v; (*node) >> v; interop::Vec3b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4b(cv::FileNode *node, interop::Vec4b *returnValue) { return cvTry([&] { cv::Vec4b v; (*node) >> v; interop::Vec4b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6b(cv::FileNode *node, interop::Vec6b *returnValue) { return cvTry([&] { cv::Vec6b v; (*node) >> v; interop::Vec6b ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2s(cv::FileNode *node, interop::Vec2s *returnValue) { return cvTry([&] { cv::Vec2s v; (*node) >> v; interop::Vec2s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3s(cv::FileNode *node, interop::Vec3s *returnValue) { return cvTry([&] { cv::Vec3s v; (*node) >> v; interop::Vec3s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4s(cv::FileNode *node, interop::Vec4s *returnValue) { return cvTry([&] { cv::Vec4s v; (*node) >> v; interop::Vec4s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6s(cv::FileNode *node, interop::Vec6s *returnValue) { return cvTry([&] { cv::Vec6s v; (*node) >> v; interop::Vec6s ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec2w(cv::FileNode *node, interop::Vec2w *returnValue) { return cvTry([&] { cv::Vec2w v; (*node) >> v; interop::Vec2w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec3w(cv::FileNode *node, interop::Vec3w *returnValue) { return cvTry([&] { cv::Vec3w v; (*node) >> v; interop::Vec3w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec4w(cv::FileNode *node, interop::Vec4w *returnValue) { return cvTry([&] { cv::Vec4w v; (*node) >> v; interop::Vec4w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
+CVAPI(ExceptionStatus) core_FileNode_read_Vec6w(cv::FileNode *node, interop::Vec6w *returnValue) { return cvTry([&] { cv::Vec6w v; (*node) >> v; interop::Vec6w ret; std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val)); *returnValue = ret; }); }
 
 
 #pragma region FileNodeIterator
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_new1(cv::FileNodeIterator **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileNodeIterator;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_delete(cv::FileNodeIterator *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorAsterisk(cv::FileNodeIterator *obj, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileNode(*(*obj));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorIncrement(cv::FileNodeIterator *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const size_t prev_remaining = obj->remaining(); 
     ++(*obj);
     *returnValue = (prev_remaining == obj->remaining()) ? 0 : 1;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorPlusEqual(cv::FileNodeIterator *obj, int ofs, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const size_t prev_remaining = obj->remaining();
     (*obj) += ofs;
     *returnValue = (prev_remaining == obj->remaining()) ? 0 : 1;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_readRaw(
     cv::FileNodeIterator *obj, const char *fmt, uchar* vec, size_t maxCount)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->readRaw(fmt, vec, maxCount);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorEqual(cv::FileNodeIterator *it1, cv::FileNodeIterator *it2, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ((*it1) == (*it2)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorMinus(cv::FileNodeIterator *it1, cv::FileNodeIterator *it2, ptrdiff_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*it1) - (*it2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileNodeIterator_operatorLessThan(cv::FileNodeIterator *it1, cv::FileNodeIterator *it2, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*it1) < (*it2);
-    END_WRAP
+    });
 }
 
 #pragma endregion 

--- a/src/OpenCvSharpExtern/core_FileStorage.h
+++ b/src/OpenCvSharpExtern/core_FileStorage.h
@@ -10,494 +10,494 @@
 
 CVAPI(ExceptionStatus) core_FileStorage_new1(cv::FileStorage **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FileStorage;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_new2(const char *source, int flags, const char *encoding, cv::FileStorage **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::string encodingStr;
     if (encoding != nullptr)
         encodingStr = std::string(encoding);
     *returnValue = new cv::FileStorage(source, flags, encodingStr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_delete(cv::FileStorage *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_open(cv::FileStorage *obj,
                                  const char *filename, int flags, const char *encoding, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::string encodingStr;
     if (encoding != nullptr)
         encodingStr = std::string(encoding);
     *returnValue = obj->open(filename, flags, encodingStr) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_isOpened(cv::FileStorage *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isOpened() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 /*
 CVAPI(ExceptionStatus) core_FileStorage_release(cv::FileStorage *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->release();
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) core_FileStorage_releaseAndGetString(
     cv::FileStorage* obj, std::string * outString)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     outString->assign(obj->releaseAndGetString());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_getFirstTopLevelNode(cv::FileStorage *obj, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto node = obj->getFirstTopLevelNode();
     *returnValue = new cv::FileNode(node);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_root(cv::FileStorage *obj, int streamIdx, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto node = obj->root(streamIdx);
     *returnValue = new cv::FileNode(node);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_indexer(cv::FileStorage *obj, const char *nodeName, cv::FileNode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto node = (*obj)[nodeName];
     *returnValue = new cv::FileNode(node);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_writeRaw(cv::FileStorage *obj, const char *fmt, const uchar *vec, size_t len)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->writeRaw(fmt, vec, len);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_writeComment(cv::FileStorage *obj, const char *comment, int append)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->writeComment(comment, append != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_getDefaultObjectName(const char *filename, std::string *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     buf->assign(cv::FileStorage::getDefaultObjectName(filename));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_elname(cv::FileStorage *obj, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->elname);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_startWriteStruct(
     cv::FileStorage *obj, const char* name, int flags, const char *typeName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->startWriteStruct(name, flags, typeName);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_endWriteStruct(    cv::FileStorage *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->endWriteStruct();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_state(cv::FileStorage *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->state;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_write_int(cv::FileStorage *fs, const char *name, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_float(cv::FileStorage *fs, const char *name, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_double(cv::FileStorage *fs, const char *name, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_String(cv::FileStorage *fs, const char *name, const char *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_Mat(cv::FileStorage *fs, const char *name, const cv::Mat *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), *value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_SparseMat(cv::FileStorage *fs, const char *name, const cv::SparseMat *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), *value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_vectorOfKeyPoint(cv::FileStorage *fs, const char *name, const std::vector<cv::KeyPoint> *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), *value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_vectorOfDMatch(cv::FileStorage *fs, const char *name, const std::vector<cv::DMatch> *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::write(*fs, cv::String(name), *value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_writeScalar_int(cv::FileStorage *fs, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::writeScalar(*fs, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_writeScalar_float(cv::FileStorage *fs, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::writeScalar(*fs, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_writeScalar_double(cv::FileStorage *fs, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::writeScalar(*fs, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_writeScalar_String(cv::FileStorage *fs, const char *value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::writeScalar(*fs, cv::String(value));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_shift_String(cv::FileStorage *fs, const char *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_int(cv::FileStorage *fs, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_float(cv::FileStorage *fs, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_double(cv::FileStorage *fs, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Mat(cv::FileStorage *fs, cv::Mat *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << *val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_SparseMat(cv::FileStorage *fs, cv::SparseMat *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << *val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Range(cv::FileStorage *fs, interop::Range val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cpp(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_KeyPoint(cv::FileStorage *fs, cv::KeyPoint val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_DMatch(cv::FileStorage *fs, cv::DMatch val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_vectorOfKeyPoint(cv::FileStorage *fs, std::vector<cv::KeyPoint> *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << *val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_vectorOfDMatch(cv::FileStorage *fs, std::vector<cv::DMatch> *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << *val;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point2i(cv::FileStorage *fs, interop::Point val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point2i(val.x, val.y);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point2f(cv::FileStorage *fs, interop::Point2f val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point2f(val.x, val.y);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point2d(cv::FileStorage *fs, interop::Point2d val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point2d(val.x, val.y);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point3i(cv::FileStorage *fs, interop::Point3i val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point3i(val.x, val.y, val.z);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point3f(cv::FileStorage *fs, interop::Point3f val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point3f(val.x, val.y, val.z);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Point3d(cv::FileStorage *fs, interop::Point3d val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Point3d(val.x, val.y, val.z);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Size2i(cv::FileStorage *fs, interop::Size val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Size2i(val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Size2f(cv::FileStorage *fs, interop::Size2f val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Size2f(val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Size2d(cv::FileStorage *fs, interop::Size2d val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Size2d(val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Rect2i(cv::FileStorage *fs, interop::Rect val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Rect2i(val.x, val.y, val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Rect2f(cv::FileStorage *fs, interop::Rect2f val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Rect2f(val.x, val.y, val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Rect2d(cv::FileStorage *fs, interop::Rect2d val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Rect2d(val.x, val.y, val.width, val.height);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Scalar(cv::FileStorage *fs, interop::Scalar val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cpp(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2i(cv::FileStorage *fs, interop::Vec2i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2i(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3i(cv::FileStorage *fs, interop::Vec3i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3i(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4i(cv::FileStorage *fs, interop::Vec4i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4i(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6i(cv::FileStorage *fs, interop::Vec6i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6i(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2d(cv::FileStorage *fs, interop::Vec2d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2d(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3d(cv::FileStorage *fs, interop::Vec3d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3d(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4d(cv::FileStorage *fs, interop::Vec4d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4d(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6d(cv::FileStorage *fs, interop::Vec6d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6d(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2f(cv::FileStorage *fs, interop::Vec2f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2f(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3f(cv::FileStorage *fs, interop::Vec3f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3f(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4f(cv::FileStorage *fs, interop::Vec4f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4f(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6f(cv::FileStorage *fs, interop::Vec6f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6f(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2b(cv::FileStorage *fs, interop::Vec2b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2b(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3b(cv::FileStorage *fs, interop::Vec3b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3b(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4b(cv::FileStorage *fs, interop::Vec4b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4b(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6b(cv::FileStorage *fs, interop::Vec6b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6b(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2s(cv::FileStorage *fs, interop::Vec2s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2s(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3s(cv::FileStorage *fs, interop::Vec3s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3s(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4s(cv::FileStorage *fs, interop::Vec4s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4s(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6s(cv::FileStorage *fs, interop::Vec6s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6s(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec2w(cv::FileStorage *fs, interop::Vec2w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec2w(v.val[0], v.val[1]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec3w(cv::FileStorage *fs, interop::Vec3w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec3w(v.val[0], v.val[1], v.val[2]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec4w(cv::FileStorage *fs, interop::Vec4w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec4w(v.val[0], v.val[1], v.val[2], v.val[3]);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_FileStorage_shift_Vec6w(cv::FileStorage *fs, interop::Vec6w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*fs) << cv::Vec6w(v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/core_InputArray.h
+++ b/src/OpenCvSharpExtern/core_InputArray.h
@@ -8,128 +8,128 @@
 
 CVAPI(ExceptionStatus) core_InputArray_new_byMat(cv::Mat *mat, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(*mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_new_byUMat(cv::UMat* mat, cv::_InputArray** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         * returnValue = new cv::_InputArray(*mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_new_byMatExpr(cv::MatExpr *expr, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(*expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_new_byScalar(interop::Scalar s, cv::Scalar **handle, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *handle = new cv::Scalar(s.val[0], s.val[1], s.val[2], s.val[3]);
     *returnValue = new cv::_InputArray(**handle);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_new_byDouble(double *handle, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(*handle);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_new_byVectorOfMat(std::vector<cv::Mat> *vector, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(*vector);
-    END_WRAP
+    });
 }
 
 #pragma region new_byVec
 
 CVAPI(ExceptionStatus) core_InputArray_new_byVecb(uchar *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_new_byVecs(short *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_new_byVecw(ushort *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_new_byVeci(int *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_new_byVecf(float *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_new_byVecd(double *vec, int n, cv::_InputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::_InputArray(vec, n);
-    END_WRAP
+    });
 }
 
 #pragma endregion 
 
 CVAPI(ExceptionStatus) core_InputArray_delete(cv::_InputArray *ia)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ia;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_delete_withScalar(cv::_InputArray *ia, cv::Scalar *handle)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ia;
     delete handle;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_getMat(cv::_InputArray *ia, int idx, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(ia->getMat(idx));
-    END_WRAP
+    });
 }
 /*CVAPI(ExceptionStatus) core_InputArray_getMat_(cv::_InputArray *ia, int idx, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(ia->getMat_(idx));
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) core_InputArray_getUMat(cv::_InputArray* ia, int idx, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     * returnValue = new cv::UMat(ia->getUMat(idx));
-    END_WRAP
+    });
     
 }
 
 CVAPI(ExceptionStatus) core_InputArray_getMatVector(cv::_InputArray *ia, std::vector<cv::Mat> *mv)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ia->getMatVector(*mv);
-    END_WRAP
+    });
 }
 /*CVAPI(void) core_InputArray_getUMatVector(cv::_InputArray *ia, std::vector<cv::UMat> *umv)
 {
@@ -138,179 +138,179 @@ CVAPI(ExceptionStatus) core_InputArray_getMatVector(cv::_InputArray *ia, std::ve
 
 CVAPI(ExceptionStatus) core_InputArray_getFlags(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->getFlags();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_getObj(cv::_InputArray *ia, void **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->getObj();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_getSz(cv::_InputArray *ia, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(ia->getSz());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_kind(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->kind();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_dims(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->dims(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_cols(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->cols(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_rows(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->rows(i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_size(cv::_InputArray *ia, int i, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(ia->size(i));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_sizend(cv::_InputArray *ia, int* sz, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->sizend(sz, i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_sameSize(cv::_InputArray *self, cv::_InputArray * target, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->sameSize(*target) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_total(cv::_InputArray *ia, int i, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->total(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_type(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->type(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_depth(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->depth(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_channels(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->channels(i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_isContinuous(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isContinuous(i) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_isSubmatrix(cv::_InputArray *ia, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isSubmatrix(i) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_empty(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_copyTo1(cv::_InputArray *ia, cv::_OutputArray *arr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ia->copyTo(*arr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_copyTo2(cv::_InputArray *ia, cv::_OutputArray *arr, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ia->copyTo(*arr, *mask);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_InputArray_offset(cv::_InputArray *ia, int i, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->offset(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_step(cv::_InputArray *ia, int i, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->step(i);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isMat(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isMat() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isUMat(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isUMat() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isMatVector(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isMatVector() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isUMatVector(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isUMatVector() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isMatx(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isMatx() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isVector(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isVector() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_InputArray_isGpuMatVector(cv::_InputArray *ia, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ia->isGpuMatVector() ? 1 : 0;
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_LDA.h
+++ b/src/OpenCvSharpExtern/core_LDA.h
@@ -8,103 +8,103 @@
 
 CVAPI(ExceptionStatus) core_LDA_new1(int num_components, cv::LDA **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::LDA(num_components);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_new2(cv::_InputArray *src, cv::_InputArray *labels, int num_components, cv::LDA **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::LDA(*src, *labels, num_components);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_delete(cv::LDA *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_save_String(cv::LDA *obj, const char *filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->save(filename);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_load_String(cv::LDA *obj, const char *filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->load(filename);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_save_FileStorage(cv::LDA *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->save(*fs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_load_FileStorage(cv::LDA *obj, cv::FileStorage *node)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->load(*node);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_compute(cv::LDA *obj, cv::_InputArray *src, cv::_InputArray *labels)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*src, *labels);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_project(cv::LDA *obj, cv::_InputArray *src, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = obj->project(*src);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_reconstruct(cv::LDA *obj, cv::_InputArray *src, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = obj->reconstruct(*src);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_eigenvectors(cv::LDA *obj, cv::Mat **returnValue)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = obj->eigenvectors();
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_eigenvalues(cv::LDA *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = obj->eigenvalues();
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_LDA_subspaceProject(cv::_InputArray *W, cv::_InputArray *mean, cv::_InputArray *src, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::LDA::subspaceProject(*W, *mean, *src);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_LDA_subspaceReconstruct(cv::_InputArray *W, cv::_InputArray *mean, cv::_InputArray *src, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::LDA::subspaceReconstruct(*W, *mean, *src);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_Mat.h
+++ b/src/OpenCvSharpExtern/core_Mat.h
@@ -14,88 +14,88 @@ CVAPI(uint64) core_Mat_sizeof()
 
 CVAPI(ExceptionStatus) core_Mat_new1(cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new2(int rows, int cols, int type, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(rows, cols, type); 
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new3(int rows, int cols, int type, interop::Scalar scalar, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(rows, cols, type, cpp(scalar));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new4(cv::Mat *mat, interop::Range rowRange, interop::Range colRange, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(*mat, cpp(rowRange), cpp(colRange));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new5(cv::Mat *mat, cv::Range rowRange, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(*mat, rowRange);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new6(cv::Mat *mat, cv::Range *ranges, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(*mat, ranges);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new7(cv::Mat *mat, interop::Rect roi, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(*mat, cpp(roi));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new8(int rows, int cols, int type, void* data, size_t step, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(rows, cols, type, data, step);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new9(int ndims, const int* sizes, int type, void* data, const size_t* steps, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(ndims, sizes, type, data, steps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new10(int ndims, int* sizes, int type, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(ndims, sizes, type);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new11(int ndims, int* sizes, int type, interop::Scalar s, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(ndims, sizes, type, cpp(s));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_new12(cv::Mat *mat, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(*mat);
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) core_Mat_release(cv::Mat *self)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->release();
-    END_WRAP
+    });
 }*/
 CVAPI(ExceptionStatus) core_Mat_delete(cv::Mat *self)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete self;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -104,131 +104,131 @@ CVAPI(ExceptionStatus) core_Mat_delete(cv::Mat *self)
 
 CVAPI(ExceptionStatus) core_Mat_getUMat(cv::Mat* self, cv::AccessFlag accessFlags, cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         * returnValue = new cv::UMat(self->getUMat(accessFlags, usageFlags));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_row(cv::Mat *self, int y, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(self->row(y));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_col(cv::Mat *self, int x, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(self->col(x));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_rowRange(cv::Mat *self, int startRow, int endRow, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(self->rowRange(startRow, endRow));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_colRange(cv::Mat *self, int startCol, int endCol, cv::Mat **returnValue)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(self->colRange(startCol, endCol));
-    END_WRAP
+    });
 }
      
 CVAPI(ExceptionStatus) core_Mat_diag(cv::Mat *self, int d, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->diag(d);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_diag_static(cv::Mat *self, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::Mat::diag(*self);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_clone(cv::Mat *self, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->clone();
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_copyTo1(cv::Mat *self, cv::_OutputArray *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_copyTo2(cv::Mat *self, cv::_OutputArray *m, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_copyTo_toMat1(cv::Mat *self, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_copyTo_toMat2(cv::Mat *self, cv::Mat *m, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_convertTo(cv::Mat *self, cv::_OutputArray *m, int rtype, double alpha, double beta)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->convertTo(*m, rtype, alpha, beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_assignTo(cv::Mat *self, cv::Mat *m, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->assignTo(*m, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_setTo_Scalar(cv::Mat *self, interop::Scalar value, cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (mask == nullptr)
         self->setTo(cpp(value));
     else 
         self->setTo(cpp(value), entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_setTo_InputArray(cv::Mat *self, cv::_InputArray *value, cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->setTo(*value, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_reshape1(cv::Mat *self, int cn, int rows, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->reshape(cn, rows);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_reshape2(cv::Mat *self, int cn, int newndims, const int* newsz, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->reshape(cn, newndims, newsz);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 // MatShape (OpenCV 5). The shape is marshaled as (ndims, sizes, layout, C):
@@ -244,7 +244,7 @@ static cv::MatShape buildMatShape(int ndims, const int* sizes, int layout, int C
 
 CVAPI(ExceptionStatus) core_Mat_shape(cv::Mat *self, int *sizes, int *outNdims, int *outLayout, int *outC, int *outEmpty)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::MatShape shape = self->shape();
     *outEmpty = shape.empty() ? 1 : 0;
     *outLayout = static_cast<int>(shape.layout);
@@ -259,202 +259,202 @@ CVAPI(ExceptionStatus) core_Mat_shape(cv::Mat *self, int *sizes, int *outNdims, 
         for (int i = 0; i < shape.dims && i < cv::MatShape::MAX_DIMS; i++)
             sizes[i] = shape[i];
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_newFromMatShape(int ndims, const int *sizes, int layout, int C, int type, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(buildMatShape(ndims, sizes, layout, C), type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_newFromMatShapeScalar(int ndims, const int *sizes, int layout, int C, int type, interop::Scalar s, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(buildMatShape(ndims, sizes, layout, C), type, cpp(s));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_reshapeMatShape(cv::Mat *self, int cn, int ndims, const int *sizes, int layout, int C, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->reshape(cn, buildMatShape(ndims, sizes, layout, C));
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_zeros_MatShape(int ndims, const int *sizes, int layout, int C, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::Mat::zeros(buildMatShape(ndims, sizes, layout, C), type);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_ones_MatShape(int ndims, const int *sizes, int layout, int C, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::Mat::ones(buildMatShape(ndims, sizes, layout, C), type);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_t(cv::Mat *self, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = self->t();
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_inv(cv::Mat *self, int method, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->inv(method);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_mul(cv::Mat *self, cv::_InputArray *m, double scale, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->mul(*m, scale);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_cross(cv::Mat *self, cv::_InputArray *m, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->cross(*m);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_dot(cv::Mat *self, cv::_InputArray *m, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dot(*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_zeros1(int rows, int cols, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::Mat::zeros(rows, cols, type);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_zeros2(int ndims, const int *sz, int type, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::Mat::zeros(ndims, sz, type);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_ones1(int rows, int cols, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::Mat::ones(rows, cols, type);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_ones2(int ndims, const int *sz, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto ret = cv::Mat::ones(ndims, sz, type);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_eye(int rows, int cols, int type, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto eye = cv::Mat::eye(rows, cols, type);
     *returnValue = new cv::MatExpr(eye);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_create1(cv::Mat *self, int rows, int cols, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->create(rows, cols, type);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_create2(cv::Mat *self, int ndims, const int *sizes, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->create(ndims, sizes, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_reserve(cv::Mat *self, size_t sz)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->reserve(sz);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_reserveBuffer(cv::Mat *self, size_t sz)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->reserveBuffer(sz);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_resize1(cv::Mat *obj, size_t sz)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->resize(sz);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_resize2(cv::Mat *obj, size_t sz, interop::Scalar s)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->resize(sz, cpp(s));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_pop_back(cv::Mat *obj, size_t nelems)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->pop_back(nelems);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_locateROI(cv::Mat *self, interop::Size *wholeSize, interop::Point *ofs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Size wholeSize2;
     cv::Point ofs2;
     self->locateROI(wholeSize2, ofs2);
     *wholeSize = c(cv::Size(wholeSize2.width, wholeSize2.height));
     *ofs = c(cv::Point(ofs2.x, ofs2.y));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_adjustROI(cv::Mat *self, int dtop, int dbottom, int dleft, int dright, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->adjustROI(dtop, dbottom, dleft, dright);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_subMat1(cv::Mat *self, int rowStart, int rowEnd, int colStart, int colEnd, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Range rowRange(rowStart, rowEnd);
     const cv::Range colRange(colStart, colEnd);
     const auto ret = (*self)(rowRange, colRange);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_subMat2(cv::Mat *self, int nRanges, interop::Range *ranges, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Range> rangesVec(nRanges);
     for (auto i = 0; i < nRanges; i++)
     {
@@ -462,219 +462,219 @@ CVAPI(ExceptionStatus) core_Mat_subMat2(cv::Mat *self, int nRanges, interop::Ran
     }
     const auto ret = (*self)(&rangesVec[0]);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_isContinuous(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->isContinuous() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_isSubmatrix(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->isSubmatrix() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_elemSize(cv::Mat *self, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->elemSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_elemSize1(cv::Mat *self, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->elemSize1();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_type(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->type();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_depth(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->depth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_channels(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->channels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_step1(cv::Mat *self, int i, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step1(i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_empty(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_total1(cv::Mat *self, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->total();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_total2(cv::Mat *self, int startDim, int endDim, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->total(startDim, endDim);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_checkVector(cv::Mat *self, int elemChannels, int depth, int requireContinuous, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->checkVector(elemChannels, depth, requireContinuous != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_ptr1d(cv::Mat *self, int i0, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->ptr(i0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_ptr2d(cv::Mat *self, int i0, int i1, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->ptr(i0, i1);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_ptr3d(cv::Mat *self, int i0, int i1, int i2, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->ptr(i0, i1, i2);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_ptrnd(cv::Mat *self, int *idx, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->ptr(idx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_flags(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->flags;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_dims(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dims;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_rows(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->rows;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_cols(cv::Mat *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->cols;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_data(cv::Mat *self, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->data;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_datastart(cv::Mat *self, const uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->datastart;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_dataend(cv::Mat *self, const uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dataend;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_datalimit(cv::Mat *self, const uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->datalimit;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_size(cv::Mat *self, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // OpenCV 5's MatSize::operator()() asserts dims <= 2, but OpenCvSharp historically
     // returns Size(size[1], size[0]) for multi-dimensional matrices (OpenCV 4 behavior).
     if (self->dims > 2)
         *returnValue = c(cv::Size(self->size[1], self->size[0]));
     else
         *returnValue = c(self->size());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_sizeAt(cv::Mat *self, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->size[i];
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_step(cv::Mat *self, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_stepAt(cv::Mat *self, int i, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step[i];
-    END_WRAP
+    });
 }
       
 CVAPI(ExceptionStatus) core_abs_Mat(cv::Mat *m, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::abs(*m);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) core_Mat_assignment_FromMat(cv::Mat *self, cv::Mat *newMat)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *self = *newMat;
-    END_WRAP
+    });
 }*/
 /*CVAPI(ExceptionStatus) core_Mat_assignment_FromScalar(cv::Mat *self, interop::Scalar scalar)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *self = cpp(scalar);
-    END_WRAP
+    });
 }*/
 
 #pragma endregion
@@ -746,16 +746,16 @@ static void internal_set_item(cv::Mat *mat, int r, int c, double *src, int &coun
 
 CVAPI(ExceptionStatus) core_Mat_setMatData(cv::Mat *obj, uchar *vals, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = internal_Mat_set(obj, vals) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_getMatData(cv::Mat *obj, uchar *vals, int *returnValue)
 {    
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = internal_Mat_get(obj, vals) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -764,269 +764,269 @@ CVAPI(ExceptionStatus) core_Mat_getMatData(cv::Mat *obj, uchar *vals, int *retur
 
 CVAPI(ExceptionStatus) core_Mat_push_back_Mat(cv::Mat *self, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_char(cv::Mat *self, char v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_uchar(cv::Mat *self, uchar v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_short(cv::Mat *self, short v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_ushort(cv::Mat *self, ushort v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_int(cv::Mat *self, int v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_float(cv::Mat *self, float v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_double(cv::Mat *self, double v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(v);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2b(cv::Mat *self, interop::Vec2b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2b(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3b(cv::Mat *self, interop::Vec3b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3b(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4b(cv::Mat *self, interop::Vec4b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4b(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6b(cv::Mat *self, interop::Vec6b v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6b(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2s(cv::Mat *self, interop::Vec2s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2s(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3s(cv::Mat *self, interop::Vec3s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3s(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4s(cv::Mat *self, interop::Vec4s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4s(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6s(cv::Mat *self, interop::Vec6s v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6s(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2w(cv::Mat *self, interop::Vec2w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2w(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3w(cv::Mat *self, interop::Vec3w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3w(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4w(cv::Mat *self, interop::Vec4w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4w(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6w(cv::Mat *self, interop::Vec6w v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6w(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2i(cv::Mat *self, interop::Vec2i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2i(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3i(cv::Mat *self, interop::Vec3i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3i(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4i(cv::Mat *self, interop::Vec4i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4i(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6i(cv::Mat *self, interop::Vec6i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6i(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2f(cv::Mat *self, interop::Vec2f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2f(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3f(cv::Mat *self, interop::Vec3f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3f(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4f(cv::Mat *self, interop::Vec4f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4f(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6f(cv::Mat *self, interop::Vec6f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6f(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec2d(cv::Mat *self, interop::Vec2d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec2d(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec3d(cv::Mat *self, interop::Vec3d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec3d(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec4d(cv::Mat *self, interop::Vec4d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec4d(v.val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Vec6d(cv::Mat *self, interop::Vec6d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Vec6d(v.val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_push_back_Point(cv::Mat *self, interop::Point v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point(v.x, v.y));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Point2f(cv::Mat *self, interop::Point2f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point2f(v.x, v.y));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Point2d(cv::Mat *self, interop::Point2d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point2d(v.x, v.y));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Point3i(cv::Mat *self, interop::Point3i v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point3i(v.x, v.y, v.z));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Point3f(cv::Mat *self, interop::Point3f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point3f(v.x, v.y, v.z));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Point3d(cv::Mat *self, interop::Point3d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Point3d(v.x, v.y, v.z));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Size(cv::Mat *self, interop::Size v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Size(v.width, v.height));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Size2f(cv::Mat *self, interop::Size2f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Size2f(v.width, v.height));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Size2d(cv::Mat *self, interop::Size2d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Size2d(v.width, v.height));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Rect(cv::Mat *self, interop::Rect v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Rect(v.x, v.y, v.width, v.height));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Rect2f(cv::Mat *self, interop::Rect2f v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Rect2f(v.x, v.y, v.width, v.height));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_push_back_Rect2d(cv::Mat *self, interop::Rect2d v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->push_back(cv::Rect2d(v.x, v.y, v.width, v.height));
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -1074,182 +1074,182 @@ struct Functor
 
 CVAPI(ExceptionStatus) core_Mat_forEach_uchar(cv::Mat *m, Mat_foreach_uchar proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_uchar, uchar> functor(proc);
     m->forEach<uchar>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec2b(cv::Mat *m, Mat_foreach_Vec2b proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec2b, cv::Vec2b> functor(proc);
     m->forEach<cv::Vec2b>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec3b(cv::Mat *m, Mat_foreach_Vec3b proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec3b, cv::Vec3b> functor(proc);
     m->forEach<cv::Vec3b>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec4b(cv::Mat *m, Mat_foreach_Vec4b proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec4b, cv::Vec4b> functor(proc);
     m->forEach<cv::Vec4b>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec6b(cv::Mat *m, Mat_foreach_Vec6b proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec6b, cv::Vec6b> functor(proc);
     m->forEach<cv::Vec6b>(functor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_forEach_short(cv::Mat *m, Mat_foreach_short proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_short, short> functor(proc);
     m->forEach<short>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec2s(cv::Mat *m, Mat_foreach_Vec2s proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec2s, cv::Vec2s> functor(proc);
     m->forEach<cv::Vec2s>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec3s(cv::Mat *m, Mat_foreach_Vec3s proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec3s, cv::Vec3s> functor(proc);
     m->forEach<cv::Vec3s>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec4s(cv::Mat *m, Mat_foreach_Vec4s proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec4s, cv::Vec4s> functor(proc);
     m->forEach<cv::Vec4s>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec6s(cv::Mat *m, Mat_foreach_Vec6s proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec6s, cv::Vec6s> functor(proc);
     m->forEach<cv::Vec6s>(functor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_forEach_int(cv::Mat *m, Mat_foreach_int proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_int, int> functor(proc);
     m->forEach<int>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec2i(cv::Mat *m, Mat_foreach_Vec2i proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec2i, cv::Vec2i> functor(proc);
     m->forEach<cv::Vec2i>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec3i(cv::Mat *m, Mat_foreach_Vec3i proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec3i, cv::Vec3i> functor(proc);
     m->forEach<cv::Vec3i>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec4i(cv::Mat *m, Mat_foreach_Vec4i proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec4i, cv::Vec4i> functor(proc);
     m->forEach<cv::Vec4i>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec6i(cv::Mat *m, Mat_foreach_Vec6i proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec6i, cv::Vec6i> functor(proc);
     m->forEach<cv::Vec6i>(functor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_forEach_float(cv::Mat *m, Mat_foreach_float proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_float, float> functor(proc);
     m->forEach<float>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec2f(cv::Mat *m, Mat_foreach_Vec2f proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec2f, cv::Vec2f> functor(proc);
     m->forEach<cv::Vec2f>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec3f(cv::Mat *m, Mat_foreach_Vec3f proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec3f, cv::Vec3f> functor(proc);
     m->forEach<cv::Vec3f>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec4f(cv::Mat *m, Mat_foreach_Vec4f proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec4f, cv::Vec4f> functor(proc);
     m->forEach<cv::Vec4f>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec6f(cv::Mat *m, Mat_foreach_Vec6f proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec6f, cv::Vec6f> functor(proc);
     m->forEach<cv::Vec6f>(functor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_forEach_double(cv::Mat *m, Mat_foreach_double proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_double, double> functor(proc);
     m->forEach<double>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec2d(cv::Mat *m, Mat_foreach_Vec2d proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec2d, cv::Vec2d> functor(proc);
     m->forEach<cv::Vec2d>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec3d(cv::Mat *m, Mat_foreach_Vec3d proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec3d, cv::Vec3d> functor(proc);
     m->forEach<cv::Vec3d>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec4d(cv::Mat *m, Mat_foreach_Vec4d proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec4d, cv::Vec4d> functor(proc);
     m->forEach<cv::Vec4d>(functor);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_forEach_Vec6d(cv::Mat *m, Mat_foreach_Vec6d proc)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const Functor<Mat_foreach_Vec6d, cv::Vec6d> functor(proc);
     m->forEach<cv::Vec6d>(functor);
-    END_WRAP
+    });
 }
 #pragma endregion
 
@@ -1257,179 +1257,179 @@ CVAPI(ExceptionStatus) core_Mat_forEach_Vec6d(cv::Mat *m, Mat_foreach_Vec6d proc
 
 CVAPI(ExceptionStatus) core_Mat_operatorUnaryMinus(cv::Mat *mat, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = -(*mat);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorAdd_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) + (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorAdd_MatScalar(cv::Mat *a, interop::Scalar s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) + cpp(s);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorAdd_ScalarMat(interop::Scalar s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cpp(s) + (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorMinus_Mat(cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = -(*a);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorSubtract_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) - (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorSubtract_MatScalar(cv::Mat *a, interop::Scalar s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) - cpp(s);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorSubtract_ScalarMat(interop::Scalar s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cpp(s) - (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorMultiply_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) * (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorMultiply_MatDouble(cv::Mat *a, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) * s;
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorMultiply_DoubleMat(double s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = s * (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorDivide_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) / (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorDivide_MatDouble(cv::Mat *a, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) / s;
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorDivide_DoubleMat(double s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = s / (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorAnd_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) & (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorAnd_MatDouble(cv::Mat *a, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) & s;
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorAnd_DoubleMat(double s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = s & (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorOr_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) | (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorOr_MatDouble(cv::Mat *a, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) | s;
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorOr_DoubleMat(double s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = s | (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorXor_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) ^ (*b);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorXor_MatDouble(cv::Mat *a, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) ^ s;
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorXor_DoubleMat(double s, cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = s ^ (*a); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_Mat_operatorNot(cv::Mat *a, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = ~(*a);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 
@@ -1438,134 +1438,134 @@ CVAPI(ExceptionStatus) core_Mat_operatorNot(cv::Mat *a, cv::MatExpr **returnValu
 // <
 CVAPI(ExceptionStatus) core_Mat_operatorLT_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) < (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorLT_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a < (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorLT_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) < b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 // <=
 CVAPI(ExceptionStatus) core_Mat_operatorLE_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) <= (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorLE_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a <= (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorLE_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) <= b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 // >
 CVAPI(ExceptionStatus) core_Mat_operatorGT_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) > (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorGT_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a > (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorGT_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) > b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 // >=
 CVAPI(ExceptionStatus) core_Mat_operatorGE_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) >= (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorGE_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a >= (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorGE_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) >= b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 // ==
 CVAPI(ExceptionStatus) core_Mat_operatorEQ_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) == (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorEQ_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a == (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorEQ_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) == b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 // !=
 CVAPI(ExceptionStatus) core_Mat_operatorNE_MatMat(cv::Mat *a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) != (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorNE_DoubleMat(double a, cv::Mat *b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = a != (*b); 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_Mat_operatorNE_MatDouble(cv::Mat *a, double b, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*a) != b; 
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/core_MatExpr.h
+++ b/src/OpenCvSharpExtern/core_MatExpr.h
@@ -8,124 +8,124 @@
 
 CVAPI(ExceptionStatus) core_MatExpr_new1(cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::MatExpr;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_MatExpr_new2(cv::Mat *mat, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::MatExpr(*mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_delete(cv::MatExpr *self)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete self;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_toMat(cv::MatExpr *self, cv::Mat *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = (*self);
-    END_WRAP
+    });
 }
 
 #pragma region Functions
 
 CVAPI(ExceptionStatus) core_MatExpr_row(cv::MatExpr *self, int y, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->row(y);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_MatExpr_col(cv::MatExpr *self, int x, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->col(x);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_diag(cv::MatExpr *self, int d, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->diag(d);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_submat(cv::MatExpr *self, int rowStart, int rowEnd, int colStart, int colEnd, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Range rowRange(rowStart, rowEnd);
     const cv::Range colRange(colStart, colEnd);
     const auto ret = (*self)(rowRange, colRange);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_t(cv::MatExpr *self, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->t();
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_inv(cv::MatExpr *self, int method, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->inv(method);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_mul_toMatExpr(cv::MatExpr *self, cv::MatExpr *e, double scale, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->mul(*e, scale);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_MatExpr_mul_toMat(cv::MatExpr *self, cv::Mat *m, double scale, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->mul(*m, scale);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_cross(cv::MatExpr *self, cv::Mat *m, cv::Mat **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->cross(*m);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_dot(cv::MatExpr *self, cv::Mat *m, double *returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dot(*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_size(cv::MatExpr *self, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(self->size());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_MatExpr_type(cv::MatExpr *self, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->type();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -134,168 +134,168 @@ CVAPI(ExceptionStatus) core_MatExpr_type(cv::MatExpr *self, int *returnValue)
 
 CVAPI(ExceptionStatus) core_operatorUnaryMinus_MatExpr(cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = -(*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorUnaryNot_MatExpr(cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = ~(*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_operatorAdd_MatExprMat(cv::MatExpr *e, cv:: Mat *m, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e) + (*m);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorAdd_MatMatExpr(cv::Mat *m, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*m) + (*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorAdd_MatExprScalar(cv::MatExpr *e, interop::Scalar s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e) + cpp(s);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorAdd_ScalarMatExpr(interop::Scalar s, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cpp(s) + (*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorAdd_MatExprMatExpr(cv::MatExpr *e1, cv::MatExpr *e2, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e1) + (*e2);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_operatorSubtract_MatExprMat(cv::MatExpr *e, cv::Mat *m, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e) - (*m);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorSubtract_MatMatExpr(cv::Mat *m, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*m) - (*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorSubtract_MatExprScalar(cv::MatExpr *e, interop::Scalar s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e) - cpp(s);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorSubtract_ScalarMatExpr(interop::Scalar s, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cpp(s) - (*e);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorSubtract_MatExprMatExpr(cv::MatExpr *e1, cv::MatExpr *e2, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = (*e1) - (*e2);
     *returnValue = new cv::MatExpr(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_operatorMultiply_MatExprMat(cv::MatExpr *e, cv::Mat *m, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e) * (*m);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorMultiply_MatMatExpr(cv::Mat *m, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*m) * (*e);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorMultiply_MatExprDouble(cv::MatExpr *e, double s, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e) * s;
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorMultiply_DoubleMatExpr(double s, cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = s * (*e);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorMultiply_MatExprMatExpr(cv::MatExpr *e1, cv::MatExpr *e2, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e1) * (*e2);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_operatorDivide_MatExprMat(cv::MatExpr *e, cv::Mat *m, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e) / (*m);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorDivide_MatMatExpr(cv::Mat *m, cv::MatExpr *e, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*m) / (*e);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorDivide_MatExprDouble(cv::MatExpr *e, double s, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e) / s;
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorDivide_DoubleMatExpr(double s, cv::MatExpr *e, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = s / (*e);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_operatorDivide_MatExprMatExpr(cv::MatExpr *e1, cv::MatExpr *e2, cv::MatExpr **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = (*e1) / (*e2);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }
 #pragma endregion
 
 CVAPI(ExceptionStatus) core_abs_MatExpr(cv::MatExpr *e, cv::MatExpr **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::abs(*e);
     *returnValue = new cv::MatExpr(ret);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_OutputArray.h
+++ b/src/OpenCvSharpExtern/core_OutputArray.h
@@ -8,10 +8,10 @@
 
 CVAPI(ExceptionStatus) core_OutputArray_new_byMat(cv::Mat *mat, cv::_OutputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::_OutputArray ia(*mat);
     *returnValue = new cv::_OutputArray(ia);
-    END_WRAP
+    });
 }
 
 /*CVAPI(cv::_OutputArray*) core_OutputArray_new_byGpuMat(cv::cuda::GpuMat *gm)
@@ -22,56 +22,56 @@ CVAPI(ExceptionStatus) core_OutputArray_new_byMat(cv::Mat *mat, cv::_OutputArray
 
 CVAPI(ExceptionStatus) core_OutputArray_new_byUMat(cv::UMat* mat, cv::_OutputArray** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         const cv::_OutputArray ia(*mat);
     *returnValue = new cv::_OutputArray(ia);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_new_byScalar(interop::Scalar scalar, cv::_OutputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar scalarVal(cpp(scalar));
     const cv::_OutputArray ia(scalarVal);
     *returnValue = new cv::_OutputArray(ia);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_new_byVectorOfMat(std::vector<cv::Mat> *vector, cv::_OutputArray **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::_OutputArray ia(*vector);
     *returnValue = new cv::_OutputArray(ia);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_delete(cv::_OutputArray *oa)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete oa;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_getMat(cv::_OutputArray *oa, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto& mat = oa->getMatRef();
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_getScalar(cv::_OutputArray *oa, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat &mat = oa->getMatRef();
     const auto scalar = mat.at<cv::Scalar>(0);
     *returnValue = c(scalar);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_OutputArray_getVectorOfMat(cv::_OutputArray *oa, std::vector<cv::Mat*> *vector)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> temp;
     oa->getMatVector(temp);
 
@@ -80,5 +80,5 @@ CVAPI(ExceptionStatus) core_OutputArray_getVectorOfMat(cv::_OutputArray *oa, std
     {
         (*vector)[i] = new cv::Mat(temp[i]);
     }
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_PCA.h
+++ b/src/OpenCvSharpExtern/core_PCA.h
@@ -8,113 +8,113 @@
 
 CVAPI(ExceptionStatus) core_PCA_new1(cv::PCA **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::PCA;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_PCA_new2(cv::_InputArray *data, cv::_InputArray *mean, int flags, int maxComponents, cv::PCA **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::PCA(*data, *mean, flags, maxComponents);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_PCA_new3(cv::_InputArray *data, cv::_InputArray *mean, int flags, double retainedVariance, cv::PCA **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::PCA(*data, *mean, flags, retainedVariance);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCA_delete(cv::PCA *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 //! operator that performs PCA. The previously stored data, if any, is released
 CVAPI(ExceptionStatus) core_PCA_operatorThis(cv::PCA *obj, cv::_InputArray *data, cv::_InputArray *mean, int flags, int maxComponents)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj)(*data, *mean, flags, maxComponents);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCA_computeVar(cv::PCA *obj, cv::_InputArray *data, cv::_InputArray *mean, int flags, double retainedVariance)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj)(*data, *mean, flags, retainedVariance);
-    END_WRAP
+    });
 }
 
 //! projects vector from the original space to the principal components subspace
 CVAPI(ExceptionStatus) core_PCA_project1(cv::PCA *obj, cv::_InputArray *vec, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->project(*vec);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 //! projects vector from the original space to the principal components subspace
 CVAPI(ExceptionStatus) core_PCA_project2(cv::PCA *obj, cv::_InputArray *vec, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->project(*vec, *result);
-    END_WRAP
+    });
 }
 
 //! reconstructs the original vector from the projection
 CVAPI(ExceptionStatus) core_PCA_backProject1(cv::PCA *obj, cv::_InputArray *vec, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->backProject(*vec);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 //! reconstructs the original vector from the projection
 CVAPI(ExceptionStatus) core_PCA_backProject2(cv::PCA *obj, cv::_InputArray *vec, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->backProject(*vec, *result);
-    END_WRAP
+    });
 }
 
 //!< eigenvectors of the covariation matrix
 CVAPI(ExceptionStatus) core_PCA_eigenvectors(cv::PCA *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->eigenvectors);
-    END_WRAP
+    });
 }
 
 //!< eigenvalues of the covariation matrix
 CVAPI(ExceptionStatus) core_PCA_eigenvalues(cv::PCA *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->eigenvalues);
-    END_WRAP
+    });
 }
 
 //!< mean value subtracted before the projection and added after the back projection
 CVAPI(ExceptionStatus) core_PCA_mean(cv::PCA *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->mean);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_PCA_write(cv::PCA *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP    
+    });    
 }
 
 CVAPI(ExceptionStatus) core_PCA_read(cv::PCA *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_SVD.h
+++ b/src/OpenCvSharpExtern/core_SVD.h
@@ -7,83 +7,83 @@
 
 CVAPI(ExceptionStatus) core_SVD_new1(cv::SVD **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::SVD;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SVD_new2(cv::_InputArray *src, int flags, cv::SVD **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::SVD(*src, flags);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SVD_delete(cv::SVD *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SVD_operatorThis(cv::SVD *obj, cv::_InputArray *src, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj)(*src, flags);
-    END_WRAP
+    });
 }
 //! performs back substitution, so that dst is the solution or pseudo-solution of m*dst = rhs, where m is the decomposed matrix
 CVAPI(ExceptionStatus) core_SVD_backSubst(cv::SVD *obj, cv::_InputArray *rhs, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->backSubst(*rhs, *dst);
-    END_WRAP
+    });
 }
 
 //! decomposes matrix and stores the results to user-provided matrices
 CVAPI(ExceptionStatus) core_SVD_static_compute1(cv::_InputArray *src, cv::_OutputArray *w,
                                                 cv::_OutputArray *u, cv::_OutputArray *vt, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVD::compute(*src, *w, *u, *vt, flags);
-    END_WRAP
+    });
 }
 //! computes singular values of a matrix
 CVAPI(ExceptionStatus) core_SVD_static_compute2(cv::_InputArray *src, cv::_OutputArray *w, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVD::compute(*src, *w, flags);
-    END_WRAP
+    });
 }
 //! performs back substitution
 CVAPI(ExceptionStatus) core_SVD_static_backSubst(cv::_InputArray *w, cv::_InputArray *u,
                                                  cv::_InputArray *vt, cv::_InputArray *rhs, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVD::backSubst(*w, *u, *vt, *rhs, *dst);
-    END_WRAP
+    });
 }
 //! finds dst = arg min_{|dst|=1} |m*dst|
 CVAPI(ExceptionStatus) core_SVD_static_solveZ(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SVD::solveZ(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SVD_u(cv::SVD *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->u);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SVD_w(cv::SVD *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->w);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SVD_vt(cv::SVD *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->vt);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_SparseMat.h
+++ b/src/OpenCvSharpExtern/core_SparseMat.h
@@ -7,202 +7,202 @@
 
 CVAPI(ExceptionStatus) core_SparseMat_new1(cv::SparseMat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::SparseMat;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_new2(int dims, const int *sizes, int type, cv::SparseMat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::SparseMat(dims, sizes, type);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_new3(cv::Mat *m, cv::SparseMat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::SparseMat(*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_delete(cv::SparseMat *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) core_SparseMat_operatorAssign_SparseMat(cv::SparseMat *obj, cv::SparseMat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *obj = *m;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_operatorAssign_Mat(cv::SparseMat *obj, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *obj = *m;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_clone(cv::SparseMat *obj, cv::SparseMat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto sm = obj->clone();
     *returnValue = new cv::SparseMat(sm);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_copyTo_SparseMat(cv::SparseMat *obj, cv::SparseMat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->copyTo(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_copyTo_Mat(cv::SparseMat *obj, cv::Mat *m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->copyTo(*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_convertTo_SparseMat(cv::SparseMat *obj, cv::SparseMat *m, int rtype, double alpha)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->convertTo(*m, rtype, alpha);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_convertTo_Mat(cv::SparseMat *obj, cv::Mat *m, int rtype, double alpha = 1, double beta = 0)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->convertTo(*m, rtype, alpha, beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_assignTo(cv::SparseMat *obj, cv::SparseMat *m, int type = -1)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->assignTo(*m, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_create(cv::SparseMat *obj, int dims, const int* sizes, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->create(dims, sizes, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_clear(cv::SparseMat *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_addref(cv::SparseMat *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addref();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_release(cv::SparseMat *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->release();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_elemSize(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->elemSize());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_elemSize1(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->elemSize1());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_type(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->type();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_depth(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->depth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_channels(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->channels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_size1(cv::SparseMat *obj, const int **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->size();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_size2(cv::SparseMat *obj, int i, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->size(i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_dims(cv::SparseMat *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->dims();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_nzcount(cv::SparseMat *obj, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->nzcount();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_hash_1d(cv::SparseMat *obj, int i0, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->hash(i0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_hash_2d(cv::SparseMat *obj, int i0, int i1, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->hash(i0, i1);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_hash_3d(cv::SparseMat *obj, int i0, int i1, int i2, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->hash(i0, i1, i2);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_SparseMat_hash_nd(cv::SparseMat *obj, const int* idx, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->hash(idx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_ptr_1d(cv::SparseMat *obj, int i0, int createMissing, uint64* hashVal, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (hashVal == nullptr)
     {
         *returnValue = obj->ptr(i0, createMissing != 0);
@@ -211,12 +211,12 @@ CVAPI(ExceptionStatus) core_SparseMat_ptr_1d(cv::SparseMat *obj, int i0, int cre
         auto hashVal0 = static_cast<size_t>(*hashVal);
         *returnValue = obj->ptr(i0, createMissing != 0, &hashVal0);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_ptr_2d(cv::SparseMat *obj, int i0, int i1, int createMissing, uint64* hashVal, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (hashVal == nullptr)
     {
         *returnValue = obj->ptr(i0, i1, createMissing != 0);
@@ -226,12 +226,12 @@ CVAPI(ExceptionStatus) core_SparseMat_ptr_2d(cv::SparseMat *obj, int i0, int i1,
         auto hashVal0 = static_cast<size_t>(*hashVal);
         *returnValue = obj->ptr(i0, i1, createMissing != 0, &hashVal0);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_ptr_3d(cv::SparseMat *obj, int i0, int i1, int i2, int createMissing, uint64* hashVal, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (hashVal == nullptr)
     {
         *returnValue = obj->ptr(i0, i1, i2, createMissing != 0);
@@ -241,12 +241,12 @@ CVAPI(ExceptionStatus) core_SparseMat_ptr_3d(cv::SparseMat *obj, int i0, int i1,
         auto hashVal0 = static_cast<size_t>(*hashVal);
         *returnValue = obj->ptr(i0, i1, i2, createMissing != 0, &hashVal0);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_SparseMat_ptr_nd(cv::SparseMat *obj, const int* idx, int createMissing, uint64* hashVal, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (hashVal == nullptr)
     {
         *returnValue = obj->ptr(idx, createMissing != 0);
@@ -256,14 +256,14 @@ CVAPI(ExceptionStatus) core_SparseMat_ptr_nd(cv::SparseMat *obj, const int* idx,
         auto hashVal0 = static_cast<size_t>(*hashVal);
         *returnValue = obj->ptr(idx, createMissing != 0, &hashVal0);
     }
-    END_WRAP
+    });
 }
 
 // Copies the indices and values of every stored (non-zero) element into caller-provided buffers.
 // outIndices must hold nzcount()*dims ints, outValues must hold nzcount()*elemSize bytes.
 CVAPI(ExceptionStatus) core_SparseMat_getNodes(cv::SparseMat *obj, int dims, int *outIndices, uchar *outValues, size_t elemSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::SparseMat *cobj = obj;
     cv::SparseMatConstIterator it = cobj->begin();
     cv::SparseMatConstIterator it_end = cobj->end();
@@ -274,13 +274,13 @@ CVAPI(ExceptionStatus) core_SparseMat_getNodes(cv::SparseMat *obj, int dims, int
             outIndices[static_cast<size_t>(i) * dims + d] = node->idx[d];
         std::memcpy(outValues + static_cast<size_t>(i) * elemSize, it.ptr, elemSize);
     }
-    END_WRAP
+    });
 }
 
 // Removes the stored element at idx (no-op if absent). idx has length dims.
 CVAPI(ExceptionStatus) core_SparseMat_erase_nd(cv::SparseMat *obj, const int *idx, uint64 *hashVal)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (hashVal == nullptr)
     {
         obj->erase(idx);
@@ -290,5 +290,5 @@ CVAPI(ExceptionStatus) core_SparseMat_erase_nd(cv::SparseMat *obj, const int *id
         auto hashVal0 = static_cast<size_t>(*hashVal);
         obj->erase(idx, &hashVal0);
     }
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/core_UMat.h
+++ b/src/OpenCvSharpExtern/core_UMat.h
@@ -8,91 +8,91 @@
 
 CVAPI(ExceptionStatus) core_UMat_new1(const cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(usageFlags);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new2(const int rows, const int cols, const int type, const cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(rows, cols, type, usageFlags);
-    END_WRAP
+    });
 }
 /*
 CVAPI(ExceptionStatus) core_UMat_new3(cv::Size size, int type, cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(size, type, usageFlags);
-    END_WRAP
+    });
 }
 */
 CVAPI(ExceptionStatus) core_UMat_new3(
     const int rows, const int cols, const int type, const interop::Scalar s, const cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(rows, cols, type, cpp(s), usageFlags);
-    END_WRAP
+    });
 }
 /*
 CVAPI(ExceptionStatus) core_UMat_new5(cv::Size size, int type, interop::Scalar s, cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(size, type, cpp(s), usageFlags);
-    END_WRAP
+    });
 }
 */
 CVAPI(ExceptionStatus) core_UMat_new4(
     const int ndims, const int* sizes, const int type, const cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(ndims, sizes, type, usageFlags);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new5(
     const int ndims, const int* sizes, const int type, const interop::Scalar s, cv::UMatUsageFlags usageFlags, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(ndims, sizes, type, cpp(s), usageFlags);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new6(cv::UMat* umat, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(*umat);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new7(cv::UMat* umat, const interop::Range rowRange, const interop::Range colRange, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(*umat, cpp(rowRange), cpp(colRange));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new8(cv::UMat* umat, const interop::Rect roi, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(*umat, cpp(roi));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_new9(cv::UMat* umat, cv::Range* ranges, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(*umat, ranges);
-    END_WRAP
+    });
 }
 /*
 CVAPI(ExceptionStatus) core_UMat_new12(cv::UMat* umat, std::vector<cv::Range>& ranges, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(*umat, ranges);
-    END_WRAP
+    });
 }
 */
 
 CVAPI(ExceptionStatus) core_UMat_delete(cv::UMat* self)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         delete self;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -101,246 +101,246 @@ CVAPI(ExceptionStatus) core_UMat_delete(cv::UMat* self)
 
 CVAPI(ExceptionStatus) core_UMat_getMat(cv::UMat* self, cv::AccessFlag accessFlag, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(self->getMat(accessFlag));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_row(cv::UMat* self, int y, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(self->row(y));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_col(cv::UMat* self, int x, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(self->col(x));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_rowRange(cv::UMat* self, int startRow, int endRow, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(self->rowRange(startRow, endRow));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_colRange(cv::UMat* self, int startCol, int endCol, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::UMat(self->colRange(startCol, endCol));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_diag(cv::UMat* self, int d, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         const auto ret = self->diag(d);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_diag_static(cv::UMat* self, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::UMat::diag(*self);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_clone(cv::UMat* self, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->clone();
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_copyTo1(cv::UMat* self, cv::_OutputArray* m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_copyTo2(cv::UMat* self, cv::_OutputArray* m, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_copyTo_toUMat1(cv::UMat* self, cv::UMat* m)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_copyTo_toUMat2(cv::UMat* self, cv::UMat* m, cv::_InputArray* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->copyTo(*m, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_convertTo(cv::UMat* self, cv::_OutputArray* m, int rtype, double alpha, double beta)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->convertTo(*m, rtype, alpha, beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_assignTo(cv::UMat* self, cv::UMat* m, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->assignTo(*m, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_setTo_Scalar(cv::UMat* self, interop::Scalar value, cv::UMat* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (mask == nullptr)
         self->setTo(cpp(value));
     else
         self->setTo(cpp(value), entity(mask));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_setTo_InputArray(cv::UMat* self, cv::_InputArray* value, cv::UMat* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->setTo(*value, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_reshape1(cv::UMat* self, int cn, int rows, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->reshape(cn, rows);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_reshape2(cv::UMat* self, int cn, int newndims, const int* newsz, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->reshape(cn, newndims, newsz);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_t(cv::UMat* self, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = self->t();
     *returnValue = new cv::UMat(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_inv(cv::UMat* self, int method, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->inv(method);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_mul(cv::UMat* self, cv::_InputArray* m, double scale, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->mul(*m, scale);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_dot(cv::UMat* self, cv::_InputArray* m, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dot(*m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_zeros1(int rows, int cols, int type, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::UMat::zeros(rows, cols, type);
     *returnValue = new cv::UMat(expr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_zeros2(int ndims, const int* sz, int type, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto expr = cv::UMat::zeros(ndims, sz, type);
     *returnValue = new cv::UMat(expr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_ones1(int rows, int cols, int type, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::UMat::ones(rows, cols, type);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_ones2(int ndims, const int* sz, int type, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::UMat ret = cv::UMat::ones(ndims, sz, type);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_eye(int rows, int cols, int type, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto eye = cv::UMat::eye(rows, cols, type);
     *returnValue = new cv::UMat(eye);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_create1(cv::UMat* self, int rows, int cols, int type, cv::UMatUsageFlags usageFlags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->create(rows, cols, type, usageFlags);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_create2(cv::UMat* self, int ndims, const int* sizes, int type, cv::UMatUsageFlags usageFlags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     self->create(ndims, sizes, type, usageFlags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_locateROI(cv::UMat* self, interop::Size* wholeSize, interop::Point* ofs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Size wholeSize2;
     cv::Point ofs2;
     self->locateROI(wholeSize2, ofs2);
     *wholeSize = c(cv::Size(wholeSize2.width, wholeSize2.height));
     *ofs = c(cv::Point(ofs2.x, ofs2.y));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_adjustROI(cv::UMat* self, int dtop, int dbottom, int dleft, int dright, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = self->adjustROI(dtop, dbottom, dleft, dright);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_subMat1(cv::UMat* self, int rowStart, int rowEnd, int colStart, int colEnd, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Range rowRange(rowStart, rowEnd);
     const cv::Range colRange(colStart, colEnd);
     const auto ret = (*self)(rowRange, colRange);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_subMat2(cv::UMat* self, int nRanges, interop::Range* ranges, cv::UMat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Range> rangesVec(nRanges);
     for (auto i = 0; i < nRanges; i++)
     {
@@ -348,148 +348,148 @@ CVAPI(ExceptionStatus) core_UMat_subMat2(cv::UMat* self, int nRanges, interop::R
     }
     const auto ret = (*self)(&rangesVec[0]);
     *returnValue = new cv::UMat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_isContinuous(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->isContinuous() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_isSubmatrix(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->isSubmatrix() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_elemSize(cv::UMat* self, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->elemSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_elemSize1(cv::UMat* self, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->elemSize1();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_type(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->type();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_depth(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->depth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_channels(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->channels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_step1(cv::UMat* self, int i, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step1(i);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_empty(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_total(cv::UMat* self, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->total();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_checkVector(cv::UMat* self, int elemChannels, int depth, int requireContinuous, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->checkVector(elemChannels, depth, requireContinuous != 0);
-    END_WRAP
+    });
 }
 
 //does this replace Ptr?
 CVAPI(ExceptionStatus) core_UMat_handle(cv::UMat* self, cv::AccessFlag accessFlag, void** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->handle(accessFlag);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_flags(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->flags;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_dims(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->dims;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_rows(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->rows;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_cols(cv::UMat* self, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->cols;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_size(cv::UMat* self, interop::Size* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // See core_Mat_size: avoid OpenCV 5's dims <= 2 assert for multi-dimensional matrices.
     if (self->dims > 2)
         *returnValue = c(cv::Size(self->size[1], self->size[0]));
     else
         *returnValue = c(self->size());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_sizeAt(cv::UMat* self, int i, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->size[i];
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) core_UMat_step(cv::UMat* self, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) core_UMat_stepAt(cv::UMat* self, int i, size_t* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = self->step[i];
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -68,7 +68,7 @@ static cv::dnn::Net dnn_readNetGated(const char *model, const char *config, cons
 
 CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *config, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     const bool hasConfig = (config != nullptr && config[0] != '\0');
     std::string modelAcp, configAcp;
@@ -92,27 +92,27 @@ CVAPI(ExceptionStatus) dnn_readNetFromTensorflow(const char *model, const char *
     const auto net = cv::dnn::readNetFromTensorflow(model, configStr, engine);
     *returnValue = new cv::dnn::Net(net);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromTensorflow_InputArray(const char *model,size_t lenModel, const char *config, size_t lenConfig, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto net = cv::dnn::readNetFromTensorflow(model, lenModel, config, lenConfig, engine);
     *returnValue = new cv::dnn::Net(net);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNet(const char *model, const char *config, const char *framework, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::Net(dnn_readNetGated(model, config, framework, engine));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromModelOptimizer(const char *xml, const char *bin, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string xmlAcp, binAcp;
     cv::dnn::Net net;
@@ -131,12 +131,12 @@ CVAPI(ExceptionStatus) dnn_readNetFromModelOptimizer(const char *xml, const char
     const auto net = cv::dnn::readNetFromModelOptimizer(xml, bin);
     *returnValue = new cv::dnn::Net(net);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromONNX(const char *onnxFile, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string acp;
     cv::dnn::Net net;
@@ -155,103 +155,103 @@ CVAPI(ExceptionStatus) dnn_readNetFromONNX(const char *onnxFile, int engine, cv:
     const auto net = cv::dnn::readNetFromONNX(cv::String(onnxFile), engine);
     *returnValue = new cv::dnn::Net(net);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromONNX_InputArray(const char* buffer, size_t sizeBuffer, int engine, cv::dnn::Net** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto net = cv::dnn::readNetFromONNX(buffer, sizeBuffer, engine);
     *returnValue = new cv::dnn::Net(net);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) dnn_readTensorFromONNX(const char *path, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::dnn::readTensorFromONNX(path);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_blobFromImage(
     cv::Mat *image, const double scalefactor, const interop::Size size, const interop::Scalar mean, const int swapRB, const int crop, 
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto blob = cv::dnn::blobFromImage(*image, scalefactor, cpp(size), cpp(mean), swapRB != 0, crop != 0);
     *returnValue = new cv::Mat(blob);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_blobFromImages(
     const cv::Mat **images, const int imagesLength, const double scalefactor, const interop::Size size, const interop::Scalar mean, const int swapRB, const int crop, 
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesLength, imagesVec);
 
     const auto blob = cv::dnn::blobFromImages(imagesVec, scalefactor, cpp(size), cpp(mean), swapRB != 0, crop != 0);
     *returnValue = new cv::Mat(blob);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_writeTextGraph(const char *model, const char *output)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::writeTextGraph(model, output);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_NMSBoxes_Rect(std::vector<cv::Rect> *bboxes, std::vector<float> *scores,
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const float eta, const int top_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::NMSBoxes(*bboxes, *scores, score_threshold, nms_threshold, *indices, eta, top_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_NMSBoxes_Rect2d(std::vector<cv::Rect2d> *bboxes, std::vector<float> *scores,
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const float eta, const int top_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::NMSBoxes(*bboxes, *scores, score_threshold, nms_threshold, *indices, eta, top_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_NMSBoxes_RotatedRect(std::vector<cv::RotatedRect> *bboxes, std::vector<float> *scores,
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const float eta, const int top_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::NMSBoxes(*bboxes, *scores, score_threshold, nms_threshold, *indices, eta, top_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_resetMyriadDevice()
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::resetMyriadDevice();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_getAvailableTargets(const int be, std::vector<int> *targets)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto v = cv::dnn::getAvailableTargets(static_cast<cv::dnn::Backend>(be));
     targets->clear();
     for (const auto t : v)
         targets->push_back(static_cast<int>(t));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_getAvailableBackends(std::vector<int> *backends, std::vector<int> *targets)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto v = cv::dnn::getAvailableBackends();
     backends->clear();
     targets->clear();
@@ -260,19 +260,19 @@ CVAPI(ExceptionStatus) dnn_getAvailableBackends(std::vector<int> *backends, std:
         backends->push_back(static_cast<int>(p.first));
         targets->push_back(static_cast<int>(p.second));
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_enableModelDiagnostics(const int isDiagnosticsMode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::enableModelDiagnostics(isDiagnosticsMode != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string acp;
     cv::dnn::Net net;
@@ -291,15 +291,15 @@ CVAPI(ExceptionStatus) dnn_readNetFromTFLite(const char *model, int engine, cv::
     const auto net = cv::dnn::readNetFromTFLite(cv::String(model), engine);
     *returnValue = new cv::dnn::Net(net);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_readNetFromTFLite_InputArray(const char *bufferModel, size_t lenModel, int engine, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto net = cv::dnn::readNetFromTFLite(bufferModel, lenModel, engine);
     *returnValue = new cv::dnn::Net(net);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_blobFromImageWithParams(
@@ -307,13 +307,13 @@ CVAPI(ExceptionStatus) dnn_blobFromImageWithParams(
     const int swapRB, const int ddepth, const int datalayout, const int paddingmode, const interop::Scalar borderValue,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::dnn::Image2BlobParams param(
         cpp(scalefactor), cpp(size), cpp(mean), swapRB != 0, ddepth,
         static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
     const auto blob = cv::dnn::blobFromImageWithParams(*image, param);
     *returnValue = new cv::Mat(blob);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_blobFromImagesWithParams(
@@ -321,7 +321,7 @@ CVAPI(ExceptionStatus) dnn_blobFromImagesWithParams(
     const int swapRB, const int ddepth, const int datalayout, const int paddingmode, const interop::Scalar borderValue,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesLength, imagesVec);
     const cv::dnn::Image2BlobParams param(
@@ -329,14 +329,14 @@ CVAPI(ExceptionStatus) dnn_blobFromImagesWithParams(
         static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
     const auto blob = cv::dnn::blobFromImagesWithParams(imagesVec, param);
     *returnValue = new cv::Mat(blob);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_imagesFromBlob(cv::Mat *blob, std::vector<cv::Mat> *images)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::imagesFromBlob(*blob, *images);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect(
@@ -344,9 +344,9 @@ CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect(
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const float eta, const int top_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::NMSBoxesBatched(*bboxes, *scores, *classIds, score_threshold, nms_threshold, *indices, eta, top_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect2d(
@@ -354,9 +354,9 @@ CVAPI(ExceptionStatus) dnn_NMSBoxesBatched_Rect2d(
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const float eta, const int top_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::NMSBoxesBatched(*bboxes, *scores, *classIds, score_threshold, nms_threshold, *indices, eta, top_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_softNMSBoxes_Rect(
@@ -364,11 +364,11 @@ CVAPI(ExceptionStatus) dnn_softNMSBoxes_Rect(
     const float score_threshold, const float nms_threshold,
     std::vector<int> *indices, const size_t top_k, const float sigma, const int method)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dnn::softNMSBoxes(
         *bboxes, *scores, *updated_scores, score_threshold, nms_threshold, *indices,
         top_k, sigma, static_cast<cv::dnn::SoftNMSMethod>(method));
-    END_WRAP
+    });
 }
 
 #endif // !#ifndef _WINRT_DLL

--- a/src/OpenCvSharpExtern/dnn_Model.h
+++ b/src/OpenCvSharpExtern/dnn_Model.h
@@ -17,111 +17,111 @@
 
 CVAPI(ExceptionStatus) dnn_Model_new_String(const char *model, const char *config, cv::dnn::Model **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::Model(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::Model(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_new_Net(cv::dnn::Net *network, cv::dnn::Model **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::Model(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_delete(cv::dnn::Model *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputSize(cv::dnn::Model *model, const interop::Size size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputSize(cpp(size));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputMean(cv::dnn::Model *model, const interop::Scalar mean)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputMean(cpp(mean));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputScale(cv::dnn::Model *model, const interop::Scalar scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputScale(cpp(scale));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputCrop(cv::dnn::Model *model, const int crop)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputCrop(crop != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputSwapRB(cv::dnn::Model *model, const int swapRB)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputSwapRB(swapRB != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setInputParams(
     cv::dnn::Model *model, const double scale, const interop::Size size, const interop::Scalar mean, const int swapRB, const int crop)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setInputParams(scale, cpp(size), cpp(mean), swapRB != 0, crop != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setOutputNames(cv::dnn::Model *model, const char **outNames, const int outNamesLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::String> outNamesVec(outNamesLength);
     for (auto i = 0; i < outNamesLength; i++)
     {
         outNamesVec[i] = outNames[i];
     }
     model->setOutputNames(outNamesVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_predict(cv::dnn::Model *model, cv::_InputArray *frame, std::vector<cv::Mat> *outs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->predict(*frame, *outs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setPreferableBackend(cv::dnn::Model *model, const int backendId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setPreferableBackend(static_cast<cv::dnn::Backend>(backendId));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_setPreferableTarget(cv::dnn::Model *model, const int targetId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setPreferableTarget(static_cast<cv::dnn::Target>(targetId));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Model_enableWinograd(cv::dnn::Model *model, const int useWinograd)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->enableWinograd(useWinograd != 0);
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -131,52 +131,52 @@ CVAPI(ExceptionStatus) dnn_Model_enableWinograd(cv::dnn::Model *model, const int
 CVAPI(ExceptionStatus) dnn_ClassificationModel_new_String(
     const char *model, const char *config, cv::dnn::ClassificationModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::ClassificationModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::ClassificationModel(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_ClassificationModel_new_Net(cv::dnn::Net *network, cv::dnn::ClassificationModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::ClassificationModel(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_ClassificationModel_delete(cv::dnn::ClassificationModel *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_ClassificationModel_setEnableSoftmaxPostProcessing(
     cv::dnn::ClassificationModel *model, const int enable)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setEnableSoftmaxPostProcessing(enable != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_ClassificationModel_getEnableSoftmaxPostProcessing(
     cv::dnn::ClassificationModel *model, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getEnableSoftmaxPostProcessing() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_ClassificationModel_classify(
     cv::dnn::ClassificationModel *model, cv::_InputArray *frame, int *classId, float *conf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->classify(*frame, *classId, *conf);
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -186,42 +186,42 @@ CVAPI(ExceptionStatus) dnn_ClassificationModel_classify(
 CVAPI(ExceptionStatus) dnn_DetectionModel_new_String(
     const char *model, const char *config, cv::dnn::DetectionModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::DetectionModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::DetectionModel(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_DetectionModel_new_Net(cv::dnn::Net *network, cv::dnn::DetectionModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::DetectionModel(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_DetectionModel_delete(cv::dnn::DetectionModel *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_DetectionModel_setNmsAcrossClasses(cv::dnn::DetectionModel *model, const int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setNmsAcrossClasses(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_DetectionModel_getNmsAcrossClasses(cv::dnn::DetectionModel *model, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getNmsAcrossClasses() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_DetectionModel_detect(
@@ -229,9 +229,9 @@ CVAPI(ExceptionStatus) dnn_DetectionModel_detect(
     std::vector<int> *classIds, std::vector<float> *confidences, std::vector<cv::Rect> *boxes,
     const float confThreshold, const float nmsThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->detect(*frame, *classIds, *confidences, *boxes, confThreshold, nmsThreshold);
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -241,36 +241,36 @@ CVAPI(ExceptionStatus) dnn_DetectionModel_detect(
 CVAPI(ExceptionStatus) dnn_SegmentationModel_new_String(
     const char *model, const char *config, cv::dnn::SegmentationModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::SegmentationModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::SegmentationModel(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_SegmentationModel_new_Net(cv::dnn::Net *network, cv::dnn::SegmentationModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::SegmentationModel(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_SegmentationModel_delete(cv::dnn::SegmentationModel *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_SegmentationModel_segment(
     cv::dnn::SegmentationModel *model, cv::_InputArray *frame, cv::_OutputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->segment(*frame, *mask);
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -280,37 +280,37 @@ CVAPI(ExceptionStatus) dnn_SegmentationModel_segment(
 CVAPI(ExceptionStatus) dnn_KeypointsModel_new_String(
     const char *model, const char *config, cv::dnn::KeypointsModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::KeypointsModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::KeypointsModel(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_KeypointsModel_new_Net(cv::dnn::Net *network, cv::dnn::KeypointsModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::KeypointsModel(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_KeypointsModel_delete(cv::dnn::KeypointsModel *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_KeypointsModel_estimate(
     cv::dnn::KeypointsModel *model, cv::_InputArray *frame, std::vector<cv::Point2f> *keypoints, const float thresh)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = model->estimate(*frame, thresh);
     keypoints->assign(result.begin(), result.end());
-    END_WRAP
+    });
 }
 
 #endif // !#ifndef _WINRT_DLL

--- a/src/OpenCvSharpExtern/dnn_Net.h
+++ b/src/OpenCvSharpExtern/dnn_Net.h
@@ -12,101 +12,101 @@
 
 CVAPI(ExceptionStatus) dnn_Net_new(cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::Net;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_delete(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete net;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_readFromModelOptimizer(const char *xml, const char *bin, cv::dnn::Net **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto net = cv::dnn::Net::readFromModelOptimizer(xml, bin);
     *returnValue = new cv::dnn::Net(net);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_empty(cv::dnn::Net* net, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = net->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_dump(cv::dnn::Net* net, std::string *outString)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     outString->assign(net->dump());
-    END_WRAP    
+    });    
 }
 
 CVAPI(ExceptionStatus) dnn_Net_dumpToFile(cv::dnn::Net* net, const char *path)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->dumpToFile(path);
-    END_WRAP    
+    });    
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayerId(cv::dnn::Net* net, const char *layer, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = net->getLayerId(layer);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayerNames(cv::dnn::Net* net, std::vector<cv::String> *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = net->getLayerNames();
     outVec->assign(result.begin(), result.end());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_connect1(cv::dnn::Net* net, const char *outPin, const char *inpPin)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->connect(outPin, inpPin);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_connect2(cv::dnn::Net* net, int outLayerId, int outNum, int inpLayerId, int inpNum)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->connect(outLayerId, outNum, inpLayerId, inpNum);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setInputsNames(cv::dnn::Net* net, const char **inputBlobNames, int inputBlobNamesLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::String> inputBlobNamesVec(inputBlobNamesLength);
     for (auto i = 0; i < inputBlobNamesLength; i++)
     {
         inputBlobNamesVec[i] = inputBlobNames[i];
     }
     net->setInputsNames(inputBlobNamesVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_forward1(cv::dnn::Net* net, const char *outputName, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto outputNameStr = (outputName == nullptr) ? cv::String() : cv::String(outputName);
     const auto ret = net->forward(outputNameStr);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_forward2(
     cv::dnn::Net* net, cv::Mat **outputBlobs, int outputBlobsLength, const char *outputName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto outputNameStr = (outputName == nullptr) ? cv::String() : cv::String(outputName);
     std::vector<cv::Mat> outputBlobsVec;
     toVec(outputBlobs, outputBlobsLength, outputBlobsVec);
@@ -117,13 +117,13 @@ CVAPI(ExceptionStatus) dnn_Net_forward2(
     {
         *outputBlobs[i] = outputBlobsVec[i];
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_forward3(
     cv::dnn::Net* net, cv::Mat **outputBlobs, int outputBlobsLength, const char **outBlobNames, int outBlobNamesLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> outputBlobsVec;
     toVec(outputBlobs, outputBlobsLength, outputBlobsVec);
 
@@ -139,34 +139,34 @@ CVAPI(ExceptionStatus) dnn_Net_forward3(
     {
         *outputBlobs[i] = outputBlobsVec[i];
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setPreferableBackend(cv::dnn::Net* net, int backendId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->setPreferableBackend(backendId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setPreferableTarget(cv::dnn::Net* net, int targetId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->setPreferableTarget(targetId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setInput(cv::dnn::Net* net, const cv::Mat *blob, const char *name)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto nameStr = (name == nullptr) ? "" : cv::String(name);
     net->setInput(*blob, nameStr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getUnconnectedOutLayers(cv::dnn::Net* net, std::vector<int> *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto v = net->getUnconnectedOutLayers();
     result->clear();
     result->resize(v.size());
@@ -174,12 +174,12 @@ CVAPI(ExceptionStatus) dnn_Net_getUnconnectedOutLayers(cv::dnn::Net* net, std::v
     {
         result->at(i) = v[i];
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getUnconnectedOutLayersNames(cv::dnn::Net* net, std::vector<std::string> *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto v = net->getUnconnectedOutLayersNames();
     result->clear();
     result->resize(v.size());
@@ -187,159 +187,159 @@ CVAPI(ExceptionStatus) dnn_Net_getUnconnectedOutLayersNames(cv::dnn::Net* net, s
     {
         result->at(i) = v[i];
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_enableFusion(cv::dnn::Net* net, int fusion)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->enableFusion(fusion != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getPerfProfile(cv::dnn::Net* net, std::vector<double> *timings, int64 *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = net->getPerfProfile(*timings);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setInputShape(cv::dnn::Net* net, const char *inputName, const int *shape, const int shapeLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::MatShape shapeObj(shape, shape + shapeLength);
     net->setInputShape(inputName, shapeObj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getParam(cv::dnn::Net* net, const int layer, const int numParam, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto m = net->getParam(layer, numParam);
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setParam(cv::dnn::Net* net, const int layer, const int numParam, cv::Mat *blob)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->setParam(layer, numParam, *blob);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayerTypes(cv::dnn::Net* net, std::vector<cv::String> *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::String> result;
     net->getLayerTypes(result);
     outVec->assign(result.begin(), result.end());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayersCount(cv::dnn::Net* net, const char *layerType, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = net->getLayersCount(layerType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_enableWinograd(cv::dnn::Net* net, const int useWinograd)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->enableWinograd(useWinograd != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_dumpToPbtxt(cv::dnn::Net* net, const char *path)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->dumpToPbtxt(path);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getModelFormat(cv::dnn::Net* net, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(net->getModelFormat());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_enableKVCache(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->enableKVCache();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_disableKVCache(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->disableKVCache();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_resetKVCache(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->resetKVCache();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_printPerfProfile(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->printPerfProfile();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_finalizeNet(cv::dnn::Net* net)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->finalizeNet();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setTracingMode(cv::dnn::Net* net, int tracingMode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->setTracingMode(static_cast<cv::dnn::TracingMode>(tracingMode));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getTracingMode(cv::dnn::Net* net, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(net->getTracingMode());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_setProfilingMode(cv::dnn::Net* net, int profilingMode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->setProfilingMode(static_cast<cv::dnn::ProfilingMode>(profilingMode));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getProfilingMode(cv::dnn::Net* net, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(net->getProfilingMode());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_registerOutput(cv::dnn::Net* net, const char *outputName, int layerId, int outputPort, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = net->registerOutput(cv::String(outputName), layerId, outputPort);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getPerfProfileDetailed(
     cv::dnn::Net* net, std::vector<std::string> *names, std::vector<std::string> *timems, std::vector<std::string> *counts)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     net->getPerfProfile(*names, *timems, *counts);
-    END_WRAP
+    });
 }
 
 // Shape / FLOPS / memory introspection (OpenCV 5).
@@ -412,42 +412,42 @@ static void dnn_encodeMatShapesNested(const std::vector<std::vector<cv::MatShape
 CVAPI(ExceptionStatus) dnn_Net_getFLOPS_netInputs(
     cv::dnn::Net* net, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength, int64 *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     *returnValue = net->getFLOPS(shapes, types);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getFLOPS_layer(
     cv::dnn::Net* net, int layerId, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength, int64 *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     *returnValue = net->getFLOPS(layerId, shapes, types);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayerShapes(
     cv::dnn::Net* net, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength,
     int layerId, std::vector<int> *outInLayerShapes, std::vector<int> *outOutLayerShapes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     std::vector<cv::MatShape> inShapes, outShapes;
     net->getLayerShapes(shapes, types, layerId, inShapes, outShapes);
     dnn_encodeMatShapes(inShapes, *outInLayerShapes);
     dnn_encodeMatShapes(outShapes, *outOutLayerShapes);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getLayersShapes(
     cv::dnn::Net* net, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength,
     std::vector<int> *outLayerIds, std::vector<int> *outInLayersShapes, std::vector<int> *outOutLayersShapes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     std::vector<int> layerIds;
@@ -456,28 +456,28 @@ CVAPI(ExceptionStatus) dnn_Net_getLayersShapes(
     outLayerIds->assign(layerIds.begin(), layerIds.end());
     dnn_encodeMatShapesNested(inShapes, *outInLayersShapes);
     dnn_encodeMatShapesNested(outShapes, *outOutLayersShapes);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getMemoryConsumption(
     cv::dnn::Net* net, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength,
     int64 *outWeights, int64 *outBlobs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     size_t weights = 0, blobs = 0;
     net->getMemoryConsumption(shapes, types, weights, blobs);
     *outWeights = static_cast<int64>(weights);
     *outBlobs = static_cast<int64>(blobs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Net_getMemoryConsumption_perLayer(
     cv::dnn::Net* net, const int *shapesData, int shapesLength, const int *netInputTypes, int netInputTypesLength,
     std::vector<int> *outLayerIds, std::vector<int64> *outWeights, std::vector<int64> *outBlobs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto shapes = dnn_decodeMatShapes(shapesData, shapesLength);
     const std::vector<int> types(netInputTypes, netInputTypes + netInputTypesLength);
     std::vector<int> layerIds;
@@ -486,7 +486,7 @@ CVAPI(ExceptionStatus) dnn_Net_getMemoryConsumption_perLayer(
     outLayerIds->assign(layerIds.begin(), layerIds.end());
     outWeights->assign(weights.begin(), weights.end());
     outBlobs->assign(blobs.begin(), blobs.end());
-    END_WRAP
+    });
 }
 
 #endif // !#ifndef _WINRT_DLL

--- a/src/OpenCvSharpExtern/dnn_TextModel.h
+++ b/src/OpenCvSharpExtern/dnn_TextModel.h
@@ -18,83 +18,83 @@
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_new_String(
     const char *model, const char *config, cv::dnn::TextRecognitionModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::TextRecognitionModel(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextRecognitionModel(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_new_Net(
     cv::dnn::Net *network, cv::dnn::TextRecognitionModel **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::TextRecognitionModel(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_delete(cv::dnn::TextRecognitionModel *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setDecodeType(
     cv::dnn::TextRecognitionModel *model, const char *decodeType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setDecodeType(decodeType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_getDecodeType(
     cv::dnn::TextRecognitionModel *model, std::string *outString)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     outString->assign(model->getDecodeType());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setDecodeOptsCTCPrefixBeamSearch(
     cv::dnn::TextRecognitionModel *model, const int beamSize, const int vocPruneSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setDecodeOptsCTCPrefixBeamSearch(beamSize, vocPruneSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_setVocabulary(
     cv::dnn::TextRecognitionModel *model, const char **vocabulary, const int vocabularyLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::string> vocabularyVec(vocabularyLength);
     for (auto i = 0; i < vocabularyLength; i++)
     {
         vocabularyVec[i] = vocabulary[i];
     }
     model->setVocabulary(vocabularyVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_getVocabulary(
     cv::dnn::TextRecognitionModel *model, std::vector<std::string> *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = model->getVocabulary();
     outVec->assign(result.begin(), result.end());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextRecognitionModel_recognize(
     cv::dnn::TextRecognitionModel *model, cv::_InputArray *frame, std::string *outString)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     outString->assign(model->recognize(*frame));
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -105,18 +105,18 @@ CVAPI(ExceptionStatus) dnn_TextDetectionModel_detect(
     cv::dnn::TextDetectionModel *model, cv::_InputArray *frame,
     std::vector<std::vector<cv::Point>> *detections, std::vector<float> *confidences)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->detect(*frame, *detections, *confidences);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_detectTextRectangles(
     cv::dnn::TextDetectionModel *model, cv::_InputArray *frame,
     std::vector<cv::RotatedRect> *detections, std::vector<float> *confidences)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->detectTextRectangles(*frame, *detections, *confidences);
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -126,61 +126,61 @@ CVAPI(ExceptionStatus) dnn_TextDetectionModel_detectTextRectangles(
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_new_String(
     const char *model, const char *config, cv::dnn::TextDetectionModel_EAST **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::TextDetectionModel_EAST(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextDetectionModel_EAST(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_new_Net(
     cv::dnn::Net *network, cv::dnn::TextDetectionModel_EAST **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::TextDetectionModel_EAST(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_delete(cv::dnn::TextDetectionModel_EAST *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_setConfidenceThreshold(
     cv::dnn::TextDetectionModel_EAST *model, const float confThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setConfidenceThreshold(confThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_getConfidenceThreshold(
     cv::dnn::TextDetectionModel_EAST *model, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getConfidenceThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_setNMSThreshold(
     cv::dnn::TextDetectionModel_EAST *model, const float nmsThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setNMSThreshold(nmsThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_getNMSThreshold(
     cv::dnn::TextDetectionModel_EAST *model, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getNMSThreshold();
-    END_WRAP
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -190,93 +190,93 @@ CVAPI(ExceptionStatus) dnn_TextDetectionModel_EAST_getNMSThreshold(
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_new_String(
     const char *model, const char *config, cv::dnn::TextDetectionModel_DB **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     *returnValue = new cv::dnn::TextDetectionModel_DB(dnn_readNetGated(model, config, "", cv::dnn::ENGINE_AUTO));
 #else
     const auto configStr = (config == nullptr) ? cv::String() : cv::String(config);
     *returnValue = new cv::dnn::TextDetectionModel_DB(model, configStr);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_new_Net(
     cv::dnn::Net *network, cv::dnn::TextDetectionModel_DB **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::TextDetectionModel_DB(*network);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_delete(cv::dnn::TextDetectionModel_DB *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete model;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setBinaryThreshold(
     cv::dnn::TextDetectionModel_DB *model, const float binaryThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setBinaryThreshold(binaryThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getBinaryThreshold(
     cv::dnn::TextDetectionModel_DB *model, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getBinaryThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setPolygonThreshold(
     cv::dnn::TextDetectionModel_DB *model, const float polygonThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setPolygonThreshold(polygonThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getPolygonThreshold(
     cv::dnn::TextDetectionModel_DB *model, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getPolygonThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setUnclipRatio(
     cv::dnn::TextDetectionModel_DB *model, const double unclipRatio)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setUnclipRatio(unclipRatio);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getUnclipRatio(
     cv::dnn::TextDetectionModel_DB *model, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getUnclipRatio();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_setMaxCandidates(
     cv::dnn::TextDetectionModel_DB *model, const int maxCandidates)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     model->setMaxCandidates(maxCandidates);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_TextDetectionModel_DB_getMaxCandidates(
     cv::dnn::TextDetectionModel_DB *model, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = model->getMaxCandidates();
-    END_WRAP
+    });
 }
 
 #endif // !#ifndef _WINRT_DLL

--- a/src/OpenCvSharpExtern/dnn_Tokenizer.h
+++ b/src/OpenCvSharpExtern/dnn_Tokenizer.h
@@ -12,31 +12,31 @@
 
 CVAPI(ExceptionStatus) dnn_Tokenizer_load(const char *modelConfig, cv::dnn::Tokenizer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn::Tokenizer(cv::dnn::Tokenizer::load(std::string(modelConfig)));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Tokenizer_delete(cv::dnn::Tokenizer *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Tokenizer_encode(cv::dnn::Tokenizer *obj, const char *text, std::vector<int> *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->encode(std::string(text));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_Tokenizer_decode(cv::dnn::Tokenizer *obj, int *tokens, int tokensLength, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<int> v(tokens, tokens + tokensLength);
     returnValue->assign(obj->decode(v));
-    END_WRAP
+    });
 }
 
 #endif // !_WINRT_DLL

--- a/src/OpenCvSharpExtern/dnn_superres.h
+++ b/src/OpenCvSharpExtern/dnn_superres.h
@@ -12,73 +12,73 @@
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_new1(
     cv::dnn_superres::DnnSuperResImpl** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn_superres::DnnSuperResImpl;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_new2(
     const char* algo, int scale, cv::dnn_superres::DnnSuperResImpl** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::dnn_superres::DnnSuperResImpl(algo, scale);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_delete(cv::dnn_superres::DnnSuperResImpl* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_readModel1(
     cv::dnn_superres::DnnSuperResImpl* obj, const char *path)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->readModel(path);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_readModel2(
     cv::dnn_superres::DnnSuperResImpl* obj, const char* weights, const char *definition)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->readModel(weights, definition);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_setModel(
     cv::dnn_superres::DnnSuperResImpl* obj, const char* algo, int scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setModel(algo, scale);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_setPreferableBackend(
     cv::dnn_superres::DnnSuperResImpl* obj, int backendId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreferableBackend(backendId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_setPreferableTarget(
     cv::dnn_superres::DnnSuperResImpl* obj, int targetId)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreferableTarget(targetId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_upsample(
     cv::dnn_superres::DnnSuperResImpl* obj, cv::_InputArray *img, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->upsample(*img, *result);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_upsampleMultioutput(
@@ -86,7 +86,7 @@ CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_upsampleMultioutput(
     const int* scale_factors, int scale_factors_size,
     const char **node_names, int node_names_size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     const std::vector<int> scale_factors_vec(scale_factors, scale_factors + scale_factors_size);
     std::vector<cv::String> node_names_vec(node_names_size);
@@ -96,23 +96,23 @@ CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_upsampleMultioutput(
     }
 
     obj->upsampleMultioutput(*img, *imgs_new, scale_factors_vec, node_names_vec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_getScale(
     cv::dnn_superres::DnnSuperResImpl* obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScale();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) dnn_superres_DnnSuperResImpl_getAlgorithm(
     cv::dnn_superres::DnnSuperResImpl* obj, std::string* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getAlgorithm());
-    END_WRAP
+    });
 }
 
 #endif //!_WINRT_DLL

--- a/src/OpenCvSharpExtern/face_FaceRecognizer.h
+++ b/src/OpenCvSharpExtern/face_FaceRecognizer.h
@@ -13,100 +13,100 @@
 CVAPI(ExceptionStatus) face_FaceRecognizer_train(
     cv::face::FaceRecognizer *obj, cv::Mat **src, int srcLength, int *labels, int labelsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcVec(srcLength);
     for (auto i = 0; i < srcLength; i++)
         srcVec[i] = *src[i];
     const std::vector<int> labelsVec(labels, labels + labelsLength);
     obj->train(srcVec, labelsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_update(
     cv::face::FaceRecognizer *obj, cv::Mat **src, int srcLength, int *labels, int labelsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcVec(srcLength);
     for (auto i = 0; i < srcLength; i++)
         srcVec[i] = *src[i];
     const std::vector<int> labelsVec(labels, labels + labelsLength);
     obj->update(srcVec, labelsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_predict1(cv::face::FaceRecognizer *obj, cv::_InputArray *src, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->predict(*src);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_FaceRecognizer_predict2(
     cv::face::FaceRecognizer *obj, cv::_InputArray *src, int *label, double *confidence)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->predict(*src, *label, *confidence);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_write1(cv::face::FaceRecognizer *obj, const char *filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(filename);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_FaceRecognizer_read1(cv::face::FaceRecognizer *obj, const char *filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(filename);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_write2(cv::face::FaceRecognizer *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_FaceRecognizer_read2(cv::face::FaceRecognizer *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_setLabelInfo(cv::face::FaceRecognizer *obj, int label, const char *strInfo)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLabelInfo(label, strInfo);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_FaceRecognizer_getLabelInfo(cv::face::FaceRecognizer *obj, int label, std::string *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getLabelInfo(label);
     dst->assign(result);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_getLabelsByString(cv::face::FaceRecognizer *obj, const char* str, std::vector<int> *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getLabelsByString(str);
     std::copy(result.begin(), result.end(), std::back_inserter(*dst));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FaceRecognizer_getThreshold(cv::face::FaceRecognizer *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_FaceRecognizer_setThreshold(cv::face::FaceRecognizer *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -115,33 +115,33 @@ CVAPI(ExceptionStatus) face_FaceRecognizer_setThreshold(cv::face::FaceRecognizer
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getNumComponents(cv::face::BasicFaceRecognizer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumComponents();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_setNumComponents(cv::face::BasicFaceRecognizer *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNumComponents(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getThreshold(cv::face::BasicFaceRecognizer *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_setThreshold(cv::face::BasicFaceRecognizer *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getProjections(cv::face::BasicFaceRecognizer *obj, std::vector<cv::Mat> *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto result = obj->getProjections();
     dst->clear();
     dst->reserve(result.size());
@@ -149,39 +149,39 @@ CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getProjections(cv::face::BasicFa
     {
         dst->push_back(result[i]);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getLabels(cv::face::BasicFaceRecognizer *obj, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getLabels();
     result.copyTo(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getEigenValues(cv::face::BasicFaceRecognizer *obj, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getEigenValues();
     result.copyTo(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getEigenVectors(cv::face::BasicFaceRecognizer *obj, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getEigenVectors();
     result.copyTo(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getMean(cv::face::BasicFaceRecognizer *obj, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getMean();
     result.copyTo(*dst);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -191,24 +191,24 @@ CVAPI(ExceptionStatus) face_BasicFaceRecognizer_getMean(cv::face::BasicFaceRecog
 CVAPI(ExceptionStatus) face_EigenFaceRecognizer_create(
     const int numComponents, const double threshold, cv::Ptr<cv::face::EigenFaceRecognizer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto r = cv::face::EigenFaceRecognizer::create(numComponents, threshold);
     *returnValue = clone(r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_EigenFaceRecognizer_get(cv::Ptr<cv::face::EigenFaceRecognizer> *obj, cv::face::EigenFaceRecognizer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_EigenFaceRecognizer_delete(cv::Ptr<cv::face::EigenFaceRecognizer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma endregion 
@@ -218,24 +218,24 @@ CVAPI(ExceptionStatus) face_Ptr_EigenFaceRecognizer_delete(cv::Ptr<cv::face::Eig
 CVAPI(ExceptionStatus) face_FisherFaceRecognizer_create(
     const int numComponents, const double threshold, cv::Ptr<cv::face::FisherFaceRecognizer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto r = cv::face::FisherFaceRecognizer::create(numComponents, threshold);
     *returnValue = clone(r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FisherFaceRecognizer_get(cv::Ptr<cv::face::FisherFaceRecognizer> *obj, cv::face::FisherFaceRecognizer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FisherFaceRecognizer_delete(cv::Ptr<cv::face::FisherFaceRecognizer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma endregion 
@@ -246,80 +246,80 @@ CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_create(
     const int radius, const int neighbors, const int gridX, const int gridY, const double threshold,
     cv::Ptr<cv::face::LBPHFaceRecognizer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto r = cv::face::LBPHFaceRecognizer::create(radius, neighbors, gridX, gridY, threshold);
     *returnValue = clone(r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getGridX(cv::face::LBPHFaceRecognizer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getGridX();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_setGridX(cv::face::LBPHFaceRecognizer *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGridX(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getGridY(cv::face::LBPHFaceRecognizer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getGridY();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_setGridY(cv::face::LBPHFaceRecognizer *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGridY(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getRadius(cv::face::LBPHFaceRecognizer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRadius();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_setRadius(cv::face::LBPHFaceRecognizer *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRadius(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getNeighbors(cv::face::LBPHFaceRecognizer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNeighbors();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_setNeighbors(cv::face::LBPHFaceRecognizer *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNeighbors(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getThreshold(cv::face::LBPHFaceRecognizer *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_setThreshold(cv::face::LBPHFaceRecognizer *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getHistograms(cv::face::LBPHFaceRecognizer *obj, std::vector<cv::Mat> *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto result = obj->getHistograms();
     dst->clear();
     dst->reserve(result.size());
@@ -327,28 +327,28 @@ CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getHistograms(cv::face::LBPHFaceR
     {
         dst->at(i) = result[i];
     }
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_LBPHFaceRecognizer_getLabels(cv::face::LBPHFaceRecognizer *obj, cv::Mat *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->getLabels();
     result.copyTo(*dst);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) face_Ptr_LBPHFaceRecognizer_get(cv::Ptr<cv::face::LBPHFaceRecognizer> *obj, cv::face::LBPHFaceRecognizer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) face_Ptr_LBPHFaceRecognizer_delete(cv::Ptr<cv::face::LBPHFaceRecognizer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -44,9 +44,9 @@ struct FacemarkAAMParamsData
 
 CVAPI(ExceptionStatus) face_Facemark_loadModel(cv::face::Facemark *obj, const char *model)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->loadModel(model);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus)
@@ -57,9 +57,9 @@ face_Facemark_fit(
     std::vector<std::vector<cv::Point2f>> *landmarks,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->fit(*image, *faces, *landmarks) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -68,42 +68,42 @@ face_Facemark_fit(
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_create(cv::face::FacemarkLBF::Params *params, cv::Ptr<cv::face::FacemarkLBF> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto obj = (params == nullptr) ? 
         cv::face::FacemarkLBF::create() :
         cv::face::FacemarkLBF::create(*params);
     *returnValue = clone(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FacemarkLBF_get(cv::Ptr<cv::face::FacemarkLBF> *obj, cv::face::FacemarkLBF **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FacemarkLBF_delete(cv::Ptr<cv::face::FacemarkLBF> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma region Params
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_new(cv::face::FacemarkLBF::Params **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::face::FacemarkLBF::Params;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_delete(cv::face::FacemarkLBF::Params *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_getAll(
@@ -116,7 +116,7 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_getAll(
     std::vector<int> *pupils0,
     std::vector<int> *pupils1)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     data->shape_offset = obj->shape_offset;
     data->verbose = obj->verbose ? 1 : 0;
     data->n_landmarks = obj->n_landmarks;
@@ -134,7 +134,7 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_getAll(
     std::copy(obj->radius_m.begin(), obj->radius_m.end(), std::back_inserter(*radiusM));
     std::copy(obj->pupils[0].begin(), obj->pupils[0].end(), std::back_inserter(*pupils0));
     std::copy(obj->pupils[1].begin(), obj->pupils[1].end(), std::back_inserter(*pupils1));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_setAll(
@@ -147,7 +147,7 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_setAll(
     std::vector<int> *pupils0,
     std::vector<int> *pupils1)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->shape_offset = data.shape_offset;
     obj->verbose = (data.verbose != 0);
     obj->n_landmarks = data.n_landmarks;
@@ -165,22 +165,22 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_setAll(
     obj->radius_m.assign(radiusM->begin(), radiusM->end());
     obj->pupils[0].assign(pupils0->begin(), pupils0->end());
     obj->pupils[1].assign(pupils1->begin(), pupils1->end());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_read(cv::face::FacemarkLBF::Params *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkLBF_Params_write(cv::face::FacemarkLBF::Params *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -190,42 +190,42 @@ CVAPI(ExceptionStatus) face_FacemarkLBF_Params_write(cv::face::FacemarkLBF::Para
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_create(cv::face::FacemarkAAM::Params *params, cv::Ptr<cv::face::FacemarkAAM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto obj = (params == nullptr) ?
         cv::face::FacemarkAAM::create() :
         cv::face::FacemarkAAM::create(*params);
     *returnValue = clone(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FacemarkAAM_get(cv::Ptr<cv::face::FacemarkAAM> *obj, cv::face::FacemarkAAM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_Ptr_FacemarkAAM_delete(cv::Ptr<cv::face::FacemarkAAM> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma region Params
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_new(cv::face::FacemarkAAM::Params **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::face::FacemarkAAM::Params;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_delete(cv::face::FacemarkAAM::Params *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_getAll(
@@ -234,7 +234,7 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_getAll(
     std::string *modelFilename,
     std::vector<float> *scales)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     data->m = obj->m;
     data->n = obj->n;
     data->n_iter = obj->n_iter;
@@ -245,7 +245,7 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_getAll(
     data->texture_max_m = obj->texture_max_m;
     modelFilename->assign(obj->model_filename);
     std::copy(obj->scales.begin(), obj->scales.end(), std::back_inserter(*scales));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_setAll(
@@ -254,7 +254,7 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_setAll(
     const char *modelFilename,
     std::vector<float> *scales)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->m = data.m;
     obj->n = data.n;
     obj->n_iter = data.n_iter;
@@ -265,22 +265,22 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_setAll(
     obj->texture_max_m = data.texture_max_m;
     obj->model_filename = modelFilename;
     obj->scales.assign(scales->begin(), scales->end());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_read(cv::face::FacemarkAAM::Params *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_write(cv::face::FacemarkAAM::Params *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/features.h
+++ b/src/OpenCvSharpExtern/features.h
@@ -12,10 +12,10 @@
 CVAPI(ExceptionStatus) features_drawKeypoints(cv::_InputArray *image, cv::KeyPoint *keypoints, int keypointsLength,
     cv::_InputOutputArray *outImage, interop::Scalar color, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::KeyPoint> keypointsVec(keypoints, keypoints + keypointsLength);
     cv::drawKeypoints(*image, keypointsVec, *outImage, cpp(color), static_cast<cv::DrawMatchesFlags>(flags));
-    END_WRAP
+    });
 }
 
 
@@ -25,7 +25,7 @@ CVAPI(ExceptionStatus) features_drawMatches(cv::Mat *img1, cv::KeyPoint *keypoin
     interop::Scalar matchColor, interop::Scalar singlePointColor,
     char *matchesMask, int matchesMaskLength, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::KeyPoint> keypoints1Vec(keypoints1, keypoints1 + keypoints1Length);
     const std::vector<cv::KeyPoint> keypoints2Vec(keypoints2, keypoints2 + keypoints2Length);
     const std::vector<cv::DMatch> matches1to2Vec(matches1to2, matches1to2 + matches1to2Length);
@@ -34,7 +34,7 @@ CVAPI(ExceptionStatus) features_drawMatches(cv::Mat *img1, cv::KeyPoint *keypoin
         matchesMaskVec = std::vector<char>(matchesMask, matchesMask + matchesMaskLength);
     cv::drawMatches(*img1, keypoints1Vec, *img2, keypoints2Vec, matches1to2Vec, *outImg,
         cpp(matchColor), cpp(singlePointColor), matchesMaskVec, static_cast<cv::DrawMatchesFlags>(flags));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_drawMatchesKnn(cv::Mat *img1, cv::KeyPoint *keypoints1, int keypoints1Length,
@@ -43,7 +43,7 @@ CVAPI(ExceptionStatus) features_drawMatchesKnn(cv::Mat *img1, cv::KeyPoint *keyp
     cv::Mat *outImg, interop::Scalar matchColor, interop::Scalar singlePointColor,
     char **matchesMask, int matchesMaskSize1, int *matchesMaskSize2, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::KeyPoint> keypoints1Vec(keypoints1, keypoints1 + keypoints1Length);
     const std::vector<cv::KeyPoint> keypoints2Vec(keypoints2, keypoints2 + keypoints2Length);
     std::vector<std::vector<cv::DMatch> > matches1to2Vec(matches1to2Size1);
@@ -66,7 +66,7 @@ CVAPI(ExceptionStatus) features_drawMatchesKnn(cv::Mat *img1, cv::KeyPoint *keyp
 
     cv::drawMatches(*img1, keypoints1Vec, *img2, keypoints2Vec, matches1to2Vec,
         *outImg, cpp(matchColor), cpp(singlePointColor), matchesMaskVec, static_cast<cv::DrawMatchesFlags>(flags));
-    END_WRAP
+    });
 }
 
 
@@ -76,11 +76,11 @@ CVAPI(ExceptionStatus) features_evaluateFeatureDetector(
     float *repeatability, int *correspCount/*,
     const Ptr<FeatureDetector>& fdetector = Ptr<FeatureDetector>()*/)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::evaluateFeatureDetector(
         *img1, *img2, *H1to2, keypoints1, keypoints2,
         *repeatability, *correspCount);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_computeRecallPrecisionCurve(
@@ -88,7 +88,7 @@ CVAPI(ExceptionStatus) features_computeRecallPrecisionCurve(
     uchar **correctMatches1to2Mask, int correctMatches1to2MaskSize1, int *correctMatches1to2MaskSize2,
     std::vector<cv::Point2f> *recallPrecisionCurve)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::DMatch> > matches1to2Vec;
     std::vector<std::vector<uchar> > correctMatches1to2MaskVec;
     matches1to2Vec.reserve(matches1to2Size1);
@@ -103,27 +103,27 @@ CVAPI(ExceptionStatus) features_computeRecallPrecisionCurve(
     }
     cv::computeRecallPrecisionCurve(
         matches1to2Vec, correctMatches1to2MaskVec, *recallPrecisionCurve);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_getRecall(
     cv::Point2f *recallPrecisionCurve, int recallPrecisionCurveSize, float l_precision, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2f> recallPrecisionCurveVec(
         recallPrecisionCurve, recallPrecisionCurve + recallPrecisionCurveSize);
     *returnValue = cv::getRecall(recallPrecisionCurveVec, l_precision);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_getNearestPoint(
     cv::Point2f *recallPrecisionCurve, int recallPrecisionCurveSize, float l_precision, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2f> recallPrecisionCurveVec(
         recallPrecisionCurve, recallPrecisionCurve + recallPrecisionCurveSize);
     *returnValue = cv::getNearestPoint(recallPrecisionCurveVec, l_precision);
-    END_WRAP
+    });
 }
 
 
@@ -132,49 +132,49 @@ CVAPI(ExceptionStatus) features_getNearestPoint(
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByImageBorder(
     std::vector<cv::KeyPoint> *keypoints, interop::Size imageSize, int borderSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::runByImageBorder(*keypoints, cpp(imageSize), borderSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByKeypointSize(
     std::vector<cv::KeyPoint> *keypoints, float minSize, float maxSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::runByKeypointSize(*keypoints, minSize, maxSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask(
     std::vector<cv::KeyPoint> *keypoints, cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::runByPixelsMask(*keypoints, *mask);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_removeDuplicated(
     std::vector<cv::KeyPoint> *keypoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::removeDuplicated(*keypoints);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_removeDuplicatedSorted(
     std::vector<cv::KeyPoint> *keypoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::removeDuplicatedSorted(*keypoints);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_retainBest(
     std::vector<cv::KeyPoint> *keypoints, int nPoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::KeyPointsFilter::retainBest(*keypoints, nPoints);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/features_ANNIndex.h
+++ b/src/OpenCvSharpExtern/features_ANNIndex.h
@@ -10,88 +10,88 @@
 
 CVAPI(ExceptionStatus) features_ANNIndex_create(int dim, int distType, cv::Ptr<cv::ANNIndex> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ANNIndex::create(dim, static_cast<cv::ANNIndex::Distance>(distType));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_ANNIndex_get(cv::Ptr<cv::ANNIndex> *ptr, cv::ANNIndex **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_ANNIndex_delete(cv::Ptr<cv::ANNIndex> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_addItems(cv::ANNIndex *obj, cv::_InputArray *features)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addItems(*features);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_build(cv::ANNIndex *obj, int trees)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->build(trees);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_knnSearch(
     cv::ANNIndex *obj, cv::_InputArray *query, cv::_OutputArray *indices, cv::_OutputArray *dists, int knn, int search_k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->knnSearch(*query, *indices, *dists, knn, search_k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_save(cv::ANNIndex *obj, const char *filename, int prefault)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->save(cv::String(filename), prefault != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_load(cv::ANNIndex *obj, const char *filename, int prefault)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->load(cv::String(filename), prefault != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_getTreeNumber(cv::ANNIndex *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTreeNumber();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_getItemNumber(cv::ANNIndex *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getItemNumber();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_setOnDiskBuild(cv::ANNIndex *obj, const char *filename, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->setOnDiskBuild(cv::String(filename)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_setSeed(cv::ANNIndex *obj, int seed)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSeed(seed);
-    END_WRAP
+    });
 }
 
 #endif // NO_FEATURES

--- a/src/OpenCvSharpExtern/features_DescriptorMatcher.h
+++ b/src/OpenCvSharpExtern/features_DescriptorMatcher.h
@@ -10,55 +10,55 @@
 #pragma region DescriptorMatcher
 CVAPI(ExceptionStatus) features_DescriptorMatcher_add(cv::DescriptorMatcher *obj, cv::Mat **descriptors, int descriptorLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> descriptorsVec(descriptorLength);
     for (int i = 0; i < descriptorLength; i++)    
         descriptorsVec[i] = *descriptors[i];
     obj->add(descriptorsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_getTrainDescriptors(cv::DescriptorMatcher *obj, std::vector<cv::Mat> *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *dst = obj->getTrainDescriptors();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_clear(cv::DescriptorMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_empty(cv::DescriptorMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DescriptorMatcher_isMaskSupported(cv::DescriptorMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isMaskSupported() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_train(cv::DescriptorMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->train();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_match1(
     cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, 
     cv::Mat *trainDescriptors, std::vector<cv::DMatch> *matches, cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->match(*queryDescriptors, *trainDescriptors, *matches, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch1(
@@ -66,9 +66,9 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch1(
     cv::Mat *trainDescriptors, std::vector<std::vector<cv::DMatch> > *matches, int k,
     cv::Mat *mask, int compactResult)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->knnMatch(*queryDescriptors, *trainDescriptors, *matches, k, entity(mask), compactResult != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch1(
@@ -76,16 +76,16 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch1(
     cv::Mat *trainDescriptors, std::vector<std::vector<cv::DMatch> > *matches, float maxDistance,
     cv::Mat *mask, int compactResult)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->radiusMatch(*queryDescriptors, *trainDescriptors, *matches, maxDistance, entity(mask), compactResult != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_match2(
     cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<cv::DMatch> *matches,
     cv::Mat **masks, int masksSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> masksVal;
     if (masksSize != 0)
     {
@@ -96,14 +96,14 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_match2(
         }
     }
     obj->match(*queryDescriptors, *matches, masksVal);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch2(
     cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<std::vector<cv::DMatch> > *matches, 
     int k, cv::Mat **masks, int masksSize, int compactResult)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> masksVal;
     if (masksSize != 0)
     {
@@ -114,14 +114,14 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch2(
         }
     }
     obj->knnMatch(*queryDescriptors, *matches, k, masksVal, compactResult != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch2(
     cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<std::vector<cv::DMatch> > *matches, 
     float maxDistance, cv::Mat **masks, int masksSize, int compactResult)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> masksVal;
     if (masksSize != 0)
     {
@@ -132,30 +132,30 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch2(
         }
     }
     obj->radiusMatch(*queryDescriptors, *matches, maxDistance, masksVal, compactResult != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_create(
     const char *descriptorMatcherType, cv::Ptr<cv::DescriptorMatcher> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Ptr<cv::DescriptorMatcher> ret = cv::DescriptorMatcher::create(descriptorMatcherType);
     *returnValue = new cv::Ptr<cv::DescriptorMatcher>(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_DescriptorMatcher_get(
     cv::Ptr<cv::DescriptorMatcher> *ptr, cv::DescriptorMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Ptr_DescriptorMatcher_delete(cv::Ptr<cv::DescriptorMatcher> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -164,37 +164,37 @@ CVAPI(ExceptionStatus) features_Ptr_DescriptorMatcher_delete(cv::Ptr<cv::Descrip
 
 CVAPI(ExceptionStatus) features_BFMatcher_new(int normType, int crossCheck, cv::BFMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::BFMatcher(normType, crossCheck != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_BFMatcher_delete(cv::BFMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_BFMatcher_isMaskSupported(cv::BFMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isMaskSupported() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_BFMatcher_get(cv::Ptr<cv::BFMatcher> *ptr, cv::BFMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_BFMatcher_delete(cv::Ptr<cv::BFMatcher> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -204,7 +204,7 @@ CVAPI(ExceptionStatus) features_Ptr_BFMatcher_delete(cv::Ptr<cv::BFMatcher> *ptr
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_new(
     cv::Ptr<cv::flann::IndexParams> *indexParams, cv::Ptr<cv::flann::SearchParams> *searchParams, cv::FlannBasedMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Ptr<cv::flann::IndexParams> indexParamsPtr;
     cv::Ptr<cv::flann::SearchParams> searchParamsPtr;
     if (indexParams == nullptr)
@@ -218,63 +218,63 @@ CVAPI(ExceptionStatus) features_FlannBasedMatcher_new(
         searchParamsPtr = *searchParams;
     
     *returnValue = new cv::FlannBasedMatcher(indexParamsPtr, searchParamsPtr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_delete(cv::FlannBasedMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_add(
     cv::FlannBasedMatcher *obj, cv::Mat **descriptors, int descriptorsSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> descriptorsVal(descriptorsSize);
     for (int i = 0; i < descriptorsSize; i++)
     {
         descriptorsVal[i] = *(descriptors[i]);
     }
     obj->add(descriptorsVal);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_clear(cv::FlannBasedMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_train(cv::FlannBasedMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->train();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_isMaskSupported(cv::FlannBasedMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isMaskSupported() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_FlannBasedMatcher_get(
     cv::Ptr<cv::FlannBasedMatcher> *ptr, cv::FlannBasedMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_FlannBasedMatcher_delete(cv::Ptr<cv::FlannBasedMatcher> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -288,52 +288,52 @@ CVAPI(ExceptionStatus) features_LightGlueMatcher_create(
     const char *modelPath, float scoreThreshold, int backend, int target,
     cv::Ptr<cv::LightGlueMatcher> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::LightGlueMatcher::create(cv::String(modelPath), scoreThreshold, backend, target);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_create_buffer(
     const uchar *modelData, size_t modelDataLength, float scoreThreshold, int backend, int target,
     cv::Ptr<cv::LightGlueMatcher> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<uchar> buf(modelData, modelData + modelDataLength);
     const auto ptr = cv::LightGlueMatcher::create(buf, scoreThreshold, backend, target);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_setPairInfo(
     cv::LightGlueMatcher *obj, cv::_InputArray *queryKpts, cv::_InputArray *trainKpts,
     interop::Size queryImageSize, interop::Size trainImageSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPairInfo(*queryKpts, *trainKpts, cpp(queryImageSize), cpp(trainImageSize));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_clearPairInfo(cv::LightGlueMatcher *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clearPairInfo();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_LightGlueMatcher_get(
     cv::Ptr<cv::LightGlueMatcher> *ptr, cv::LightGlueMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_LightGlueMatcher_delete(cv::Ptr<cv::LightGlueMatcher> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/features_Feature2D.h
+++ b/src/OpenCvSharpExtern/features_Feature2D.h
@@ -16,9 +16,9 @@ CVAPI(ExceptionStatus) features_Feature2D_detect_Mat1(
     std::vector<cv::KeyPoint> *keypoints,
     cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     detector->detect(*image, *keypoints, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_detect_Mat2(
@@ -27,7 +27,7 @@ CVAPI(ExceptionStatus) features_Feature2D_detect_Mat2(
     std::vector<std::vector<cv::KeyPoint> > *keypoints, 
     cv::Mat **mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imageVec(imageLength);
     std::vector<cv::Mat> maskVec;
 
@@ -42,31 +42,31 @@ CVAPI(ExceptionStatus) features_Feature2D_detect_Mat2(
     }
 
     detector->detect(imageVec, *keypoints, maskVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_detect_InputArray(
     cv::Feature2D *obj, cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, cv::Mat *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*image, *keypoints, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_compute1(
     cv::Feature2D *obj,
     cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, cv::_OutputArray *descriptors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*image, *keypoints, *descriptors);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_compute2(
     cv::Feature2D *detector, cv::Mat **images, int imageLength,
     std::vector<std::vector<cv::KeyPoint> > *keypoints, cv::Mat **descriptors, int descriptorsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imageVec(imageLength);
     std::vector<cv::Mat> descriptorsVec(descriptorsLength);
 
@@ -76,63 +76,63 @@ CVAPI(ExceptionStatus) features_Feature2D_compute2(
         descriptorsVec.push_back(*descriptors[i]);
 
     detector->compute(imageVec, *keypoints, descriptorsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_detectAndCompute(
     cv::Feature2D *detector, cv::_InputArray *image, cv::_InputArray *mask, 
     std::vector<cv::KeyPoint> *keypoints, cv::_OutputArray *descriptors, int useProvidedKeypoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     detector->detectAndCompute(entity(image), entity(mask), *keypoints, *descriptors, useProvidedKeypoints != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_descriptorSize(cv::Feature2D *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Feature2D_descriptorType(cv::Feature2D *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Feature2D_defaultNorm(cv::Feature2D *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->defaultNorm();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Feature2D_empty(cv::Feature2D *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_write(cv::Feature2D *obj, const char *fileName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::String fileNameString(fileName);
     obj->write(fileNameString);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_read(cv::Feature2D *obj, const char *fileName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(fileName);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_getDefaultName(cv::Feature2D *obj, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getDefaultName());
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -144,18 +144,18 @@ CVAPI(ExceptionStatus) features_SIFT_create(
     double contrastThreshold, double edgeThreshold, double sigma, 
     cv::Ptr<cv::SIFT> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::SIFT::create(
         nfeatures, nOctaveLayers, contrastThreshold, edgeThreshold, sigma);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_SIFT_delete(cv::Ptr<cv::SIFT> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -168,134 +168,134 @@ CVAPI(ExceptionStatus) features_ORB_create(
     int firstLevel, int wtaK, int scoreType, int patchSize, int fastThreshold,
     cv::Ptr<cv::ORB> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ORB::create(
         nFeatures, scaleFactor, nlevels, edgeThreshold, firstLevel, wtaK, static_cast<cv::ORB::ScoreType>(scoreType), patchSize, fastThreshold);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Ptr_ORB_delete(cv::Ptr<cv::ORB> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setMaxFeatures(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxFeatures(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getMaxFeatures(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxFeatures();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setScaleFactor(cv::ORB *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScaleFactor(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getScaleFactor(cv::ORB *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScaleFactor();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setNLevels(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNLevels(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getNLevels(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNLevels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setEdgeThreshold(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEdgeThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getEdgeThreshold(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getEdgeThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setFirstLevel(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setFirstLevel(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getFirstLevel(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getFirstLevel();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setWTA_K(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWTA_K(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getWTA_K(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getWTA_K();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setScoreType(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScoreType(static_cast<cv::ORB::ScoreType>(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getScoreType(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getScoreType());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setPatchSize(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPatchSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getPatchSize(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPatchSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ORB_setFastThreshold(cv::ORB *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setFastThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_ORB_getFastThreshold(cv::ORB *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getFastThreshold();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -307,17 +307,17 @@ CVAPI(ExceptionStatus) features_MSER_create(int delta, int minArea, int maxArea,
     double areaThreshold, double minMargin, int edgeBlurSize,
     cv::Ptr<cv::MSER> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::MSER::create(delta, minArea, maxArea, maxVariation, minDiversity, maxEvolution,
         areaThreshold, minMargin, edgeBlurSize);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Ptr_MSER_delete(cv::Ptr<cv::MSER> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_MSER_detectRegions(
@@ -326,61 +326,61 @@ CVAPI(ExceptionStatus) features_MSER_detectRegions(
     std::vector<std::vector<cv::Point> > *msers,
     std::vector<cv::Rect> *bboxes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectRegions(*image, *msers, *bboxes);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_MSER_setDelta(cv::MSER *obj, int delta)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDelta(delta);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_MSER_getDelta(cv::MSER *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDelta();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_MSER_setMinArea(cv::MSER *obj, int minArea)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinArea(minArea);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_MSER_getMinArea(cv::MSER *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinArea();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_MSER_setMaxArea(cv::MSER *obj, int maxArea)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxArea(maxArea);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_MSER_getMaxArea(cv::MSER *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxArea();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_MSER_setPass2Only(cv::MSER *obj, int f)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPass2Only(f != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_MSER_getPass2Only(cv::MSER *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPass2Only() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -389,71 +389,71 @@ CVAPI(ExceptionStatus) features_MSER_getPass2Only(cv::MSER *obj, int *returnValu
 
 CVAPI(ExceptionStatus) features_FAST1(cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, int threshold, int nonmaxSupression)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::FAST(*image, *keypoints, threshold, nonmaxSupression != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FAST2(cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, int threshold, int nonmaxSupression, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::FAST(*image, *keypoints, threshold, nonmaxSupression != 0, static_cast<cv::FastFeatureDetector::DetectorType>(type));
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) features_FastFeatureDetector_create(
     int threshold, int nonmaxSuppression, cv::Ptr<cv::FastFeatureDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::FastFeatureDetector::create(threshold, nonmaxSuppression != 0);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Ptr_FastFeatureDetector_delete(cv::Ptr<cv::FastFeatureDetector> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FastFeatureDetector_setThreshold(cv::FastFeatureDetector *obj, int threshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(threshold);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_FastFeatureDetector_getThreshold(cv::FastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FastFeatureDetector_setNonmaxSuppression(cv::FastFeatureDetector *obj, int f)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNonmaxSuppression(f != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_FastFeatureDetector_getNonmaxSuppression(cv::FastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNonmaxSuppression() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_FastFeatureDetector_setType(cv::FastFeatureDetector *obj, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setType(static_cast<cv::FastFeatureDetector::DetectorType>(type));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_FastFeatureDetector_getType(cv::FastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getType());
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -466,96 +466,96 @@ CVAPI(ExceptionStatus) features_GFTTDetector_create(
     int blockSize, int useHarrisDetector, double k,
     cv::Ptr<cv::GFTTDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::GFTTDetector::create(
         maxCorners, qualityLevel, minDistance,
         blockSize, useHarrisDetector != 0, k);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_Ptr_GFTTDetector_delete(cv::Ptr<cv::GFTTDetector> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setMaxFeatures(cv::GFTTDetector *obj, int maxFeatures)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxFeatures(maxFeatures);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getMaxFeatures(cv::GFTTDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxFeatures();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setQualityLevel(cv::GFTTDetector *obj, double qlevel)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setQualityLevel(qlevel);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getQualityLevel(cv::GFTTDetector *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getQualityLevel();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setMinDistance(cv::GFTTDetector *obj, double minDistance)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinDistance(minDistance);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getMinDistance(cv::GFTTDetector *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinDistance();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setBlockSize(cv::GFTTDetector *obj, int blockSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBlockSize(blockSize);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getBlockSize(cv::GFTTDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBlockSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setHarrisDetector(cv::GFTTDetector *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setHarrisDetector(val != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getHarrisDetector(cv::GFTTDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getHarrisDetector() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_GFTTDetector_setK(cv::GFTTDetector *obj, double k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setK(k);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_GFTTDetector_getK(cv::GFTTDetector *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getK();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -589,7 +589,7 @@ struct SimpleBlobDetector_Params
 CVAPI(ExceptionStatus) features_SimpleBlobDetector_create(
     SimpleBlobDetector_Params *p, cv::Ptr<cv::SimpleBlobDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::SimpleBlobDetector::Params p2;
     if (p != nullptr)
     {
@@ -615,14 +615,14 @@ CVAPI(ExceptionStatus) features_SimpleBlobDetector_create(
     }
     const auto ptr = cv::SimpleBlobDetector::create(p2);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_SimpleBlobDetector_delete(cv::Ptr<cv::SimpleBlobDetector> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -631,9 +631,9 @@ CVAPI(ExceptionStatus) features_Ptr_SimpleBlobDetector_delete(cv::Ptr<cv::Simple
 
 CVAPI(ExceptionStatus) features_Ptr_Feature2D_get(cv::Ptr<cv::Feature2D> *obj, cv::Feature2D **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
@@ -643,35 +643,35 @@ CVAPI(ExceptionStatus) features_AffineFeature_create(
     cv::Ptr<cv::Feature2D> *backend, int maxTilt, int minTilt, float tiltStep, float rotateStepBase,
     cv::Ptr<cv::AffineFeature> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::AffineFeature::create(*backend, maxTilt, minTilt, tiltStep, rotateStepBase);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_AffineFeature_setViewParams(
     cv::AffineFeature *obj, float *tilts, int tiltsLength, float *rolls, int rollsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<float> tiltsVec(tilts, tilts + tiltsLength);
     const std::vector<float> rollsVec(rolls, rolls + rollsLength);
     obj->setViewParams(tiltsVec, rollsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_AffineFeature_getViewParams(
     cv::AffineFeature *obj, std::vector<float> *tilts, std::vector<float> *rolls)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getViewParams(*tilts, *rolls);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_AffineFeature_delete(cv::Ptr<cv::AffineFeature> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -685,65 +685,65 @@ CVAPI(ExceptionStatus) features_DISK_create(
     const char *modelPath, int maxKeypoints, float scoreThreshold, interop::Size imageSize, int backendId, int targetId,
     cv::Ptr<cv::DISK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::DISK::create(cv::String(modelPath), maxKeypoints, scoreThreshold, cpp(imageSize), backendId, targetId);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DISK_create_buffer(
     const uchar *bufferModel, size_t bufferModelLength, int maxKeypoints, float scoreThreshold, interop::Size imageSize, int backendId, int targetId,
     cv::Ptr<cv::DISK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<uchar> buf(bufferModel, bufferModel + bufferModelLength);
     const auto ptr = cv::DISK::create(buf, maxKeypoints, scoreThreshold, cpp(imageSize), backendId, targetId);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_DISK_setMaxKeypoints(cv::DISK *obj, int maxKeypoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxKeypoints(maxKeypoints);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DISK_getMaxKeypoints(cv::DISK *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxKeypoints();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DISK_setScoreThreshold(cv::DISK *obj, float threshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScoreThreshold(threshold);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DISK_getScoreThreshold(cv::DISK *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScoreThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DISK_setImageSize(cv::DISK *obj, interop::Size size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageSize(cpp(size));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) features_DISK_getImageSize(cv::DISK *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getImageSize());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_DISK_delete(cv::Ptr<cv::DISK> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -755,7 +755,7 @@ CVAPI(ExceptionStatus) features_ALIKED_create(
     const char *modelPath, interop::Size inputSize, int normalizeDescriptors, int engine, int backend, int target,
     cv::Ptr<cv::ALIKED> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ALIKED::Params params;
     params.inputSize = cpp(inputSize);
     params.normalizeDescriptors = normalizeDescriptors != 0;
@@ -764,14 +764,14 @@ CVAPI(ExceptionStatus) features_ALIKED_create(
     params.target = target;
     const auto ptr = cv::ALIKED::create(cv::String(modelPath), params);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_ALIKED_create_buffer(
     const uchar *modelData, size_t modelDataLength, interop::Size inputSize, int normalizeDescriptors, int engine, int backend, int target,
     cv::Ptr<cv::ALIKED> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<uchar> buf(modelData, modelData + modelDataLength);
     cv::ALIKED::Params params;
     params.inputSize = cpp(inputSize);
@@ -781,14 +781,14 @@ CVAPI(ExceptionStatus) features_ALIKED_create_buffer(
     params.target = target;
     const auto ptr = cv::ALIKED::create(buf, params);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) features_Ptr_ALIKED_delete(cv::Ptr<cv::ALIKED> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/flann.h
+++ b/src/OpenCvSharpExtern/flann.h
@@ -13,79 +13,79 @@
 CVAPI(ExceptionStatus) flann_Index_new(
     cv::_InputArray *features, cv::flann::IndexParams* params, cvflann::flann_distance_t distType, cv::flann::Index **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::flann::Index(*features, *params, distType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Index_delete(cv::flann::Index* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Index_knnSearch1(cv::flann::Index* obj, float* queries, int queries_length, int* indices, float* dists, int knn, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<float> queries_vec(queries, queries + queries_length);
     std::vector<int> indices_vec(knn);
     std::vector<float> dists_vec(knn);
     obj->knnSearch(queries_vec, indices_vec, dists_vec, knn, *params);
     memcpy(indices, &indices_vec[0], sizeof(int) * knn);
     memcpy(dists, &dists_vec[0], sizeof(float) * knn);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_Index_knnSearch2(cv::flann::Index* obj, cv::Mat* queries, cv::Mat* indices, cv::Mat* dists, int knn, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->knnSearch(*queries, *indices, *dists, knn, *params);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_Index_knnSearch3(cv::flann::Index* obj, cv::Mat* queries, int* indices, float* dists, int knn, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat indices_mat(1, knn, CV_32SC1);
     cv::Mat dists_mat(1, knn, CV_32FC1);
     obj->knnSearch(*queries, indices_mat, dists_mat, knn, *params);
     memcpy(indices, indices_mat.ptr<int>(0), sizeof(int) * knn);
     memcpy(dists, dists_mat.ptr<float>(0), sizeof(float) * knn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Index_radiusSearch1(cv::flann::Index* obj, float* queries, int queries_length, int* indices, int indices_length, float* dists, int dists_length, double radius, int maxResults, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<float> queries_vec(queries, queries + queries_length);
     std::vector<int> indices_vec(indices_length);
     std::vector<float> dists_vec(dists_length);
     obj->radiusSearch(queries_vec, indices_vec, dists_vec, radius, maxResults, *params);
     memcpy(indices, &indices_vec[0], sizeof(int) * indices_length);
     memcpy(dists, &dists_vec[0], sizeof(float) * dists_length);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_Index_radiusSearch2(cv::flann::Index* obj, cv::Mat* queries, cv::Mat* indices, cv::Mat* dists, double radius, int maxResults, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->radiusSearch(*queries, *indices, *dists, radius, maxResults, *params);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_Index_radiusSearch3(cv::flann::Index* obj, cv::Mat* queries, int* indices, int indices_length, float* dists, int dists_length, double radius, int maxResults, cv::flann::SearchParams* params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat indices_mat(1, indices_length, CV_32SC1);
     cv::Mat dists_mat(1, dists_length, CV_32FC1);
     obj->radiusSearch(*queries, indices_mat, dists_mat, radius, maxResults, *params);
     memcpy(indices, indices_mat.ptr<int>(0), sizeof(int) * indices_length);
     memcpy(dists, dists_mat.ptr<float>(0), sizeof(float) * dists_length);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Index_save(cv::flann::Index* obj, const char* filename)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->save(filename);
-    END_WRAP
+    });
 }
 
 #endif // NO_FLANN

--- a/src/OpenCvSharpExtern/flann_IndexParams.h
+++ b/src/OpenCvSharpExtern/flann_IndexParams.h
@@ -13,81 +13,81 @@
 
 CVAPI(ExceptionStatus) flann_Ptr_IndexParams_new(cv::Ptr<cv::flann::IndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::IndexParams>(new cv::flann::IndexParams);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_IndexParams_get(
     cv::Ptr<cv::flann::IndexParams> *ptr, cv::flann::IndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_IndexParams_delete(cv::Ptr<cv::flann::IndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_IndexParams_getString(
     cv::flann::IndexParams *obj, const char *key, const char *defaultVal, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getString(key, defaultVal));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_getInt(cv::flann::IndexParams* obj, const char* key, int defaultVal, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getInt(key, defaultVal);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_getDouble(cv::flann::IndexParams* obj, const char* key, double defaultVal, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDouble(key, defaultVal);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_IndexParams_setString(cv::flann::IndexParams* obj, const char* key, const char* value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setString(key, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_setInt(cv::flann::IndexParams* obj, const char* key, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setInt(key, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_setDouble(cv::flann::IndexParams* obj, const char* key, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDouble(key, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_setFloat(cv::flann::IndexParams* obj, const char* key, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setFloat(key, value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_setBool(cv::flann::IndexParams* obj, const char* key, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBool(key, (value != 0));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) flann_IndexParams_setAlgorithm(cv::flann::IndexParams* obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAlgorithm(value);
-    END_WRAP
+    });
 }
 
 
@@ -95,24 +95,24 @@ CVAPI(ExceptionStatus) flann_IndexParams_setAlgorithm(cv::flann::IndexParams* ob
 
 CVAPI(ExceptionStatus) flann_Ptr_LinearIndexParams_new(cv::Ptr<cv::flann::LinearIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::LinearIndexParams>(new cv::flann::LinearIndexParams);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_LinearIndexParams_get(
     cv::Ptr<cv::flann::LinearIndexParams> *ptr, cv::flann::LinearIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_LinearIndexParams_delete(cv::Ptr<cv::flann::LinearIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -120,24 +120,24 @@ CVAPI(ExceptionStatus) flann_Ptr_LinearIndexParams_delete(cv::Ptr<cv::flann::Lin
 
 CVAPI(ExceptionStatus) flann_Ptr_KDTreeIndexParams_new(int trees, cv::Ptr<cv::flann::KDTreeIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::KDTreeIndexParams>(new cv::flann::KDTreeIndexParams(trees));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_KDTreeIndexParams_get(
     cv::Ptr<cv::flann::KDTreeIndexParams> *ptr, cv::flann::KDTreeIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_KDTreeIndexParams_delete(cv::Ptr<cv::flann::KDTreeIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -146,24 +146,24 @@ CVAPI(ExceptionStatus) flann_Ptr_KDTreeIndexParams_delete(cv::Ptr<cv::flann::KDT
 CVAPI(ExceptionStatus) flann_Ptr_KMeansIndexParams_new(
     int branching, int iterations, cvflann::flann_centers_init_t centers_init, float cb_index, cv::Ptr<cv::flann::KMeansIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::KMeansIndexParams>(new cv::flann::KMeansIndexParams(branching, iterations, centers_init, cb_index));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_KMeansIndexParams_get(
     cv::Ptr<cv::flann::KMeansIndexParams> *ptr, cv::flann::KMeansIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_KMeansIndexParams_delete(cv::Ptr<cv::flann::KMeansIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -172,24 +172,24 @@ CVAPI(ExceptionStatus) flann_Ptr_KMeansIndexParams_delete(cv::Ptr<cv::flann::KMe
 CVAPI(ExceptionStatus) flann_Ptr_LshIndexParams_new(
     int table_number, int key_size, int multi_probe_level, cv::Ptr<cv::flann::LshIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::LshIndexParams>(new cv::flann::LshIndexParams(table_number, key_size, multi_probe_level));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_LshIndexParams_get(
     cv::Ptr<cv::flann::LshIndexParams> *ptr, cv::flann::LshIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_LshIndexParams_delete(cv::Ptr<cv::flann::LshIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -198,24 +198,24 @@ CVAPI(ExceptionStatus) flann_Ptr_LshIndexParams_delete(cv::Ptr<cv::flann::LshInd
 CVAPI(ExceptionStatus) flann_Ptr_CompositeIndexParams_new(
     int trees, int branching, int iterations, cvflann::flann_centers_init_t centers_init, float cb_index, cv::Ptr<cv::flann::CompositeIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::CompositeIndexParams>(new cv::flann::CompositeIndexParams(trees, branching, iterations, centers_init, cb_index));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_CompositeIndexParams_get(
     cv::Ptr<cv::flann::CompositeIndexParams> *ptr, cv::flann::CompositeIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_CompositeIndexParams_delete(cv::Ptr<cv::flann::CompositeIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -224,24 +224,24 @@ CVAPI(ExceptionStatus) flann_Ptr_CompositeIndexParams_delete(cv::Ptr<cv::flann::
 CVAPI(ExceptionStatus) flann_Ptr_AutotunedIndexParams_new(
     float target_precision, float build_weight, float memory_weight, float sample_fraction, cv::Ptr<cv::flann::AutotunedIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::AutotunedIndexParams>(new cv::flann::AutotunedIndexParams(target_precision, build_weight, memory_weight, sample_fraction));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_AutotunedIndexParams_get(
     cv::Ptr<cv::flann::AutotunedIndexParams> *ptr, cv::flann::AutotunedIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_AutotunedIndexParams_delete(cv::Ptr<cv::flann::AutotunedIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -249,24 +249,24 @@ CVAPI(ExceptionStatus) flann_Ptr_AutotunedIndexParams_delete(cv::Ptr<cv::flann::
 
 CVAPI(ExceptionStatus) flann_Ptr_SavedIndexParams_new(const char* filename, cv::Ptr<cv::flann::SavedIndexParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::SavedIndexParams>(new cv::flann::SavedIndexParams(filename));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_SavedIndexParams_get(
     cv::Ptr<cv::flann::SavedIndexParams> *ptr, cv::flann::SavedIndexParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_SavedIndexParams_delete(cv::Ptr<cv::flann::SavedIndexParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -274,24 +274,24 @@ CVAPI(ExceptionStatus) flann_Ptr_SavedIndexParams_delete(cv::Ptr<cv::flann::Save
 
 CVAPI(ExceptionStatus) flann_Ptr_SearchParams_new(int checks, float eps, int sorted, cv::Ptr<cv::flann::SearchParams> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::flann::SearchParams>(new cv::flann::SearchParams(checks, eps, (sorted != 0)));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_SearchParams_get(
     cv::Ptr<cv::flann::SearchParams> *ptr, cv::flann::SearchParams **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) flann_Ptr_SearchParams_delete(cv::Ptr<cv::flann::SearchParams> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #endif // NO_FLANN

--- a/src/OpenCvSharpExtern/geometry.h
+++ b/src/OpenCvSharpExtern/geometry.h
@@ -27,9 +27,9 @@ struct CV_EXPORTS_W_SIMPLE MyUsacParams
 
 CVAPI(ExceptionStatus) geometry_Rodrigues(cv::_InputArray *src, cv::_OutputArray *dst, cv::_OutputArray *jacobian)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rodrigues(*src, *dst, entity(jacobian));
-    END_WRAP
+    });
 }
 
 
@@ -39,10 +39,10 @@ CVAPI(ExceptionStatus) geometry_findHomography_InputArray(
     int maxIters, double confidence,
     cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::findHomography(*srcPoints, *dstPoints, method, ransacReprojThreshold, entity(mask), maxIters, confidence);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findHomography_vector(
@@ -52,20 +52,20 @@ CVAPI(ExceptionStatus) geometry_findHomography_vector(
     int maxIters, double confidence,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat srcPointsMat(srcPointsLength, 1, CV_64FC2, srcPoints);
     const cv::Mat dstPointsMat(dstPointsLength, 1, CV_64FC2, dstPoints);
 
     const auto ret = cv::findHomography(srcPointsMat, dstPointsMat, method, ransacReprojThreshold, entity(mask), maxIters, confidence);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findHomography_UsacParams(
     cv::_InputArray* srcPoints, cv::_InputArray* dstPoints, cv::_OutputArray* mask, MyUsacParams *params,
     cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::UsacParams p;
     p.confidence = params->confidence;
     p.isParallel = params->isParallel != 0;
@@ -82,14 +82,14 @@ CVAPI(ExceptionStatus) geometry_findHomography_UsacParams(
     p.final_polisher_iterations = params->finalPolisherIterations;
     const auto ret = cv::findHomography(*srcPoints, *dstPoints, entity(mask), p);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findFundamentalMat_UsacParams(
     cv::_InputArray* points1, cv::_InputArray* points2, cv::_OutputArray* mask, MyUsacParams *params,
     cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::UsacParams p;
     p.confidence = params->confidence;
     p.isParallel = params->isParallel != 0;
@@ -106,7 +106,7 @@ CVAPI(ExceptionStatus) geometry_findFundamentalMat_UsacParams(
     p.final_polisher_iterations = params->finalPolisherIterations;
     const auto ret = cv::findFundamentalMat(*points1, *points2, entity(mask), p);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 
@@ -114,18 +114,18 @@ CVAPI(ExceptionStatus) geometry_RQDecomp3x3_InputArray(
     cv::_InputArray *src, cv::_OutputArray *mtxR, cv::_OutputArray *mtxQ,
     cv::_OutputArray *qx, cv::_OutputArray *qy, cv::_OutputArray *qz, cv::Vec3d *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *outVec = cv::RQDecomp3x3(*src, *mtxR, *mtxQ, entity(qx), entity(qy), entity(qz));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_RQDecomp3x3_Mat(
     cv::Mat *src, cv::Mat *mtxR, cv::Mat *mtxQ,
     cv::Mat *qx, cv::Mat *qy, cv::Mat *qz, cv::Vec3d *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *outVec = cv::RQDecomp3x3(*src, *mtxR, *mtxQ, *qx, *qy, *qz);
-    END_WRAP
+    });
 }
 
 
@@ -134,10 +134,10 @@ CVAPI(ExceptionStatus) geometry_decomposeProjectionMatrix_InputArray(
     cv::_OutputArray *rotMatrix, cv::_OutputArray *transVect, cv::_OutputArray *rotMatrixX,
     cv::_OutputArray *rotMatrixY, cv::_OutputArray *rotMatrixZ, cv::_OutputArray *eulerAngles)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::decomposeProjectionMatrix(*projMatrix, *cameraMatrix, *rotMatrix,
         *transVect, entity(rotMatrixX), entity(rotMatrixY), entity(rotMatrixZ), entity(eulerAngles));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_decomposeProjectionMatrix_Mat(
@@ -145,10 +145,10 @@ CVAPI(ExceptionStatus) geometry_decomposeProjectionMatrix_Mat(
     cv::Mat *rotMatrix, cv::Mat *transVect, cv::Mat *rotMatrixX,
     cv::Mat *rotMatrixY, cv::Mat *rotMatrixZ, cv::Mat *eulerAngles)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::decomposeProjectionMatrix(*projMatrix, *cameraMatrix, *rotMatrix,
         *transVect, *rotMatrixX, *rotMatrixY, *rotMatrixZ, *eulerAngles);
-    END_WRAP
+    });
 }
 
 
@@ -156,9 +156,9 @@ CVAPI(ExceptionStatus) geometry_matMulDeriv(
     cv::_InputArray *a, cv::_InputArray *b,
     cv::_OutputArray *dABdA, cv::_OutputArray *dABdB)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::matMulDeriv(*a, *b, *dABdA, *dABdB);
-    END_WRAP
+    });
 }
 
 
@@ -171,11 +171,11 @@ CVAPI(ExceptionStatus) geometry_composeRT_InputArray(
     cv::_OutputArray *dt3dr1, cv::_OutputArray *dt3dt1,
     cv::_OutputArray *dt3dr2, cv::_OutputArray *dt3dt2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::composeRT(*rvec1, *tvec1, *rvec2, *tvec2, *rvec3, *tvec3,
         entity(dr3dr1), entity(dr3dt1), entity(dr3dr2), entity(dr3dt2),
         entity(dt3dr1), entity(dt3dt1), entity(dt3dr2), entity(dt3dt2));
-    END_WRAP
+    });
 }
 
 
@@ -188,11 +188,11 @@ CVAPI(ExceptionStatus) geometry_composeRT_Mat(
     cv::Mat *dt3dr1, cv::Mat *dt3dt1,
     cv::Mat *dt3dr2, cv::Mat *dt3dt2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::composeRT(*rvec1, *tvec1, *rvec2, *tvec2, *rvec3, *tvec3,
         entity(dr3dr1), entity(dr3dt1), entity(dr3dr2), entity(dr3dt2),
         entity(dt3dr1), entity(dt3dt1), entity(dt3dr2), entity(dt3dt2));
-    END_WRAP
+    });
 }
 
 
@@ -204,10 +204,10 @@ CVAPI(ExceptionStatus) geometry_projectPoints_InputArray(
     cv::_OutputArray *jacobian,
     double aspectRatio)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::projectPoints(*objectPoints, *rvec, *tvec, *cameraMatrix, *distCoeffs,
         *imagePoints, entity(jacobian), aspectRatio);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_projectPoints_Mat(
@@ -218,10 +218,10 @@ CVAPI(ExceptionStatus) geometry_projectPoints_Mat(
     cv::Mat *jacobian,
     double aspectRatio)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::projectPoints(*objectPoints, *rvec, *tvec, *cameraMatrix, *distCoeffs,
         *imagePoints, *jacobian, aspectRatio);
-    END_WRAP
+    });
 }
 
 
@@ -229,9 +229,9 @@ CVAPI(ExceptionStatus) geometry_solvePnP_InputArray(
     cv::_InputArray *objectPoints, cv::_InputArray *imagePoints, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_OutputArray *rvec, cv::_OutputArray *tvec, int useExtrinsicGuess, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::solvePnP(*objectPoints, *imagePoints, *cameraMatrix, entity(distCoeffs), *rvec, *tvec, useExtrinsicGuess != 0, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_solvePnP_vector(cv::Point3f *objectPoints, int objectPointsLength,
@@ -240,7 +240,7 @@ CVAPI(ExceptionStatus) geometry_solvePnP_vector(cv::Point3f *objectPoints, int o
     double *rvec, double *tvec, int useExtrinsicGuess,
     int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat objectPointsMat(objectPointsLength, 1, CV_32FC3, objectPoints);
     const cv::Mat imagePointsMat(imagePointsLength, 1, CV_32FC2, imagePoints);
     cv::Mat distCoeffsMat;
@@ -252,7 +252,7 @@ CVAPI(ExceptionStatus) geometry_solvePnP_vector(cv::Point3f *objectPoints, int o
     cv::solvePnP(objectPointsMat, imagePointsMat, cameraMatrixMat, distCoeffsMat, rvecMat, tvecMat, useExtrinsicGuess != 0, flags);
     memcpy(rvec, rvecMat.val, sizeof(double) * 3);
     memcpy(tvec, tvecMat.val, sizeof(double) * 3);
-    END_WRAP
+    });
 }
 
 
@@ -262,11 +262,11 @@ CVAPI(ExceptionStatus) geometry_solvePnPRansac_InputArray(
     bool useExtrinsicGuess, int iterationsCount, float reprojectionError, double confidence,
     cv::_OutputArray *inliers, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::solvePnPRansac(*objectPoints, *imagePoints, *cameraMatrix, entity(distCoeffs), *rvec, *tvec,
         useExtrinsicGuess != 0, iterationsCount, reprojectionError, confidence,
         entity(inliers), flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_solvePnPRansac_vector(
@@ -278,7 +278,7 @@ CVAPI(ExceptionStatus) geometry_solvePnPRansac_vector(
     int useExtrinsicGuess, int iterationsCount, float reprojectionError, double confidence,
     std::vector<int> *inliers, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat objectPointsMat(objectPointsLength, 1, CV_64FC3, objectPoints);
     const cv::Mat imagePointsMat(imagePointsLength, 1, CV_64FC2, imagePoints);
     cv::Mat distCoeffsMat;
@@ -293,7 +293,7 @@ CVAPI(ExceptionStatus) geometry_solvePnPRansac_vector(
 
     memcpy(rvec, rvecM.val, sizeof(double) * 3);
     memcpy(tvec, tvecM.val, sizeof(double) * 3);
-    END_WRAP
+    });
 }
 
 
@@ -301,7 +301,7 @@ CVAPI(ExceptionStatus) geometry_calibrationMatrixValues_InputArray(cv::_InputArr
     double apertureWidth, double apertureHeight, double *fovx, double *fovy, double *focalLength,
     cv::Point2d *principalPoint, double *aspectRatio)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     double fovx0, fovy0, focalLength0, aspectRatio0;
     cv::Point2d principalPoint0;
     cv::calibrationMatrixValues(*cameraMatrix, cpp(imageSize), apertureWidth, apertureHeight,
@@ -311,19 +311,19 @@ CVAPI(ExceptionStatus) geometry_calibrationMatrixValues_InputArray(cv::_InputArr
     *principalPoint = principalPoint0;
     *focalLength = focalLength0;
     *aspectRatio = aspectRatio0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_calibrationMatrixValues_array(double *cameraMatrix, interop::Size imageSize,
     double apertureWidth, double apertureHeight, double *fovx, double *fovy, double *focalLength,
     cv::Point2d *principalPoint, double *aspectRatio)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat cameraMatrixM(3, 3, CV_64FC1, cameraMatrix);
     cv::_InputArray cameraMatrixI(cameraMatrixM);
     geometry_calibrationMatrixValues_InputArray(&cameraMatrixI, imageSize, apertureWidth, apertureHeight,
         fovx, fovy, focalLength, principalPoint, aspectRatio);
-    END_WRAP
+    });
 }
 
 
@@ -333,13 +333,13 @@ CVAPI(ExceptionStatus) geometry_getOptimalNewCameraMatrix_InputArray(
     interop::Rect* validPixROI, int centerPrincipalPoint,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect _validPixROI;
     const auto mat = cv::getOptimalNewCameraMatrix(*cameraMatrix, entity(distCoeffs),
         cpp(imageSize), alpha, cpp(newImgSize), &_validPixROI, centerPrincipalPoint != 0);
     *validPixROI = c(_validPixROI);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_getOptimalNewCameraMatrix_array(
@@ -349,7 +349,7 @@ CVAPI(ExceptionStatus) geometry_getOptimalNewCameraMatrix_array(
     interop::Rect* validPixROI, int centerPrincipalPoint,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat cameraMatrixM(3, 3, CV_64FC1, cameraMatrix);
     const auto distCoeffsM = (distCoeffs == nullptr) ? cv::Mat() : cv::Mat(distCoeffsSize, 1, CV_64FC1, distCoeffs);
 
@@ -358,67 +358,67 @@ CVAPI(ExceptionStatus) geometry_getOptimalNewCameraMatrix_array(
         alpha, cpp(newImgSize), &_validPixROI, centerPrincipalPoint != 0);
     *validPixROI = c(_validPixROI);
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) geometry_convertPointsToHomogeneous_InputArray(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convertPointsToHomogeneous(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_convertPointsToHomogeneous_array1(cv::Vec2f *src, cv::Vec3f *dst, int length)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat srcMat(length, 1, CV_64FC2, src);
     cv::Mat dstMat(length, 1, CV_64FC3, dst);
     cv::convertPointsFromHomogeneous(srcMat, dstMat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_convertPointsToHomogeneous_array2(cv::Vec3f *src, cv::Vec4f *dst, int length)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat srcMat(length, 1, CV_64FC3, src);
     cv::Mat dstMat(length, 1, CV_64FC4, dst);
     cv::convertPointsFromHomogeneous(srcMat, dstMat);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) geometry_convertPointsFromHomogeneous_InputArray(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convertPointsFromHomogeneous(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_convertPointsFromHomogeneous_array1(cv::Vec3f *src, cv::Vec2f *dst, int length)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat srcMat(length, 1, CV_64FC3, src);
     cv::Mat dstMat(length, 1, CV_64FC2, dst);
     cv::convertPointsFromHomogeneous(srcMat, dstMat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_convertPointsFromHomogeneous_array2(cv::Vec4f *src, cv::Vec3f *dst, int length)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat srcMat(length, 1, CV_64FC4, src);
     cv::Mat dstMat(length, 1, CV_64FC3, dst);
     cv::convertPointsFromHomogeneous(srcMat, dstMat);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) geometry_convertPointsHomogeneous(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convertPointsHomogeneous(*src, *dst);
-    END_WRAP
+    });
 }
 
 
@@ -428,11 +428,11 @@ CVAPI(ExceptionStatus) geometry_findFundamentalMat_InputArray(
     cv::_OutputArray *mask,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::findFundamentalMat(
         *points1, *points2, method, param1, param2, entity(mask));
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findFundamentalMat_arrayF64(
@@ -442,13 +442,13 @@ CVAPI(ExceptionStatus) geometry_findFundamentalMat_arrayF64(
     cv::_OutputArray *mask,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat points1M(points1Size, 1, CV_64FC2, points1);
     const cv::Mat points2M(points2Size, 1, CV_64FC2, points2);
     const auto mat = cv::findFundamentalMat(
         points1M, points2M, method, param1, param2, entity(mask));
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findFundamentalMat_arrayF32(
@@ -458,13 +458,13 @@ CVAPI(ExceptionStatus) geometry_findFundamentalMat_arrayF32(
     cv::_OutputArray *mask,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat points1M(points1Size, 1, CV_32FC2, points1);
     const cv::Mat points2M(points2Size, 1, CV_32FC2, points2);
     const auto mat = cv::findFundamentalMat(
         points1M, points2M, method, param1, param2, entity(mask));
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 
@@ -473,9 +473,9 @@ CVAPI(ExceptionStatus) geometry_computeCorrespondEpilines_InputArray(
     int whichImage, cv::_InputArray *F,
     cv::_OutputArray *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::computeCorrespondEpilines(*points, whichImage, *F, *lines);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_computeCorrespondEpilines_array2d(
@@ -483,12 +483,12 @@ CVAPI(ExceptionStatus) geometry_computeCorrespondEpilines_array2d(
     int whichImage, double *F,
     cv::Point3f *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2d> pointsM(pointsSize, 1, points);
     const cv::Mat_<double> FM(3, 3, F);
     cv::Mat_<cv::Point3f> linesM(pointsSize, 1, lines);
     cv::computeCorrespondEpilines(pointsM, whichImage, FM, linesM);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_computeCorrespondEpilines_array3d(
@@ -496,12 +496,12 @@ CVAPI(ExceptionStatus) geometry_computeCorrespondEpilines_array3d(
     int whichImage, double *F,
     cv::Point3f *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point3d> pointsM(pointsSize, 1, points);
     const cv::Mat_<double> FM(3, 3, F);
     cv::Mat_<cv::Point3f> linesM(pointsSize, 1, lines);
     cv::computeCorrespondEpilines(pointsM, whichImage, FM, linesM);
-    END_WRAP
+    });
 }
 
 
@@ -510,9 +510,9 @@ CVAPI(ExceptionStatus) geometry_triangulatePoints_InputArray(
     cv::_InputArray *projPoints1, cv::_InputArray *projPoints2,
     cv::_OutputArray *points4D)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::triangulatePoints(*projMatr1, *projMatr2, *projPoints1, *projPoints2, *points4D);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_triangulatePoints_array(
@@ -521,7 +521,7 @@ CVAPI(ExceptionStatus) geometry_triangulatePoints_array(
     cv::Point2d *projPoints2, int projPoints2Size,
     cv::Vec4d *points4D)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<double> projMatr1M(3, 4, projMatr1);
     const cv::Mat_<double> projMatr2M(3, 4, projMatr2);
     const cv::Mat_<cv::Point2d> projPoints1M(projPoints1Size, 1, projPoints1);
@@ -529,7 +529,7 @@ CVAPI(ExceptionStatus) geometry_triangulatePoints_array(
     cv::Mat_<cv::Vec4d> points4DM(1, projPoints1Size, points4D);
     cv::triangulatePoints(projMatr1M, projMatr2M,
         projPoints1M, projPoints2M, points4DM);
-    END_WRAP
+    });
 }
 
 
@@ -537,9 +537,9 @@ CVAPI(ExceptionStatus) geometry_correctMatches_InputArray(
     cv::_InputArray *F, cv::_InputArray *points1, cv::_InputArray *points2,
     cv::_OutputArray *newPoints1, cv::_OutputArray *newPoints2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::correctMatches(*F, *points1, *points2, *newPoints1, *newPoints2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_correctMatches_array(
@@ -548,7 +548,7 @@ CVAPI(ExceptionStatus) geometry_correctMatches_array(
     cv::Point2d *points2, int points2Size,
     cv::Point2d *newPoints1, cv::Point2d *newPoints2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat_<double> FM(3, 3, F);
     cv::Mat_<cv::Point2d> points1M(points1Size, 1, points1);
     cv::Mat_<cv::Point2d> points2M(points2Size, 1, points2);
@@ -559,7 +559,7 @@ CVAPI(ExceptionStatus) geometry_correctMatches_array(
     cv::Mat_<double> newPoints1MM = points1M.reshape(2);
     cv::Mat_<double> newPoints2MM = points2M.reshape(2);
     cv::correctMatches(FM, points1MM, points2MM, newPoints1MM, newPoints2MM);
-    END_WRAP
+    });
 }
 
 
@@ -568,9 +568,9 @@ CVAPI(ExceptionStatus) geometry_estimateAffine3D(cv::_InputArray *src, cv::_Inpu
     double ransacThreshold, double confidence,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::estimateAffine3D(*src, *dst, *out, *inliers, ransacThreshold, confidence);
-    END_WRAP
+    });
 }
 
 
@@ -579,23 +579,23 @@ CVAPI(ExceptionStatus) geometry_sampsonDistance_InputArray(
     cv::_InputArray *pt1, cv::_InputArray *pt2, cv::_InputArray *F,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::sampsonDistance(*pt1, *pt2, *F);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_sampsonDistance_Point3d(
     interop::Point3d pt1, interop::Point3d pt2, interop::Point3d *F,
     double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point3d> f(9);
     for (size_t i = 0; i < 9; i++)
     {
         f[i] = cpp(F[i]);
     }
     *returnValue = cv::sampsonDistance(cv::Mat(cpp(pt1)), cv::Mat(cpp(pt2)), f);
-    END_WRAP
+    });
 }
 
 
@@ -605,11 +605,11 @@ CVAPI(ExceptionStatus) geometry_estimateAffine2D(
     uint64_t maxIters, double confidence, uint64_t refineIters,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = cv::estimateAffine2D(
         *from, *to, entity(inliers), method, ransacReprojThreshold, static_cast<size_t>(maxIters), confidence, static_cast<size_t>(refineIters));
     *returnValue = new cv::Mat(result);
-    END_WRAP
+    });
 }
 
 
@@ -619,11 +619,11 @@ CVAPI(ExceptionStatus) geometry_estimateAffinePartial2D(
     uint64_t maxIters, double confidence, uint64_t refineIters,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = cv::estimateAffinePartial2D(
         *from, *to, entity(inliers), method, ransacReprojThreshold, static_cast<size_t>(maxIters), confidence, static_cast<size_t>(refineIters));
     *returnValue = new cv::Mat(result);
-    END_WRAP
+    });
 }
 
 
@@ -635,9 +635,9 @@ CVAPI(ExceptionStatus) geometry_decomposeHomographyMat(
     std::vector<cv::Mat> *normals,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::decomposeHomographyMat(*H, *K, *rotations, *translations, *normals);
-    END_WRAP
+    });
 }
 
 
@@ -649,9 +649,9 @@ CVAPI(ExceptionStatus) geometry_filterHomographyDecompByVisibleRefpoints(
     cv::_OutputArray *possibleSolutions,
     cv::_InputArray *pointsMask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::filterHomographyDecompByVisibleRefpoints(*rotations, *normals, *beforePoints, *afterPoints, *possibleSolutions, entity(pointsMask));
-    END_WRAP
+    });
 }
 
 
@@ -659,10 +659,10 @@ CVAPI(ExceptionStatus) geometry_getDefaultNewCameraMatrix(
     cv::_InputArray *cameraMatrix, interop::Size imgsize, int centerPrincipalPoint,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = cv::getDefaultNewCameraMatrix(*cameraMatrix, cpp(imgsize), centerPrincipalPoint != 0);
     *returnValue = new cv::Mat(result);
-    END_WRAP
+    });
 }
 
 
@@ -671,9 +671,9 @@ CVAPI(ExceptionStatus) geometry_undistortPoints(
     cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_InputArray *R, cv::_InputArray *P)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::undistortPoints(*src, *dst, *cameraMatrix, *distCoeffs, entity(R), entity(P));
-    END_WRAP
+    });
 }
 
 
@@ -682,9 +682,9 @@ CVAPI(ExceptionStatus) geometry_undistortPointsIter(
     cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_InputArray *R, cv::_InputArray *P, interop::TermCriteria criteria)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::undistortPoints(*src, *dst, *cameraMatrix, *distCoeffs, entity(R), entity(P), cpp(criteria));
-    END_WRAP
+    });
 }
 
 
@@ -694,9 +694,9 @@ CVAPI(ExceptionStatus) geometry_recoverPose_InputArray1(
     cv::_OutputArray *R, cv::_OutputArray *t, cv::_InputOutputArray *mask,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::recoverPose(*E, *points1, *points2, *cameraMatrix, *R, *t, entity(mask));
-    END_WRAP
+    });
 }
 
 
@@ -706,9 +706,9 @@ CVAPI(ExceptionStatus) geometry_recoverPose_InputArray2(
     cv::_InputOutputArray *mask,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::recoverPose(*E, *points1, *points2, *R, *t, focal, cpp(pp), entity(mask));
-    END_WRAP
+    });
 }
 
 
@@ -719,9 +719,9 @@ CVAPI(ExceptionStatus) geometry_recoverPose_InputArray3(
     cv::_InputOutputArray *mask, cv::_OutputArray *triangulatedPoints,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::recoverPose(*E, *points1, *points2, *cameraMatrix, *R, *t, distanceTresh, entity(mask), entity(triangulatedPoints));
-    END_WRAP
+    });
 }
 
 
@@ -731,11 +731,11 @@ CVAPI(ExceptionStatus) geometry_findEssentialMat_InputArray1(
     cv::_OutputArray *mask,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::findEssentialMat(
         *points1, *points2, *cameraMatrix, method, prob, threshold, 1000, entity(mask));
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_findEssentialMat_InputArray2(
@@ -744,11 +744,11 @@ CVAPI(ExceptionStatus) geometry_findEssentialMat_InputArray2(
     cv::_OutputArray *mask,
     cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mat = cv::findEssentialMat(
         *points1, *points2, focal, cpp(pp), method, prob, threshold, 1000, entity(mask));
     *returnValue = new cv::Mat(mat);
-    END_WRAP
+    });
 }
 
 
@@ -756,35 +756,35 @@ CVAPI(ExceptionStatus) geometry_solvePnPRefineLM(
     cv::_InputArray *objectPoints, cv::_InputArray *imagePoints, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_InputOutputArray *rvec, cv::_InputOutputArray *tvec, interop::TermCriteria criteria)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::solvePnPRefineLM(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_solvePnPRefineVVS(
     cv::_InputArray *objectPoints, cv::_InputArray *imagePoints, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_InputOutputArray *rvec, cv::_InputOutputArray *tvec, interop::TermCriteria criteria, double vvsLambda)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::solvePnPRefineVVS(*objectPoints, *imagePoints, *cameraMatrix, *distCoeffs, *rvec, *tvec, cpp(criteria), vvsLambda);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_decomposeEssentialMat(
     cv::_InputArray *e, cv::_OutputArray *r1, cv::_OutputArray *r2, cv::_OutputArray *t)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::decomposeEssentialMat(*e, *r1, *r2, *t);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_estimateTranslation3D(
     cv::_InputArray *src, cv::_InputArray *dst, cv::_OutputArray *out, cv::_OutputArray *inliers,
     double ransacThreshold, double confidence, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::estimateTranslation3D(*src, *dst, *out, *inliers, ransacThreshold, confidence) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) geometry_estimateTranslation2D(
@@ -792,11 +792,11 @@ CVAPI(ExceptionStatus) geometry_estimateTranslation2D(
     int method, double ransacReprojThreshold, uint64_t maxIters, double confidence, uint64_t refineIters,
     cv::Vec2d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::estimateTranslation2D(
         *from, *to, entity(inliers), method, ransacReprojThreshold,
         static_cast<size_t>(maxIters), confidence, static_cast<size_t>(refineIters));
-    END_WRAP
+    });
 }
 
 #endif // NO_GEOMETRY

--- a/src/OpenCvSharpExtern/highgui.h
+++ b/src/OpenCvSharpExtern/highgui.h
@@ -10,189 +10,189 @@
 
 CVAPI(ExceptionStatus) highgui_namedWindow(const char *winname, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::namedWindow(winname, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_destroyWindow(const char *winName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::destroyWindow(winName);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_destroyAllWindows()
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::destroyAllWindows();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_startWindowThread(int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::startWindowThread();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_waitKeyEx(int delay, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::waitKeyEx(delay);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_waitKey(int delay, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::waitKey(delay);
-    END_WRAP
+    });
 }
   
 
 CVAPI(ExceptionStatus) highgui_imshow(const char *winname, cv::Mat *mat)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::imshow(winname, *mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_imshow_umat(const char* winname, cv::UMat* mat)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         cv::imshow(winname, *mat);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_resizeWindow(const char *winName, int width, int height)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::resizeWindow(winName, width, height);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_moveWindow(const char *winName, int x, int y)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::moveWindow(winName, x, y);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_setWindowProperty(const char *winName, int propId, double propValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setWindowProperty(winName, propId, propValue);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_setWindowTitle(const char *winname, const char *title)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // TODO Resolve:
 #ifndef _WINRT_DLL
     cv::setWindowTitle(winname, title);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_getWindowProperty(const char *winName, int propId, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getWindowProperty(winName, propId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_getWindowImageRect(const char *winName, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::getWindowImageRect(winName));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_setMouseCallback(const char *winName, cv::MouseCallback onMouse, void* userData)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setMouseCallback(winName, onMouse, userData);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_getMouseWheelDelta(int flags, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getMouseWheelDelta(flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_selectROI1(const char *windowName, cv::_InputArray *img, int showCrosshair, int fromCenter, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::selectROI(windowName, *img, showCrosshair != 0, fromCenter != 0));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_selectROI2(cv::_InputArray *img, int showCrosshair, int fromCenter, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::selectROI(*img, showCrosshair != 0, fromCenter != 0));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_selectROIs(const char * windowName, cv::_InputArray *img,
                              std::vector<cv::Rect> *boundingBoxes, int showCrosshair, int fromCenter)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::selectROIs(windowName, *img, *boundingBoxes, showCrosshair != 0, fromCenter != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_createTrackbar(const char *trackbarName, const char *winName,
     int* value, int count, cv::TrackbarCallback onChange, void* userData, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::createTrackbar(trackbarName, winName, value, count, onChange, userData);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) highgui_getTrackbarPos(const char *trackbarName, const char *winName, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getTrackbarPos(trackbarName, winName);
-    END_WRAP  
+    });  
 }
 CVAPI(ExceptionStatus) highgui_setTrackbarPos(const char *trackbarName, const char *winName, int pos)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setTrackbarPos(trackbarName, winName, pos);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) highgui_setTrackbarMax(const char *trackbarName, const char *winName, int maxVal)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setTrackbarMax(trackbarName, winName, maxVal);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) highgui_setTrackbarMin(const char *trackbarName, const char *winName, int minVal)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::setTrackbarMin(trackbarName, winName, minVal);
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) highgui_createButton(const char *bar_name, cv::ButtonCallback on_change,
     void* user_data, int type, int initial_button_state, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::createButton(bar_name, on_change, user_data, type, initial_button_state != 0);
-    END_WRAP
+    });
 }*/
 
 #ifdef _WINRT_DLL
 CVAPI(ExceptionStatus) highgui_initContainer(::Windows::UI::Xaml::Controls::Panel^ panel)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::winrt_initContainer(panel);
-    END_WRAP
+    });
 }
 #endif
 

--- a/src/OpenCvSharpExtern/img_hash.h
+++ b/src/OpenCvSharpExtern/img_hash.h
@@ -11,16 +11,16 @@
 
 CVAPI(ExceptionStatus) img_hash_ImgHashBase_compute(cv::img_hash::ImgHashBase *obj, cv::_InputArray *inputArr, cv::_OutputArray *outputArr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*inputArr, *outputArr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_ImgHashBase_compare(cv::img_hash::ImgHashBase *obj, cv::_InputArray *hashOne, cv::_InputArray *hashTwo, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->compare(*hashOne, *hashTwo);
-    END_WRAP
+    });
 }
 
 
@@ -28,24 +28,24 @@ CVAPI(ExceptionStatus) img_hash_ImgHashBase_compare(cv::img_hash::ImgHashBase *o
 
 CVAPI(ExceptionStatus) img_hash_AverageHash_create(cv::Ptr<cv::img_hash::AverageHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::AverageHash::create();
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_AverageHash_delete(cv::Ptr<cv::img_hash::AverageHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_AverageHash_get(cv::Ptr<cv::img_hash::AverageHash> *ptr, cv::img_hash::AverageHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 
@@ -53,40 +53,40 @@ CVAPI(ExceptionStatus) img_hash_Ptr_AverageHash_get(cv::Ptr<cv::img_hash::Averag
 
 CVAPI(ExceptionStatus) img_hash_BlockMeanHash_create(const int mode, cv::Ptr<cv::img_hash::BlockMeanHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::BlockMeanHash::create(mode);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_BlockMeanHash_delete(cv::Ptr<cv::img_hash::BlockMeanHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_BlockMeanHash_get(cv::Ptr<cv::img_hash::BlockMeanHash> *ptr, cv::img_hash::BlockMeanHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_BlockMeanHash_setMode(cv::img_hash::BlockMeanHash *obj, const int mode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMode(mode);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_BlockMeanHash_getMean(cv::img_hash::BlockMeanHash *obj, std::vector<double> *outVec)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto mean = obj->getMean();
     outVec->clear();
     outVec->assign(mean.begin(), mean.end());
-    END_WRAP
+    });
 }
 
 
@@ -94,24 +94,24 @@ CVAPI(ExceptionStatus) img_hash_BlockMeanHash_getMean(cv::img_hash::BlockMeanHas
 
 CVAPI(ExceptionStatus) img_hash_ColorMomentHash_create(cv::Ptr<cv::img_hash::ColorMomentHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::ColorMomentHash::create();
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_ColorMomentHash_delete(cv::Ptr<cv::img_hash::ColorMomentHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_ColorMomentHash_get(cv::Ptr<cv::img_hash::ColorMomentHash> *ptr, cv::img_hash::ColorMomentHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 
@@ -119,45 +119,45 @@ CVAPI(ExceptionStatus) img_hash_Ptr_ColorMomentHash_get(cv::Ptr<cv::img_hash::Co
 
 CVAPI(ExceptionStatus) img_hash_MarrHildrethHash_create(const float alpha, const float scale, cv::Ptr<cv::img_hash::MarrHildrethHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::MarrHildrethHash::create(alpha, scale);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_MarrHildrethHash_delete(cv::Ptr<cv::img_hash::MarrHildrethHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_MarrHildrethHash_get(cv::Ptr<cv::img_hash::MarrHildrethHash> *ptr, cv::img_hash::MarrHildrethHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_MarrHildrethHash_setKernelParam(cv::img_hash::MarrHildrethHash *obj, const float alpha, const float scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setKernelParam(alpha, scale);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_MarrHildrethHash_getAlpha(cv::img_hash::MarrHildrethHash *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAlpha();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_MarrHildrethHash_getScale(cv::img_hash::MarrHildrethHash *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScale();
-    END_WRAP
+    });
 }
 
 
@@ -165,24 +165,24 @@ CVAPI(ExceptionStatus) img_hash_MarrHildrethHash_getScale(cv::img_hash::MarrHild
 
 CVAPI(ExceptionStatus) img_hash_PHash_create(cv::Ptr<cv::img_hash::PHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::PHash::create();
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_PHash_delete(cv::Ptr<cv::img_hash::PHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_PHash_get(cv::Ptr<cv::img_hash::PHash> *ptr, cv::img_hash::PHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 
@@ -190,52 +190,52 @@ CVAPI(ExceptionStatus) img_hash_Ptr_PHash_get(cv::Ptr<cv::img_hash::PHash> *ptr,
 
 CVAPI(ExceptionStatus) img_hash_RadialVarianceHash_create(const double sigma, const int numOfAngleLine, cv::Ptr<cv::img_hash::RadialVarianceHash> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::img_hash::RadialVarianceHash::create(sigma, numOfAngleLine);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_RadialVarianceHash_delete(cv::Ptr<cv::img_hash::RadialVarianceHash> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_Ptr_RadialVarianceHash_get(cv::Ptr<cv::img_hash::RadialVarianceHash> *ptr, cv::img_hash::RadialVarianceHash **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_RadialVarianceHash_setNumOfAngleLine(cv::img_hash::RadialVarianceHash *obj, const int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNumOfAngleLine(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_RadialVarianceHash_setSigma(cv::img_hash::RadialVarianceHash *obj, const double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigma(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_RadialVarianceHash_getNumOfAngleLine(cv::img_hash::RadialVarianceHash *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumOfAngleLine();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) img_hash_RadialVarianceHash_getSigma(cv::img_hash::RadialVarianceHash *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigma();
-    END_WRAP
+    });
 }
 
 // (no NO_CONTRIB guard: kept in every profile for OpenCV 5)

--- a/src/OpenCvSharpExtern/imgcodecs.h
+++ b/src/OpenCvSharpExtern/imgcodecs.h
@@ -80,7 +80,7 @@ static bool imgcodecs_withWideFile(const char *utf8, TDecodeGuarded decodeGuarde
 
 CVAPI(ExceptionStatus) imgcodecs_imread(const char *filename, int flags, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string acp;
     cv::Mat ret;
@@ -99,12 +99,12 @@ CVAPI(ExceptionStatus) imgcodecs_imread(const char *filename, int flags, cv::Mat
     const auto ret = cv::imread(filename, flags);
     *returnValue = new cv::Mat(ret);
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imreadmulti(const char *filename, std::vector<cv::Mat> *mats, int flags, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string acp;
     if (pathRoundTripsAcp(filename, acp))
@@ -121,12 +121,12 @@ CVAPI(ExceptionStatus) imgcodecs_imreadmulti(const char *filename, std::vector<c
 #else
     *returnValue = cv::imreadmulti(filename, *mats, flags) ? 1 : 0;
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imwrite(const char *filename, cv::Mat *img, int *params, int paramsLength, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<int> paramsVec;
     paramsVec.assign(params, params + paramsLength);
 #ifdef _WIN32
@@ -146,12 +146,12 @@ CVAPI(ExceptionStatus) imgcodecs_imwrite(const char *filename, cv::Mat *img, int
 #else
     *returnValue = cv::imwrite(filename, *img, paramsVec) ? 1 : 0;
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imwrite_multi(const char *filename, std::vector<cv::Mat> *img, int *params, int paramsLength, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<int> paramsVec;
     paramsVec.assign(params, params + paramsLength);
 #ifdef _WIN32
@@ -171,50 +171,50 @@ CVAPI(ExceptionStatus) imgcodecs_imwrite_multi(const char *filename, std::vector
 #else
     *returnValue = cv::imwrite(filename, *img, paramsVec) ? 1 : 0;
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imdecode_Mat(cv::Mat *buf, int flags, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::imdecode(*buf, flags);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgcodecs_imdecode_vector(uchar *buf, int bufLength, int flags, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     //const std::vector<uchar> bufVec(buf, buf + bufLength);
     const cv::Mat bufMat(1, bufLength, CV_8UC1, buf, cv::Mat::AUTO_STEP);
     const auto ret = cv::imdecode(bufMat, flags);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgcodecs_imdecode_InputArray(cv::_InputArray *buf, int flags, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::imdecode(*buf, flags);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_imencode_vector(
     const char *ext, cv::_InputArray *img,
     std::vector<uchar> *buf, int *params, int paramsLength, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<int> paramsVec;
     if (params != nullptr)
         paramsVec = std::vector<int>(params, params + paramsLength);
     *returnValue = cv::imencode(ext, *img, *buf, paramsVec) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
 
 CVAPI(ExceptionStatus) imgcodecs_haveImageReader(const char *filename, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 #ifdef _WIN32
     std::string acp;
     if (pathRoundTripsAcp(filename, acp))
@@ -233,12 +233,12 @@ CVAPI(ExceptionStatus) imgcodecs_haveImageReader(const char *filename, int *retu
 #else
     *returnValue = cv::haveImageReader(filename) ? 1 : 0;
 #endif
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgcodecs_haveImageWriter(const char *filename, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::haveImageWriter(filename) ? 1 : 0;
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -9,96 +9,96 @@
 
 CVAPI(ExceptionStatus) imgproc_getGaussianKernel(int ksize, double sigma, int ktype, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getGaussianKernel(ksize, sigma, ktype);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getDerivKernels(cv::_OutputArray *kx, cv::_OutputArray *ky,
     int dx, int dy, int ksize, int normalize, int ktype)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::getDerivKernels(*kx, *ky, dx, dy, ksize, normalize != 0, ktype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getGaborKernel(interop::Size ksize, double sigma, double theta,
     double lambd, double gamma, double psi, int ktype, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getGaborKernel(cpp(ksize), sigma, theta, lambd, gamma, psi, ktype);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getStructuringElement(int shape, interop::Size ksize, interop::Point anchor, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getStructuringElement(shape, cpp(ksize), cpp(anchor));
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_medianBlur(cv::_InputArray *src, cv::_OutputArray *dst, int ksize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::medianBlur(*src, *dst, ksize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GaussianBlur(cv::_InputArray *src, cv::_OutputArray *dst,
                                             interop::Size ksize, double sigmaX, double sigmaY, int borderType, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::GaussianBlur(*src, *dst, cpp(ksize), sigmaX, sigmaY, borderType, static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_bilateralFilter(cv::_InputArray *src, cv::_OutputArray *dst,
                                     int d, double sigmaColor, double sigmaSpace, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::bilateralFilter(*src, *dst, d, sigmaColor, sigmaSpace, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_boxFilter(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                               interop::Size ksize, interop::Point anchor, int normalize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::boxFilter(*src, *dst, ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_sqrBoxFilter(
     cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
     interop::Size ksize, interop::Point anchor, int normalize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::sqrBoxFilter(*src, *dst, ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_blur(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size ksize, interop::Point anchor, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::blur(*src, *dst, cpp(ksize), cpp(anchor), borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_filter2D(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                              cv::_InputArray *kernel, interop::Point anchor, double delta, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::filter2D(*src, *dst, ddepth, *kernel, cpp(anchor), delta, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_filter2Dp(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
                              int anchorX, int anchorY, int borderType, interop::Scalar borderValue, int ddepth, double scale, double shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Filter2DParams params;
     params.anchorX = anchorX;
     params.anchorY = anchorY;
@@ -108,132 +108,132 @@ CVAPI(ExceptionStatus) imgproc_filter2Dp(cv::_InputArray *src, cv::_OutputArray 
     params.scale = scale;
     params.shift = shift;
     cv::filter2D(*src, *dst, *kernel, params);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_sepFilter2D(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                                 cv::_InputArray *kernelX, cv::_InputArray *kernelY,
                                 interop::Point anchor, double delta, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::sepFilter2D(*src, *dst, ddepth, *kernelX, *kernelY, cpp(anchor), delta, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Sobel(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                           int dx, int dy, int ksize, double scale, double delta, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_spatialGradient(
     cv::_InputArray *src, cv::_OutputArray *dx, cv::_OutputArray *dy, int ksize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::spatialGradient(*src, *dx, *dy, ksize, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Scharr(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                            int dx, int dy, double scale, double delta, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scharr(*src, *dst, ddepth, dx, dy, scale, delta, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Laplacian(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
                               int ksize, double scale, double delta, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Laplacian(*src, *dst, ddepth, ksize, scale, delta, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Canny1(cv::_InputArray *src, cv::_OutputArray *edges,
                           double threshold1, double threshold2, int apertureSize, int L2gradient)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Canny(*src, *edges, threshold1, threshold2, apertureSize, L2gradient != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Canny2(
     cv::_InputArray *dx, cv::_InputArray *dy, cv::_OutputArray *edges,
     double threshold1, double threshold2, int L2gradient = false)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Canny(*dx, *dy, *edges, threshold1, threshold2, L2gradient != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cornerMinEigenVal(cv::_InputArray *src, cv::_OutputArray *dst,
                                       int blockSize, int ksize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cornerMinEigenVal(*src, *dst, blockSize, ksize, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cornerHarris(cv::_InputArray *src, cv::_OutputArray *dst,
                                  int blockSize, int ksize, double k, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cornerHarris(*src, *dst, blockSize, ksize, k, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cornerEigenValsAndVecs(cv::_InputArray *src, cv::_OutputArray *dst,
                                            int blockSize, int ksize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cornerEigenValsAndVecs(*src, *dst, blockSize, ksize, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_preCornerDetect(cv::_InputArray *src, cv::_OutputArray *dst, int ksize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::preCornerDetect(*src, *dst, ksize, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cornerSubPix(cv::_InputArray *image, std::vector<cv::Point2f> *corners,
                                  interop::Size winSize, interop::Size zeroZone, interop::TermCriteria criteria)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cornerSubPix(*image, *corners, cpp(winSize), cpp(zeroZone), cpp(criteria));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(cv::_InputArray *src, std::vector<cv::Point2f> *corners,
                                         int maxCorners, double qualityLevel, double minDistance,
                                         cv::_InputArray *mask, int blockSize, int useHarrisDetector, double k)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::goodFeaturesToTrack(*src, *corners, maxCorners, qualityLevel, minDistance, 
         entity(mask), blockSize, useHarrisDetector != 0, k);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughLines(cv::_InputArray *src, std::vector<cv::Vec2f> *lines,
                                double rho, double theta, int threshold,
                                double srn, double stn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::HoughLines(*src, *lines, rho, theta, threshold, srn, stn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughLinesP(cv::_InputArray *src, std::vector<cv::Vec4i> *lines,
                                 double rho, double theta, int threshold,
                                 double minLineLength, double maxLineGap)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::HoughLinesP(*src, *lines, rho, theta, threshold, minLineLength, maxLineGap);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughLinesPointSet(
@@ -241,254 +241,254 @@ CVAPI(ExceptionStatus) imgproc_HoughLinesPointSet(
     double min_rho, double max_rho, double rho_step,
     double min_theta, double max_theta, double theta_step)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::HoughLinesPointSet(*_point, *_lines, lines_max, threshold, min_rho, max_rho, rho_step, min_theta, max_theta, theta_step);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughCircles(cv::_InputArray *src, std::vector<cv::Vec3f> *circles,
                                  int method, double dp, double minDist,
                                  double param1, double param2, int minRadius, int maxRadius)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::HoughCircles(*src, *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_erode(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
                           interop::Point anchor, int iterations,    int borderType, interop::Scalar borderValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::erode(*src, *dst, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_dilate(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
                            interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::dilate(*src, *dst, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_morphologyEx(cv::_InputArray *src, cv::_OutputArray *dst, int op, cv::_InputArray *kernel,
                                  interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::morphologyEx(*src, *dst, op, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_resize(cv::_InputArray* src, cv::_OutputArray* dst, interop::Size dsize, double fx, double fy, int interpolation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::resize(*src, *dst, cpp(dsize), fx, fy, interpolation);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpAffine(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* M, interop::Size dsize,
                                           int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::warpAffine(*src, *dst, *M, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpPerspective_MisInputArray(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* m, interop::Size dsize,
                                                              int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::warpPerspective(*src, *dst, *m, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpPerspective_MisArray(cv::_InputArray* src, cv::_OutputArray* dst, float* m, int mRow, int mCol, interop::Size dsize,
                                                         int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat mmat(mRow, mCol, CV_32FC1, m);
     cv::warpPerspective(*src, *dst, mmat, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_remap(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* map1, cv::_InputArray* map2,
                                      int interpolation, int borderMode, interop::Scalar borderValue, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::remap(*src, *dst, *map1, *map2, interpolation, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_convertMaps(cv::_InputArray* map1, cv::_InputArray* map2, cv::_OutputArray* dstmap1, cv::_OutputArray* dstmap2,
                                            int dstmap1type, int nnInterpolation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convertMaps(*map1, *map2, *dstmap1, *dstmap2, dstmap1type, nnInterpolation != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getRotationMatrix2D(interop::Point2f center, double angle, double scale, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getRotationMatrix2D(cpp(center), angle, scale);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 
 }
 CVAPI(ExceptionStatus) imgproc_invertAffineTransform(cv::_InputArray* M, cv::_OutputArray *iM)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::invertAffineTransform(*M, *iM);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform1(cv::Point2f *src, cv::Point2f *dst, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getPerspectiveTransform(src, dst);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform2(cv::_InputArray *src, cv::_InputArray *dst, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getPerspectiveTransform(*src, *dst);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getAffineTransform1(cv::Point2f *src, cv::Point2f *dst, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getAffineTransform(src, dst);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_getAffineTransform2(cv::_InputArray *src, cv::_InputArray *dst, cv::Mat** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::getAffineTransform(*src, *dst);
     *returnValue = new cv::Mat(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getRectSubPix(cv::_InputArray *image, interop::Size patchSize, interop::Point2f center, cv::_OutputArray *patch, int patchType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::getRectSubPix(*image, cpp(patchSize), cpp(center), *patch, patchType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpPolar(
     cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dsize,
     interop::Point2f center, double maxRadius, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::warpPolar(*src, *dst, cpp(dsize), cpp(center), maxRadius, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_integral1(cv::_InputArray *src, cv::_OutputArray *sum, int sdepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::integral(*src, *sum, sdepth);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_integral2(cv::_InputArray *src, cv::_OutputArray *sum, cv::_OutputArray *sqsum, int sdepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::integral(*src, *sum, *sqsum, sdepth);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_integral3(cv::_InputArray *src, cv::_OutputArray *sum, cv::_OutputArray *sqsum, cv::_OutputArray *tilted, int sdepth, int sqdepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::integral(*src, *sum, *sqsum, *tilted, sdepth, sqdepth);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_accumulate(cv::_InputArray *src, cv::_InputOutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::accumulate(*src, *dst, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_accumulateSquare(cv::_InputArray* src, cv::_InputOutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::accumulateSquare(*src, *dst, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_accumulateProduct(cv::_InputArray *src1, cv::_InputArray *src2, cv::_InputOutputArray *dst, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::accumulateProduct(*src1, *src2, *dst, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_accumulateWeighted(cv::_InputArray *src, cv::_InputOutputArray *dst, double alpha, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::accumulateWeighted(*src, *dst, alpha, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_phaseCorrelate(cv::_InputArray *src1, cv::_InputArray *src2,
                                               cv::_InputArray *window, double* response, interop::Point2d* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::phaseCorrelate(*src1, *src2, *window, response);
     *returnValue = { p.x, p.y };
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_createHanningWindow(cv::_OutputArray *dst, interop::Size winSize, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::createHanningWindow(*dst, cpp(winSize), type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_threshold(cv::_InputArray *src, cv::_OutputArray *dst,
                                 double thresh, double maxVal, int type, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::threshold(*src, *dst, thresh, maxVal, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_adaptiveThreshold(cv::_InputArray *src, cv::_OutputArray *dst,
                                       double maxValue, int adaptiveMethod,
                                       int thresholdType, int blockSize, double C)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::adaptiveThreshold(*src, *dst, maxValue, adaptiveMethod, thresholdType, blockSize, C);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_pyrDown(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dstSize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::pyrDown(*src, *dst, cpp(dstSize), borderType);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_pyrUp(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dstSize, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::pyrUp(*src, *dst, cpp(dstSize), borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_buildPyramid(cv::_InputArray *src, std::vector<cv::Mat> *dst,int maxlevel, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         cv::buildPyramid(*src, *dst, maxlevel, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_calcHist(cv::Mat **images, int nimages,
@@ -496,175 +496,175 @@ CVAPI(ExceptionStatus) imgproc_calcHist(cv::Mat **images, int nimages,
                               cv::_OutputArray *hist, int dims, const int* histSize,
                               const float** ranges, int uniform, int accumulate)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec(nimages);
     for (auto i = 0; i < nimages; i++)
         imagesVec[i] = *(images[i]);
     cv::calcHist(&imagesVec[0], nimages, channels, entity(mask), *hist, dims, histSize, ranges, uniform != 0, accumulate != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_calcBackProject(cv::Mat **images, int nimages,
                                     const int* channels, cv::_InputArray *hist, cv::_OutputArray *backProject, 
                                     const float** ranges, int uniform)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec(nimages);
     for (auto i = 0; i < nimages; i++)
         imagesVec[i] = *(images[i]);
     cv::calcBackProject(&imagesVec[0], nimages, channels, *hist, *backProject, ranges, uniform != 0);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_compareHist(cv::_InputArray *h1, cv::_InputArray *h2, int method, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::compareHist(*h1, *h2, method);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_equalizeHist(cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::equalizeHist(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_EMD(cv::_InputArray *signature1, cv::_InputArray *signature2,
                          int distType, cv::_InputArray *cost, float* lowerBound, cv::_OutputArray *flow, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::EMD(*signature1, *signature2, distType, entity(cost), lowerBound, entity(flow));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_watershed(cv::_InputArray *image, cv::_InputOutputArray *markers)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::watershed(*image, *markers);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_pyrMeanShiftFiltering(cv::_InputArray *src, cv::_InputOutputArray *dst,
                                           double sp, double sr, int maxLevel, interop::TermCriteria termCrit)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::pyrMeanShiftFiltering(*src, *dst, sp, sr, maxLevel, cpp(termCrit));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_grabCut(cv::_InputArray *img, cv::_InputOutputArray *mask, interop::Rect rect,
                             cv::_InputOutputArray *bgdModel, cv::_InputOutputArray *fgdModel,
                             int iterCount, int mode)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::grabCut(*img, *mask, cpp(rect), *bgdModel, *fgdModel, iterCount, mode);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_distanceTransformWithLabels(cv::_InputArray *src, cv::_OutputArray *dst,
                                                 cv::_OutputArray *labels, int distanceType, int maskSize,
                                                 int labelType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_distanceTransform(cv::_InputArray *src, cv::_OutputArray *dst,
                                       int distanceType, int maskSize, int dstType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::distanceTransform(*src, *dst, distanceType, maskSize, dstType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_floodFill1(cv::_InputOutputArray *image,
                               interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
                               interop::Scalar loDiff, interop::Scalar upDiff, int flags, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect rect0;
     *returnValue = cv::floodFill(*image, cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
     *rect = c(rect0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_floodFill2(cv::_InputOutputArray *image, cv::_InputOutputArray *mask,
                               interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
                               interop::Scalar loDiff, interop::Scalar upDiff, int flags, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect rect0;
     *returnValue = cv::floodFill(*image, *mask, cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
     *rect = c(rect0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_blendLinear(
     cv::_InputArray* src1, cv::_InputArray* src2, cv::_InputArray* weights1, cv::_InputArray* weights2, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         cv::blendLinear(*src1, *src2, *weights1, *weights2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cvtColor(cv::_InputArray *src, cv::_OutputArray *dst, int code, int dstCn, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cvtColor(*src, *dst, code, dstCn, static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_cvtColorTwoPlane(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int code, int hint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::cvtColorTwoPlane(*src1, *src2, *dst, code, static_cast<cv::AlgorithmHint>(hint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_demosaicing(cv::_InputArray *src, cv::_OutputArray *dst, int code, int dstCn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::demosaicing(*src, *dst, code, dstCn);
-    END_WRAP    
+    });    
 }
 
 CVAPI(ExceptionStatus) imgproc_moments(cv::_InputArray *arr, int binaryImage, interop::Moments *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto m = cv::moments(*arr, binaryImage != 0);
     *returnValue = c(m);
-    END_WRAP
+    });
 }
 /*
 CVAPI(ExceptionStatus) imgproc_HuMoments(interop::Moments *moments, double hu[7])
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::HuMoments(cpp(*moments), hu);
-    END_WRAP
+    });
 }
 */
 CVAPI(ExceptionStatus) imgproc_matchTemplate(cv::_InputArray *image, cv::_InputArray *templ,
                                   cv::_OutputArray *result, int method, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::matchTemplate(*image, *templ, *result, method, entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithAlgorithm(
     cv::_InputArray *image, cv::_OutputArray *labels, int connectivity, int ltype, int ccltype, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::connectedComponents(entity(image), entity(labels), connectivity, ltype, ccltype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponents(cv::_InputArray *image, cv::_OutputArray *labels,
                                        int connectivity, int ltype, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::connectedComponents(entity(image), entity(labels), connectivity, ltype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStatsWithAlgorithm(
@@ -672,520 +672,520 @@ CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStatsWithAlgorithm(
     cv::_OutputArray *stats, cv::_OutputArray *centroids,
     int connectivity, int ltype, int ccltype, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::connectedComponentsWithStats(
             entity(image), entity(labels), entity(stats), entity(centroids), connectivity, ltype, ccltype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStats(cv::_InputArray *image, cv::_OutputArray *labels,
                                                 cv::_OutputArray *stats, cv::_OutputArray *centroids, int connectivity, int ltype, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::connectedComponentsWithStats(
         entity(image), entity(labels), entity(stats), entity(centroids), connectivity, ltype);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_findContours1_vector(cv::_InputArray *image, std::vector<std::vector<cv::Point> > *contours,
                                          std::vector<cv::Vec4i> *hierarchy, int mode, int method, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContours(*image, *contours, *hierarchy, mode, method, cpp(offset));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_findContours1_OutputArray(cv::_InputArray *image, std::vector<cv::Mat> *contours,
                                               cv::_OutputArray *hierarchy, int mode, int method, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContours(*image, *contours, *hierarchy, mode, method, cpp(offset));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_findContours2_vector(cv::_InputArray *image, std::vector<std::vector<cv::Point> > *contours,
                                          int mode, int method, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContours(*image, *contours, mode, method, cpp(offset));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(cv::_InputArray *image, std::vector<cv::Mat> *contours,
                                               int mode, int method, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContours(*image, *contours, mode, method, cpp(offset));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(cv::_InputArray *image,
                                           std::vector<std::vector<cv::Point> > *contours, std::vector<cv::Vec4i> *hierarchy)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContoursLinkRuns(*image, *contours, *hierarchy);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(cv::_InputArray *image,
                                           std::vector<std::vector<cv::Point> > *contours)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findContoursLinkRuns(*image, *contours);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_approxPolyDP_InputArray(cv::_InputArray *curve, cv::_OutputArray *approxCurve, double epsilon, int closed)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::approxPolyDP(*curve, *approxCurve, epsilon, closed != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point(cv::Point *curve, int curveLength, std::vector<cv::Point> *approxCurve, double epsilon, int closed)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     cv::approxPolyDP(curveMat, *approxCurve, epsilon, closed != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point2f(cv::Point2f *curve, int curveLength, std::vector<cv::Point2f> *approxCurve, double epsilon, int closed)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
     cv::approxPolyDP(curveMat, *approxCurve, epsilon, closed != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_arcLength_InputArray(cv::_InputArray *curve, int closed, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::arcLength(*curve, closed != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_arcLength_Point(cv::Point *curve, int curveLength, int closed, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     *returnValue = cv::arcLength(curveMat, closed != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_arcLength_Point2f(cv::Point2f *curve, int curveLength, int closed, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
     *returnValue = cv::arcLength(curveMat, closed != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_boundingRect_InputArray(cv::_InputArray *curve, interop::Rect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::boundingRect(*curve));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_boundingRect_Point(cv::Point *curve, int curveLength, interop::Rect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     *returnValue = c(cv::boundingRect(curveMat));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_boundingRect_Point2f(cv::Point2f *curve, int curveLength, interop::Rect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
     *returnValue = c(cv::boundingRect(curveMat));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_contourArea_InputArray(cv::_InputArray *contour, int oriented, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::contourArea(*contour, oriented != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_contourArea_Point(cv::Point *contour, int contourLength, int oriented, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
     *returnValue = cv::contourArea(contourMat, oriented != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_contourArea_Point2f(cv::Point2f *contour, int contourLength, int oriented, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
     *returnValue = cv::contourArea(contourMat, oriented != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_minAreaRect_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::minAreaRect(*points));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minAreaRect_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     *returnValue = c(cv::minAreaRect(pointsMat));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minAreaRect_Point2f(cv::Point2f *points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     *returnValue = c(cv::minAreaRect(pointsMat));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_boxPoints_OutputArray(interop::RotatedRect box, cv::_OutputArray* points)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::boxPoints(cpp(box), *points);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_boxPoints_Point2f(interop::RotatedRect box, cv::Point2f points[4])
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cpp(box).points(points);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_InputArray(cv::_InputArray *points, interop::Point2f *center, float *radius)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2f center0;
     float radius0;
     cv::minEnclosingCircle(*points, center0, radius0);
     *center = c(center0);
     *radius = radius0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point(cv::Point *points, int pointsLength, interop::Point2f*center, float *radius)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     cv::Point2f center0;
     float radius0;
     cv::minEnclosingCircle(pointsMat, center0, radius0);
     *center = c(center0);
     *radius = radius0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point2f(cv::Point2f *points, int pointsLength, interop::Point2f*center, float *radius)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     cv::Point2f center0;
     float radius0;
     cv::minEnclosingCircle(pointsMat, center0, radius0);
     *center = c(center0);
     *radius = radius0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_InputOutputArray(cv::_InputArray *points, cv::_OutputArray *triangle, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::minEnclosingTriangle(*points, *triangle);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point(cv::Point* points, int pointsLength, std::vector<cv::Point2f>* triangle, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     *returnValue = cv::minEnclosingTriangle(pointsMat, *triangle);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point2f(cv::Point2f* points, int pointsLength, std::vector<cv::Point2f>* triangle, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     *returnValue = cv::minEnclosingTriangle(pointsMat, *triangle);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_matchShapes_InputArray(
     cv::_InputArray *contour1, cv::_InputArray *contour2, int method, double parameter, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::matchShapes(*contour1, *contour2, method, parameter);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_matchShapes_Point(
     cv::Point *contour1, int contour1Length, cv::Point *contour2, int contour2Length, int method, double parameter, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> contour1Mat(contour1Length, 1, contour1);
     const cv::Mat_<cv::Point> contour2Mat(contour2Length, 1, contour2);
     *returnValue = cv::matchShapes(contour1Mat, contour2Mat, method, parameter);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_convexHull_InputArray(cv::_InputArray *points, cv::_OutputArray *hull, int clockwise, int returnPoints)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convexHull(*points, *hull, clockwise != 0, returnPoints != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsPoints(cv::Point *points, int pointsLength, std::vector<cv::Point> *hull, int clockwise)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, true);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsPoints(cv::Point2f *points, int pointsLength, std::vector<cv::Point2f> *hull, int clockwise)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, true);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsIndices(cv::Point *points, int pointsLength, std::vector<int> *hull, int clockwise)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, false);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsIndices(cv::Point2f *points, int pointsLength, std::vector<int> *hull, int clockwise)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, false);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_convexityDefects_InputArray(cv::_InputArray *contour, cv::_InputArray *convexHull,
                                                 cv::_OutputArray *convexityDefects)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::convexityDefects(*contour, *convexHull, *convexityDefects);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexityDefects_Point(cv::Point *contour, int contourLength, int *convexHull, int convexHullLength,
                                            std::vector<cv::Vec4i> *convexityDefects)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
     const cv::Mat_<int> convexHullMat(convexHullLength, 1,  convexHull);
     cv::convexityDefects(contourMat, convexHullMat, *convexityDefects);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_convexityDefects_Point2f(cv::Point2f *contour, int contourLength, int *convexHull, int convexHullLength,
                                              std::vector<cv::Vec4i> *convexityDefects)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
     const cv::Mat_<int> convexHullMat(convexHullLength, 1, convexHull);
     cv::convexityDefects(contourMat, convexHullMat, *convexityDefects);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_isContourConvex_InputArray(cv::_InputArray *contour, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::isContourConvex(*contour) ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_isContourConvex_Point(cv::Point *contour, int contourLength, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
     *returnValue = cv::isContourConvex(contourMat) ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_isContourConvex_Point2f(cv::Point2f *contour, int contourLength, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
     *returnValue = cv::isContourConvex(contourMat) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_InputArray(cv::_InputArray *p1, cv::_InputArray *p2,
                                                       cv::_OutputArray *p12, int handleNested, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::intersectConvexConvex(*p1, *p2, *p12, handleNested != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point(cv::Point *p1, int p1Length, cv::Point *p2, int p2Length,
                                                  std::vector<cv::Point> *p12, int handleNested, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> p1Vec(p1Length, 1, p1);
     const cv::Mat_<cv::Point> p2Vec(p2Length, 1, p2);
     *returnValue = cv::intersectConvexConvex(p1Vec, p2Vec, *p12, handleNested != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point2f(cv::Point2f *p1, int p1Length, cv::Point2f *p2, int p2Length,
                                                    std::vector<cv::Point2f> *p12, int handleNested, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> p1Vec(p1Length, 1, p1);
     const cv::Mat_<cv::Point2f> p2Vec(p2Length, 1, p2);
     *returnValue = cv::intersectConvexConvex(p1Vec, p2Vec, *p12, handleNested != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fitEllipse_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::fitEllipse(*points));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipse_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipse(pointsVec));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipse_Point2f(cv::Point2f *points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipse(pointsVec));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::fitEllipseAMS(*points));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseAMS(pointsVec));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point2f(cv::Point2f* points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseAMS(pointsVec));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_InputArray(cv::_InputArray* points, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::fitEllipseDirect(*points));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseDirect(pointsVec));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point2f(cv::Point2f* points, int pointsLength, interop::RotatedRect* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseDirect(pointsVec));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fitLine_InputArray(cv::_InputArray *points, cv::_OutputArray *line,
                                        int distType, double param, double reps, double aeps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fitLine(*points, *line, distType, param, reps, aeps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitLine_Point(cv::Point *points, int pointsLength, float *line, int distType,
                                   double param, double reps, double aeps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     cv::Mat_<float> lineVec(4, 1, line);
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitLine_Point2f(cv::Point2f *points, int pointsLength, float *line, int distType,
                                     double param, double reps, double aeps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
     cv::Mat_<float> lineVec(4, 1, line);
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitLine_Point3i(cv::Point3i *points, int pointsLength, float *line, int distType,
                                     double param, double reps, double aeps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point3i> pointsVec(pointsLength, 1, points);
     cv::Mat_<float> lineVec(6, 1, line);
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fitLine_Point3f(cv::Point3f *points, int pointsLength, float *line, int distType,
                                     double param, double reps, double aeps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point3f> pointsVec(pointsLength, 1, points);
     cv::Mat_<float> lineVec(6, 1, line);
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_InputArray(
     cv::_InputArray* contour, interop::Point2f pt, int measureDist, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::pointPolygonTest(*contour, cpp(pt), measureDist != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point(
     cv::Point *contour, int contourLength, interop::Point2f pt, int measureDist, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point> contourVec(contourLength, 1, contour);
     *returnValue = cv::pointPolygonTest(contourVec, cpp(pt), measureDist != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point2f(
     cv::Point2f *contour, int contourLength, interop::Point2f pt, int measureDist, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourVec(contourLength, 1, contour);
     *returnValue = cv::pointPolygonTest(contourVec, cpp(pt), measureDist != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_OutputArray(
     interop::RotatedRect rect1, interop::RotatedRect rect2, cv::_OutputArray *intersectingRegion, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), *intersectingRegion);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_vector(
     interop::RotatedRect rect1, interop::RotatedRect rect2, std::vector<cv::Point2f> *intersectingRegion, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), *intersectingRegion);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_applyColorMap1(cv::_InputArray *src, cv::_OutputArray *dst, int colorMap)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::applyColorMap(*src, *dst, colorMap);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_applyColorMap2(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *userColor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::applyColorMap(*src, *dst, *userColor);
-    END_WRAP    
+    });    
 }
 
 #pragma region Drawing
@@ -1194,18 +1194,18 @@ CVAPI(ExceptionStatus) imgproc_line(
     cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
     int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::line(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_arrowedLine(
     cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
     int thickness, int line_type, int shift, double tipLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::arrowedLine(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, line_type, shift, tipLength);
-    END_WRAP
+    });
 }
 
 
@@ -1213,33 +1213,33 @@ CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Point(
     cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rectangle(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Rect(
     cv::_InputOutputArray* img, interop::Rect rect,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rectangle(*img, cpp(rect), cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Point(
     cv::Mat* img, interop::Point pt1, interop::Point pt2,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rectangle(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Rect(
     cv::Mat *img, interop::Rect rect,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rectangle(*img, cpp(rect), cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 
 
@@ -1247,9 +1247,9 @@ CVAPI(ExceptionStatus) imgproc_circle(
     cv::_InputOutputArray *img, interop::Point center, int radius,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::circle(*img, cpp(center), radius, cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse1(
@@ -1257,55 +1257,55 @@ CVAPI(ExceptionStatus) imgproc_ellipse1(
     double angle, double startAngle, double endAngle,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ellipse(*img, cpp(center), cpp(axes), angle, startAngle, endAngle, cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_ellipse2(
     cv::_InputOutputArray *img, interop::RotatedRect box, interop::Scalar color, int thickness, int lineType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ellipse(*img, cpp(box), cpp(color), thickness, lineType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_drawMarker(
     cv::_InputOutputArray *img, interop::Point position, interop::Scalar color,
     int markerType, int markerSize, int thickness, int lineType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::drawMarker(*img, cpp(position), cpp(color), markerType, markerSize, thickness, lineType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fillConvexPoly_Mat(
     cv::Mat *img, cv::Point *pts, int npts, interop::Scalar color, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fillConvexPoly(*img, pts, npts, cpp(color), lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fillConvexPoly_InputOutputArray(
     cv::_InputOutputArray *img, cv::_InputArray *points, interop::Scalar color, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fillConvexPoly(*img, *points, cpp(color), lineType, shift);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_fillPoly_Mat(cv::Mat *img, const cv::Point **pts, const int *npts,
                                  int ncontours, interop::Scalar color, int lineType, int shift, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fillPoly(*img, pts, npts, ncontours, cpp(color), lineType, shift, cpp(offset));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_fillPoly_InputOutputArray(cv::_InputOutputArray *img, cv::_InputArray *pts,
                                               interop::Scalar color, int lineType, int shift, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fillPoly(*img, *pts, cpp(color), lineType, shift, cpp(offset));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_polylines_Mat(
@@ -1313,18 +1313,18 @@ CVAPI(ExceptionStatus) imgproc_polylines_Mat(
     int ncontours, int isClosed, interop::Scalar color,
     int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::polylines(
         *img, pts, npts, ncontours, isClosed != 0, cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_polylines_InputOutputArray(
     cv::_InputOutputArray *img, cv::_InputArray *pts, int isClosed, interop::Scalar color,
     int thickness, int lineType, int shift)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::polylines(*img, *pts, isClosed != 0, cpp(color), thickness, lineType, shift);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_drawContours_vector(cv::_InputOutputArray *image,
@@ -1332,7 +1332,7 @@ CVAPI(ExceptionStatus) imgproc_drawContours_vector(cv::_InputOutputArray *image,
                                         int contourIdx, interop::Scalar color, int thickness, int lineType,
                                         cv::Vec4i *hierarchy, int hiearchyLength, int maxLevel, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Point> > contoursVec;
     for (auto i = 0; i < contoursSize1; i++)
     {
@@ -1347,84 +1347,84 @@ CVAPI(ExceptionStatus) imgproc_drawContours_vector(cv::_InputOutputArray *image,
 
     cv::drawContours(
         *image, contoursVec, contourIdx, cpp(color), thickness, lineType, hierarchyVec, maxLevel, cpp(offset));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_drawContours_InputArray(cv::_InputOutputArray *image,
                                             cv::Mat **contours, int contoursLength,
                                             int contourIdx, interop::Scalar color, int thickness, int lineType,
                                             cv::_InputArray *hierarchy, int maxLevel, interop::Point offset)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Point> > contoursVec(contoursLength);
     for (auto i = 0; i < contoursLength; i++)
         contoursVec[i] = *contours[i];
     cv::drawContours(
         *image, contoursVec, contourIdx, cpp(color), thickness, lineType, entity(hierarchy), maxLevel, cpp(offset));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_clipLine1(interop::Size imgSize, interop::Point *pt1, interop::Point *pt2, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto pt1c = cpp(*pt1), pt2c = cpp(*pt2);
     const auto result = cv::clipLine(cpp(imgSize), pt1c, pt2c);
     *pt1 = c(pt1c);
     *pt2 = c(pt2c);
     *returnValue = result ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_clipLine2(interop::Rect imgRect, interop::Point *pt1, interop::Point *pt2, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto pt1c = cpp(*pt1), pt2c = cpp(*pt2);
     const auto result = cv::clipLine(cpp(imgRect), pt1c, pt2c);
     *pt1 = c(pt1c);
     *pt2 = c(pt2c);
     *returnValue = result ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse2Poly_int(
     interop::Point center, interop::Size axes, int angle, int arcStart, int arcEnd,
     int delta, std::vector<cv::Point>* pts)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ellipse2Poly(cpp(center), cpp(axes), angle, arcStart, arcEnd, delta, *pts);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse2Poly_double(
     interop::Point2d center, interop::Size2d axes, int angle, int arcStart, int arcEnd,
     int delta, std::vector<cv::Point2d>* pts)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ellipse2Poly(cpp(center), cpp(axes), angle, arcStart, arcEnd, delta, *pts);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_putText(cv::_InputOutputArray *img, const char *text, interop::Point org,
                          int fontFace, double fontScale, interop::Scalar color,
                          int thickness, int lineType, int bottomLeftOrigin)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::putText(*img, text, cpp(org), fontFace, fontScale, cpp(color), thickness, lineType, bottomLeftOrigin != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getTextSize(const char *text, int fontFace,
                                  double fontScale, int thickness, int *baseLine, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::getTextSize(text, fontFace, fontScale, thickness, baseLine));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getFontScaleFromHeight(
     int fontFace, int pixelHeight, int thickness, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::getFontScaleFromHeight(fontFace, pixelHeight, thickness);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/imgproc_CLAHE.h
+++ b/src/OpenCvSharpExtern/imgproc_CLAHE.h
@@ -9,65 +9,65 @@
 
 CVAPI(ExceptionStatus) imgproc_createCLAHE(double clipLimit, interop::Size tileGridSize, cv::Ptr<cv::CLAHE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::createCLAHE(clipLimit, cpp(tileGridSize));
     *returnValue = clone(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Ptr_CLAHE_delete(cv::Ptr<cv::CLAHE> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Ptr_CLAHE_get(cv::Ptr<cv::CLAHE> *obj, cv::CLAHE **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_apply(cv::CLAHE *obj, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->apply(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_setClipLimit(cv::CLAHE *obj, double clipLimit)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setClipLimit(clipLimit);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_getClipLimit(cv::CLAHE *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getClipLimit();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_setTilesGridSize(cv::CLAHE *obj, interop::Size tileGridSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTilesGridSize(cpp(tileGridSize));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_getTilesGridSize(cv::CLAHE *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTilesGridSize());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_CLAHE_collectGarbage(cv::CLAHE *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_FontFace.h
+++ b/src/OpenCvSharpExtern/imgproc_FontFace.h
@@ -10,52 +10,52 @@
 
 CVAPI(ExceptionStatus) imgproc_FontFace_new1(cv::FontFace **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FontFace();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_new2(const char *fontPathOrName, cv::FontFace **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::FontFace(cv::String(fontPathOrName));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_delete(cv::FontFace *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_set(cv::FontFace *obj, const char *fontPathOrName, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->set(cv::String(fontPathOrName)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_getName(cv::FontFace *obj, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getName());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_setInstance(cv::FontFace *obj, int *params, int paramsLength, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<int> v(params, params + paramsLength);
     *returnValue = obj->setInstance(v) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(cv::FontFace *obj, std::vector<int> *params, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getInstance(*params) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -67,12 +67,12 @@ CVAPI(ExceptionStatus) imgproc_putText_FontFace(
     cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
     interop::Point *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::putText(
         *img, cv::String(text), cpp(org), cpp(color), *fface, size, weight,
         static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
     *returnValue = c(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_getTextSize_FontFace(
@@ -80,12 +80,12 @@ CVAPI(ExceptionStatus) imgproc_getTextSize_FontFace(
     cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
     interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto r = cv::getTextSize(
         cpp(imgsize), cv::String(text), cpp(org), *fface, size, weight,
         static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
     *returnValue = c(r);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/imgproc_GeneralizedHough.h
+++ b/src/OpenCvSharpExtern/imgproc_GeneralizedHough.h
@@ -10,96 +10,96 @@
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setTemplate1(
     cv::GeneralizedHough *obj, cv::_InputArray *templ, interop::Point templCenter)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTemplate(*templ, cpp(templCenter));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setTemplate2(
     cv::GeneralizedHough *obj, cv::_InputArray *edges, cv::_InputArray *dx, cv::_InputArray *dy, interop::Point templCenter)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTemplate(*edges, *dx, *dy, cpp(templCenter));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_detect1(
     cv::GeneralizedHough *obj, cv::_InputArray *image, cv::_OutputArray *positions, cv::_OutputArray *votes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*image, *positions, entity(votes));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_detect2(
     cv::GeneralizedHough *obj, cv::_InputArray *edges, cv::_InputArray *dx, cv::_InputArray *dy, cv::_OutputArray *positions, cv::_OutputArray *votes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*edges, *dx, *dy, *positions, entity(votes));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setCannyLowThresh(cv::GeneralizedHough *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCannyLowThresh(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getCannyLowThresh(cv::GeneralizedHough *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCannyLowThresh();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setCannyHighThresh(cv::GeneralizedHough *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCannyHighThresh(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getCannyHighThresh(cv::GeneralizedHough *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCannyHighThresh();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setMinDist(cv::GeneralizedHough *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinDist(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getMinDist(cv::GeneralizedHough *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinDist();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setDp(cv::GeneralizedHough *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDp(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getDp(cv::GeneralizedHough *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDp();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_setMaxBufferSize(cv::GeneralizedHough *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxBufferSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getMaxBufferSize(cv::GeneralizedHough *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxBufferSize();
-    END_WRAP
+    });
 }
 
 
@@ -107,49 +107,49 @@ CVAPI(ExceptionStatus) imgproc_GeneralizedHough_getMaxBufferSize(cv::Generalized
 
 CVAPI(ExceptionStatus) imgproc_createGeneralizedHoughBallard(cv::Ptr<cv::GeneralizedHoughBallard> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createGeneralizedHoughBallard();
     *returnValue = new cv::Ptr<cv::GeneralizedHoughBallard>(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Ptr_GeneralizedHoughBallard_get(
     cv::Ptr<cv::GeneralizedHoughBallard> *obj, cv::GeneralizedHoughBallard **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Ptr_GeneralizedHoughBallard_delete(cv::Ptr<cv::GeneralizedHoughBallard> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughBallard_setLevels(cv::GeneralizedHoughBallard *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLevels(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughBallard_getLevels(cv::GeneralizedHoughBallard *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLevels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughBallard_setVotesThreshold(cv::GeneralizedHoughBallard *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setVotesThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughBallard_getVotesThreshold(cv::GeneralizedHoughBallard *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getVotesThreshold();
-    END_WRAP
+    });
 }
 
 
@@ -157,178 +157,178 @@ CVAPI(ExceptionStatus) imgproc_GeneralizedHoughBallard_getVotesThreshold(cv::Gen
 
 CVAPI(ExceptionStatus) imgproc_createGeneralizedHoughGuil(cv::Ptr<cv::GeneralizedHoughGuil> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createGeneralizedHoughGuil();
     *returnValue = new cv::Ptr<cv::GeneralizedHoughGuil>(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Ptr_GeneralizedHoughGuil_get(
     cv::Ptr<cv::GeneralizedHoughGuil> *obj, cv::GeneralizedHoughGuil **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Ptr_GeneralizedHoughGuil_delete(cv::Ptr<cv::GeneralizedHoughGuil> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setXi(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setXi(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getXi(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getXi();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setLevels(cv::GeneralizedHoughGuil *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLevels(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getLevels(cv::GeneralizedHoughGuil *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLevels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setAngleEpsilon(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAngleEpsilon(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getAngleEpsilon(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAngleEpsilon();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setMinAngle(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinAngle(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getMinAngle(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinAngle();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setMaxAngle(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxAngle(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getMaxAngle(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxAngle();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setAngleStep(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAngleStep(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getAngleStep(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAngleStep();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setAngleThresh(cv::GeneralizedHoughGuil *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAngleThresh(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getAngleThresh(cv::GeneralizedHoughGuil *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAngleThresh();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setMinScale(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinScale(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getMinScale(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinScale();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setMaxScale(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxScale(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getMaxScale(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxScale();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setScaleStep(cv::GeneralizedHoughGuil *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScaleStep(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getScaleStep(cv::GeneralizedHoughGuil *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScaleStep();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setScaleThresh(cv::GeneralizedHoughGuil *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScaleThresh(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getScaleThresh(cv::GeneralizedHoughGuil *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScaleThresh();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_setPosThresh(cv::GeneralizedHoughGuil *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPosThresh(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_GeneralizedHoughGuil_getPosThresh(cv::GeneralizedHoughGuil *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPosThresh();
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_LineIterator.h
+++ b/src/OpenCvSharpExtern/imgproc_LineIterator.h
@@ -10,93 +10,93 @@
 CVAPI(ExceptionStatus) imgproc_LineIterator_new(
     cv::Mat *img, interop::Point pt1, interop::Point pt2, int connectivity, int leftToRight, cv::LineIterator** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::LineIterator(*img, cpp(pt1), cpp(pt2), connectivity, leftToRight != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_delete(cv::LineIterator *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_getValuePosAndShiftToNext(cv::LineIterator* obj, uchar** returnValue, interop::Point *returnPos)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = **obj;
     *returnPos = c(obj->pos());
     (*obj)++;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_ptr_get(cv::LineIterator *obj, uchar **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_ptr0_get(cv::LineIterator *obj, const uchar** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->ptr0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_step_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->step;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_elemSize_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->elemSize;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_err_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->err;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_count_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->count;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_minusDelta_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->minusDelta;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_plusDelta_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->plusDelta;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_minusStep_get(cv::LineIterator *obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->minusStep;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_LineIterator_plusStep_get(cv::LineIterator *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->plusStep;
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_LineSegmentDetector.h
+++ b/src/OpenCvSharpExtern/imgproc_LineSegmentDetector.h
@@ -40,14 +40,14 @@ CVAPI(cv::Ptr<cv::LineSegmentDetector>*) imgproc_createLineSegmentDetector(
 
 CVAPI(ExceptionStatus) imgproc_Ptr_LineSegmentDetector_delete(cv::Ptr<cv::LineSegmentDetector> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Ptr_LineSegmentDetector_get(cv::Ptr<cv::LineSegmentDetector> *obj, cv::LineSegmentDetector **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_Segmentation.h
+++ b/src/OpenCvSharpExtern/imgproc_Segmentation.h
@@ -10,17 +10,17 @@
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_new(
     cv::segmentation::IntelligentScissorsMB** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::segmentation::IntelligentScissorsMB();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_delete(
     cv::segmentation::IntelligentScissorsMB *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
@@ -28,27 +28,27 @@ CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_setWeights(
     cv::segmentation::IntelligentScissorsMB *obj,
     float weight_non_edge, float weight_gradient_direction, float weight_gradient_magnitude)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWeights(weight_non_edge, weight_gradient_direction, weight_gradient_magnitude);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_setGradientMagnitudeMaxLimit(
     cv::segmentation::IntelligentScissorsMB *obj,
     float gradient_magnitude_threshold_max)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGradientMagnitudeMaxLimit(gradient_magnitude_threshold_max);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_setEdgeFeatureZeroCrossingParameters(
     cv::segmentation::IntelligentScissorsMB *obj,
     float gradient_magnitude_min_value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEdgeFeatureZeroCrossingParameters(gradient_magnitude_min_value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_setEdgeFeatureCannyParameters(
@@ -56,18 +56,18 @@ CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_setEdgeFeature
     double threshold1, double threshold2,
     int apertureSize, int L2gradient)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEdgeFeatureCannyParameters(threshold1, threshold2, apertureSize, L2gradient != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_applyImage(
     cv::segmentation::IntelligentScissorsMB *obj,
     cv::_InputArray *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->applyImage(*image);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_applyImageFeatures(
@@ -77,25 +77,25 @@ CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_applyImageFeat
     cv::_InputArray *gradient_magnitude,
     cv::_InputArray *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->applyImageFeatures(*non_edge, *gradient_direction, *gradient_magnitude, entity(image));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_buildMap(
     cv::segmentation::IntelligentScissorsMB *obj,
     interop::Point sourcePt)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->buildMap(cpp(sourcePt));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_segmentation_IntelligentScissorsMB_getContour(
     cv::segmentation::IntelligentScissorsMB *obj,
     interop::Point targetPt, cv::_OutputArray *contour, int backward)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getContour(cpp(targetPt), *contour, backward != 0);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_Subdiv2D.h
+++ b/src/OpenCvSharpExtern/imgproc_Subdiv2D.h
@@ -7,161 +7,161 @@
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_new1(cv::Subdiv2D **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Subdiv2D;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_new2(interop::Rect rect, cv::Subdiv2D **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Subdiv2D(cpp(rect));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_new3(interop::Rect2f rect, cv::Subdiv2D** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Subdiv2D(cpp(rect));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_delete(cv::Subdiv2D *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_initDelaunay1(cv::Subdiv2D *obj, interop::Rect rect)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->initDelaunay(cpp(rect));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_initDelaunay2(cv::Subdiv2D* obj, interop::Rect2f rect)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->initDelaunay(cpp(rect));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_insert1(cv::Subdiv2D *obj, interop::Point2f pt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->insert(cpp(pt));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_insert2(cv::Subdiv2D *obj, interop::Point2f *ptArray, int length)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point2f> ptVec(length);
     for (int i = 0; i < length; i++)
     {
         ptVec[i] = cpp(ptArray[i]);
     }
     obj->insert(ptVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_locate(
     cv::Subdiv2D *obj, interop::Point2f pt, int *edge, int *vertex, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->locate(cpp(pt), *edge, *vertex);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_findNearest(
     cv::Subdiv2D *obj, interop::Point2f pt, interop::Point2f* nearestPt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2f nearestPt0;
     *returnValue = obj->findNearest(cpp(pt), &nearestPt0);
     *nearestPt = c(nearestPt0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getEdgeList(cv::Subdiv2D *obj, std::vector<cv::Vec4f> *edgeList)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getEdgeList(*edgeList);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getLeadingEdgeList(cv::Subdiv2D *obj,  std::vector<int> *leadingEdgeList)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLeadingEdgeList(*leadingEdgeList);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getTriangleList(cv::Subdiv2D *obj, std::vector<cv::Vec6f> *triangleList)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getTriangleList(*triangleList);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getVoronoiFacetList(
     cv::Subdiv2D *obj, int *idx, int idxCount,
     std::vector<std::vector<cv::Point2f> > *facetList, std::vector<cv::Point2f> *facetCenters)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<int> idxVec;
     if (idx != nullptr)
         idxVec = std::vector<int>(idx, idx + idxCount);
     obj->getVoronoiFacetList(idxVec, *facetList, *facetCenters);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getVertex(cv::Subdiv2D *obj, int vertex, int* firstEdge, interop::Point2f *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getVertex(vertex, firstEdge));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_getEdge(cv::Subdiv2D *obj, int edge, int nextEdgeType, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getEdge(edge, nextEdgeType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_nextEdge(cv::Subdiv2D *obj, int edge, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->nextEdge(edge);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_rotateEdge(cv::Subdiv2D *obj, int edge, int rotate, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->rotateEdge(edge, rotate);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_symEdge(cv::Subdiv2D *obj, int edge, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->symEdge(edge);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_edgeOrg(cv::Subdiv2D *obj, int edge, interop::Point2f *orgPt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2f orgPt0;
     *returnValue = obj->edgeOrg(edge, &orgPt0);
     *orgPt = c(orgPt0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) imgproc_Subdiv2D_edgeDst(cv::Subdiv2D *obj, int edge, interop::Point2f *dstPt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Point2f dstPt0;
     *returnValue = obj->edgeDst(edge, &dstPt0);
     *dstPt = c(dstPt0);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/imgproc_undistort.h
+++ b/src/OpenCvSharpExtern/imgproc_undistort.h
@@ -11,9 +11,9 @@ CVAPI(ExceptionStatus) imgproc_drawFrameAxes(
     cv::_InputOutputArray *image, cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs,
     cv::_InputArray *rvec, cv::_InputArray *tvec, float length, int thickness)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::drawFrameAxes(*image, *cameraMatrix, *distCoeffs, *rvec, *tvec, length, thickness);
-    END_WRAP
+    });
 }
 
 
@@ -21,9 +21,9 @@ CVAPI(ExceptionStatus) imgproc_undistort(
     cv::_InputArray *src, cv::_OutputArray *dst,
     cv::_InputArray *cameraMatrix, cv::_InputArray *distCoeffs, cv::_InputArray *newCameraMatrix)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::undistort(*src, *dst, *cameraMatrix, entity(distCoeffs), entity(newCameraMatrix));
-    END_WRAP
+    });
 }
 
 
@@ -32,9 +32,9 @@ CVAPI(ExceptionStatus) imgproc_initUndistortRectifyMap(
     cv::_InputArray *R, cv::_InputArray *newCameraMatrix,
     interop::Size size, int m1type, cv::_OutputArray *map1, cv::_OutputArray *map2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::initUndistortRectifyMap(*cameraMatrix, *distCoeffs, *R, *newCameraMatrix, cpp(size), m1type, *map1, *map2);
-    END_WRAP
+    });
 }
 
 
@@ -45,8 +45,8 @@ CVAPI(ExceptionStatus) imgproc_initWideAngleProjMap(
     int projType, double alpha,
     float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::initWideAngleProjMap(*cameraMatrix, *distCoeffs, cpp(imageSize), destImageWidth, m1type, 
         *map1, *map2, static_cast<cv::UndistortTypes>(projType), alpha);
-    END_WRAP
+    });
 }

--- a/src/OpenCvSharpExtern/line_descriptor.h
+++ b/src/OpenCvSharpExtern/line_descriptor.h
@@ -12,9 +12,9 @@
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_new1(
     cv::line_descriptor::LSDDetector** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::line_descriptor::LSDDetector;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_new2(
@@ -27,7 +27,7 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_new2(
     const int n_bins,
     cv::line_descriptor::LSDDetector** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::line_descriptor::LSDParam param;
     param.scale = scale;
     param.sigma_scale = sigma_scale;
@@ -37,23 +37,23 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_new2(
     param.density_th = density_th;
     param.n_bins = n_bins;
     *returnValue = new cv::line_descriptor::LSDDetector(param);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_delete(cv::line_descriptor::LSDDetector* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect1(
     cv::line_descriptor::LSDDetector* obj,
     cv::Mat* image, std::vector<cv::line_descriptor::KeyLine> *keypoints, int scale, int numOctaves, cv::Mat* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*image, *keypoints, scale, numOctaves, entity(mask));    
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
@@ -62,7 +62,7 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
     std::vector<std::vector<cv::line_descriptor::KeyLine> > *keylines, int scale, int numOctaves,
     cv::Mat** masks, int32_t masksSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec(imagesSize);
     std::vector<cv::Mat> masksVec(masksSize);
     for (int i = 0; i < imagesSize; i++)
@@ -76,7 +76,7 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
     
     obj->detect(imagesVec, *keylines, scale, numOctaves, masksVec);
 
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ml_ANN_MLP.h
+++ b/src/OpenCvSharpExtern/ml_ANN_MLP.h
@@ -10,189 +10,189 @@
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_setTrainMethod(cv::ml::ANN_MLP *obj, int method, double param1, double param2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTrainMethod(method, param1, param2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getTrainMethod(cv::ml::ANN_MLP *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTrainMethod();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_setActivationFunction(cv::ml::ANN_MLP *obj, int type, double param1, double param2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setActivationFunction(type, param1, param2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_setLayerSizes(cv::ml::ANN_MLP *obj, cv::_InputArray *_layer_sizes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLayerSizes(entity(_layer_sizes));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getLayerSizes(cv::ml::ANN_MLP *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->getLayerSizes());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getTermCriteria(cv::ml::ANN_MLP *obj, interop::TermCriteria *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTermCriteria());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setTermCriteria(cv::ml::ANN_MLP *obj, interop::TermCriteria val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTermCriteria(cpp(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getBackpropWeightScale(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBackpropWeightScale();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setBackpropWeightScale(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBackpropWeightScale(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getBackpropMomentumScale(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBackpropMomentumScale();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setBackpropMomentumScale(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBackpropMomentumScale(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getRpropDW0(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRpropDW0();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDW0(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRpropDW0(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getRpropDWPlus(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRpropDWPlus();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDWPlus(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRpropDWPlus(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getRpropDWMinus(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRpropDWMinus();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDWMinus(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRpropDWMinus(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getRpropDWMin(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRpropDWMin();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDWMin(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRpropDWMin(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getRpropDWMax(cv::ml::ANN_MLP *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRpropDWMax();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDWMax(cv::ml::ANN_MLP *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRpropDWMax(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_getWeights(cv::ml::ANN_MLP *obj, int layerIdx, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->getWeights(layerIdx));
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_create(cv::Ptr<cv::ml::ANN_MLP> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::ANN_MLP::create();
     *returnValue = new cv::Ptr<cv::ml::ANN_MLP>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_ANN_MLP_delete(cv::Ptr<cv::ml::ANN_MLP> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_ANN_MLP_get(cv::Ptr<cv::ml::ANN_MLP> *obj, cv::ml::ANN_MLP **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_load(const char *filePath, cv::Ptr<cv::ml::ANN_MLP> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::ANN_MLP::load(filePath);
     *returnValue = new cv::Ptr<cv::ml::ANN_MLP>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_ANN_MLP_loadFromString(const char *strModel, cv::Ptr<cv::ml::ANN_MLP> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::ANN_MLP::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::ANN_MLP>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::ANN_MLP>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_Boost.h
+++ b/src/OpenCvSharpExtern/ml_Boost.h
@@ -9,81 +9,81 @@
 
 CVAPI(ExceptionStatus) ml_Boost_getBoostType(cv::ml::Boost *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBoostType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_Boost_setBoostType(cv::ml::Boost *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBoostType(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Boost_getWeakCount(cv::ml::Boost *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getWeakCount();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_Boost_setWeakCount(cv::ml::Boost *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWeakCount(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Boost_getWeightTrimRate(cv::ml::Boost *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getWeightTrimRate();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_Boost_setWeightTrimRate(cv::ml::Boost *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWeightTrimRate(val);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_Boost_create(cv::Ptr<cv::ml::Boost> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::Boost::create();
     *returnValue = new cv::Ptr<cv::ml::Boost>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_Boost_delete(cv::Ptr<cv::ml::Boost> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_Boost_get(cv::Ptr<cv::ml::Boost>* obj, cv::ml::Boost **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Boost_load(const char *filePath, cv::Ptr<cv::ml::Boost> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::Boost>(filePath);
     *returnValue = new cv::Ptr<cv::ml::Boost>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Boost_loadFromString(const char *strModel, cv::Ptr<cv::ml::Boost> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::Boost::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::Boost>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::Boost>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_DTrees.h
+++ b/src/OpenCvSharpExtern/ml_DTrees.h
@@ -58,125 +58,125 @@ DTrees_Split c(const cv::ml::DTrees::Split obj)
 
 CVAPI(ExceptionStatus) ml_DTrees_getMaxCategories(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxCategories();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setMaxCategories(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxCategories(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getMaxDepth(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxDepth();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setMaxDepth(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxDepth(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getMinSampleCount(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinSampleCount();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setMinSampleCount(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinSampleCount(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getCVFolds(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCVFolds();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setCVFolds(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCVFolds(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getUseSurrogates(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUseSurrogates() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setUseSurrogates(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUseSurrogates(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getUse1SERule(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUse1SERule() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setUse1SERule(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUse1SERule(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getTruncatePrunedTree(cv::ml::DTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTruncatePrunedTree() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setTruncatePrunedTree(cv::ml::DTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTruncatePrunedTree(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getRegressionAccuracy(cv::ml::DTrees *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRegressionAccuracy();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setRegressionAccuracy(cv::ml::DTrees *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRegressionAccuracy(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getPriors(cv::ml::DTrees *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto m = obj->getPriors();
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_DTrees_setPriors(cv::ml::DTrees *obj, cv::Mat *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPriors(*val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getRoots(cv::ml::DTrees *obj, std::vector<int> *result)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& org = obj->getRoots();
 
     result->clear();
@@ -184,12 +184,12 @@ CVAPI(ExceptionStatus) ml_DTrees_getRoots(cv::ml::DTrees *obj, std::vector<int> 
     {
         result->push_back(i);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getNodes(cv::ml::DTrees *obj, std::vector<DTrees_Node> *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& org = obj->getNodes();
 
     result->clear();
@@ -197,12 +197,12 @@ CVAPI(ExceptionStatus) ml_DTrees_getNodes(cv::ml::DTrees *obj, std::vector<DTree
     {
         result->push_back(c(i));
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getSplits(cv::ml::DTrees *obj, std::vector<DTrees_Split> *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& org = obj->getSplits();
 
     result->clear();
@@ -210,12 +210,12 @@ CVAPI(ExceptionStatus) ml_DTrees_getSplits(cv::ml::DTrees *obj, std::vector<DTre
     {
         result->push_back(c(i));
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_getSubsets(cv::ml::DTrees *obj, std::vector<int> *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto& org = obj->getSubsets();
 
     result->clear();
@@ -223,46 +223,46 @@ CVAPI(ExceptionStatus) ml_DTrees_getSubsets(cv::ml::DTrees *obj, std::vector<int
     {
         result->push_back(i);
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_create(cv::Ptr<cv::ml::DTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto  ptr = cv::ml::DTrees::create();
     *returnValue = new cv::Ptr<cv::ml::DTrees>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_DTrees_delete(cv::Ptr<cv::ml::DTrees> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_DTrees_get(cv::Ptr<cv::ml::DTrees> *obj, cv::ml::DTrees **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_load(const char *filePath, cv::Ptr<cv::ml::DTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::DTrees>(filePath);
     *returnValue = new cv::Ptr<cv::ml::DTrees>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_DTrees_loadFromString(const char *strModel, cv::Ptr<cv::ml::DTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::DTrees::create()->getDefaultName();
     const auto  ptr = cv::Algorithm::loadFromString<cv::ml::DTrees>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::DTrees>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_EM.h
+++ b/src/OpenCvSharpExtern/ml_EM.h
@@ -11,62 +11,62 @@
 
 CVAPI(ExceptionStatus) ml_EM_getClustersNumber(cv::ml::EM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getClustersNumber();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_EM_setClustersNumber(cv::ml::EM *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setClustersNumber(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_getCovarianceMatrixType(cv::ml::EM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCovarianceMatrixType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_EM_setCovarianceMatrixType(cv::ml::EM *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCovarianceMatrixType(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_getTermCriteria(cv::ml::EM *obj, interop::TermCriteria *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTermCriteria());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_EM_setTermCriteria(cv::ml::EM *obj, interop::TermCriteria val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTermCriteria(cpp(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_getWeights(cv::ml::EM *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto m = obj->getWeights();
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_getMeans(cv::ml::EM *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto m = obj->getMeans();
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_getCovs(cv::ml::EM *obj, std::vector<cv::Mat*> *covs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> raw;
     obj->getCovs(raw);
     covs->resize(raw.size());
@@ -74,20 +74,20 @@ CVAPI(ExceptionStatus) ml_EM_getCovs(cv::ml::EM *obj, std::vector<cv::Mat*> *cov
     {
         covs->at(i) = new cv::Mat(raw[i]);
     }
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_EM_predict2(
     cv::ml::EM *obj, cv::_InputArray *sample, cv::_OutputArray *probs, interop::Vec2d *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto vec = obj->predict2(*sample, *probs);
     interop::Vec2d ret;
     ret.val[0] = vec[0];
     ret.val[1] = vec[1];
     *returnValue = ret;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_trainEM(
@@ -98,10 +98,10 @@ CVAPI(ExceptionStatus) ml_EM_trainEM(
     cv::_OutputArray *probs, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->trainEM(*samples, entity(logLikelihoods), entity(labels), entity(probs));
     *returnValue = ret ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_trainE(
@@ -115,12 +115,12 @@ CVAPI(ExceptionStatus) ml_EM_trainE(
     cv::_OutputArray *probs, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->trainE(
         *samples, *means0, entity(covs0), entity(weights0),
         entity(logLikelihoods), entity(labels), entity(probs));
     *returnValue = ret ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_trainM(
@@ -132,51 +132,51 @@ CVAPI(ExceptionStatus) ml_EM_trainM(
     cv::_OutputArray *probs, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->trainM(
         *samples, *probs0, entity(logLikelihoods), entity(labels), entity(probs));
     *returnValue = ret ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_EM_create(cv::Ptr<cv::ml::EM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto obj = cv::ml::EM::create();
     *returnValue = new cv::Ptr<cv::ml::EM>(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_EM_delete(cv::Ptr<cv::ml::EM> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_EM_get(cv::Ptr<cv::ml::EM> *obj, cv::ml::EM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_load(const char *filePath, cv::Ptr<cv::ml::EM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::EM>(filePath);
     *returnValue = new cv::Ptr<cv::ml::EM>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_EM_loadFromString(const char *strModel, cv::Ptr<cv::ml::EM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::EM::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::EM>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::EM>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_KNearest.h
+++ b/src/OpenCvSharpExtern/ml_KNearest.h
@@ -11,104 +11,104 @@
 
 CVAPI(ExceptionStatus) ml_KNearest_getDefaultK(cv::ml::KNearest *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDefaultK();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_KNearest_setDefaultK(cv::ml::KNearest *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDefaultK(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_KNearest_getIsClassifier(cv::ml::KNearest *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIsClassifier() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_KNearest_setIsClassifier(cv::ml::KNearest *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIsClassifier(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_KNearest_getEmax(cv::ml::KNearest *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getEmax();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_KNearest_setEmax(cv::ml::KNearest *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEmax(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_KNearest_getAlgorithmType(cv::ml::KNearest *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAlgorithmType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_KNearest_setAlgorithmType(cv::ml::KNearest *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAlgorithmType(val);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_KNearest_findNearest(cv::ml::KNearest *obj, cv::_InputArray *samples, int k,
     cv::_OutputArray *results, cv::_OutputArray *neighborResponses, cv::_OutputArray *dist, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->findNearest(
         entity(samples), k, entity(results), entity(neighborResponses), entity(dist));
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_KNearest_create(cv::Ptr<cv::ml::KNearest> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto  ptr = cv::ml::KNearest::create();
     *returnValue = new cv::Ptr<cv::ml::KNearest>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_KNearest_delete(cv::Ptr<cv::ml::KNearest> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_KNearest_get(cv::Ptr<cv::ml::KNearest>* obj, cv::ml::KNearest **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_KNearest_load(const char *filePath, cv::Ptr<cv::ml::KNearest> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto  ptr = cv::Algorithm::load<cv::ml::KNearest>(filePath);
     *returnValue = new cv::Ptr<cv::ml::KNearest>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_KNearest_loadFromString(const char *strModel, cv::Ptr<cv::ml::KNearest> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::KNearest::create()->getDefaultName();
     const auto  ptr = cv::Algorithm::loadFromString<cv::ml::KNearest>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::KNearest>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_LogisticRegression.h
+++ b/src/OpenCvSharpExtern/ml_LogisticRegression.h
@@ -9,139 +9,139 @@
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getLearningRate(cv::ml::LogisticRegression *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLearningRate();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setLearningRate(cv::ml::LogisticRegression *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLearningRate(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getIterations(cv::ml::LogisticRegression *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIterations();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setIterations(cv::ml::LogisticRegression *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIterations(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getRegularization(cv::ml::LogisticRegression *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRegularization();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setRegularization(cv::ml::LogisticRegression *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRegularization(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getTrainMethod(cv::ml::LogisticRegression *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTrainMethod();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setTrainMethod(cv::ml::LogisticRegression *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTrainMethod(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getMiniBatchSize(cv::ml::LogisticRegression *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMiniBatchSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setMiniBatchSize(cv::ml::LogisticRegression *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMiniBatchSize(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_getTermCriteria(cv::ml::LogisticRegression *obj, interop::TermCriteria *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTermCriteria());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_LogisticRegression_setTermCriteria(cv::ml::LogisticRegression *obj, interop::TermCriteria val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTermCriteria(cpp(val));
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_predict(
     cv::ml::LogisticRegression *obj, cv::_InputArray *samples, cv::_OutputArray *results, int flags, float *returnValue)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->predict(entity(samples), entity(results), flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_get_learnt_thetas(cv::ml::LogisticRegression *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->get_learnt_thetas());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_create(cv::Ptr<cv::ml::LogisticRegression> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::LogisticRegression::create();
     *returnValue = new cv::Ptr<cv::ml::LogisticRegression>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_LogisticRegression_delete(cv::Ptr<cv::ml::LogisticRegression> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_LogisticRegression_get(
     cv::Ptr<cv::ml::LogisticRegression> *obj, cv::ml::LogisticRegression **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_load(
     const char *filePath, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::LogisticRegression>(filePath);
     *returnValue = new cv::Ptr<cv::ml::LogisticRegression>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_loadFromString(
     const char *strModel, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::LogisticRegression::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::LogisticRegression>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::LogisticRegression>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_NormalBayesClassifier.h
+++ b/src/OpenCvSharpExtern/ml_NormalBayesClassifier.h
@@ -11,50 +11,50 @@ CVAPI(ExceptionStatus) ml_NormalBayesClassifier_predictProb(
     cv::ml::NormalBayesClassifier *obj, cv::_InputArray *inputs, 
     cv::_OutputArray *samples, cv::_OutputArray *outputProbs, int flags, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->predictProb(entity(inputs), entity(samples), entity(outputProbs), flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_NormalBayesClassifier_create(cv::Ptr<cv::ml::NormalBayesClassifier> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::NormalBayesClassifier::create();
     *returnValue = new cv::Ptr<cv::ml::NormalBayesClassifier>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_NormalBayesClassifier_delete(cv::Ptr<cv::ml::NormalBayesClassifier> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_NormalBayesClassifier_get(
     cv::Ptr<cv::ml::NormalBayesClassifier>* obj, cv::ml::NormalBayesClassifier **returnValue)
 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_NormalBayesClassifier_load(const char *filePath, cv::Ptr<cv::ml::NormalBayesClassifier> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto  ptr = cv::Algorithm::load<cv::ml::NormalBayesClassifier>(filePath);
     *returnValue = new cv::Ptr<cv::ml::NormalBayesClassifier>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_NormalBayesClassifier_loadFromString(const char *strModel, cv::Ptr<cv::ml::NormalBayesClassifier> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::NormalBayesClassifier::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::NormalBayesClassifier>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::NormalBayesClassifier>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_RTrees.h
+++ b/src/OpenCvSharpExtern/ml_RTrees.h
@@ -11,87 +11,87 @@
 
 CVAPI(ExceptionStatus) ml_RTrees_getCalculateVarImportance(cv::ml::RTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCalculateVarImportance() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_RTrees_setCalculateVarImportance(cv::ml::RTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCalculateVarImportance(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_getActiveVarCount(cv::ml::RTrees *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getActiveVarCount();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_RTrees_setActiveVarCount(cv::ml::RTrees *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setActiveVarCount(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_getTermCriteria(cv::ml::RTrees *obj, interop::TermCriteria *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTermCriteria());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_RTrees_setTermCriteria(cv::ml::RTrees *obj, interop::TermCriteria val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTermCriteria(cpp(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_getVarImportance(cv::ml::RTrees *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->getVarImportance());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_create(cv::Ptr<cv::ml::RTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::RTrees::create();
     *returnValue = new cv::Ptr<cv::ml::RTrees>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_RTrees_delete(cv::Ptr<cv::ml::RTrees> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_RTrees_get(cv::Ptr<cv::ml::RTrees> *obj, cv::ml::RTrees **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_load(const char *filePath, cv::Ptr<cv::ml::RTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::RTrees>(filePath);
     *returnValue = new cv::Ptr<cv::ml::RTrees>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_RTrees_loadFromString(const char *strModel, cv::Ptr<cv::ml::RTrees> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::RTrees::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::RTrees>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::RTrees>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_SVM.h
+++ b/src/OpenCvSharpExtern/ml_SVM.h
@@ -10,148 +10,148 @@
 
 CVAPI(ExceptionStatus) ml_SVM_getType(cv::ml::SVM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setType(cv::ml::SVM *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setType(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getGamma(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getGamma();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setGamma(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGamma(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getCoef0(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCoef0();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setCoef0(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCoef0(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getDegree(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDegree();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setDegree(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDegree(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getC(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getC();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setC(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setC(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getP(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getP();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setP(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setP(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getNu(cv::ml::SVM *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNu();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setNu(cv::ml::SVM *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNu(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getClassWeights(cv::ml::SVM *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->getClassWeights());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setClassWeights(cv::ml::SVM *obj, cv::Mat *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setClassWeights(*val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getTermCriteria(cv::ml::SVM *obj, interop::TermCriteria *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getTermCriteria());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ml_SVM_setTermCriteria(cv::ml::SVM *obj, interop::TermCriteria val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTermCriteria(cpp(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getKernelType(cv::ml::SVM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getKernelType();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_setKernel(cv::ml::SVM *obj, int kernelType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setKernel(kernelType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getSupportVectors(cv::ml::SVM *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Mat(obj->getSupportVectors());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getDecisionFunction(
     cv::ml::SVM *obj, int i, cv::_OutputArray *alpha, cv::_OutputArray *svidx, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDecisionFunction(i, entity(alpha), entity(svidx));
-    END_WRAP
+    });
 }
 
 
@@ -159,48 +159,48 @@ CVAPI(ExceptionStatus) ml_SVM_getDecisionFunction(
 
 CVAPI(ExceptionStatus) ml_SVM_getDefaultGrid(int param_id, ParamGridStruct *returnValue)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::ml::SVM::getDefaultGrid(param_id));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_create(cv::Ptr<cv::ml::SVM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::SVM::create();
     *returnValue = new cv::Ptr<cv::ml::SVM>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_SVM_delete(cv::Ptr<cv::ml::SVM> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_Ptr_SVM_get(cv::Ptr<cv::ml::SVM>* obj, cv::ml::SVM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_load(const char *filePath, cv::Ptr<cv::ml::SVM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ml::SVM::load(filePath);
     *returnValue = new cv::Ptr<cv::ml::SVM>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_SVM_loadFromString(const char *strModel, cv::Ptr<cv::ml::SVM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto objName = cv::ml::SVM::create()->getDefaultName();
     const auto ptr = cv::Algorithm::loadFromString<cv::ml::SVM>(strModel, objName);
     *returnValue = new cv::Ptr<cv::ml::SVM>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_StatModel.h
+++ b/src/OpenCvSharpExtern/ml_StatModel.h
@@ -9,69 +9,69 @@
 
 CVAPI(ExceptionStatus) ml_StatModel_clear(cv::ml::StatModel *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_StatModel_getVarCount(cv::ml::StatModel *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getVarCount();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_StatModel_empty(cv::ml::StatModel *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_StatModel_isTrained(cv::ml::StatModel *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isTrained() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ml_StatModel_isClassifier(cv::ml::StatModel *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isClassifier() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) ml_StatModel_train1(
     cv::ml::StatModel *obj, cv::Ptr<cv::ml::TrainData> *trainData, int flags, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->train(*trainData, flags) ? 1 : 0;
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) ml_StatModel_train2(
     cv::ml::StatModel *obj, cv::_InputArray *samples, int layout, cv::_InputArray *responses, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->train(*samples, layout, *responses) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) ml_StatModel_calcError(
     cv::ml::StatModel *obj, cv::Ptr<cv::ml::TrainData> *data, int test, cv::_OutputArray *resp, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->calcError(*data, test != 0, *resp);
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) ml_StatModel_predict(
     cv::ml::StatModel *obj, cv::_InputArray *samples, cv::_OutputArray *results, int flags, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->predict(entity(samples), entity(results), flags);
-    END_WRAP
+    });
 }
 
 #endif // NO_ML

--- a/src/OpenCvSharpExtern/my_functions.h
+++ b/src/OpenCvSharpExtern/my_functions.h
@@ -132,13 +132,32 @@ static bool writeAllBytesWide(const char *utf8Path, const uchar *data, size_t si
 // catch all exception
 enum class ExceptionStatus : int { NotOccurred = 0, Occurred = 1 };
 
+// Runs an exported function body and reports whether a C++ exception escaped it via the
+// ExceptionStatus return value. This is a drop-in replacement for the former
+// BEGIN_WRAP / END_WRAP macros and preserves their exact, per-platform behavior:
+//   * Windows: no try/catch -- exceptions propagate as before (a managed exception thrown
+//     from the OpenCV error callback unwinds through native frames via SEH).
+//   * Other:   the body runs inside try/catch and a caught std::exception is reported as
+//     Occurred.
+// (A later change unifies these onto a single portable path.)
+template <typename TFunc>
+ExceptionStatus cvTry(TFunc&& body)
+{
 #if defined WIN32 || defined _WIN32
-#define BEGIN_WRAP
-#define END_WRAP return ExceptionStatus::NotOccurred;
+    body();
+    return ExceptionStatus::NotOccurred;
 #else
-#define BEGIN_WRAP try{
-#define END_WRAP return ExceptionStatus::NotOccurred;}catch(std::exception){return ExceptionStatus::Occurred;}
+    try
+    {
+        body();
+        return ExceptionStatus::NotOccurred;
+    }
+    catch (const std::exception&)
+    {
+        return ExceptionStatus::Occurred;
+    }
 #endif
+}
 
 
 static cv::_InputArray entity(cv::_InputArray *obj)

--- a/src/OpenCvSharpExtern/objdetect.h
+++ b/src/OpenCvSharpExtern/objdetect.h
@@ -17,43 +17,43 @@
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_new(cv::CascadeClassifier **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::CascadeClassifier;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_newFromFile(const char *fileName, cv::CascadeClassifier **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::CascadeClassifier(fileName);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_delete(cv::CascadeClassifier *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_empty(cv::CascadeClassifier *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_load(
     cv::CascadeClassifier *obj, const char *fileName, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->load(fileName) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_read(
     cv::CascadeClassifier* obj, cv::FileNode* fn, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         * returnValue = obj->read(*fn) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_detectMultiScale1(
@@ -61,10 +61,10 @@ CVAPI(ExceptionStatus) objdetect_CascadeClassifier_detectMultiScale1(
     cv::Mat *image, std::vector<cv::Rect> *objects,
     double scaleFactor, int minNeighbors, int flags, interop::Size minSize, interop::Size maxSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectMultiScale(*image, *objects,
         scaleFactor, minNeighbors, flags, cpp(minSize), cpp(maxSize));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_detectMultiScale2(
@@ -76,30 +76,30 @@ CVAPI(ExceptionStatus) objdetect_CascadeClassifier_detectMultiScale2(
     double scaleFactor, int minNeighbors, int flags,
     interop::Size minSize, interop::Size maxSize, int outputRejectLevels)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectMultiScale(*image, *objects, *rejectLevels, *levelWeights,
         scaleFactor, minNeighbors, flags, cpp(minSize), cpp(maxSize), outputRejectLevels != 0);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_isOldFormatCascade(cv::CascadeClassifier *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isOldFormatCascade() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_getOriginalWindowSize(cv::CascadeClassifier *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getOriginalWindowSize());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_CascadeClassifier_getFeatureType(cv::CascadeClassifier *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getFeatureType();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -107,37 +107,37 @@ CVAPI(ExceptionStatus) objdetect_CascadeClassifier_getFeatureType(cv::CascadeCla
 CVAPI(ExceptionStatus) objdetect_groupRectangles1(
     std::vector<cv::Rect> *rectList, int groupThreshold, double eps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::groupRectangles(*rectList, groupThreshold, eps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_groupRectangles2(
     std::vector<cv::Rect> *rectList, std::vector<int> *weights, int groupThreshold, double eps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::groupRectangles(*rectList, *weights, groupThreshold, eps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_groupRectangles3(
     std::vector<cv::Rect> *rectList, int groupThreshold, double eps, std::vector<int> *weights, std::vector<double> *levelWeights)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::groupRectangles(*rectList, groupThreshold, eps, weights, levelWeights);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_groupRectangles4(
     std::vector<cv::Rect> *rectList, std::vector<int> *rejectLevels, std::vector<double> *levelWeights, int groupThreshold, double eps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::groupRectangles(*rectList, *rejectLevels, *levelWeights, groupThreshold, eps);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_groupRectangles_meanshift(
     std::vector<cv::Rect> *rectList, std::vector<double> *foundWeights, std::vector<double> *foundScales, double detectThreshold, interop::Size winDetSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::groupRectangles_meanshift(*rectList, *foundWeights, *foundScales, detectThreshold, cpp(winDetSize));
-    END_WRAP
+    });
 }
 
 #endif

--- a/src/OpenCvSharpExtern/objdetect_FaceDetectorYN.h
+++ b/src/OpenCvSharpExtern/objdetect_FaceDetectorYN.h
@@ -23,36 +23,36 @@ CVAPI(ExceptionStatus) objdetect_FaceDetectorYN_create(
     int targetId,
     cv::Ptr<cv::FaceDetectorYN>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::FaceDetectorYN::create(
         *model, *config, cpp(*inputSize),
         scoreThreshold, nmsThreshold, topK,
         backendId, targetId);
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_Ptr_FaceDetectorYN_delete(cv::Ptr<cv::FaceDetectorYN>* ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_Ptr_FaceDetectorYN_get(
     cv::Ptr<cv::FaceDetectorYN>* ptr, cv::FaceDetectorYN** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_FaceDetectorYN_detect(
     cv::FaceDetectorYN* obj, cv::_InputArray* image, cv::_OutputArray* faces, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->detect(*image, *faces);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/objdetect_HOGDescriptor.h
+++ b/src/OpenCvSharpExtern/objdetect_HOGDescriptor.h
@@ -13,123 +13,123 @@
 // include_opencv.h); it stays in the cv:: namespace and is kept in all profiles.
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_new1(cv::HOGDescriptor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::HOGDescriptor;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_new2(
     interop::Size winSize, interop::Size blockSize, interop::Size blockStride, interop::Size cellSize,
     int nbins, int derivAperture, double winSigma, int histogramNormType, double L2HysThreshold, int gammaCorrection, int nlevels,
     cv::HOGDescriptor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::HOGDescriptor(cpp(winSize), cpp(blockSize), cpp(blockStride), cpp(cellSize), nbins, derivAperture, 
                                  winSigma, static_cast<cv::HOGDescriptor::HistogramNormType>(histogramNormType), L2HysThreshold, gammaCorrection != 0, nlevels);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_new3(const char *filename, cv::HOGDescriptor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::HOGDescriptor(filename);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_delete(cv::HOGDescriptor *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_getDescriptorSize(cv::HOGDescriptor *obj, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDescriptorSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_checkDetectorSize(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->checkDetectorSize() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_getWinSigma(cv::HOGDescriptor *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getWinSigma();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_setSVMDetector(cv::HOGDescriptor *obj, std::vector<float> *svmDetector)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSVMDetector(*svmDetector);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_load(cv::HOGDescriptor *obj, const char *filename, const char *objName, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::string objNameStr;
     if (objName != nullptr)
         objNameStr = std::string(objName);
     *returnValue = obj->load(filename, objNameStr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_save(cv::HOGDescriptor *obj, const char *filename, const char *objName)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::string objNameStr;
     if (objName != nullptr)
         objNameStr = cv::String(objName);
     obj->save(filename, objNameStr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_copyTo(cv::HOGDescriptor *obj, cv::HOGDescriptor *c)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->copyTo(*c);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_compute(
     cv::HOGDescriptor *obj, cv::Mat *img, std::vector<float> *descriptors,
     interop::Size winStride, interop::Size padding, cv::Point* locations, int locationsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point> locationsVec;
     if (locations != nullptr)    
         locationsVec = std::vector<cv::Point>(locations, locations + locationsLength);    
     obj->compute(*img, *descriptors, cpp(winStride), cpp(padding), locationsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detect1(
     cv::HOGDescriptor *obj, cv::Mat *img, std::vector<cv::Point> *foundLocations,
     double hitThreshold, interop::Size winStride, interop::Size padding, cv::Point* searchLocations, int searchLocationsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point> slVec;
     if (searchLocations != nullptr)    
         slVec = std::vector<cv::Point>(searchLocations, searchLocations + searchLocationsLength);    
     obj->detect(*img, *foundLocations, hitThreshold, cpp(winStride), cpp(padding), slVec);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detect2(
     cv::HOGDescriptor *obj, cv::Mat *img, 
     std::vector<cv::Point> *foundLocations, std::vector<double> *weights,
     double hitThreshold, interop::Size winStride, interop::Size padding, cv::Point* searchLocations, int searchLocationsLength)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point> slVec;
     if (searchLocations != nullptr)    
         slVec = std::vector<cv::Point>(searchLocations, searchLocations + searchLocationsLength);    
     obj->detect(*img, *foundLocations, *weights, hitThreshold, cpp(winStride), cpp(padding), slVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScale1(
@@ -137,29 +137,29 @@ CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScale1(
     std::vector<cv::Rect> *foundLocations,
     double hitThreshold, interop::Size winStride, interop::Size padding, double scale, int groupThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectMultiScale(*img, *foundLocations, 
                           hitThreshold, cpp(winStride), cpp(padding), scale, groupThreshold);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScale2(
     cv::HOGDescriptor *obj, cv::Mat *img, 
     std::vector<cv::Rect> *foundLocations, std::vector<double> *foundWeights,
     double hitThreshold, interop::Size winStride, interop::Size padding, double scale, int groupThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectMultiScale(*img, *foundLocations, *foundWeights, 
                           hitThreshold, cpp(winStride), cpp(padding), scale, groupThreshold);    
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_computeGradient(
     cv::HOGDescriptor *obj, cv::Mat* img, 
     cv::Mat* grad, cv::Mat* angleOfs, interop::Size paddingTL, interop::Size paddingBR)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->computeGradient(*img, *grad, *angleOfs, cpp(paddingTL), cpp(paddingBR));    
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectROI(
@@ -167,10 +167,10 @@ CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectROI(
     std::vector<cv::Point> *foundLocations, std::vector<double> *confidences,
     double hitThreshold, interop::Size winStride, interop::Size padding)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point> locationsVec(locations, locations + locationsLength);
     obj->detectROI(*img, locationsVec, *foundLocations, *confidences, hitThreshold, cpp(winStride), cpp(padding));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScaleROI(
@@ -178,7 +178,7 @@ CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScaleROI(
     std::vector<double> *roiScales, std::vector<std::vector<cv::Point> > *roiLocations, std::vector<std::vector<double> > *roiConfidences,
     double hitThreshold, int groupThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::DetectionROI> locations;
     obj->detectMultiScaleROI(*img, *foundLocations, locations, hitThreshold, groupThreshold);
 
@@ -191,164 +191,164 @@ CVAPI(ExceptionStatus) objdetect_HOGDescriptor_detectMultiScaleROI(
         (*roiLocations)[i] = locations[i].locations;
         (*roiConfidences)[i] = locations[i].confidences;
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_groupRectangles(cv::HOGDescriptor *obj,
                                                     std::vector<cv::Rect> *rectList, std::vector<double> *weights, int groupThreshold, double eps)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->groupRectangles(*rectList, *weights, groupThreshold, eps);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_winSize_get(cv::HOGDescriptor *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->winSize);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_blockSize_get(cv::HOGDescriptor *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->blockSize);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_blockStride_get(cv::HOGDescriptor *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->blockStride);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_cellSize_get(cv::HOGDescriptor *obj, interop::Size *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->cellSize);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_nbins_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->nbins;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_derivAperture_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->derivAperture;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_winSigma_get(cv::HOGDescriptor *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->winSigma;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_histogramNormType_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->histogramNormType;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_L2HysThreshold_get(cv::HOGDescriptor *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->L2HysThreshold;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_gammaCorrection_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->gammaCorrection ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_nlevels_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->nlevels;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_signedGradient_get(cv::HOGDescriptor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->signedGradient;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_winSize_set(cv::HOGDescriptor *obj, interop::Size value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->winSize = cpp(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_blockSize_set(cv::HOGDescriptor *obj, interop::Size value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->blockSize = cpp(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_blockStride_set(cv::HOGDescriptor *obj, interop::Size value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->blockStride = cpp(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_cellSize_set(cv::HOGDescriptor *obj, interop::Size value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->cellSize = cpp(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_nbins_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->nbins = value;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_derivAperture_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->derivAperture = value;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_winSigma_set(cv::HOGDescriptor *obj, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->winSigma = value;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_histogramNormType_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->histogramNormType = static_cast<cv::HOGDescriptor::HistogramNormType>(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_L2HysThreshold_set(cv::HOGDescriptor *obj, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->L2HysThreshold = value;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_gammaCorrection_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->gammaCorrection = (value != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_nlevels_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->nlevels = value;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_HOGDescriptor_signedGradient_set(cv::HOGDescriptor *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->signedGradient = (value != 0);
-    END_WRAP
+    });
 }
 
 #endif

--- a/src/OpenCvSharpExtern/objdetect_QRCodeDetector.h
+++ b/src/OpenCvSharpExtern/objdetect_QRCodeDetector.h
@@ -12,79 +12,79 @@
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_new(cv::QRCodeDetector **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::QRCodeDetector();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_delete(cv::QRCodeDetector *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_setEpsX(cv::QRCodeDetector *obj, double epsX)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEpsX(epsX);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_setEpsY(cv::QRCodeDetector *obj, double epsY)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEpsY(epsY);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_detect(
     cv::QRCodeDetector *obj, cv::_InputArray *img, std::vector<cv::Point2f> *points, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->detect(*img, *points) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_decode(
     cv::QRCodeDetector *obj, cv::_InputArray *img, std::vector<cv::Point2f> *points, cv::_OutputArray *straight_qrcode, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->decode(*img, *points, entity(straight_qrcode));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_detectAndDecode(
     cv::QRCodeDetector *obj, cv::_InputArray *img, std::vector<cv::Point2f> *points,
     cv::_OutputArray *straight_qrcode, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->detectAndDecode(*img, *points, entity(straight_qrcode));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_detectMulti(
     cv::QRCodeDetector* obj, cv::_InputArray* img, std::vector<cv::Point2f>* points, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->detectMulti(*img, *points) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_decodeMulti(
     cv::QRCodeDetector* obj, cv::_InputArray* img, std::vector<cv::Point2f>* points, std::vector<std::string>* decoded_info, std::vector<cv::Mat>* straight_qrcode, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->decodeMulti(*img, *points, *decoded_info, *straight_qrcode) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_QRCodeDetector_decodeMulti_NoStraightQrCode(
     cv::QRCodeDetector* obj, cv::_InputArray* img, std::vector<cv::Point2f>* points, std::vector<std::string>* decoded_info, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->decodeMulti(*img, *points, *decoded_info) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #endif

--- a/src/OpenCvSharpExtern/objdetect_chessboard.h
+++ b/src/OpenCvSharpExtern/objdetect_chessboard.h
@@ -12,9 +12,9 @@
 CVAPI(ExceptionStatus) objdetect_checkChessboard(
     cv::_InputArray *img, interop::Size size, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::checkChessboard(*img, cpp(size)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
@@ -22,18 +22,18 @@ CVAPI(ExceptionStatus) objdetect_findChessboardCornersSB_OutputArray(
     cv::_InputArray *image, interop::Size patternSize, cv::_OutputArray *corners, int flags, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findChessboardCornersSB(*image, cpp(patternSize), *corners, flags) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_findChessboardCornersSB_vector(
     cv::_InputArray *image, interop::Size patternSize, std::vector<cv::Point2f> *corners, int flags, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findChessboardCornersSB(*image, cpp(patternSize), *corners, flags) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
@@ -41,18 +41,18 @@ CVAPI(ExceptionStatus) objdetect_find4QuadCornerSubpix_InputArray(
     cv::_InputArray *img, cv::_InputOutputArray *corners, interop::Size regionSize, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::find4QuadCornerSubpix(*img, *corners, cpp(regionSize)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_find4QuadCornerSubpix_vector(
     cv::_InputArray *img, std::vector<cv::Point2f> *corners, interop::Size regionSize, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::find4QuadCornerSubpix(*img, *corners, cpp(regionSize)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
@@ -60,19 +60,19 @@ CVAPI(ExceptionStatus) objdetect_drawChessboardCorners_InputArray(
     cv::_InputOutputArray *image, interop::Size patternSize,
     cv::_InputArray *corners, int patternWasFound)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::drawChessboardCorners(*image, cpp(patternSize), *corners, patternWasFound != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) objdetect_drawChessboardCorners_array(
     cv::_InputOutputArray *image, interop::Size patternSize,
     cv::Point2f *corners, int cornersLength, int patternWasFound)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2f> cornersVec(corners, corners + cornersLength);
     cv::drawChessboardCorners(*image, cpp(patternSize), cornersVec, patternWasFound != 0);
-    END_WRAP
+    });
 }
 
 #endif // NO_OBJDETECT

--- a/src/OpenCvSharpExtern/optflow.h
+++ b/src/OpenCvSharpExtern/optflow.h
@@ -16,9 +16,9 @@ CVAPI(ExceptionStatus) optflow_calcOpticalFlowSF1(
     int averagingBlockSize,
     int maxFlow)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::optflow::calcOpticalFlowSF(*from, *to, *flow, layers, averagingBlockSize, maxFlow);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) optflow_calcOpticalFlowSF2(
@@ -39,22 +39,22 @@ CVAPI(ExceptionStatus) optflow_calcOpticalFlowSF2(
     double upscaleSigmaColor,
     double speedUpThr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::optflow::calcOpticalFlowSF(*from, *to, *flow, layers, averagingBlockSize, maxFlow,
         sigmaDist, sigmaColor, postprocessWindow, sigmaDistFix, sigmaColorFix,
         occThr, upscaleAveragingRadius, upscaleSigmaDist, upscaleSigmaColor, speedUpThr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) optflow_calcOpticalFlowSparseToDense(
     cv::_InputArray *from,  cv::_InputArray *to,  cv::_OutputArray *flow,
     int grid_step, int k, float sigma, int use_post_proc, float fgs_lambda, float fgs_sigma )
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::optflow::calcOpticalFlowSparseToDense(
         *from, *to, *flow,
         grid_step, k, sigma, use_post_proc != 0, fgs_lambda, fgs_sigma);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/optflow_motempl.h
+++ b/src/OpenCvSharpExtern/optflow_motempl.h
@@ -12,27 +12,27 @@ CVAPI(ExceptionStatus) optflow_motempl_updateMotionHistory(
     cv::_InputArray *silhouette, cv::_InputOutputArray *mhi,
     double timestamp, double duration)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::motempl::updateMotionHistory(*silhouette, *mhi, timestamp, duration);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) optflow_motempl_calcMotionGradient(
     cv::_InputArray *mhi, cv::_OutputArray *mask, cv::_OutputArray *orientation,
     double delta1, double delta2, int apertureSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::motempl::calcMotionGradient(*mhi, *mask, *orientation, delta1, delta2, apertureSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) optflow_motempl_calcGlobalOrientation(
     cv::_InputArray *orientation, cv::_InputArray *mask,
     cv::_InputArray *mhi, double timestamp, double duration, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::motempl::calcGlobalOrientation(*orientation, *mask, *mhi, timestamp, duration);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) optflow_motempl_segmentMotion(
@@ -40,9 +40,9 @@ CVAPI(ExceptionStatus) optflow_motempl_segmentMotion(
     std::vector<cv::Rect> *boundingRects,
     double timestamp, double segThresh)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::motempl::segmentMotion(*mhi, *segmask, *boundingRects, timestamp, segThresh);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/photo.h
+++ b/src/OpenCvSharpExtern/photo.h
@@ -12,32 +12,32 @@
 CVAPI(ExceptionStatus) photo_inpaint(cv::_InputArray *src, cv::_InputArray *inpaintMask,
     cv::_OutputArray *dst, double inpaintRadius, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::inpaint(*src, *inpaintMask, *dst, inpaintRadius, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_fastNlMeansDenoising(cv::_InputArray *src, cv::_OutputArray *dst, float h,
     int templateWindowSize, int searchWindowSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fastNlMeansDenoising(*src, *dst, h, templateWindowSize, searchWindowSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColored(cv::_InputArray *src, cv::_OutputArray *dst,
     float h, float hColor, int templateWindowSize, int searchWindowSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::fastNlMeansDenoisingColored(*src, *dst, h, hColor, templateWindowSize, searchWindowSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(cv::Mat **srcImgs, int srcImgsLength,
     cv::_OutputArray* dst, int imgToDenoiseIndex, int temporalWindowSize,
     float h, int templateWindowSize, int searchWindowSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
     for (int i = 0; i < srcImgsLength; i++)
@@ -46,14 +46,14 @@ CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(cv::Mat **srcImgs, int sr
     cv::fastNlMeansDenoisingMulti(
         srcImgsVec, *dst, imgToDenoiseIndex, temporalWindowSize, h, templateWindowSize, searchWindowSize);
 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColoredMulti(cv::Mat**srcImgs, int srcImgsLength,
     cv::_OutputArray *dst, int imgToDenoiseIndex, int temporalWindowSize,
     float h, float hColor, int templateWindowSize, int searchWindowSize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
     for (int i = 0; i < srcImgsLength; i++)
@@ -62,20 +62,20 @@ CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColoredMulti(cv::Mat**srcImgs, 
     cv::fastNlMeansDenoisingColoredMulti(
         srcImgsVec, *dst, imgToDenoiseIndex, temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize);
 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_denoise_TVL1(
     cv::Mat **observations, int observationsSize, cv::Mat *result, double lambda, int niters)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> observationsVec(observationsSize);
     for (int i = 0; i < observationsSize; i++)
     {
         observationsVec[i] = *observations[i];
     }
     cv::denoise_TVL1(observationsVec, *result, lambda, niters);
-    END_WRAP
+    });
 }
 
 
@@ -83,78 +83,78 @@ CVAPI(ExceptionStatus) photo_denoise_TVL1(
 CVAPI(ExceptionStatus) photo_decolor(
     cv::_InputArray *src, cv::_OutputArray *grayscale, cv::_OutputArray *color_boost)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::decolor(*src, *grayscale, *color_boost);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_seamlessClone(
     cv::_InputArray *src, cv::_InputArray *dst, cv::_InputArray *mask, interop::Point p,
     cv::_OutputArray *blend, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::seamlessClone(*src, *dst, entity(mask), cpp(p), *blend, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_colorChange(
     cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst, float red_mul,
     float green_mul, float blue_mul)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::colorChange(*src, entity(mask), *dst, red_mul, green_mul, blue_mul);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_illuminationChange(
     cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst,
     float alpha, float beta = 0.4f)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::illuminationChange(*src, entity(mask), *dst, alpha, beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_textureFlattening(
     cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst,
     float low_threshold, float high_threshold, int kernel_size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::textureFlattening(*src, entity(mask), *dst, low_threshold, high_threshold, kernel_size);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_edgePreservingFilter(
     cv::_InputArray *src, cv::_OutputArray *dst, int flags,    float sigma_s, float sigma_r)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::edgePreservingFilter(*src, *dst, flags, sigma_s, sigma_r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_detailEnhance(
     cv::_InputArray *src, cv::_OutputArray *dst, float sigma_s,    float sigma_r)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::detailEnhance(*src, *dst, sigma_s, sigma_r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_pencilSketch(
     cv::_InputArray *src, cv::_OutputArray *dst1, cv::_OutputArray *dst2,
     float sigma_s, float sigma_r, float shade_factor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::pencilSketch(*src, *dst1, *dst2, sigma_s, sigma_r, shade_factor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_stylization(
     cv::_InputArray *src, cv::_OutputArray *dst, float sigma_s,    float sigma_r)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::stylization(*src, *dst, sigma_s, sigma_r);
-    END_WRAP
+    });
 }
 
 #endif // NO_PHOTO

--- a/src/OpenCvSharpExtern/photo_HDR.h
+++ b/src/OpenCvSharpExtern/photo_HDR.h
@@ -11,117 +11,117 @@
 CVAPI(ExceptionStatus) photo_createCalibrateDebevec(
     int samples, float lambda, int random, cv::Ptr<cv::CalibrateDebevec> **returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::createCalibrateDebevec(samples, lambda, random != 0));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_CalibrateDebevec_delete(cv::Ptr<cv::CalibrateDebevec> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_CalibrateDebevec_get(cv::Ptr<cv::CalibrateDebevec> *obj, cv::CalibrateDebevec **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_getLambda(cv::CalibrateDebevec *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLambda();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_setLambda(cv::CalibrateDebevec *obj, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLambda(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_getSamples(cv::CalibrateDebevec *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLambda();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_setSamples(cv::CalibrateDebevec *obj, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLambda(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_getRandom(cv::CalibrateDebevec *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRandom() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_CalibrateDebevec_setRandom(cv::CalibrateDebevec *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRandom(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createCalibrateRobertson(
     int max_iter, float threshold, cv::Ptr<cv::CalibrateRobertson> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::createCalibrateRobertson(max_iter, threshold));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_CalibrateRobertson_delete(cv::Ptr<cv::CalibrateRobertson> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_CalibrateRobertson_get(cv::Ptr<cv::CalibrateRobertson> *obj, cv::CalibrateRobertson **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateRobertson_getMaxIter(cv::CalibrateRobertson *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxIter();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_CalibrateRobertson_setMaxIter(cv::CalibrateRobertson *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxIter(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateRobertson_getThreshold(cv::CalibrateRobertson *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_CalibrateRobertson_setThreshold(cv::CalibrateRobertson *obj, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_CalibrateRobertson_getRadiance(cv::CalibrateRobertson *obj, cv::Mat *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getRadiance().copyTo(*returnValue);
-    END_WRAP
+    });
 }
 
 
@@ -129,7 +129,7 @@ CVAPI(ExceptionStatus) photo_CalibrateCRF_process(
     cv::CalibrateCRF *obj, 
     cv::Mat ** srcImgs, int srcImgsLength, cv::_OutputArray *dst, float* times)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     // Build Mat Vector of images
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
@@ -143,52 +143,52 @@ CVAPI(ExceptionStatus) photo_CalibrateCRF_process(
     }
 
     obj->process(srcImgsVec, *dst, times_vec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createMergeDebevec(cv::Ptr<cv::MergeDebevec>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::createMergeDebevec());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_delete(cv::Ptr<cv::MergeDebevec>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeDebevec_get(cv::Ptr<cv::MergeDebevec>* obj, cv::MergeDebevec **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createMergeMertens(cv::Ptr<cv::MergeMertens>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::createMergeMertens());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_delete(cv::Ptr<cv::MergeMertens>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_Ptr_MergeMertens_get(cv::Ptr<cv::MergeMertens>* obj, cv::MergeMertens **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_MergeExposures_process(
     cv::MergeExposures* obj,
     cv::Mat** srcImgs, int srcImgsLength, cv::_OutputArray* dst, float* times, cv::_InputArray* response)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
     std::vector<float> times_vec(srcImgsLength);
     for (int i = 0; i < srcImgsLength; i++) {
@@ -196,20 +196,20 @@ CVAPI(ExceptionStatus) photo_MergeExposures_process(
         times_vec[i] = times[i];
     }
     obj->process(srcImgsVec, *dst, times_vec, *response);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_MergeMertens_process(
     cv::MergeMertens* obj,
     cv::Mat** srcImgs, int srcImgsLength, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> srcImgsVec(srcImgsLength);
     for (int i = 0; i < srcImgsLength; i++) {
         srcImgsVec[i] = *srcImgs[i];
     }
     obj->process(srcImgsVec, *dst);
-    END_WRAP
+    });
 }
 
 #endif // NO_PHOTO

--- a/src/OpenCvSharpExtern/photo_Tonemap.h
+++ b/src/OpenCvSharpExtern/photo_Tonemap.h
@@ -12,44 +12,44 @@
 
 CVAPI(ExceptionStatus) photo_Tonemap_process(cv::Tonemap *obj, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->process(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Tonemap_getGamma(cv::Tonemap *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getGamma();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_Tonemap_setGamma(cv::Tonemap *obj, float gamma)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setGamma(gamma);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createTonemap(float gamma, cv::Ptr<cv::Tonemap> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createTonemap(gamma);
     *returnValue = clone(p);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_Tonemap_delete(cv::Ptr<cv::Tonemap> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_Tonemap_get(cv::Ptr<cv::Tonemap> *ptr, cv::Tonemap **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -58,50 +58,50 @@ CVAPI(ExceptionStatus) photo_Ptr_Tonemap_get(cv::Ptr<cv::Tonemap> *ptr, cv::Tone
 
 CVAPI(ExceptionStatus) photo_TonemapDrago_getSaturation(cv::TonemapDrago *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSaturation();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapDrago_setSaturation(cv::TonemapDrago *obj, float saturation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSaturation(saturation);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_TonemapDrago_getBias(cv::TonemapDrago *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBias();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapDrago_setBias(cv::TonemapDrago *obj, float bias)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBias(bias);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createTonemapDrago(float gamma, float saturation, float bias, cv::Ptr<cv::TonemapDrago> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createTonemapDrago(gamma, saturation, bias);
     *returnValue = clone(p);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapDrago_delete(cv::Ptr<cv::TonemapDrago> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapDrago_get(cv::Ptr<cv::TonemapDrago> *ptr, cv::TonemapDrago **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -110,63 +110,63 @@ CVAPI(ExceptionStatus) photo_Ptr_TonemapDrago_get(cv::Ptr<cv::TonemapDrago> *ptr
 
 CVAPI(ExceptionStatus) photo_TonemapReinhard_getIntensity(cv::TonemapReinhard *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIntensity();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapReinhard_setIntensity(cv::TonemapReinhard *obj, float intensity)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIntensity(intensity);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_TonemapReinhard_getLightAdaptation(cv::TonemapReinhard *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getLightAdaptation();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapReinhard_setLightAdaptation(cv::TonemapReinhard *obj, float light_adapt)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setLightAdaptation(light_adapt);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_TonemapReinhard_getColorAdaptation(cv::TonemapReinhard *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getColorAdaptation();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapReinhard_setColorAdaptation(cv::TonemapReinhard *obj, float color_adapt)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setColorAdaptation(color_adapt);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createTonemapReinhard(float gamma, float intensity, float light_adapt, float color_adapt, cv::Ptr<cv::TonemapReinhard> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createTonemapReinhard(gamma, intensity, light_adapt, color_adapt);
     *returnValue = clone(p);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapReinhard_delete(cv::Ptr<cv::TonemapReinhard> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapReinhard_get(cv::Ptr<cv::TonemapReinhard> *ptr, cv::TonemapReinhard **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -175,50 +175,50 @@ CVAPI(ExceptionStatus) photo_Ptr_TonemapReinhard_get(cv::Ptr<cv::TonemapReinhard
 
 CVAPI(ExceptionStatus) photo_TonemapMantiuk_getScale(cv::TonemapMantiuk *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getScale();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapMantiuk_setScale(cv::TonemapMantiuk *obj, float scale)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setScale(scale);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_TonemapMantiuk_getSaturation(cv::TonemapMantiuk *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSaturation();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) photo_TonemapMantiuk_setSaturation(cv::TonemapMantiuk *obj, float saturation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSaturation(saturation);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_createTonemapMantiuk(float gamma, float scale, float saturation, cv::Ptr<cv::TonemapMantiuk> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createTonemapMantiuk(gamma, scale, saturation);
     *returnValue = clone(p);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapMantiuk_delete(cv::Ptr<cv::TonemapMantiuk> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) photo_Ptr_TonemapMantiuk_get(cv::Ptr<cv::TonemapMantiuk> *ptr, cv::TonemapMantiuk **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/ptcloud_Odometry.h
+++ b/src/OpenCvSharpExtern/ptcloud_Odometry.h
@@ -11,76 +11,76 @@
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_new1(cv::Odometry **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Odometry();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_new2(int otype, cv::Odometry **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Odometry(static_cast<cv::OdometryType>(otype));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_new3(int otype, cv::OdometrySettings *settings, int algtype, cv::Odometry **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Odometry(static_cast<cv::OdometryType>(otype), *settings, static_cast<cv::OdometryAlgoType>(algtype));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_delete(cv::Odometry *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrame(cv::Odometry *obj, cv::OdometryFrame *frame)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->prepareFrame(*frame);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrames(cv::Odometry *obj, cv::OdometryFrame *srcFrame, cv::OdometryFrame *dstFrame)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->prepareFrames(*srcFrame, *dstFrame);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_Frame(
     cv::Odometry *obj, cv::OdometryFrame *srcFrame, cv::OdometryFrame *dstFrame, cv::_OutputArray *Rt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->compute(*srcFrame, *dstFrame, entity(Rt)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_Depth(
     cv::Odometry *obj, cv::_InputArray *srcDepth, cv::_InputArray *dstDepth, cv::_OutputArray *Rt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->compute(entity(srcDepth), entity(dstDepth), entity(Rt)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_DepthRGB(
     cv::Odometry *obj, cv::_InputArray *srcDepth, cv::_InputArray *srcRGB, cv::_InputArray *dstDepth, cv::_InputArray *dstRGB,
     cv::_OutputArray *Rt, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->compute(entity(srcDepth), entity(srcRGB), entity(dstDepth), entity(dstRGB), entity(Rt)) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_getNormalsComputer(cv::Odometry *obj, cv::Ptr<cv::RgbdNormals> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::RgbdNormals>(obj->getNormalsComputer());
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_OdometryFrame.h
+++ b/src/OpenCvSharpExtern/ptcloud_OdometryFrame.h
@@ -12,72 +12,72 @@ CVAPI(ExceptionStatus) ptcloud_OdometryFrame_new(
     cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *mask, cv::_InputArray *normals,
     cv::OdometryFrame **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::OdometryFrame(entity(depth), entity(image), entity(mask), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_delete(cv::OdometryFrame *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getImage(cv::OdometryFrame *obj, cv::_OutputArray *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getImage(entity(image));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getGrayImage(cv::OdometryFrame *obj, cv::_OutputArray *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getGrayImage(entity(image));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getDepth(cv::OdometryFrame *obj, cv::_OutputArray *depth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getDepth(entity(depth));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getProcessedDepth(cv::OdometryFrame *obj, cv::_OutputArray *depth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getProcessedDepth(entity(depth));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getMask(cv::OdometryFrame *obj, cv::_OutputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getMask(entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getNormals(cv::OdometryFrame *obj, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getNormals(entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getPyramidLevels(cv::OdometryFrame *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPyramidLevels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getPyramidAt(cv::OdometryFrame *obj, cv::_OutputArray *img, int pyrType, size_t level)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getPyramidAt(entity(img), static_cast<cv::OdometryFramePyramidType>(pyrType), level);
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_OdometrySettings.h
+++ b/src/OpenCvSharpExtern/ptcloud_OdometrySettings.h
@@ -10,224 +10,224 @@
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_new(cv::OdometrySettings **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::OdometrySettings();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_delete(cv::OdometrySettings *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setCameraMatrix(cv::OdometrySettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCameraMatrix(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getCameraMatrix(cv::OdometrySettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getCameraMatrix(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setIterCounts(cv::OdometrySettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIterCounts(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getIterCounts(cv::OdometrySettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getIterCounts(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMinDepth(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinDepth(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinDepth(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinDepth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMaxDepth(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxDepth(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMaxDepth(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxDepth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMaxDepthDiff(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxDepthDiff(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMaxDepthDiff(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxDepthDiff();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMaxPointsPart(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxPointsPart(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMaxPointsPart(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxPointsPart();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setSobelSize(cv::OdometrySettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSobelSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getSobelSize(cv::OdometrySettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSobelSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setSobelScale(cv::OdometrySettings *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSobelScale(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getSobelScale(cv::OdometrySettings *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSobelScale();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setNormalWinSize(cv::OdometrySettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNormalWinSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getNormalWinSize(cv::OdometrySettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNormalWinSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setNormalDiffThreshold(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNormalDiffThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getNormalDiffThreshold(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNormalDiffThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setNormalMethod(cv::OdometrySettings *obj, int nm)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNormalMethod(static_cast<cv::RgbdNormals::RgbdNormalsMethod>(nm));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getNormalMethod(cv::OdometrySettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getNormalMethod());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setAngleThreshold(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAngleThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getAngleThreshold(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAngleThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMaxTranslation(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxTranslation(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMaxTranslation(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxTranslation();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMaxRotation(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxRotation(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMaxRotation(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxRotation();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMinGradientMagnitude(cv::OdometrySettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinGradientMagnitude(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinGradientMagnitude(cv::OdometrySettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinGradientMagnitude();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMinGradientMagnitudes(cv::OdometrySettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinGradientMagnitudes(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinGradientMagnitudes(cv::OdometrySettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getMinGradientMagnitudes(entity(val));
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_RgbdNormals.h
+++ b/src/OpenCvSharpExtern/ptcloud_RgbdNormals.h
@@ -13,110 +13,110 @@ CVAPI(ExceptionStatus) ptcloud_RgbdNormals_create(
     int rows, int cols, int depth, cv::_InputArray *K, int window_size, float diff_threshold, int method,
     cv::Ptr<cv::RgbdNormals> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::RgbdNormals::create(
         rows, cols, depth, entity(K), window_size, diff_threshold,
         static_cast<cv::RgbdNormals::RgbdNormalsMethod>(method));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Ptr_RgbdNormals_delete(cv::Ptr<cv::RgbdNormals> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Ptr_RgbdNormals_get(cv::Ptr<cv::RgbdNormals> *obj, cv::RgbdNormals **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_apply(cv::RgbdNormals *obj, cv::_InputArray *points, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->apply(entity(points), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_cache(cv::RgbdNormals *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->cache();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getRows(cv::RgbdNormals *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRows();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setRows(cv::RgbdNormals *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRows(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getCols(cv::RgbdNormals *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getCols();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setCols(cv::RgbdNormals *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCols(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getWindowSize(cv::RgbdNormals *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getWindowSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setWindowSize(cv::RgbdNormals *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWindowSize(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getDepth(cv::RgbdNormals *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDepth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getK(cv::RgbdNormals *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getK(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setK(cv::RgbdNormals *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setK(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getMethod(cv::RgbdNormals *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getMethod());
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_Volume.h
+++ b/src/OpenCvSharpExtern/ptcloud_Volume.h
@@ -10,128 +10,128 @@
 
 CVAPI(ExceptionStatus) ptcloud_Volume_new(int vtype, cv::VolumeSettings *settings, cv::Volume **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Volume(static_cast<cv::VolumeType>(vtype), *settings);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_delete(cv::Volume *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_integrateFrame(cv::Volume *obj, cv::OdometryFrame *frame, cv::_InputArray *pose)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->integrate(*frame, entity(pose));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_integrate(cv::Volume *obj, cv::_InputArray *depth, cv::_InputArray *pose)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->integrate(entity(depth), entity(pose));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_integrateColor(cv::Volume *obj, cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *pose)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->integrate(entity(depth), entity(image), entity(pose));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_raycast(cv::Volume *obj, cv::_InputArray *cameraPose, cv::_OutputArray *points, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->raycast(entity(cameraPose), entity(points), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_raycastColor(cv::Volume *obj, cv::_InputArray *cameraPose, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->raycast(entity(cameraPose), entity(points), entity(normals), entity(colors));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_raycastEx(cv::Volume *obj, cv::_InputArray *cameraPose, int height, int width, cv::_InputArray *K, cv::_OutputArray *points, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->raycast(entity(cameraPose), height, width, entity(K), entity(points), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_raycastExColor(cv::Volume *obj, cv::_InputArray *cameraPose, int height, int width, cv::_InputArray *K, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->raycast(entity(cameraPose), height, width, entity(K), entity(points), entity(normals), entity(colors));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_fetchNormals(cv::Volume *obj, cv::_InputArray *points, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->fetchNormals(entity(points), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormals(cv::Volume *obj, cv::_OutputArray *points, cv::_OutputArray *normals)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->fetchPointsNormals(entity(points), entity(normals));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormalsColors(cv::Volume *obj, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->fetchPointsNormalsColors(entity(points), entity(normals), entity(colors));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_reset(cv::Volume *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->reset();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_getVisibleBlocks(cv::Volume *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getVisibleBlocks();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_getTotalVolumeUnits(cv::Volume *obj, size_t *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTotalVolumeUnits();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_getBoundingBox(cv::Volume *obj, cv::_OutputArray *bb, int precision)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getBoundingBox(entity(bb), precision);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_setEnableGrowth(cv::Volume *obj, int v)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setEnableGrowth(v != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Volume_getEnableGrowth(cv::Volume *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getEnableGrowth() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_VolumeSettings.h
+++ b/src/OpenCvSharpExtern/ptcloud_VolumeSettings.h
@@ -10,205 +10,205 @@
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_new(int volumeType, cv::VolumeSettings **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VolumeSettings(static_cast<cv::VolumeType>(volumeType));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_delete(cv::VolumeSettings *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setIntegrateWidth(cv::VolumeSettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIntegrateWidth(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getIntegrateWidth(cv::VolumeSettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIntegrateWidth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setIntegrateHeight(cv::VolumeSettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIntegrateHeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getIntegrateHeight(cv::VolumeSettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIntegrateHeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setRaycastWidth(cv::VolumeSettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRaycastWidth(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getRaycastWidth(cv::VolumeSettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRaycastWidth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setRaycastHeight(cv::VolumeSettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRaycastHeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getRaycastHeight(cv::VolumeSettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRaycastHeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setDepthFactor(cv::VolumeSettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDepthFactor(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getDepthFactor(cv::VolumeSettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDepthFactor();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVoxelSize(cv::VolumeSettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setVoxelSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVoxelSize(cv::VolumeSettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getVoxelSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setTsdfTruncateDistance(cv::VolumeSettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTsdfTruncateDistance(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getTsdfTruncateDistance(cv::VolumeSettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTsdfTruncateDistance();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setMaxDepth(cv::VolumeSettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxDepth(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getMaxDepth(cv::VolumeSettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxDepth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setMaxWeight(cv::VolumeSettings *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxWeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getMaxWeight(cv::VolumeSettings *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxWeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setRaycastStepFactor(cv::VolumeSettings *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRaycastStepFactor(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getRaycastStepFactor(cv::VolumeSettings *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRaycastStepFactor();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumePose(cv::VolumeSettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setVolumePose(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumePose(cv::VolumeSettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getVolumePose(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumeResolution(cv::VolumeSettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setVolumeResolution(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeResolution(cv::VolumeSettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getVolumeResolution(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeStrides(cv::VolumeSettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getVolumeStrides(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(cv::VolumeSettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCameraIntegrateIntrinsics(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(cv::VolumeSettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getCameraIntegrateIntrinsics(entity(val));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraRaycastIntrinsics(cv::VolumeSettings *obj, cv::_InputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCameraRaycastIntrinsics(entity(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraRaycastIntrinsics(cv::VolumeSettings *obj, cv::_OutputArray *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getCameraRaycastIntrinsics(entity(val));
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_depth.h
+++ b/src/OpenCvSharpExtern/ptcloud_depth.h
@@ -14,47 +14,47 @@ CVAPI(ExceptionStatus) ptcloud_registerDepth(
     cv::_InputArray *Rt, cv::_InputArray *unregisteredDepth, interop::Size outputImagePlaneSize,
     cv::_OutputArray *registeredDepth, int depthDilation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::registerDepth(
         entity(unregisteredCameraMatrix), entity(registeredCameraMatrix), entity(registeredDistCoeffs),
         entity(Rt), entity(unregisteredDepth), cpp(outputImagePlaneSize),
         entity(registeredDepth), depthDilation != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_depthTo3dSparse(
     cv::_InputArray *depth, cv::_InputArray *in_K, cv::_InputArray *in_points, cv::_OutputArray *points3d)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::depthTo3dSparse(entity(depth), entity(in_K), entity(in_points), entity(points3d));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_depthTo3d(
     cv::_InputArray *depth, cv::_InputArray *K, cv::_OutputArray *points3d, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::depthTo3d(entity(depth), entity(K), entity(points3d), entity(mask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_rescaleDepth(
     cv::_InputArray *in, int type, cv::_OutputArray *out, double depth_factor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::rescaleDepth(entity(in), type, entity(out), depth_factor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_warpFrame(
     cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *mask, cv::_InputArray *Rt, cv::_InputArray *cameraMatrix,
     cv::_OutputArray *warpedDepth, cv::_OutputArray *warpedImage, cv::_OutputArray *warpedMask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::warpFrame(
         entity(depth), entity(image), entity(mask), entity(Rt), entity(cameraMatrix),
         entity(warpedDepth), entity(warpedImage), entity(warpedMask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_findPlanes(
@@ -62,13 +62,13 @@ CVAPI(ExceptionStatus) ptcloud_findPlanes(
     int block_size, int min_size, double threshold,
     double sensor_error_a, double sensor_error_b, double sensor_error_c, int method)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::findPlanes(
         entity(points3d), entity(normals), entity(mask), entity(plane_coefficients),
         block_size, min_size, threshold,
         sensor_error_a, sensor_error_b, sensor_error_c,
         static_cast<cv::RgbdPlaneMethod>(method));
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/ptcloud_io.h
+++ b/src/OpenCvSharpExtern/ptcloud_io.h
@@ -12,35 +12,35 @@
 CVAPI(ExceptionStatus) ptcloud_loadPointCloud(
     const char *filename, cv::_OutputArray *vertices, cv::_OutputArray *normals, cv::_OutputArray *rgb)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::loadPointCloud(filename, *vertices, entity(normals), entity(rgb));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_savePointCloud(
     const char *filename, cv::_InputArray *vertices, cv::_InputArray *normals, cv::_InputArray *rgb)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::savePointCloud(filename, *vertices, entity(normals), entity(rgb));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_loadMesh(
     const char *filename, cv::_OutputArray *vertices, std::vector<cv::Mat> *indices,
     cv::_OutputArray *normals, cv::_OutputArray *colors, cv::_OutputArray *texCoords)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::loadMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ptcloud_saveMesh(
     const char *filename, cv::_InputArray *vertices, std::vector<cv::Mat> *indices,
     cv::_InputArray *normals, cv::_InputArray *colors, cv::_InputArray *texCoords)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::saveMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
-    END_WRAP
+    });
 }
 
 #endif // NO_PTCLOUD

--- a/src/OpenCvSharpExtern/quality.h
+++ b/src/OpenCvSharpExtern/quality.h
@@ -13,31 +13,31 @@
 
 CVAPI(ExceptionStatus) quality_QualityBase_compute(cv::quality::QualityBase *obj, cv::_InputArray *img, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = obj->compute(*img);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityBase_getQualityMap(cv::quality::QualityBase *obj, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getQualityMap(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityBase_clear(cv::quality::QualityBase *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityBase_empty(cv::quality::QualityBase *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->empty() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -47,52 +47,52 @@ CVAPI(ExceptionStatus) quality_QualityBase_empty(cv::quality::QualityBase *obj, 
 CVAPI(ExceptionStatus) quality_createQualityPSNR(
     cv::_InputArray *ref, double maxPixelValue, cv::Ptr<cv::quality::QualityPSNR> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualityPSNR::create(*ref, maxPixelValue);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityPSNR_delete(cv::Ptr<cv::quality::QualityPSNR> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityPSNR_get(
     cv::Ptr<cv::quality::QualityPSNR>* ptr, cv::quality::QualityPSNR **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityPSNR_staticCompute(
     cv::_InputArray *ref, cv::_InputArray *cmp, cv::_OutputArray *qualityMap, double maxPixelValue, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar ret;
     if (qualityMap == nullptr)
         ret = cv::quality::QualityPSNR::compute(*ref, *cmp, cv::noArray(), maxPixelValue);
     else
         ret = cv::quality::QualityPSNR::compute(*ref, *cmp, *qualityMap, maxPixelValue);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityPSNR_getMaxPixelValue(cv::quality::QualityPSNR *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMaxPixelValue();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityPSNR_setMaxPixelValue(cv::quality::QualityPSNR *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMaxPixelValue(val);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -101,38 +101,38 @@ CVAPI(ExceptionStatus) quality_QualityPSNR_setMaxPixelValue(cv::quality::Quality
 
 CVAPI(ExceptionStatus) quality_createQualitySSIM(cv::_InputArray* ref, cv::Ptr<cv::quality::QualitySSIM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualitySSIM::create(*ref);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualitySSIM_delete(cv::Ptr<cv::quality::QualitySSIM>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualitySSIM_get(
     cv::Ptr<cv::quality::QualitySSIM>* ptr, cv::quality::QualitySSIM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualitySSIM_staticCompute(
     cv::_InputArray* ref, cv::_InputArray* cmp, cv::_OutputArray* qualityMap, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar ret;
     if (qualityMap == nullptr)
         ret = cv::quality::QualitySSIM::compute(*ref, *cmp, cv::noArray());
     else
         ret = cv::quality::QualitySSIM::compute(*ref, *cmp, *qualityMap);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -141,38 +141,38 @@ CVAPI(ExceptionStatus) quality_QualitySSIM_staticCompute(
 
 CVAPI(ExceptionStatus) quality_createQualityGMSD(cv::_InputArray* ref, cv::Ptr<cv::quality::QualityGMSD> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualityGMSD::create(*ref);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityGMSD_delete(cv::Ptr<cv::quality::QualityGMSD>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityGMSD_get(
     cv::Ptr<cv::quality::QualityGMSD>* ptr, cv::quality::QualityGMSD **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityGMSD_staticCompute(
     cv::_InputArray* ref, cv::_InputArray* cmp, cv::_OutputArray* qualityMap, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar ret;
     if (qualityMap == nullptr)
         ret = cv::quality::QualityGMSD::compute(*ref, *cmp, cv::noArray());
     else
         ret = cv::quality::QualityGMSD::compute(*ref, *cmp, *qualityMap);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -181,38 +181,38 @@ CVAPI(ExceptionStatus) quality_QualityGMSD_staticCompute(
 
 CVAPI(ExceptionStatus) quality_createQualityMSE(cv::_InputArray* ref, cv::Ptr<cv::quality::QualityMSE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualityMSE::create(*ref);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityMSE_delete(cv::Ptr<cv::quality::QualityMSE>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityMSE_get(
     cv::Ptr<cv::quality::QualityMSE>* ptr, cv::quality::QualityMSE **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityMSE_staticCompute(
     cv::_InputArray* ref, cv::_InputArray* cmp, cv::_OutputArray* qualityMap, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Scalar ret;
     if (qualityMap == nullptr)
         ret = cv::quality::QualityMSE::compute(*ref, *cmp, cv::noArray());
     else
         ret = cv::quality::QualityMSE::compute(*ref, *cmp, *qualityMap);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -222,51 +222,51 @@ CVAPI(ExceptionStatus) quality_QualityMSE_staticCompute(
 CVAPI(ExceptionStatus) quality_createQualityBRISQUE1(
     const char *modelFilePath, const char *rangeFilePath, cv::Ptr<cv::quality::QualityBRISQUE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualityBRISQUE::create(modelFilePath, rangeFilePath);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_createQualityBRISQUE2(
     cv::ml::SVM *model, cv::Mat *range, cv::Ptr<cv::quality::QualityBRISQUE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::quality::QualityBRISQUE::create(model, *range);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityBRISQUE_delete(cv::Ptr<cv::quality::QualityBRISQUE>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_Ptr_QualityBRISQUE_get(
     cv::Ptr<cv::quality::QualityBRISQUE>* ptr, cv::quality::QualityBRISQUE **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityBRISQUE_staticCompute(
     cv::_InputArray* ref, const char* modelFilePath, const char* rangeFilePath, interop::Scalar *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ret = cv::quality::QualityBRISQUE::compute(*ref, modelFilePath, rangeFilePath);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) quality_QualityBRISQUE_computeFeatures(
     cv::_InputArray* img, cv::_OutputArray *features)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::quality::QualityBRISQUE::computeFeatures(*img, *features);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/saliency_MotionSaliencyBinWangApr2014.h
+++ b/src/OpenCvSharpExtern/saliency_MotionSaliencyBinWangApr2014.h
@@ -11,84 +11,84 @@
 CVAPI(ExceptionStatus) saliency_Ptr_MotionSaliencyBinWangApr2014_delete(
     cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_Ptr_MotionSaliencyBinWangApr2014_get(
     cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> *ptr,
     cv::saliency::MotionSaliencyBinWangApr2014 **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_create(
     cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::saliency::MotionSaliencyBinWangApr2014::create();
     *returnValue = new cv::Ptr<cv::saliency::MotionSaliencyBinWangApr2014>(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_computeSaliency(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj,
     cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImagesize(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int W, int H)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImagesize(W, H);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_init(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->init() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_getImageWidth(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getImageWidth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImageWidth(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageWidth(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_getImageHeight(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getImageHeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_MotionSaliencyBinWangApr2014_setImageHeight(
     cv::saliency::MotionSaliencyBinWangApr2014 *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageHeight(val);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_ObjectnessBING.h
+++ b/src/OpenCvSharpExtern/saliency_ObjectnessBING.h
@@ -11,27 +11,27 @@
 CVAPI(ExceptionStatus) saliency_Ptr_ObjectnessBING_delete(
     cv::Ptr<cv::saliency::ObjectnessBING> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_Ptr_ObjectnessBING_get(
     cv::Ptr<cv::saliency::ObjectnessBING> *ptr,
     cv::saliency::ObjectnessBING **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_create(
     cv::Ptr<cv::saliency::ObjectnessBING> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::saliency::ObjectnessBING::create();
     *returnValue = new cv::Ptr<cv::saliency::ObjectnessBING>(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_computeSaliency(
@@ -40,81 +40,81 @@ CVAPI(ExceptionStatus) saliency_ObjectnessBING_computeSaliency(
     std::vector<cv::Vec4i> *objectnessBoundingBox,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeSaliency(*image, *objectnessBoundingBox) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_getobjectnessValues(
     cv::saliency::ObjectnessBING *obj, std::vector<float> *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getobjectnessValues();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_setTrainingPath(
     cv::saliency::ObjectnessBING *obj, const char *trainingPath)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTrainingPath(trainingPath);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_setBBResDir(
     cv::saliency::ObjectnessBING *obj, const char *resultsDir)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBBResDir(resultsDir);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_getBase(
     cv::saliency::ObjectnessBING *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBase();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_setBase(
     cv::saliency::ObjectnessBING *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBase(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_getNSS(
     cv::saliency::ObjectnessBING *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNSS();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_setNSS(
     cv::saliency::ObjectnessBING *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNSS(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_getW(
     cv::saliency::ObjectnessBING *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getW();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_ObjectnessBING_setW(
     cv::saliency::ObjectnessBING *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setW(val);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_StaticSaliencyFineGrained.h
+++ b/src/OpenCvSharpExtern/saliency_StaticSaliencyFineGrained.h
@@ -11,45 +11,45 @@
 CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencyFineGrained_delete(
     cv::Ptr<cv::saliency::StaticSaliencyFineGrained> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencyFineGrained_get(
     cv::Ptr<cv::saliency::StaticSaliencyFineGrained> *ptr,
     cv::saliency::StaticSaliencyFineGrained **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_create(
     cv::Ptr<cv::saliency::StaticSaliencyFineGrained> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::saliency::StaticSaliencyFineGrained::create();
     *returnValue = new cv::Ptr<cv::saliency::StaticSaliencyFineGrained>(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_computeSaliency(
     cv::saliency::StaticSaliencyFineGrained *obj,
     cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencyFineGrained_computeBinaryMap(
     cv::saliency::StaticSaliencyFineGrained *obj,
     cv::_InputArray *saliencyMap, cv::_OutputArray *binaryMap, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeBinaryMap(*saliencyMap, *binaryMap) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/saliency_StaticSaliencySpectralResidual.h
+++ b/src/OpenCvSharpExtern/saliency_StaticSaliencySpectralResidual.h
@@ -11,77 +11,77 @@
 CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencySpectralResidual_delete(
     cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_Ptr_StaticSaliencySpectralResidual_get(
     cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> *ptr,
     cv::saliency::StaticSaliencySpectralResidual **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_create(
     cv::Ptr<cv::saliency::StaticSaliencySpectralResidual> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::saliency::StaticSaliencySpectralResidual::create();
     *returnValue = new cv::Ptr<cv::saliency::StaticSaliencySpectralResidual>(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_computeSaliency(
     cv::saliency::StaticSaliencySpectralResidual *obj,
     cv::_InputArray *image, cv::_OutputArray *saliencyMap, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeSaliency(*image, *saliencyMap) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_computeBinaryMap(
     cv::saliency::StaticSaliencySpectralResidual *obj,
     cv::_InputArray *saliencyMap, cv::_OutputArray *binaryMap, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeBinaryMap(*saliencyMap, *binaryMap) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_getImageWidth(
     cv::saliency::StaticSaliencySpectralResidual *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getImageWidth();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_setImageWidth(
     cv::saliency::StaticSaliencySpectralResidual *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageWidth(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_getImageHeight(
     cv::saliency::StaticSaliencySpectralResidual *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getImageHeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) saliency_StaticSaliencySpectralResidual_setImageHeight(
     cv::saliency::StaticSaliencySpectralResidual *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageHeight(val);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/shape_HistogramCostExtractor.h
+++ b/src/OpenCvSharpExtern/shape_HistogramCostExtractor.h
@@ -21,41 +21,41 @@ CVAPI(ExceptionStatus) shape_HistogramCostExtractor_buildCostMatrix(
     cv::_InputArray *descriptors2,
     cv::_OutputArray *costMatrix)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->buildCostMatrix(*descriptors1, *descriptors2, *costMatrix);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_HistogramCostExtractor_setNDummies(
     cv::HistogramCostExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNDummies(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_HistogramCostExtractor_getNDummies(
     cv::HistogramCostExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNDummies();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_HistogramCostExtractor_setDefaultCost(
     cv::HistogramCostExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDefaultCost(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_HistogramCostExtractor_getDefaultCost(
     cv::HistogramCostExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDefaultCost();
-    END_WRAP
+    });
 }
 
 
@@ -68,18 +68,18 @@ CVAPI(ExceptionStatus) shape_HistogramCostExtractor_getDefaultCost(
 CVAPI(ExceptionStatus) shape_Ptr_HistogramCostExtractor_delete(
     cv::Ptr<cv::HistogramCostExtractor> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_HistogramCostExtractor_get(
     cv::Ptr<cv::HistogramCostExtractor> *ptr,
     cv::HistogramCostExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 
@@ -93,26 +93,26 @@ CVAPI(ExceptionStatus) shape_createNormHistogramCostExtractor(
     int flag, int nDummies, float defaultCost,
     cv::Ptr<cv::HistogramCostExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createNormHistogramCostExtractor(flag, nDummies, defaultCost);
     *returnValue = new cv::Ptr<cv::HistogramCostExtractor>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_NormHistogramCostExtractor_setNormFlag(
     cv::HistogramCostExtractor *obj, int flag)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     static_cast<cv::NormHistogramCostExtractor*>(obj)->setNormFlag(flag);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_NormHistogramCostExtractor_getNormFlag(
     cv::HistogramCostExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<cv::NormHistogramCostExtractor*>(obj)->getNormFlag();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -128,26 +128,26 @@ CVAPI(ExceptionStatus) shape_createEMDHistogramCostExtractor(
     int flag, int nDummies, float defaultCost,
     cv::Ptr<cv::HistogramCostExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createEMDHistogramCostExtractor(flag, nDummies, defaultCost);
     *returnValue = new cv::Ptr<cv::HistogramCostExtractor>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_EMDHistogramCostExtractor_setNormFlag(
     cv::HistogramCostExtractor *obj, int flag)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     static_cast<cv::EMDHistogramCostExtractor*>(obj)->setNormFlag(flag);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_EMDHistogramCostExtractor_getNormFlag(
     cv::HistogramCostExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<cv::EMDHistogramCostExtractor*>(obj)->getNormFlag();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -163,10 +163,10 @@ CVAPI(ExceptionStatus) shape_createChiHistogramCostExtractor(
     int nDummies, float defaultCost,
     cv::Ptr<cv::HistogramCostExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createChiHistogramCostExtractor(nDummies, defaultCost);
     *returnValue = new cv::Ptr<cv::HistogramCostExtractor>(ptr);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -182,10 +182,10 @@ CVAPI(ExceptionStatus) shape_createEMDL1HistogramCostExtractor(
     int nDummies, float defaultCost,
     cv::Ptr<cv::HistogramCostExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createEMDL1HistogramCostExtractor(nDummies, defaultCost);
     *returnValue = new cv::Ptr<cv::HistogramCostExtractor>(ptr);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -198,9 +198,9 @@ CVAPI(ExceptionStatus) shape_createEMDL1HistogramCostExtractor(
 CVAPI(ExceptionStatus) shape_EMDL1(
     cv::_InputArray *signature1, cv::_InputArray *signature2, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::EMDL1(*signature1, *signature2);
-    END_WRAP
+    });
 }
 
 

--- a/src/OpenCvSharpExtern/shape_ShapeDistanceExtractor.h
+++ b/src/OpenCvSharpExtern/shape_ShapeDistanceExtractor.h
@@ -12,9 +12,9 @@
 CVAPI(ExceptionStatus) shape_ShapeDistanceExtractor_computeDistance(
     cv::ShapeDistanceExtractor* obj, cv::_InputArray *contour1, cv::_InputArray *contour2, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->computeDistance(*contour1, *contour2);
-    END_WRAP
+    });
 }
 
 #pragma region ShapeContextDistanceExtractor
@@ -22,192 +22,192 @@ CVAPI(ExceptionStatus) shape_ShapeDistanceExtractor_computeDistance(
 CVAPI(ExceptionStatus) shape_Ptr_ShapeContextDistanceExtractor_get(
     cv::Ptr<cv::ShapeContextDistanceExtractor> *obj, cv::ShapeContextDistanceExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_ShapeContextDistanceExtractor_delete(
     cv::Ptr<cv::ShapeContextDistanceExtractor> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setAngularBins(
     cv::ShapeContextDistanceExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAngularBins(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getAngularBins(
     cv::ShapeContextDistanceExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAngularBins();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setRadialBins(
     cv::ShapeContextDistanceExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRadialBins(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getRadialBins(
     cv::ShapeContextDistanceExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRadialBins();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setInnerRadius(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setInnerRadius(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getInnerRadius(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getInnerRadius();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setOuterRadius(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setOuterRadius(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getOuterRadius(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getOuterRadius();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setRotationInvariant(
     cv::ShapeContextDistanceExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRotationInvariant(val != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getRotationInvariant(
     cv::ShapeContextDistanceExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRotationInvariant() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setShapeContextWeight(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setShapeContextWeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getShapeContextWeight(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getShapeContextWeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setImageAppearanceWeight(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImageAppearanceWeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getImageAppearanceWeight(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getImageAppearanceWeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setBendingEnergyWeight(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBendingEnergyWeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getBendingEnergyWeight(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBendingEnergyWeight();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setImages(
     cv::ShapeContextDistanceExtractor *obj, cv::_InputArray *image1, cv::_InputArray *image2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImages(*image1, *image2);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getImages(
     cv::ShapeContextDistanceExtractor *obj, cv::_OutputArray *image1, cv::_OutputArray *image2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getImages(*image1, *image2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setIterations(
     cv::ShapeContextDistanceExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setIterations(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getIterations(
     cv::ShapeContextDistanceExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getIterations();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setCostExtractor(
     cv::ShapeContextDistanceExtractor *obj,
     cv::Ptr<cv::HistogramCostExtractor> *comparer)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCostExtractor(*comparer);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setStdDev(
     cv::ShapeContextDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setStdDev(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_getStdDev(
     cv::ShapeContextDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getStdDev();
-    END_WRAP
+    });
 }
 
 // shape_ShapeContextDistanceExtractor_setTransformAlgorithm is defined in shape_ShapeTransformer.h
@@ -219,11 +219,11 @@ CVAPI(ExceptionStatus) shape_createShapeContextDistanceExtractor(
     const Ptr<ShapeTransformer> &transformer = createThinPlateSplineShapeTransformer()*/,
     cv::Ptr<cv::ShapeContextDistanceExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createShapeContextDistanceExtractor(
         nAngularBins, nRadialBins, innerRadius, outerRadius, iterations);
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -233,59 +233,59 @@ CVAPI(ExceptionStatus) shape_createShapeContextDistanceExtractor(
 CVAPI(ExceptionStatus) shape_Ptr_HausdorffDistanceExtractor_get(
     cv::Ptr<cv::HausdorffDistanceExtractor> *obj, cv::HausdorffDistanceExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_HausdorffDistanceExtractor_delete(
     cv::Ptr<cv::HausdorffDistanceExtractor> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) shape_HausdorffDistanceExtractor_setDistanceFlag(
     cv::HausdorffDistanceExtractor *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDistanceFlag(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_HausdorffDistanceExtractor_getDistanceFlag(
     cv::HausdorffDistanceExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDistanceFlag();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_HausdorffDistanceExtractor_setRankProportion(
     cv::HausdorffDistanceExtractor *obj, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRankProportion(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) shape_HausdorffDistanceExtractor_getRankProportion(
     cv::HausdorffDistanceExtractor *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRankProportion();
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) shape_createHausdorffDistanceExtractor(
     int distanceFlag, float rankProp, cv::Ptr<cv::HausdorffDistanceExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::createHausdorffDistanceExtractor(
         distanceFlag, rankProp);
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/shape_ShapeTransformer.h
+++ b/src/OpenCvSharpExtern/shape_ShapeTransformer.h
@@ -21,9 +21,9 @@ CVAPI(ExceptionStatus) shape_ShapeTransformer_estimateTransformation(
     cv::_InputArray *targetShape,
     std::vector<cv::DMatch> *matches)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->estimateTransformation(*transformingShape, *targetShape, *matches);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeTransformer_applyTransformation(
@@ -32,12 +32,12 @@ CVAPI(ExceptionStatus) shape_ShapeTransformer_applyTransformation(
     cv::_OutputArray *output,
     float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (output == nullptr)
         *returnValue = obj->applyTransformation(*input);
     else
         *returnValue = obj->applyTransformation(*input, *output);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeTransformer_warpImage(
@@ -48,9 +48,9 @@ CVAPI(ExceptionStatus) shape_ShapeTransformer_warpImage(
     int borderMode,
     interop::Scalar borderValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->warpImage(*transformingImage, *output, flags, borderMode, cpp(borderValue));
-    END_WRAP
+    });
 }
 
 
@@ -63,44 +63,44 @@ CVAPI(ExceptionStatus) shape_ShapeTransformer_warpImage(
 CVAPI(ExceptionStatus) shape_Ptr_ThinPlateSplineShapeTransformer_delete(
     cv::Ptr<cv::ThinPlateSplineShapeTransformer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_ThinPlateSplineShapeTransformer_get(
     cv::Ptr<cv::ThinPlateSplineShapeTransformer> *ptr,
     cv::ThinPlateSplineShapeTransformer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_createThinPlateSplineShapeTransformer(
     double regularizationParameter,
     cv::Ptr<cv::ThinPlateSplineShapeTransformer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createThinPlateSplineShapeTransformer(regularizationParameter);
     *returnValue = new cv::Ptr<cv::ThinPlateSplineShapeTransformer>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ThinPlateSplineShapeTransformer_setRegularizationParameter(
     cv::ThinPlateSplineShapeTransformer *obj, double beta)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRegularizationParameter(beta);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ThinPlateSplineShapeTransformer_getRegularizationParameter(
     cv::ThinPlateSplineShapeTransformer *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getRegularizationParameter();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -115,44 +115,44 @@ CVAPI(ExceptionStatus) shape_ThinPlateSplineShapeTransformer_getRegularizationPa
 CVAPI(ExceptionStatus) shape_Ptr_AffineTransformer_delete(
     cv::Ptr<cv::AffineTransformer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_AffineTransformer_get(
     cv::Ptr<cv::AffineTransformer> *ptr,
     cv::AffineTransformer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_createAffineTransformer(
     int fullAffine,
     cv::Ptr<cv::AffineTransformer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createAffineTransformer(fullAffine != 0);
     *returnValue = new cv::Ptr<cv::AffineTransformer>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_AffineTransformer_setFullAffine(
     cv::AffineTransformer *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setFullAffine(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_AffineTransformer_getFullAffine(
     cv::AffineTransformer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getFullAffine() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -167,35 +167,35 @@ CVAPI(ExceptionStatus) shape_Ptr_ThinPlateSplineShapeTransformer_upcast(
     cv::Ptr<cv::ThinPlateSplineShapeTransformer> *src,
     cv::Ptr<cv::ShapeTransformer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::ShapeTransformer>(*src);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_AffineTransformer_upcast(
     cv::Ptr<cv::AffineTransformer> *src,
     cv::Ptr<cv::ShapeTransformer> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::ShapeTransformer>(*src);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_Ptr_ShapeTransformer_delete(
     cv::Ptr<cv::ShapeTransformer> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) shape_ShapeContextDistanceExtractor_setTransformAlgorithm(
     cv::ShapeContextDistanceExtractor *obj,
     cv::Ptr<cv::ShapeTransformer> *transformer)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTransformAlgorithm(*transformer);
-    END_WRAP
+    });
 }
 
 

--- a/src/OpenCvSharpExtern/stereo.h
+++ b/src/OpenCvSharpExtern/stereo.h
@@ -19,14 +19,14 @@ CVAPI(ExceptionStatus) stereo_stereoRectify_InputArray(
     double alpha, interop::Size newImageSize,
     interop::Rect *validPixROI1, interop::Rect *validPixROI2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect _validPixROI1, _validPixROI2;
     cv::stereoRectify(*cameraMatrix1, *distCoeffs1, *cameraMatrix2, *distCoeffs2,
         cpp(imageSize), *R, *T, *R1, *R2, *P1, *P2, *Q, flags, alpha, cpp(newImageSize),
         &_validPixROI1, &_validPixROI2);
     *validPixROI1 = c(_validPixROI1);
     *validPixROI2 = c(_validPixROI2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_stereoRectify_array(double *cameraMatrix1,
@@ -39,7 +39,7 @@ CVAPI(ExceptionStatus) stereo_stereoRectify_array(double *cameraMatrix1,
     double *Q, int flags, double alpha, interop::Size newImageSize,
     interop::Rect *validPixROI1, interop::Rect *validPixROI2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat cameraMatrix1M(3, 3, CV_64FC1, cameraMatrix1);
     cv::Mat cameraMatrix2M(3, 3, CV_64FC1, cameraMatrix2);
     cv::Mat distCoeffs1M(dc1Size, 1, CV_64FC1, distCoeffs1);
@@ -59,7 +59,7 @@ CVAPI(ExceptionStatus) stereo_stereoRectify_array(double *cameraMatrix1,
         &_validPixROI1, &_validPixROI2);
     *validPixROI1 = c(_validPixROI1);
     *validPixROI2 = c(_validPixROI2);
-    END_WRAP
+    });
 }
 
 
@@ -69,9 +69,9 @@ CVAPI(ExceptionStatus) stereo_stereoRectifyUncalibrated_InputArray(cv::_InputArr
     double threshold,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::stereoRectifyUncalibrated(*points1, *points2, *F, cpp(imgSize), *H1, *H2, threshold) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_stereoRectifyUncalibrated_array(cv::Point2d *points1, int points1Size,
@@ -81,13 +81,13 @@ CVAPI(ExceptionStatus) stereo_stereoRectifyUncalibrated_array(cv::Point2d *point
     double threshold,
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat points1Mat(points1Size, 1, CV_64FC2, points1);
     const cv::Mat points2Mat(points2Size, 1, CV_64FC2, points2);
     cv::Mat H1M(3, 3, CV_64FC1, H1);
     cv::Mat H2M(3, 3, CV_64FC1, H2);
     *returnValue = cv::stereoRectifyUncalibrated(points1Mat, points2Mat, *F, cpp(imgSize), H1M, H2M, threshold) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 
@@ -105,7 +105,7 @@ CVAPI(ExceptionStatus) stereo_rectify3Collinear_InputArray(
     interop::Rect *roi1, interop::Rect *roi2, int flags,
     float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imgpt1Vec(imgpt1Size);
     std::vector<cv::Mat> imgpt3Vec(imgpt3Size);
     for (auto i = 0; i < imgpt1Size; i++)
@@ -122,7 +122,7 @@ CVAPI(ExceptionStatus) stereo_rectify3Collinear_InputArray(
     *roi1 = c(_roi1);
     *roi2 = c(_roi2);
     *returnValue = ret;
-    END_WRAP
+    });
 }
 
 
@@ -130,9 +130,9 @@ CVAPI(ExceptionStatus) stereo_rectify3Collinear_InputArray(
 CVAPI(ExceptionStatus) stereo_filterSpeckles(
     cv::_InputOutputArray *img, double newVal, int maxSpeckleSize, double maxDiff, cv::_InputOutputArray *buf)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::filterSpeckles(*img, newVal, maxSpeckleSize, maxDiff, entity(buf));
-    END_WRAP
+    });
 }
 
 
@@ -141,10 +141,10 @@ CVAPI(ExceptionStatus) stereo_getValidDisparityROI(
     int minDisparity, int numberOfDisparities, int SADWindowSize,
     interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::getValidDisparityROI(
         cpp(roi1), cpp(roi2), minDisparity, numberOfDisparities, SADWindowSize));
-    END_WRAP
+    });
 }
 
 
@@ -152,9 +152,9 @@ CVAPI(ExceptionStatus) stereo_validateDisparity(
     cv::_InputOutputArray *disparity, cv::_InputArray *cost,
     int minDisparity, int numberOfDisparities, int disp12MaxDisp)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::validateDisparity(*disparity, *cost, minDisparity, numberOfDisparities, disp12MaxDisp);
-    END_WRAP
+    });
 }
 
 
@@ -162,9 +162,9 @@ CVAPI(ExceptionStatus) stereo_reprojectImageTo3D(
     cv::_InputArray *disparity, cv::_OutputArray *_3dImage,
     cv::_InputArray *Q, int handleMissingValues, int ddepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::reprojectImageTo3D(*disparity, *_3dImage, *Q, handleMissingValues != 0, ddepth);
-    END_WRAP
+    });
 }
 
 #endif // NO_STEREO

--- a/src/OpenCvSharpExtern/stereo_StereoMatcher.h
+++ b/src/OpenCvSharpExtern/stereo_StereoMatcher.h
@@ -13,99 +13,99 @@
 CVAPI(ExceptionStatus) stereo_StereoMatcher_compute(
     cv::StereoMatcher *obj, cv::_InputArray *left, cv::_InputArray *right, cv::_OutputArray *disparity)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*left, *right, *disparity);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getMinDisparity(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinDisparity();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setMinDisparity(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinDisparity(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getNumDisparities(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumDisparities();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setNumDisparities(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNumDisparities(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getBlockSize(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getBlockSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setBlockSize(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBlockSize(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getSpeckleWindowSize(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSpeckleWindowSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setSpeckleWindowSize(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSpeckleWindowSize(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getSpeckleRange(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSpeckleRange();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setSpeckleRange(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSpeckleRange(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoMatcher_getDisp12MaxDiff(
     cv::StereoMatcher *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDisp12MaxDiff();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoMatcher_setDisp12MaxDiff(
     cv::StereoMatcher *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDisp12MaxDiff(value);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -115,146 +115,146 @@ CVAPI(ExceptionStatus) stereo_StereoMatcher_setDisp12MaxDiff(
 CVAPI(ExceptionStatus) stereo_Ptr_StereoBM_get(
     cv::Ptr<cv::StereoBM> *obj, cv::StereoBM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_Ptr_StereoBM_delete(
     cv::Ptr<cv::StereoBM> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_create(
     int numDisparities, int blockSize, cv::Ptr<cv::StereoBM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto obj = cv::StereoBM::create(numDisparities, blockSize);
     *returnValue = clone(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getPreFilterType(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPreFilterType();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setPreFilterType(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreFilterType(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getPreFilterSize(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPreFilterSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setPreFilterSize(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreFilterSize(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getPreFilterCap(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPreFilterCap();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setPreFilterCap(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreFilterCap(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getTextureThreshold(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTextureThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setTextureThreshold(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTextureThreshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getUniquenessRatio(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUniquenessRatio();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setUniquenessRatio(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUniquenessRatio(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getSmallerBlockSize(
     cv::StereoBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSmallerBlockSize();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setSmallerBlockSize(
     cv::StereoBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSmallerBlockSize(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getROI1(
     cv::StereoBM *obj, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getROI1());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setROI1(
     cv::StereoBM *obj, interop::Rect value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setROI1(cpp(value));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoBM_getROI2(
     cv::StereoBM *obj, interop::Rect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(obj->getROI2());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoBM_setROI2(
     cv::StereoBM *obj, interop::Rect value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setROI2(cpp(value));
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -264,16 +264,16 @@ CVAPI(ExceptionStatus) stereo_StereoBM_setROI2(
 CVAPI(ExceptionStatus) stereo_Ptr_StereoSGBM_get(
     cv::Ptr<cv::StereoSGBM> *obj, cv::StereoSGBM **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_Ptr_StereoSGBM_delete(cv::Ptr<cv::StereoSGBM> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_create(
@@ -283,79 +283,79 @@ CVAPI(ExceptionStatus) stereo_StereoSGBM_create(
     int speckleWindowSize, int speckleRange, int mode,
     cv::Ptr<cv::StereoSGBM> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto obj = cv::StereoSGBM::create(
         minDisparity, numDisparities, blockSize,
         P1, P2, disp12MaxDiff,
         preFilterCap, uniquenessRatio,
         speckleWindowSize, speckleRange, mode);
     *returnValue = new cv::Ptr<cv::StereoSGBM>(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_getPreFilterCap(cv::StereoSGBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPreFilterCap();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoSGBM_setPreFilterCap(cv::StereoSGBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPreFilterCap(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_getUniquenessRatio(cv::StereoSGBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUniquenessRatio();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoSGBM_setUniquenessRatio(cv::StereoSGBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUniquenessRatio(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_getP1(cv::StereoSGBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getP1();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoSGBM_setP1(cv::StereoSGBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setP1(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_getP2(cv::StereoSGBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getP2();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoSGBM_setP2(cv::StereoSGBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setP2(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stereo_StereoSGBM_getMode(cv::StereoSGBM *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMode();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stereo_StereoSGBM_setMode(cv::StereoSGBM *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMode(value);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/stitching.h
+++ b/src/OpenCvSharpExtern/stitching.h
@@ -10,104 +10,104 @@
 
 CVAPI(ExceptionStatus) stitching_Stitcher_create(int mode, cv::Ptr<cv::Stitcher> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::Stitcher::create(static_cast<cv::Stitcher::Mode>(mode));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Ptr_Stitcher_delete(cv::Ptr<cv::Stitcher> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Ptr_Stitcher_get(cv::Ptr<cv::Stitcher> *obj, cv::Stitcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 #pragma region getter/setter
 
 CVAPI(ExceptionStatus) stitching_Stitcher_registrationResol(cv::Stitcher *obj, double *returnValue)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->registrationResol();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setRegistrationResol(cv::Stitcher *obj, const double resol_mpx)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setRegistrationResol(resol_mpx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_seamEstimationResol(cv::Stitcher *obj, double *returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->seamEstimationResol();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setSeamEstimationResol(cv::Stitcher *obj, const double resol_mpx)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSeamEstimationResol(resol_mpx); 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_compositingResol(cv::Stitcher *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->compositingResol();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setCompositingResol(cv::Stitcher *obj, const double resol_mpx)
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setCompositingResol(resol_mpx);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_panoConfidenceThresh(cv::Stitcher *obj, double *returnValue) 
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->panoConfidenceThresh();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setPanoConfidenceThresh(cv::Stitcher *obj, const double conf_thresh)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPanoConfidenceThresh(conf_thresh);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_waveCorrection(cv::Stitcher *obj, int *returnValue) 
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->waveCorrection() ? 1 : 0; 
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setWaveCorrection(cv::Stitcher *obj, const int flag)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWaveCorrection(flag != 0); 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_waveCorrectKind(cv::Stitcher *obj, int *returnValue) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->waveCorrectKind());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_setWaveCorrectKind(cv::Stitcher *obj, int kind) 
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWaveCorrectKind(static_cast<cv::detail::WaveCorrectKind>(kind)); 
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -115,37 +115,37 @@ CVAPI(ExceptionStatus) stitching_Stitcher_setWaveCorrectKind(cv::Stitcher *obj, 
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_InputArray1(
     cv::Stitcher *obj, cv::_InputArray *images, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->estimateTransform(*images));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_InputArray2(
     cv::Stitcher *obj, cv::_InputArray *images,
     const interop::Rect **rois, const int roisSize1, const int *roisSize2, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Rect> > roisVec;
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
     *returnValue = static_cast<int>(obj->estimateTransform(*images, roisVec));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray1(
     cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
     *returnValue = static_cast<int>(obj->estimateTransform(imagesVec));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray2(
     cv::Stitcher *obj, const cv::Mat **images, const int imagesSize,
     const interop::Rect **rois, const int roisSize1, const int *roisSize2, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
@@ -153,54 +153,54 @@ CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray2(
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
     *returnValue = static_cast<int>(obj->estimateTransform(imagesVec, roisVec));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama1(
     cv::Stitcher *obj, cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->composePanorama(*pano));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama2_InputArray(
     cv::Stitcher *obj, cv::_InputArray *images, cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->composePanorama(*images, *pano));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama2_MatArray(
     cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, 
     cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
     *returnValue = static_cast<int>(obj->composePanorama(imagesVec, *pano));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch1_InputArray(
     cv::Stitcher *obj, cv::_InputArray *images, 
     cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->stitch(*images, *pano));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch1_MatArray(
     cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, 
     cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
     *returnValue = static_cast<int>(obj->stitch(imagesVec, *pano));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_InputArray(
@@ -208,12 +208,12 @@ CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_InputArray(
     const interop::Rect **rois, const int roisSize1, int *roisSize2,
     cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<std::vector<cv::Rect> > roisVec;
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
     *returnValue = static_cast<int>(obj->stitch(*images, roisVec, *pano));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_MatArray(
@@ -221,7 +221,7 @@ CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_MatArray(
     const interop::Rect **rois, const int roisSize1, int *roisSize2,
     cv::_OutputArray *pano, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
@@ -229,26 +229,26 @@ CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_MatArray(
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
     *returnValue = static_cast<int>(obj->stitch(imagesVec, roisVec, *pano));
-    END_WRAP
+    });
 }
 
 
 
 CVAPI(ExceptionStatus) stitching_Stitcher_component(cv::Stitcher *obj, std::vector<int>* returnValue) 
 { 
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto component = obj->component();
     std::copy(component.begin(), component.end(), std::back_inserter(*returnValue));
-    END_WRAP
+    });
 }
 
 // std::vector<detail::CameraParams> cameras() const { return cameras_; }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_workScale(cv::Stitcher *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->workScale();
-    END_WRAP
+    });
 }
 
 #endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_Matchers.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Matchers.h
@@ -16,7 +16,7 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures1(
     std::vector<cv::detail::ImageFeatures> *featuresVec,
     cv::Mat **masks)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     // Do not free Feature2D
     const cv::Ptr<cv::Feature2D> featuresFinderPtr(featuresFinder, [](cv::Feature2D*){});
@@ -41,7 +41,7 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures1(
     std::vector<cv::detail::ImageFeatures> rawFeatures;
     cv::detail::computeImageFeatures(featuresFinderPtr, imagesVec, *featuresVec, masksArrays);
     
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) stitching_computeImageFeatures2(
@@ -50,7 +50,7 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures2(
     detail_ImageFeatures *features,
     cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
 
     // Do not free Feature2D
     const cv::Ptr<cv::Feature2D> featuresFinderPtr(featuresFinder, [](cv::Feature2D*){});
@@ -63,7 +63,7 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures2(
     std::copy(rawFeature.keypoints.begin(), rawFeature.keypoints.end(), std::back_inserter(*features->keypoints));
     rawFeature.descriptors.copyTo(*features->descriptors); 
 
-    END_WRAP  
+    });  
 }
 
 
@@ -81,7 +81,7 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply(
     cv::Mat *out_H,
     double *out_confidence)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::detail::ImageFeatures features1Cpp{
         features1->img_idx,
         cpp(features1->img_size),
@@ -107,7 +107,7 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply(
     *out_num_inliers = result.num_inliers;
     result.H.copyTo(*out_H);
     *out_confidence = result.confidence;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply2(
@@ -122,7 +122,7 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply2(
     std::vector<cv::Mat> *out_H,
     std::vector<double> *out_confidence)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::detail::ImageFeatures> featuresVec(featuresSize);
     for (int i = 0; i < featuresSize; i++)
     {
@@ -162,23 +162,23 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply2(
         out_confidence->push_back(m.confidence);
     }
 
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_FeaturesMatcher_isThreadSafe(
     cv::detail::FeaturesMatcher* obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isThreadSafe() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_FeaturesMatcher_collectGarbage(
     cv::detail::FeaturesMatcher* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 
@@ -188,25 +188,25 @@ CVAPI(ExceptionStatus) stitching_BestOf2NearestMatcher_new(
     int try_use_gpu, float match_conf, int num_matches_thresh1,int num_matches_thresh2,
     cv::detail::BestOf2NearestMatcher **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::detail::BestOf2NearestMatcher(
         try_use_gpu != 0, match_conf, num_matches_thresh1, num_matches_thresh2);
-    END_WRAP    
+    });    
 }
 
 CVAPI(ExceptionStatus) stitching_BestOf2NearestMatcher_delete(cv::detail::BestOf2NearestMatcher* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_BestOf2NearestMatcher_collectGarbage(
     cv::detail::BestOf2NearestMatcher* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 
@@ -216,18 +216,18 @@ CVAPI(ExceptionStatus) stitching_AffineBestOf2NearestMatcher_new(
     int full_affine, int try_use_gpu, float match_conf, int num_matches_thresh1,
     cv::detail::AffineBestOf2NearestMatcher** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::detail::AffineBestOf2NearestMatcher(
         full_affine != 0, try_use_gpu != 0, match_conf, num_matches_thresh1);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) stitching_AffineBestOf2NearestMatcher_delete(
     cv::detail::AffineBestOf2NearestMatcher* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/superres.h
+++ b/src/OpenCvSharpExtern/superres.h
@@ -14,57 +14,57 @@
 CVAPI(ExceptionStatus) superres_FrameSource_nextFrame(
     cv::superres::FrameSource *obj, cv::_OutputArray *frame)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->nextFrame(*frame);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_FrameSource_reset(
     cv::superres::FrameSource *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->reset();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_createFrameSource_Empty(cv::Ptr<cv::superres::FrameSource> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createFrameSource_Empty() );
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createFrameSource_Video(const char *fileName, cv::Ptr<cv::superres::FrameSource> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createFrameSource_Video(fileName) );
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createFrameSource_Video_CUDA(const char *fileName, cv::Ptr<cv::superres::FrameSource> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createFrameSource_Video_CUDA(fileName) );
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createFrameSource_Camera(int deviceId, cv::Ptr<cv::superres::FrameSource> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createFrameSource_Camera(deviceId) );
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_FrameSource_delete(cv::Ptr<cv::superres::FrameSource> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_FrameSource_get(cv::Ptr<cv::superres::FrameSource> *obj, cv::superres::FrameSource **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -74,91 +74,91 @@ CVAPI(ExceptionStatus) superres_Ptr_FrameSource_get(cv::Ptr<cv::superres::FrameS
 CVAPI(ExceptionStatus) superres_SuperResolution_setInput(
     cv::superres::SuperResolution *obj, cv::Ptr<cv::superres::FrameSource> *frameSource)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setInput(*frameSource);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_SuperResolution_nextFrame(
     cv::superres::SuperResolution *obj, cv::_OutputArray *frame)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->nextFrame(*frame);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_SuperResolution_reset(cv::superres::SuperResolution *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->reset();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_SuperResolution_collectGarbage(cv::superres::SuperResolution *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_createSuperResolution_BTVL1(cv::Ptr<cv::superres::SuperResolution> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createSuperResolution_BTVL1() );
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createSuperResolution_BTVL1_CUDA(cv::Ptr<cv::superres::SuperResolution> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone( cv::superres::createSuperResolution_BTVL1_CUDA() );
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_SuperResolution_get(cv::Ptr<cv::superres::SuperResolution> *obj, cv::superres::SuperResolution **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_SuperResolution_delete(cv::Ptr<cv::superres::SuperResolution> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) superres_SuperResolution_getScale(cv::superres::SuperResolution *obj, int *returnValue)              { BEGIN_WRAP *returnValue = obj->getScale(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setScale(cv::superres::SuperResolution *obj, int val)                       { BEGIN_WRAP obj->setScale(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getIterations(cv::superres::SuperResolution *obj, int *returnValue)         { BEGIN_WRAP *returnValue = obj->getIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setIterations(cv::superres::SuperResolution *obj, int val)                  { BEGIN_WRAP obj->setIterations(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getTau(cv::superres::SuperResolution *obj, double *returnValue)             { BEGIN_WRAP *returnValue = obj->getTau(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setTau(cv::superres::SuperResolution *obj, double val)                      { BEGIN_WRAP obj->setTau(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getLambda(cv::superres::SuperResolution *obj, double *returnValue)          { BEGIN_WRAP *returnValue = obj->getLambda(); END_WRAP } 
-CVAPI(ExceptionStatus) superres_SuperResolution_setLambda(cv::superres::SuperResolution *obj, double val)                   { BEGIN_WRAP obj->setLambda(val); END_WRAP } 
-CVAPI(ExceptionStatus) superres_SuperResolution_getAlpha(cv::superres::SuperResolution *obj, double *returnValue)           { BEGIN_WRAP *returnValue = obj->getAlpha(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setAlpha(cv::superres::SuperResolution *obj, double val)                    { BEGIN_WRAP obj->setAlpha(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getKernelSize(cv::superres::SuperResolution *obj, int *returnValue)         { BEGIN_WRAP *returnValue = obj->getKernelSize(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setKernelSize(cv::superres::SuperResolution *obj, int val)                  { BEGIN_WRAP obj->setKernelSize(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getBlurKernelSize(cv::superres::SuperResolution *obj, int *returnValue)     { BEGIN_WRAP *returnValue = obj->getBlurKernelSize(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setBlurKernelSize(cv::superres::SuperResolution *obj, int val)              { BEGIN_WRAP obj->setBlurKernelSize(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getBlurSigma(cv::superres::SuperResolution *obj, double *returnValue)       { BEGIN_WRAP *returnValue = obj->getBlurSigma(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setBlurSigma(cv::superres::SuperResolution *obj, double val)                { BEGIN_WRAP obj->setBlurSigma(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_getTemporalAreaRadius(cv::superres::SuperResolution *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getTemporalAreaRadius(); END_WRAP }
-CVAPI(ExceptionStatus) superres_SuperResolution_setTemporalAreaRadius(cv::superres::SuperResolution *obj, int val)          { BEGIN_WRAP obj->setTemporalAreaRadius(val); END_WRAP }
+CVAPI(ExceptionStatus) superres_SuperResolution_getScale(cv::superres::SuperResolution *obj, int *returnValue)              { return cvTry([&] { *returnValue = obj->getScale(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setScale(cv::superres::SuperResolution *obj, int val)                       { return cvTry([&] { obj->setScale(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getIterations(cv::superres::SuperResolution *obj, int *returnValue)         { return cvTry([&] { *returnValue = obj->getIterations(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setIterations(cv::superres::SuperResolution *obj, int val)                  { return cvTry([&] { obj->setIterations(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getTau(cv::superres::SuperResolution *obj, double *returnValue)             { return cvTry([&] { *returnValue = obj->getTau(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setTau(cv::superres::SuperResolution *obj, double val)                      { return cvTry([&] { obj->setTau(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getLambda(cv::superres::SuperResolution *obj, double *returnValue)          { return cvTry([&] { *returnValue = obj->getLambda(); }); } 
+CVAPI(ExceptionStatus) superres_SuperResolution_setLambda(cv::superres::SuperResolution *obj, double val)                   { return cvTry([&] { obj->setLambda(val); }); } 
+CVAPI(ExceptionStatus) superres_SuperResolution_getAlpha(cv::superres::SuperResolution *obj, double *returnValue)           { return cvTry([&] { *returnValue = obj->getAlpha(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setAlpha(cv::superres::SuperResolution *obj, double val)                    { return cvTry([&] { obj->setAlpha(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getKernelSize(cv::superres::SuperResolution *obj, int *returnValue)         { return cvTry([&] { *returnValue = obj->getKernelSize(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setKernelSize(cv::superres::SuperResolution *obj, int val)                  { return cvTry([&] { obj->setKernelSize(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getBlurKernelSize(cv::superres::SuperResolution *obj, int *returnValue)     { return cvTry([&] { *returnValue = obj->getBlurKernelSize(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setBlurKernelSize(cv::superres::SuperResolution *obj, int val)              { return cvTry([&] { obj->setBlurKernelSize(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getBlurSigma(cv::superres::SuperResolution *obj, double *returnValue)       { return cvTry([&] { *returnValue = obj->getBlurSigma(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setBlurSigma(cv::superres::SuperResolution *obj, double val)                { return cvTry([&] { obj->setBlurSigma(val); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_getTemporalAreaRadius(cv::superres::SuperResolution *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getTemporalAreaRadius(); }); }
+CVAPI(ExceptionStatus) superres_SuperResolution_setTemporalAreaRadius(cv::superres::SuperResolution *obj, int val)          { return cvTry([&] { obj->setTemporalAreaRadius(val); }); }
 
 CVAPI(ExceptionStatus) superres_SuperResolution_getOpticalFlow(cv::superres::SuperResolution *obj, cv::Ptr<cv::superres::DenseOpticalFlowExt> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::Ptr<cv::superres::DenseOpticalFlowExt>(obj->getOpticalFlow());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_SuperResolution_setOpticalFlow(cv::superres::SuperResolution *obj, cv::Ptr<cv::superres::DenseOpticalFlowExt> *val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setOpticalFlow(*val);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -166,64 +166,64 @@ CVAPI(ExceptionStatus) superres_SuperResolution_setOpticalFlow(cv::superres::Sup
 CVAPI(ExceptionStatus) superres_DenseOpticalFlowExt_calc(cv::superres::DenseOpticalFlowExt* obj,
     cv::_InputArray *frame0, cv::_InputArray *frame1, cv::_OutputArray *flow1, cv::_OutputArray *flow2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->calc(*frame0, *frame1, *flow1, entity(flow2));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_DenseOpticalFlowExt_collectGarbage(cv::superres::DenseOpticalFlowExt* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 #pragma region FarnebackOpticalFlow
 
 CVAPI(ExceptionStatus) superres_createOptFlow_Farneback(cv::Ptr<cv::superres::FarnebackOpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_Farneback());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createOptFlow_Farneback_CUDA(cv::Ptr<cv::superres::FarnebackOpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_Farneback_CUDA());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_FarnebackOpticalFlow_get(
     cv::Ptr<cv::superres::FarnebackOpticalFlow> *obj, cv::superres::FarnebackOpticalFlow **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_FarnebackOpticalFlow_delete(
     cv::Ptr<cv::superres::FarnebackOpticalFlow> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPyrScale(cv::superres::FarnebackOpticalFlow *obj, double *returnValue)  { BEGIN_WRAP *returnValue = obj->getPyrScale(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPyrScale(cv::superres::FarnebackOpticalFlow *obj, double val)           { BEGIN_WRAP obj->setPyrScale(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getLevelsNumber(cv::superres::FarnebackOpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getLevelsNumber(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setLevelsNumber(cv::superres::FarnebackOpticalFlow *obj, int val)          { BEGIN_WRAP obj->setLevelsNumber(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getWindowSize(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)   { BEGIN_WRAP *returnValue = obj->getWindowSize(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setWindowSize(cv::superres::FarnebackOpticalFlow *obj, int val)            { BEGIN_WRAP obj->setWindowSize(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getIterations(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)   { BEGIN_WRAP *returnValue = obj->getIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setIterations(cv::superres::FarnebackOpticalFlow *obj, int val)            { BEGIN_WRAP obj->setIterations(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPolyN(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)        { BEGIN_WRAP *returnValue = obj->getPolyN(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPolyN(cv::superres::FarnebackOpticalFlow *obj, int val)                 { BEGIN_WRAP obj->setPolyN(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPolySigma(cv::superres::FarnebackOpticalFlow *obj, double *returnValue) { BEGIN_WRAP *returnValue = obj->getPolySigma(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPolySigma(cv::superres::FarnebackOpticalFlow *obj, double val)          { BEGIN_WRAP obj->setPolySigma(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getFlags(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)        { BEGIN_WRAP *returnValue = obj->getFlags(); END_WRAP }
-CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setFlags(cv::superres::FarnebackOpticalFlow *obj, int val)                 { BEGIN_WRAP obj->setFlags(val); END_WRAP }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPyrScale(cv::superres::FarnebackOpticalFlow *obj, double *returnValue)  { return cvTry([&] { *returnValue = obj->getPyrScale(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPyrScale(cv::superres::FarnebackOpticalFlow *obj, double val)           { return cvTry([&] { obj->setPyrScale(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getLevelsNumber(cv::superres::FarnebackOpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getLevelsNumber(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setLevelsNumber(cv::superres::FarnebackOpticalFlow *obj, int val)          { return cvTry([&] { obj->setLevelsNumber(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getWindowSize(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)   { return cvTry([&] { *returnValue = obj->getWindowSize(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setWindowSize(cv::superres::FarnebackOpticalFlow *obj, int val)            { return cvTry([&] { obj->setWindowSize(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getIterations(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)   { return cvTry([&] { *returnValue = obj->getIterations(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setIterations(cv::superres::FarnebackOpticalFlow *obj, int val)            { return cvTry([&] { obj->setIterations(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPolyN(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)        { return cvTry([&] { *returnValue = obj->getPolyN(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPolyN(cv::superres::FarnebackOpticalFlow *obj, int val)                 { return cvTry([&] { obj->setPolyN(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getPolySigma(cv::superres::FarnebackOpticalFlow *obj, double *returnValue) { return cvTry([&] { *returnValue = obj->getPolySigma(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setPolySigma(cv::superres::FarnebackOpticalFlow *obj, double val)          { return cvTry([&] { obj->setPolySigma(val); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_getFlags(cv::superres::FarnebackOpticalFlow *obj, int *returnValue)        { return cvTry([&] { *returnValue = obj->getFlags(); }); }
+CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setFlags(cv::superres::FarnebackOpticalFlow *obj, int val)                 { return cvTry([&] { obj->setFlags(val); }); }
 
 #pragma endregion
 
@@ -231,50 +231,50 @@ CVAPI(ExceptionStatus) superres_FarnebackOpticalFlow_setFlags(cv::superres::Farn
 
 CVAPI(ExceptionStatus) superres_createOptFlow_DualTVL1(cv::Ptr<cv::superres::DualTVL1OpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_DualTVL1());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) superres_createOptFlow_DualTVL1_CUDA(cv::Ptr<cv::superres::DualTVL1OpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_DualTVL1_CUDA());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_DualTVL1OpticalFlow_get(
     cv::Ptr<cv::superres::DualTVL1OpticalFlow> *obj, cv::superres::DualTVL1OpticalFlow **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_DualTVL1OpticalFlow_delete(
     cv::Ptr<cv::superres::DualTVL1OpticalFlow> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getTau(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)         { BEGIN_WRAP *returnValue = obj->getTau(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setTau(cv::superres::DualTVL1OpticalFlow *obj, double val)                  { BEGIN_WRAP obj->setTau(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getLambda(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)      { BEGIN_WRAP *returnValue = obj->getLambda(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setLambda(cv::superres::DualTVL1OpticalFlow *obj, double val)               { BEGIN_WRAP obj->setLambda(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getTheta(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)       { BEGIN_WRAP *returnValue = obj->getTheta(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setTheta(cv::superres::DualTVL1OpticalFlow *obj, double val)                { BEGIN_WRAP obj->setTheta(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getScalesNumber(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue)   { BEGIN_WRAP *returnValue = obj->getScalesNumber(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setScalesNumber(cv::superres::DualTVL1OpticalFlow *obj, int val)            { BEGIN_WRAP obj->setScalesNumber(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getWarpingsNumber(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getWarpingsNumber(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setWarpingsNumber(cv::superres::DualTVL1OpticalFlow *obj, int val)          { BEGIN_WRAP obj->setWarpingsNumber(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getEpsilon(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)     { BEGIN_WRAP *returnValue = obj->getEpsilon(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setEpsilon(cv::superres::DualTVL1OpticalFlow *obj, double val)              { BEGIN_WRAP obj->setEpsilon(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getIterations(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue)     { BEGIN_WRAP *returnValue = obj->getIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setIterations(cv::superres::DualTVL1OpticalFlow *obj, int val)              { BEGIN_WRAP obj->setIterations(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getUseInitialFlow(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getUseInitialFlow() ? 1 : 0; END_WRAP }
-CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setUseInitialFlow(cv::superres::DualTVL1OpticalFlow *obj, int val)          { BEGIN_WRAP obj->setUseInitialFlow(val != 0); END_WRAP }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getTau(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)         { return cvTry([&] { *returnValue = obj->getTau(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setTau(cv::superres::DualTVL1OpticalFlow *obj, double val)                  { return cvTry([&] { obj->setTau(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getLambda(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)      { return cvTry([&] { *returnValue = obj->getLambda(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setLambda(cv::superres::DualTVL1OpticalFlow *obj, double val)               { return cvTry([&] { obj->setLambda(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getTheta(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)       { return cvTry([&] { *returnValue = obj->getTheta(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setTheta(cv::superres::DualTVL1OpticalFlow *obj, double val)                { return cvTry([&] { obj->setTheta(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getScalesNumber(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue)   { return cvTry([&] { *returnValue = obj->getScalesNumber(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setScalesNumber(cv::superres::DualTVL1OpticalFlow *obj, int val)            { return cvTry([&] { obj->setScalesNumber(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getWarpingsNumber(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getWarpingsNumber(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setWarpingsNumber(cv::superres::DualTVL1OpticalFlow *obj, int val)          { return cvTry([&] { obj->setWarpingsNumber(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getEpsilon(cv::superres::DualTVL1OpticalFlow *obj, double *returnValue)     { return cvTry([&] { *returnValue = obj->getEpsilon(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setEpsilon(cv::superres::DualTVL1OpticalFlow *obj, double val)              { return cvTry([&] { obj->setEpsilon(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getIterations(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue)     { return cvTry([&] { *returnValue = obj->getIterations(); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setIterations(cv::superres::DualTVL1OpticalFlow *obj, int val)              { return cvTry([&] { obj->setIterations(val); }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_getUseInitialFlow(cv::superres::DualTVL1OpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getUseInitialFlow() ? 1 : 0; }); }
+CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setUseInitialFlow(cv::superres::DualTVL1OpticalFlow *obj, int val)          { return cvTry([&] { obj->setUseInitialFlow(val != 0); }); }
 
 #pragma endregion
 
@@ -282,40 +282,40 @@ CVAPI(ExceptionStatus) superres_DualTVL1OpticalFlow_setUseInitialFlow(cv::superr
 
 CVAPI(ExceptionStatus) superres_createOptFlow_Brox_CUDA(cv::Ptr<cv::superres::BroxOpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_Brox_CUDA());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_BroxOpticalFlow_get(
     cv::Ptr<cv::superres::BroxOpticalFlow> *obj, cv::superres::BroxOpticalFlow **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_BroxOpticalFlow_delete(
     cv::Ptr<cv::superres::BroxOpticalFlow> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getAlpha(cv::superres::BroxOpticalFlow *obj, double *returnValue)         { BEGIN_WRAP *returnValue = obj->getAlpha(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setAlpha(cv::superres::BroxOpticalFlow *obj, double val)                  { BEGIN_WRAP obj->setAlpha(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getGamma(cv::superres::BroxOpticalFlow *obj, double *returnValue)         { BEGIN_WRAP *returnValue = obj->getGamma(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setGamma(cv::superres::BroxOpticalFlow *obj, double val)                  { BEGIN_WRAP obj->setGamma(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getScaleFactor(cv::superres::BroxOpticalFlow *obj, double *returnValue)   { BEGIN_WRAP *returnValue = obj->getScaleFactor(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setScaleFactor(cv::superres::BroxOpticalFlow *obj, double val)            { BEGIN_WRAP obj->setScaleFactor(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getInnerIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue)  { BEGIN_WRAP *returnValue = obj->getInnerIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setInnerIterations(cv::superres::BroxOpticalFlow *obj, int val)           { BEGIN_WRAP obj->setInnerIterations(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getOuterIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue)  { BEGIN_WRAP *returnValue = obj->getOuterIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setOuterIterations(cv::superres::BroxOpticalFlow *obj, int val)           { BEGIN_WRAP obj->setOuterIterations(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getSolverIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getSolverIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setSolverIterations(cv::superres::BroxOpticalFlow *obj, int val)          { BEGIN_WRAP obj->setSolverIterations(val); END_WRAP }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getAlpha(cv::superres::BroxOpticalFlow *obj, double *returnValue)         { return cvTry([&] { *returnValue = obj->getAlpha(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setAlpha(cv::superres::BroxOpticalFlow *obj, double val)                  { return cvTry([&] { obj->setAlpha(val); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getGamma(cv::superres::BroxOpticalFlow *obj, double *returnValue)         { return cvTry([&] { *returnValue = obj->getGamma(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setGamma(cv::superres::BroxOpticalFlow *obj, double val)                  { return cvTry([&] { obj->setGamma(val); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getScaleFactor(cv::superres::BroxOpticalFlow *obj, double *returnValue)   { return cvTry([&] { *returnValue = obj->getScaleFactor(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setScaleFactor(cv::superres::BroxOpticalFlow *obj, double val)            { return cvTry([&] { obj->setScaleFactor(val); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getInnerIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue)  { return cvTry([&] { *returnValue = obj->getInnerIterations(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setInnerIterations(cv::superres::BroxOpticalFlow *obj, int val)           { return cvTry([&] { obj->setInnerIterations(val); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getOuterIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue)  { return cvTry([&] { *returnValue = obj->getOuterIterations(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setOuterIterations(cv::superres::BroxOpticalFlow *obj, int val)           { return cvTry([&] { obj->setOuterIterations(val); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_getSolverIterations(cv::superres::BroxOpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getSolverIterations(); }); }
+CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setSolverIterations(cv::superres::BroxOpticalFlow *obj, int val)          { return cvTry([&] { obj->setSolverIterations(val); }); }
 
 #pragma endregion
 
@@ -323,34 +323,34 @@ CVAPI(ExceptionStatus) superres_BroxOpticalFlow_setSolverIterations(cv::superres
 
 CVAPI(ExceptionStatus) superres_createOptFlow_PyrLK_CUDA(cv::Ptr<cv::superres::PyrLKOpticalFlow> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::superres::createOptFlow_PyrLK_CUDA());
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) superres_Ptr_PyrLKOpticalFlow_get(
     cv::Ptr<cv::superres::PyrLKOpticalFlow> *obj, cv::superres::PyrLKOpticalFlow **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) superres_Ptr_PyrLKOpticalFlow_delete(
     cv::Ptr<cv::superres::PyrLKOpticalFlow> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getWindowSize(cv::superres::PyrLKOpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getWindowSize(); END_WRAP }
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setWindowSize(cv::superres::PyrLKOpticalFlow *obj, int val)          { BEGIN_WRAP obj->setWindowSize(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getMaxLevel(cv::superres::PyrLKOpticalFlow *obj, int *returnValue)   { BEGIN_WRAP *returnValue = obj->getMaxLevel(); END_WRAP }
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setMaxLevel(cv::superres::PyrLKOpticalFlow *obj, int val)            { BEGIN_WRAP obj->setMaxLevel(val); END_WRAP }
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getIterations(cv::superres::PyrLKOpticalFlow *obj, int *returnValue) { BEGIN_WRAP *returnValue = obj->getIterations(); END_WRAP }
-CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setIterations(cv::superres::PyrLKOpticalFlow *obj, int val)          { BEGIN_WRAP obj->setIterations(val); END_WRAP }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getWindowSize(cv::superres::PyrLKOpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getWindowSize(); }); }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setWindowSize(cv::superres::PyrLKOpticalFlow *obj, int val)          { return cvTry([&] { obj->setWindowSize(val); }); }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getMaxLevel(cv::superres::PyrLKOpticalFlow *obj, int *returnValue)   { return cvTry([&] { *returnValue = obj->getMaxLevel(); }); }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setMaxLevel(cv::superres::PyrLKOpticalFlow *obj, int val)            { return cvTry([&] { obj->setMaxLevel(val); }); }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_getIterations(cv::superres::PyrLKOpticalFlow *obj, int *returnValue) { return cvTry([&] { *returnValue = obj->getIterations(); }); }
+CVAPI(ExceptionStatus) superres_PyrLKOpticalFlow_setIterations(cv::superres::PyrLKOpticalFlow *obj, int val)          { return cvTry([&] { obj->setIterations(val); }); }
 
 #pragma endregion
 

--- a/src/OpenCvSharpExtern/text.h
+++ b/src/OpenCvSharpExtern/text.h
@@ -20,9 +20,9 @@ CVAPI(ExceptionStatus) text_OCRTesseract_run1(
     std::vector<float> *component_confidences,
     int component_level)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->run(*image, *output_text, component_rects, component_texts, component_confidences, component_level);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_OCRTesseract_run2(
@@ -35,9 +35,9 @@ CVAPI(ExceptionStatus) text_OCRTesseract_run2(
     std::vector<float> *component_confidences,
     int component_level)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->run(*image, *mask, *output_text, component_rects, component_texts, component_confidences, component_level);
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) text_OCRTesseract_run3(
@@ -47,10 +47,10 @@ CVAPI(ExceptionStatus) text_OCRTesseract_run2(
     int component_level, 
     std::string *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = (*obj)->run(*image, min_confidence, component_level);
     dst->assign(result);
-    END_WRAP
+    });
 }*/
 
 /*CVAPI(ExceptionStatus) text_OCRTesseract_run4(
@@ -61,19 +61,19 @@ CVAPI(ExceptionStatus) text_OCRTesseract_run2(
     int component_level,
     std::string *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = (*obj)->run(*image, *mask, min_confidence, component_level);
     dst->assign(result);
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) text_OCRTesseract_setWhiteList(
     cv::text::OCRTesseract* obj,
     const char *char_whitelist)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setWhiteList(char_whitelist);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_OCRTesseract_create(
@@ -84,26 +84,26 @@ CVAPI(ExceptionStatus) text_OCRTesseract_create(
     int psmode,
     cv::Ptr<cv::text::OCRTesseract> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = cv::text::OCRTesseract::create(datapath, language, char_whitelist, oem, psmode);
     *returnValue = clone(result);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_Ptr_OCRTesseract_get(
     cv::Ptr<cv::text::OCRTesseract> *ptr, cv::text::OCRTesseract **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_Ptr_OCRTesseract_delete(
     cv::Ptr<cv::text::OCRTesseract> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 #pragma region swt_text_detection.hpp
@@ -111,9 +111,9 @@ CVAPI(ExceptionStatus) text_Ptr_OCRTesseract_delete(
 CVAPI(ExceptionStatus) text_detectTextSWT(
     cv::_InputArray *input, std::vector<cv::Rect> *result, int dark_on_light, cv::_OutputArray *draw, cv::_OutputArray *chainBBs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::text::detectTextSWT(*input, *result, dark_on_light != 0, entity(draw), entity(chainBBs));
-    END_WRAP    
+    });    
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/text_TextDetector.h
+++ b/src/OpenCvSharpExtern/text_TextDetector.h
@@ -11,23 +11,23 @@
 
 CVAPI(ExceptionStatus) text_TextDetector_detect(cv::Ptr<cv::text::TextDetector>* obj, cv::_InputArray *inputImage, std::vector<cv::Rect> *Bbox, std::vector<float> *confidence)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj)->detect(*inputImage, *Bbox, *confidence);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_TextDetectorCNN_detect(cv::Ptr<cv::text::TextDetectorCNN>* obj, cv::_InputArray *inputImage, std::vector<cv::Rect> *Bbox, std::vector<float> *confidence)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj)->detect(*inputImage, *Bbox, *confidence);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_TextDetectorCNN_create1(
     const char *modelArchFilename, const char *modelWeightsFilename, interop::Size *detectionSizes, int detectionSizesLength,
     cv::Ptr<cv::text::TextDetectorCNN> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Size> detectionSizesVec;
     if (detectionSizes != nullptr)
     {
@@ -38,23 +38,23 @@ CVAPI(ExceptionStatus) text_TextDetectorCNN_create1(
 
     const auto ptr = cv::text::TextDetectorCNN::create(modelArchFilename, modelWeightsFilename, detectionSizesVec);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_TextDetectorCNN_create2(
     const char *modelArchFilename, const char *modelWeightsFilename, cv::Ptr<cv::text::TextDetectorCNN> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::text::TextDetectorCNN::create(modelArchFilename, modelWeightsFilename);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) text_Ptr_TextDetectorCNN_delete(cv::Ptr<cv::text::TextDetectorCNN> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 

--- a/src/OpenCvSharpExtern/tracking.h
+++ b/src/OpenCvSharpExtern/tracking.h
@@ -80,40 +80,40 @@ cv::TrackerCSRT::Params tracking_TrackerCSRT_Param_ToCpp(const tracker_TrackerCS
 
 CVAPI(ExceptionStatus) tracking_TrackerCSRT_create1(cv::Ptr<cv::TrackerCSRT> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::TrackerCSRT::create();
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_TrackerCSRT_create2(tracker_TrackerCSRT_Params* parameters, cv::Ptr<cv::TrackerCSRT> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = tracking_TrackerCSRT_Param_ToCpp(parameters);
     const auto obj = cv::TrackerCSRT::create(p);
     *returnValue = clone(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_TrackerCSRT_delete(cv::Ptr<cv::TrackerCSRT>* ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_TrackerCSRT_get(cv::Ptr<cv::TrackerCSRT>* ptr, cv::TrackerCSRT **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_TrackerCSRT_setInitialMask(cv::TrackerCSRT *tracker, cv::_InputArray *mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     tracker->setInitialMask(*mask);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -122,31 +122,31 @@ CVAPI(ExceptionStatus) tracking_TrackerCSRT_setInitialMask(cv::TrackerCSRT *trac
 
 CVAPI(ExceptionStatus) tracking_TrackerKCF_create1(cv::Ptr<cv::TrackerKCF> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::TrackerKCF::create();
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) tracking_TrackerKCF_create2(cv::TrackerKCF::Params *parameters, cv::Ptr<cv::TrackerKCF> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::TrackerKCF::create(*parameters);
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_TrackerKCF_delete(cv::Ptr<cv::TrackerKCF> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_TrackerKCF_get(cv::Ptr<cv::TrackerKCF> *ptr, cv::TrackerKCF **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/tracking_UnscentedKalmanFilter.h
+++ b/src/OpenCvSharpExtern/tracking_UnscentedKalmanFilter.h
@@ -12,27 +12,27 @@
 CVAPI(ExceptionStatus) tracking_createUnscentedKalmanFilter(
     cv::Ptr<cv::tracking::UnscentedKalmanFilter> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::tracking::createUnscentedKalmanFilter();
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_UnscentedKalmanFilter_delete(
     cv::Ptr<cv::tracking::UnscentedKalmanFilter> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) tracking_Ptr_UnscentedKalmanFilter_get(
     cv::Ptr<cv::tracking::UnscentedKalmanFilter> *ptr, 
     cv::tracking::UnscentedKalmanFilter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #endif

--- a/src/OpenCvSharpExtern/video_background_segm.h
+++ b/src/OpenCvSharpExtern/video_background_segm.h
@@ -13,30 +13,30 @@
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractor_getBackgroundImage(cv::BackgroundSubtractor *obj, cv::_OutputArray *backgroundImage)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getBackgroundImage(*backgroundImage);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractor_apply(cv::BackgroundSubtractor *obj, cv::_InputArray *image, cv::_OutputArray *fgmask, double learningRate)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->apply(*image, *fgmask, learningRate);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractor_delete(cv::Ptr<cv::BackgroundSubtractor> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractor_get(cv::Ptr<cv::BackgroundSubtractor> *ptr, cv::BackgroundSubtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -45,181 +45,181 @@ CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractor_get(cv::Ptr<cv::Background
 
 CVAPI(ExceptionStatus) video_createBackgroundSubtractorMOG2(int history, double varThreshold, int detectShadows, cv::Ptr<cv::BackgroundSubtractorMOG2> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createBackgroundSubtractorMOG2(history, varThreshold, detectShadows != 0);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractorMOG2_delete(cv::Ptr<cv::BackgroundSubtractorMOG2> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractorMOG2_get(
     cv::Ptr<cv::BackgroundSubtractorMOG2> *ptr, cv::BackgroundSubtractorMOG2 **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getHistory(cv::BackgroundSubtractorMOG2 *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getHistory();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setHistory(cv::BackgroundSubtractorMOG2 *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setHistory(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getNMixtures(cv::BackgroundSubtractorMOG2 *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getNMixtures();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setNMixtures(cv::BackgroundSubtractorMOG2 *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setNMixtures(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getBackgroundRatio(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getBackgroundRatio();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setBackgroundRatio(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setBackgroundRatio(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getVarThreshold(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getVarThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setVarThreshold(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setVarThreshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getVarThresholdGen(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
      *returnValue = ptr->getVarThresholdGen();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setVarThresholdGen(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setVarThresholdGen(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getVarInit(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getVarInit();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setVarInit(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setVarInit(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getVarMin(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getVarMin();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setVarMin(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setVarMin(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getVarMax(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getVarMax();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setVarMax(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setVarMax(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getComplexityReductionThreshold(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getComplexityReductionThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setComplexityReductionThreshold(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setComplexityReductionThreshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getDetectShadows(cv::BackgroundSubtractorMOG2 *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getDetectShadows() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setDetectShadows(cv::BackgroundSubtractorMOG2 *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setDetectShadows(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getShadowValue(cv::BackgroundSubtractorMOG2 *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getShadowValue();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setShadowValue(cv::BackgroundSubtractorMOG2 *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setShadowValue(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_getShadowThreshold(cv::BackgroundSubtractorMOG2 *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getShadowThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setShadowThreshold(cv::BackgroundSubtractorMOG2 *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setShadowThreshold(value);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -229,117 +229,117 @@ CVAPI(ExceptionStatus) video_BackgroundSubtractorMOG2_setShadowThreshold(cv::Bac
 CVAPI(ExceptionStatus) video_createBackgroundSubtractorKNN(
     int history, double dist2Threshold, int detectShadows, cv::Ptr<cv::BackgroundSubtractorKNN> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::createBackgroundSubtractorKNN(
         history, dist2Threshold, detectShadows != 0);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractorKNN_delete(cv::Ptr<cv::BackgroundSubtractorKNN> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_BackgroundSubtractorKNN_get(
     cv::Ptr<cv::BackgroundSubtractorKNN> *ptr, cv::BackgroundSubtractorKNN **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getHistory(cv::BackgroundSubtractorKNN *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getHistory();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setHistory(cv::BackgroundSubtractorKNN *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setHistory(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getNSamples(cv::BackgroundSubtractorKNN *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getNSamples();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setNSamples(cv::BackgroundSubtractorKNN *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setNSamples(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getDist2Threshold(cv::BackgroundSubtractorKNN *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getDist2Threshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setDist2Threshold(cv::BackgroundSubtractorKNN *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setDist2Threshold(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getkNNSamples(cv::BackgroundSubtractorKNN *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getkNNSamples();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setkNNSamples(cv::BackgroundSubtractorKNN *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setkNNSamples(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getDetectShadows(cv::BackgroundSubtractorKNN *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getDetectShadows() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setDetectShadows(cv::BackgroundSubtractorKNN *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setDetectShadows(value != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getShadowValue(cv::BackgroundSubtractorKNN *ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getShadowValue();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setShadowValue(cv::BackgroundSubtractorKNN *ptr, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setShadowValue(value);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_getShadowThreshold(cv::BackgroundSubtractorKNN *ptr, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getShadowThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_BackgroundSubtractorKNN_setShadowThreshold(cv::BackgroundSubtractorKNN *ptr, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setShadowThreshold(value);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/video_tracking.h
+++ b/src/OpenCvSharpExtern/video_tracking.h
@@ -11,23 +11,23 @@
 CVAPI(ExceptionStatus) video_CamShift(
     cv::_InputArray *probImage, interop::Rect *window, interop::TermCriteria criteria, interop::RotatedRect *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect window0 = cpp(*window);
     const auto ret = cv::CamShift(*probImage, window0, cpp(criteria));
     *window = c(window0);
     *returnValue = c(ret);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_meanShift(
     cv::_InputArray *probImage, interop::Rect *window, interop::TermCriteria criteria, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect window0 = cpp(*window);
     const auto ret = cv::meanShift(*probImage, window0, cpp(criteria));
     *window = c(window0);
     *returnValue = ret;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid1(
@@ -36,11 +36,11 @@ CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid1(
     int pyrBorder, int derivBorder, int tryReuseInputImage,
     int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     * returnValue = cv::buildOpticalFlowPyramid(
         *img, *pyramid, cpp(winSize), maxLevel, withDerivatives != 0,
         pyrBorder, derivBorder, tryReuseInputImage != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid2(
     cv::_InputArray* img, std::vector<cv::Mat>* pyramidVec,
@@ -48,11 +48,11 @@ CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid2(
     int pyrBorder, int derivBorder, int tryReuseInputImage,
     int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     * returnValue = cv::buildOpticalFlowPyramid(
         *img, *pyramidVec, cpp(winSize), maxLevel, withDerivatives != 0,
         pyrBorder, derivBorder, tryReuseInputImage != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_InputArray(
@@ -62,10 +62,10 @@ CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_InputArray(
     interop::Size winSize, int maxLevel, interop::TermCriteria criteria,
     int flags, double minEigThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err,
         cpp(winSize), maxLevel, cpp(criteria), flags, minEigThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_vector(
@@ -77,11 +77,11 @@ CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_vector(
     interop::Size winSize, int maxLevel, interop::TermCriteria criteria,
     int flags, double minEigThreshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Point2f> prevPtsVec(prevPts, prevPts + prevPtsSize);
     cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, prevPtsVec, *nextPts,
     *status, *err, cpp(winSize), maxLevel, cpp(criteria), flags, minEigThreshold);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowFarneback(
@@ -89,10 +89,10 @@ CVAPI(ExceptionStatus) video_calcOpticalFlowFarneback(
     cv::_InputOutputArray* flow, double pyrScale, int levels, int winSize,
     int iterations, int polyN, double polySigma, int flags)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::calcOpticalFlowFarneback(*prev, *next, *flow, pyrScale, levels, winSize,
         iterations, polyN, polySigma, flags);
-    END_WRAP
+    });
 }
 
 /* deprecated
@@ -104,9 +104,9 @@ CVAPI(ExceptionStatus) video_estimateRigidTransform(cv::_InputArray *src, cv::_I
 
 CVAPI(ExceptionStatus) video_computeECC(cv::_InputArray *templateImage, cv::_InputArray *inputImage, cv::_InputArray *inputMask, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::computeECC(*templateImage, *inputImage, entity(inputMask));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_findTransformECC1(
@@ -115,11 +115,11 @@ CVAPI(ExceptionStatus) video_findTransformECC1(
     interop::TermCriteria criteria,
     cv::_InputArray *inputMask, int gaussFiltSize, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findTransformECC(
         *templateImage, *inputImage, *warpMatrix, motionType, 
         cpp(criteria),entity(inputMask), gaussFiltSize);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_findTransformECC2(
@@ -127,116 +127,116 @@ CVAPI(ExceptionStatus) video_findTransformECC2(
     cv::_InputOutputArray *warpMatrix, int motionType,
     interop::TermCriteria criteria, cv::_InputArray *inputMask, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::findTransformECC(
         *templateImage, *inputImage, *warpMatrix, motionType,
         cpp(criteria), entity(inputMask));
-    END_WRAP
+    });
 }
 
 #pragma region KalmanFilter
 
 CVAPI(ExceptionStatus) video_KalmanFilter_new1(cv::KalmanFilter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::KalmanFilter;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_new2(int dynamParams, int measureParams, int controlParams, int type, cv::KalmanFilter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::KalmanFilter(dynamParams, measureParams, controlParams, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_KalmanFilter_init(cv::KalmanFilter *obj, int dynamParams, int measureParams, int controlParams, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->init(dynamParams, measureParams, controlParams, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_KalmanFilter_delete(cv::KalmanFilter *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_KalmanFilter_predict(cv::KalmanFilter *obj, cv::Mat *control, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->predict(entity(control));
     *returnValue = new cv::Mat(result);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_correct(cv::KalmanFilter *obj, cv::Mat *measurement, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto result = obj->correct(*measurement);
     *returnValue = new cv::Mat(result);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_KalmanFilter_statePre(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->statePre);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_statePost(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->statePost);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_transitionMatrix(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->transitionMatrix);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_controlMatrix(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->controlMatrix);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_measurementMatrix(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->measurementMatrix);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_processNoiseCov(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->processNoiseCov);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_measurementNoiseCov(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->measurementNoiseCov);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPre(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->errorCovPre);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_gain(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->gain);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPost(cv::KalmanFilter *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = &(obj->errorCovPost);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -245,14 +245,14 @@ CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPost(cv::KalmanFilter *obj, cv
 
 CVAPI(ExceptionStatus) video_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const interop::Rect boundingBox)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     tracker->init(*image, cpp(boundingBox));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, interop::Rect* boundingBox, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Rect bb = cpp(*boundingBox);
     const bool ret = tracker->update(*image, bb);
     if (ret)
@@ -264,7 +264,7 @@ CVAPI(ExceptionStatus) video_Tracker_update(cv::Tracker* tracker, const cv::Mat*
     }
 
     *returnValue = ret ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -273,32 +273,32 @@ CVAPI(ExceptionStatus) video_Tracker_update(cv::Tracker* tracker, const cv::Mat*
 
 CVAPI(ExceptionStatus) video_TrackerMIL_create1(cv::Ptr<cv::TrackerMIL>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::TrackerMIL::create();
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_TrackerMIL_create2(cv::TrackerMIL::Params* parameters, cv::Ptr<cv::TrackerMIL>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::TrackerMIL::create(*parameters);
     *returnValue = clone(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_delete(cv::Ptr<cv::TrackerMIL>* ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_get(cv::Ptr<cv::TrackerMIL>* ptr, cv::TrackerMIL** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -310,30 +310,30 @@ CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_get(cv::Ptr<cv::TrackerMIL>* ptr, cv
     cv::DenseOpticalFlow *obj,
     cv::_InputArray *i0, cv::_InputArray *i1, cv::_InputOutputArray *flow)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->calc(*i0, *i1, *flow);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_DenseOpticalFlow_collectGarbage(cv::DenseOpticalFlow *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_DenseOpticalFlow_get(cv::Ptr<cv::DenseOpticalFlow> *ptr, cv::DenseOpticalFlow **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) video_Ptr_DenseOpticalFlow_delete(cv::Ptr<cv::DenseOpticalFlow> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 */
 

--- a/src/OpenCvSharpExtern/videoio.h
+++ b/src/OpenCvSharpExtern/videoio.h
@@ -13,171 +13,171 @@
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_new1(cv::VideoCapture **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoCapture;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoCapture_new2(const char *filename, int apiPreference, cv::VideoCapture **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoCapture(filename, apiPreference);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoCapture_new3(int device, int apiPreference, cv::VideoCapture **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoCapture(device, apiPreference);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_new4(const char* filename, int apiPreference, int* params, int paramsLength, cv::VideoCapture** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         std::string filenameStr(filename);
         std::vector<int> paramsVec;
         paramsVec.assign(params, params + paramsLength);
         * returnValue = new cv::VideoCapture(filenameStr, apiPreference, paramsVec);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoCapture_new5(int device, int apiPreference, int* params, int paramsLength, cv::VideoCapture** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         std::vector<int> paramsVec;
         paramsVec.assign(params, params + paramsLength);
         * returnValue = new cv::VideoCapture(device, apiPreference, paramsVec);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_delete(cv::VideoCapture *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_open1(cv::VideoCapture *obj, const char *filename, int apiPreference, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->open(filename, apiPreference) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_open2(cv::VideoCapture *obj, int device, int apiPreference, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->open(device, apiPreference) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_isOpened(cv::VideoCapture *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isOpened() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_release(cv::VideoCapture *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->release();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_grab(cv::VideoCapture *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->grab() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_retrieve_OutputArray(cv::VideoCapture *obj, cv::_OutputArray *image, int flag, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->retrieve(*image, flag) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_retrieve_Mat(cv::VideoCapture *obj, cv::Mat *image, int flag, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->retrieve(*image, flag) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_operatorRightShift_Mat(cv::VideoCapture *obj, cv::Mat *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj) >> (*image);
-    END_WRAP
+    });
 }
 /*CVAPI(ExceptionStatus) videoio_VideoCapture_operatorRightShift_UMat(cv::VideoCapture *obj, cv::UMat *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj) >> (*image);
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_read_OutputArray(cv::VideoCapture *obj, cv::_OutputArray *image, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->read(*image) ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoCapture_read_Mat(cv::VideoCapture *obj, cv::Mat *image, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->read(*image) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_set(cv::VideoCapture *obj, int propId, double value, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->set(propId, value) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_get(cv::VideoCapture *obj, int propId, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get(propId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_getBackendName(cv::VideoCapture *obj, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getBackendName());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_setExceptionMode(cv::VideoCapture *obj, int enable)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setExceptionMode(enable != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_getExceptionMode(cv::VideoCapture *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getExceptionMode() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoCapture_waitAny(
     cv::VideoCapture** streams, const size_t streamsSize,
     std::vector<int> *readyIndex, const int64 timeoutNs, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::VideoCapture> streamsVec(streamsSize);
     for (size_t i = 0; i < streamsSize; i++)
         streamsVec[i] = *streams[i];
 
     *returnValue = cv::VideoCapture::waitAny(streamsVec, *readyIndex, timeoutNs) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -186,9 +186,9 @@ CVAPI(ExceptionStatus) videoio_VideoCapture_waitAny(
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_new1(cv::VideoWriter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoWriter;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoWriter_new2(
     const char *filename, 
@@ -196,9 +196,9 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_new2(
     interop::Size frameSize, int isColor, 
     cv::VideoWriter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoWriter(filename, fourcc, fps, cpp(frameSize), isColor != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoWriter_new3(
     const char *filename, int apiPreference, 
@@ -206,9 +206,9 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_new3(
     interop::Size frameSize, int isColor, 
     cv::VideoWriter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::VideoWriter(filename, apiPreference, fourcc, fps, cpp(frameSize), isColor != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoWriter_new4(
     const char* filename,
@@ -216,11 +216,11 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_new4(
     interop::Size frameSize, int* params, int paramsLength,
     cv::VideoWriter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         std::vector<int> paramsVec;
         paramsVec.assign(params, params + paramsLength);
         * returnValue = new cv::VideoWriter(filename, fourcc, fps, cpp(frameSize), paramsVec);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoWriter_new5(
     const char* filename, int apiPreference,
@@ -228,18 +228,18 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_new5(
     interop::Size frameSize, int* params, int paramsLength,
     cv::VideoWriter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
         std::vector<int> paramsVec;
         paramsVec.assign(params, params + paramsLength);
         * returnValue = new cv::VideoWriter(filename, apiPreference, fourcc, fps, cpp(frameSize), paramsVec);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_delete(cv::VideoWriter *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_open1(
@@ -248,9 +248,9 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_open1(
     interop::Size frameSize, int isColor, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->open(filename, fourcc, fps, cpp(frameSize), isColor != 0) ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) videoio_VideoWriter_open2(
     cv::VideoWriter *obj, const char *filename, int apiPreference, 
@@ -258,65 +258,65 @@ CVAPI(ExceptionStatus) videoio_VideoWriter_open2(
     interop::Size frameSize, int isColor, 
     int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->open(filename, apiPreference, fourcc, fps, cpp(frameSize), isColor != 0) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_isOpened(cv::VideoWriter *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->isOpened() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_release(cv::VideoWriter *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->release();
-    END_WRAP
+    });
 }
 
 /*CVAPI(ExceptionStatus) videoio_VideoWriter_OperatorLeftShift(cv::VideoWriter *obj, cv::Mat *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     (*obj) << (*image);
-    END_WRAP
+    });
 }*/
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_write(cv::VideoWriter *obj, cv::_InputArray *image)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*image);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_set(cv::VideoWriter *obj, int propId, double value, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->set(propId, value) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_get(cv::VideoWriter *obj, int propId, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get(propId);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_fourcc(char c1, char c2, char c3, char c4, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = cv::VideoWriter::fourcc(c1, c2, c3, c4);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) videoio_VideoWriter_getBackendName(cv::VideoWriter *obj, std::string *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     returnValue->assign(obj->getBackendName());
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/wechat_qrcode.h
+++ b/src/OpenCvSharpExtern/wechat_qrcode.h
@@ -8,33 +8,33 @@ CVAPI(ExceptionStatus) wechat_qrcode_create1(
     const char *detector_model_path,
     const char *super_resolution_model_path, cv::wechat_qrcode::WeChatQRCode **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // OpenCV 5: WeChatQRCode takes one ONNX detector model path and one ONNX super-resolution
     // model path (Caffe prototxt/caffemodel pairs dropped).
     *returnValue = new cv::wechat_qrcode::WeChatQRCode(
         detector_model_path == nullptr ? std::string() : std::string(detector_model_path),
         super_resolution_model_path == nullptr ? std::string() : std::string(super_resolution_model_path));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) wechat_qrcode_delete(cv::wechat_qrcode::WeChatQRCode* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) wechat_qrcode_WeChatQRCode_detectAndDecode(cv::wechat_qrcode::WeChatQRCode* obj, cv::_InputArray* inputImage, std::vector<cv::Mat>* points, std::vector<std::string>* texts)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *texts = obj->detectAndDecode(*inputImage, *points);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) wechat_qrcode_WeChatQRCode_detectAndDecode_points(cv::wechat_qrcode::WeChatQRCode* obj, cv::_InputArray* inputImage, std::vector<std::vector<cv::Point2f> >* points, std::vector<std::string>* texts)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Mat> matPoints;
     *texts = obj->detectAndDecode(*inputImage, matPoints);
     points->clear();
@@ -45,7 +45,7 @@ CVAPI(ExceptionStatus) wechat_qrcode_WeChatQRCode_detectAndDecode_points(cv::wec
             pts.emplace_back(mat.at<float>(i, 0), mat.at<float>(i, 1));
         points->push_back(std::move(pts));
     }
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d.h
+++ b/src/OpenCvSharpExtern/xfeatures2d.h
@@ -14,58 +14,58 @@
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_create(
     int bytes, cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::BriefDescriptorExtractor::create(bytes);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_BriefDescriptorExtractor_delete(
     cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_BriefDescriptorExtractor_get(
     cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor> *obj, cv::xfeatures2d::BriefDescriptorExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_read(
     cv::xfeatures2d::BriefDescriptorExtractor *obj, cv::FileNode *fn)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->read(*fn);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_write(
     cv::xfeatures2d::BriefDescriptorExtractor *obj, cv::FileStorage *fs)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->write(*fs);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_descriptorSize(
     cv::xfeatures2d::BriefDescriptorExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_descriptorType(
     cv::xfeatures2d::BriefDescriptorExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorType();
-    END_WRAP
+    });
 }
 
 
@@ -78,27 +78,27 @@ CVAPI(ExceptionStatus) xfeatures2d_FREAK_create(
     int *selectedPairs, int selectedPairsLength, 
     cv::Ptr<cv::xfeatures2d::FREAK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<int> selectedPairsVec;
     if (selectedPairs != nullptr)
         selectedPairsVec = std::vector<int>(selectedPairs, selectedPairs + selectedPairsLength);
     const auto ptr = cv::xfeatures2d::FREAK::create(
         orientationNormalized != 0, scaleNormalized != 0, patternScale, nOctaves, selectedPairsVec);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_FREAK_delete(cv::Ptr<cv::xfeatures2d::FREAK> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_FREAK_get(cv::Ptr<cv::xfeatures2d::FREAK> *obj, cv::xfeatures2d::FREAK **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
@@ -111,25 +111,25 @@ CVAPI(ExceptionStatus) xfeatures2d_StarDetector_create(
     int lineThresholdProjected, int lineThresholdBinarized, int suppressNonmaxSize, 
     cv::Ptr<cv::xfeatures2d::StarDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::StarDetector::create(
         maxSize, responseThreshold, lineThresholdProjected, lineThresholdBinarized, suppressNonmaxSize);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_StarDetector_delete(cv::Ptr<cv::xfeatures2d::StarDetector> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_StarDetector_get(cv::Ptr<cv::xfeatures2d::StarDetector> *obj, cv::xfeatures2d::StarDetector **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
@@ -139,24 +139,24 @@ CVAPI(ExceptionStatus) xfeatures2d_Ptr_StarDetector_get(cv::Ptr<cv::xfeatures2d:
 
 CVAPI(ExceptionStatus) xfeatures2d_LUCID_create(const int lucid_kernel, const int blur_kernel, cv::Ptr<cv::xfeatures2d::LUCID> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::LUCID::create(lucid_kernel, blur_kernel);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_LUCID_delete(cv::Ptr<cv::xfeatures2d::LUCID> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_LUCID_get(cv::Ptr<cv::xfeatures2d::LUCID> *obj, cv::xfeatures2d::LUCID **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
@@ -168,24 +168,24 @@ CVAPI(ExceptionStatus) xfeatures2d_LATCH_create(
     int bytes, int rotationInvariance, int half_ssd_size, double sigma, 
     cv::Ptr<cv::xfeatures2d::LATCH> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::LATCH::create(bytes, rotationInvariance != 0, half_ssd_size, sigma);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_LATCH_delete(cv::Ptr<cv::xfeatures2d::LATCH> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_LATCH_get(cv::Ptr<cv::xfeatures2d::LATCH> *obj, cv::xfeatures2d::LATCH **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 
@@ -199,87 +199,87 @@ CVAPI(ExceptionStatus) xfeatures2d_SURF_create(
     int nOctaveLayers, int extended, int upright, 
     cv::Ptr<cv::xfeatures2d::SURF> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::SURF::create(
         hessianThreshold, nOctaves, nOctaveLayers, extended != 0, upright != 0);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_SURF_delete(cv::Ptr<cv::xfeatures2d::SURF> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_SURF_get(cv::Ptr<cv::xfeatures2d::SURF> *obj, cv::xfeatures2d::SURF **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_SURF_getHessianThreshold(cv::xfeatures2d::SURF *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getHessianThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_getNOctaves(cv::xfeatures2d::SURF *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaves();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_getNOctaveLayers(cv::xfeatures2d::SURF *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaveLayers();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_getExtended(cv::xfeatures2d::SURF *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getExtended() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_getUpright(cv::xfeatures2d::SURF *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUpright() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_SURF_setHessianThreshold(cv::xfeatures2d::SURF *obj, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setHessianThreshold(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_setNOctaves(cv::xfeatures2d::SURF *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaves(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_setNOctaveLayers(cv::xfeatures2d::SURF *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaveLayers(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_setExtended(cv::xfeatures2d::SURF *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setExtended(value != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_SURF_setUpright(cv::xfeatures2d::SURF *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUpright(value != 0);
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/xfeatures2d_BOW.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_BOW.h
@@ -17,31 +17,31 @@
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWTrainer_add(cv::xfeatures2d::BOWTrainer *obj, cv::Mat *descriptors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->add(*descriptors);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWTrainer_getDescriptors(cv::xfeatures2d::BOWTrainer *obj, std::vector<cv::Mat> *descriptors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<cv::Mat> d = obj->getDescriptors();
     std::copy(d.begin(), d.end(), std::back_inserter(*descriptors));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWTrainer_descriptorsCount(cv::xfeatures2d::BOWTrainer *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorsCount();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWTrainer_clear(cv::xfeatures2d::BOWTrainer *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clear();
-    END_WRAP
+    });
 }
 
 
@@ -50,31 +50,31 @@ CVAPI(ExceptionStatus) xfeatures2d_BOWTrainer_clear(cv::xfeatures2d::BOWTrainer 
 CVAPI(ExceptionStatus) xfeatures2d_BOWKMeansTrainer_new(
     int clusterCount, interop::TermCriteria termcrit, int attempts, int flags, cv::xfeatures2d::BOWKMeansTrainer **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::xfeatures2d::BOWKMeansTrainer(clusterCount, cpp(termcrit), attempts, flags);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWKMeansTrainer_delete(cv::xfeatures2d::BOWKMeansTrainer *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWKMeansTrainer_cluster1(cv::xfeatures2d::BOWKMeansTrainer *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat m = obj->cluster();
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_BOWKMeansTrainer_cluster2(cv::xfeatures2d::BOWKMeansTrainer *obj, cv::Mat *descriptors, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const cv::Mat m = obj->cluster(*descriptors);
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 
 // BOWImgDescriptorExtractor
@@ -85,98 +85,98 @@ static void DescriptorMatcherDeleter(cv::DescriptorMatcher *) { }
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_new1_Ptr(
     cv::Ptr<cv::DescriptorExtractor> *dextractor, cv::Ptr<cv::DescriptorMatcher> *dmatcher, cv::xfeatures2d::BOWImgDescriptorExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::xfeatures2d::BOWImgDescriptorExtractor(*dextractor, *dmatcher);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_new2_Ptr(
     cv::Ptr<cv::DescriptorMatcher> *dmatcher, cv::xfeatures2d::BOWImgDescriptorExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = new cv::xfeatures2d::BOWImgDescriptorExtractor(*dmatcher);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_new1_RawPtr(
     cv::DescriptorExtractor *dextractor, cv::DescriptorMatcher *dmatcher, cv::xfeatures2d::BOWImgDescriptorExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // do not delete dextractor and dmatcher
     const cv::Ptr<cv::DescriptorExtractor> dextractorPtr(dextractor, DescriptorExtractorDeleter);
     const cv::Ptr<cv::DescriptorMatcher> dmatcherPtr(dmatcher, DescriptorMatcherDeleter);
     *returnValue = new cv::xfeatures2d::BOWImgDescriptorExtractor(dextractorPtr, dmatcherPtr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_new2_RawPtr(
     cv::DescriptorMatcher *dmatcher, cv::xfeatures2d::BOWImgDescriptorExtractor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     // do not delete dmatcher
     const cv::Ptr<cv::DescriptorMatcher> dmatcherPtr(dmatcher, DescriptorMatcherDeleter);
     *returnValue = new cv::xfeatures2d::BOWImgDescriptorExtractor(dmatcherPtr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_delete(cv::xfeatures2d::BOWImgDescriptorExtractor *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(cv::xfeatures2d::BOWImgDescriptorExtractor *obj, cv::Mat *vocabulary)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setVocabulary(*vocabulary);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_getVocabulary(cv::xfeatures2d::BOWImgDescriptorExtractor *obj, cv::Mat **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::Mat m = obj->getVocabulary();
     *returnValue = new cv::Mat(m);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_compute11(
     cv::xfeatures2d::BOWImgDescriptorExtractor *obj, cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, cv::_OutputArray *imgDescriptor, 
     std::vector<std::vector<int> >* pointIdxsOfClusters, cv::Mat* descriptors)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*image, *keypoints, *imgDescriptor, pointIdxsOfClusters, descriptors);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_compute12(
     cv::xfeatures2d::BOWImgDescriptorExtractor *obj, cv::_InputArray *keypointDescriptors, 
     cv::_OutputArray *imgDescriptor,     std::vector<std::vector<int> >* pointIdxsOfClusters)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute(*keypointDescriptors, *imgDescriptor, pointIdxsOfClusters);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_compute2(
     cv::xfeatures2d::BOWImgDescriptorExtractor *obj, cv::Mat *image, std::vector<cv::KeyPoint> *keypoints, cv::Mat *imgDescriptor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->compute2(*image, *keypoints, *imgDescriptor);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_descriptorSize(cv::xfeatures2d::BOWImgDescriptorExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BOWImgDescriptorExtractor_descriptorType(cv::xfeatures2d::BOWImgDescriptorExtractor *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->descriptorType();
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_FeatureDetectors.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_FeatureDetectors.h
@@ -14,10 +14,10 @@
 CVAPI(ExceptionStatus) xfeatures2d_BRISK_create1(
     int thresh, int octaves, float patternScale, cv::Ptr<cv::xfeatures2d::BRISK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::BRISK::create(thresh, octaves, patternScale);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_BRISK_create2(
     float *radiusList, int radiusListLength, 
@@ -26,7 +26,7 @@ CVAPI(ExceptionStatus) xfeatures2d_BRISK_create2(
     int *indexChange, int indexChangeLength, 
     cv::Ptr<cv::xfeatures2d::BRISK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<float> radiusListVec(radiusList, radiusList + radiusListLength);
     const std::vector<int> numberListVec(numberList, numberList + numberListLength);
     std::vector<int> indexChangeVec;
@@ -35,7 +35,7 @@ CVAPI(ExceptionStatus) xfeatures2d_BRISK_create2(
 
     const auto ptr = cv::xfeatures2d::BRISK::create(radiusListVec, numberListVec, dMax, dMin, indexChangeVec);
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_BRISK_create3(
@@ -46,7 +46,7 @@ CVAPI(ExceptionStatus) xfeatures2d_BRISK_create3(
     int *indexChange, int indexChangeLength, 
     cv::Ptr<cv::xfeatures2d::BRISK> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::vector<float> radiusListVec(radiusList, radiusList + radiusListLength);
     const std::vector<int> numberListVec(numberList, numberList + numberListLength);
     std::vector<int> indexChangeVec;
@@ -55,14 +55,14 @@ CVAPI(ExceptionStatus) xfeatures2d_BRISK_create3(
 
     const auto ptr = cv::xfeatures2d::BRISK::create(thresh, octaves, radiusListVec, numberListVec, dMax, dMin, indexChangeVec);
     *returnValue = clone(ptr);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_BRISK_delete(cv::Ptr<cv::xfeatures2d::BRISK> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -72,70 +72,70 @@ CVAPI(ExceptionStatus) xfeatures2d_AGAST(
     cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints,
     int threshold, int nonmaxSuppression, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xfeatures2d::AGAST(
         entity(image),
         *keypoints,
         threshold,
         nonmaxSuppression != 0, 
         static_cast<cv::xfeatures2d::AgastFeatureDetector::DetectorType>(type));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_create(
     int threshold, int nonmaxSuppression, int type, cv::Ptr<cv::xfeatures2d::AgastFeatureDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::AgastFeatureDetector::create(
         threshold, nonmaxSuppression != 0, static_cast<cv::xfeatures2d::AgastFeatureDetector::DetectorType>(type));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_AgastFeatureDetector_delete(cv::Ptr<cv::xfeatures2d::AgastFeatureDetector> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_setThreshold(cv::xfeatures2d::AgastFeatureDetector *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_getThreshold(cv::xfeatures2d::AgastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_setNonmaxSuppression(cv::xfeatures2d::AgastFeatureDetector *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNonmaxSuppression(val != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_getNonmaxSuppression(cv::xfeatures2d::AgastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNonmaxSuppression() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_setType(cv::xfeatures2d::AgastFeatureDetector *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setType(static_cast<cv::xfeatures2d::AgastFeatureDetector::DetectorType>(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AgastFeatureDetector_getType(cv::xfeatures2d::AgastFeatureDetector *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getType());
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -146,96 +146,96 @@ CVAPI(ExceptionStatus) xfeatures2d_KAZE_create(
     int nOctaves, int nOctaveLayers, int diffusivity,
     cv::Ptr<cv::xfeatures2d::KAZE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::KAZE::create(
         extended != 0, upright != 0, threshold,
         nOctaves, nOctaveLayers, static_cast<cv::xfeatures2d::KAZE::DiffusivityType>(diffusivity));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_KAZE_delete(cv::Ptr<cv::xfeatures2d::KAZE> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setDiffusivity(cv::xfeatures2d::KAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDiffusivity(static_cast<cv::xfeatures2d::KAZE::DiffusivityType>(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getDiffusivity(cv::xfeatures2d::KAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getDiffusivity());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setExtended(cv::xfeatures2d::KAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setExtended(val != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getExtended(cv::xfeatures2d::KAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getExtended() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setNOctaveLayers(cv::xfeatures2d::KAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaveLayers(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getNOctaveLayers(cv::xfeatures2d::KAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaveLayers();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setNOctaves(cv::xfeatures2d::KAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaves(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getNOctaves(cv::xfeatures2d::KAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaves();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setThreshold(cv::xfeatures2d::KAZE *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getThreshold(cv::xfeatures2d::KAZE *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_setUpright(cv::xfeatures2d::KAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUpright(val != 0);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_KAZE_getUpright(cv::xfeatures2d::KAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUpright() ? 1 : 0;
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -247,110 +247,110 @@ CVAPI(ExceptionStatus) xfeatures2d_AKAZE_create(
     float threshold, int nOctaves, int nOctaveLayers, int diffusivity,
     cv::Ptr<cv::xfeatures2d::AKAZE> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xfeatures2d::AKAZE::create(
         static_cast<cv::xfeatures2d::AKAZE::DescriptorType>(descriptor_type), descriptor_size, descriptor_channels,
         threshold, nOctaves, nOctaveLayers, static_cast<cv::xfeatures2d::KAZE::DiffusivityType>(diffusivity));
     *returnValue = clone(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_Ptr_AKAZE_delete(cv::Ptr<cv::xfeatures2d::AKAZE> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setDescriptorType(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDescriptorType(static_cast<cv::xfeatures2d::AKAZE::DescriptorType>(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getDescriptorType(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getDescriptorType());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setDescriptorSize(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDescriptorSize(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getDescriptorSize(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDescriptorSize();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setDescriptorChannels(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDescriptorChannels(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getDescriptorChannels(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getDescriptorChannels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setThreshold(cv::xfeatures2d::AKAZE *obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setThreshold(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getThreshold(cv::xfeatures2d::AKAZE *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getThreshold();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setNOctaves(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaves(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getNOctaves(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaves();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setNOctaveLayers(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setNOctaveLayers(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getNOctaveLayers(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNOctaveLayers();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_setDiffusivity(cv::xfeatures2d::AKAZE *obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setDiffusivity(static_cast<cv::xfeatures2d::KAZE::DiffusivityType>(val));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xfeatures2d_AKAZE_getDiffusivity(cv::xfeatures2d::AKAZE *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = static_cast<int>(obj->getDiffusivity());
-    END_WRAP
+    });
 }
 
 #pragma endregion

--- a/src/OpenCvSharpExtern/ximgproc.h
+++ b/src/OpenCvSharpExtern/ximgproc.h
@@ -12,101 +12,101 @@ CVAPI(ExceptionStatus) ximgproc_niBlackThreshold(cv::_InputArray *src, cv::_Outp
     double maxValue, int type,
     int blockSize, double k, int binarizationMethod, double r)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_thinning(cv::_InputArray *src, cv::_OutputArray *dst, int thinningType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::thinning(*src, *dst, thinningType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_anisotropicDiffusion(cv::_InputArray *src, cv::_OutputArray *dst, float alpha, float K, int niters)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);
-    END_WRAP
+    });
 }
 
 // brightedges.hpp
 
 CVAPI(ExceptionStatus) ximgproc_BrightEdges(cv::Mat *original, cv::Mat *edgeview, int contrast, int shortrange, int longrange)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::BrightEdges(*original, *edgeview, contrast, shortrange, longrange);
-    END_WRAP
+    });
 }
 
 // color_match.hpp
 
 CVAPI(ExceptionStatus) ximgproc_createQuaternionImage(cv::_InputArray *img, cv::_OutputArray *qimg)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::createQuaternionImage(*img, *qimg);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_qconj(cv::_InputArray *qimg, cv::_OutputArray *qcimg)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::qconj(*qimg, *qcimg);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_qunitary(cv::_InputArray *qimg, cv::_OutputArray *qnimg)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::qunitary(*qimg, *qnimg);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_qmultiply(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::qmultiply(*src1, *src2, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_qdft(cv::_InputArray *img, cv::_OutputArray *qimg, int flags, int sideLeft)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::qdft(*img, *qimg, flags, sideLeft != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_colorMatchTemplate(cv::_InputArray *img, cv::_InputArray *templ, cv::_OutputArray *result)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::colorMatchTemplate(*img, *templ, *result);
-    END_WRAP
+    });
 }
 
 // deriche_filter.hpp
 
 CVAPI(ExceptionStatus) ximgproc_GradientDericheY(cv::_InputArray *op, cv::_OutputArray *dst, double alpha, double omega)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::GradientDericheY(*op, *dst, alpha, omega);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_GradientDericheX(cv::_InputArray *op, cv::_OutputArray *dst, double alpha, double omega)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::GradientDericheX(*op, *dst, alpha, omega);
-    END_WRAP
+    });
 }
 
 // edgepreserving_filter.hpp
 
 CVAPI(ExceptionStatus) ximgproc_edgePreservingFilter(cv::_InputArray *src, cv::_OutputArray *dst, int d, double threshold)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
-    END_WRAP
+    });
 }
 
 // estimated_covariance.hpp
@@ -114,9 +114,9 @@ CVAPI(ExceptionStatus) ximgproc_edgePreservingFilter(cv::_InputArray *src, cv::_
 CVAPI(ExceptionStatus) ximgproc_covarianceEstimation(
     cv::_InputArray *src, cv::_OutputArray *dst, int windowRows, int windowCols)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::covarianceEstimation(*src, *dst, windowRows, windowCols);
-    END_WRAP
+    });
 }
 
 // fast_hough_transform.hpp
@@ -125,40 +125,40 @@ CVAPI(ExceptionStatus) ximgproc_FastHoughTransform(
     cv::_InputArray* src, cv::_OutputArray* dst,
     int dstMatDepth, int angleRange, int op, int makeSkew)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::FastHoughTransform(*src, *dst, dstMatDepth, angleRange, op, makeSkew);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_HoughPoint2Line(interop::Point houghPoint, cv::_InputArray* srcImgInfo,
     int angleRange, int makeSkew, int rules, interop::Vec4i* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = c(cv::ximgproc::HoughPoint2Line(cpp(houghPoint), *srcImgInfo, angleRange, makeSkew, rules));
-    END_WRAP
+    });
 }
 
 // paillou_filter.hpp
 
 CVAPI(ExceptionStatus) ximgproc_GradientPaillouY(cv::_InputArray* op, cv::_OutputArray* dst, double alpha, double omega)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::GradientPaillouY(*op, *dst, alpha, omega);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_GradientPaillouX(cv::_InputArray* op, cv::_OutputArray* dst, double alpha, double omega)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::GradientPaillouX(*op, *dst, alpha, omega);
-    END_WRAP
+    });
 }
 
 // peilin.hpp
 
 CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_Mat23d(cv::_InputArray *I, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto ret = cv::ximgproc::PeiLinNormalization(*I);
     for (int r = 0; r < 2; r++)
     {
@@ -167,83 +167,83 @@ CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_Mat23d(cv::_InputArray *I, d
             returnValue[r * 3 + c] = ret(r, c);
         }
     }
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_OutputArray(cv::_InputArray *I, cv::_OutputArray *T)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::PeiLinNormalization(*I, *T);
-    END_WRAP
+    });
 }
 
 // run_length_morphology.hpp
 
 CVAPI(ExceptionStatus) ximgproc_rl_threshold(cv::_InputArray *src, cv::_OutputArray *rlDest, double thresh, int type)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rl::threshold(*src, *rlDest, thresh, type);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_dilate(
     cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, cv::_InputArray *rlKernel, interop::Point anchor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rl::dilate(*rlSrc, *rlDest, *rlKernel, cpp(anchor));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_erode(
     cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, cv::_InputArray *rlKernel,
     int bBoundaryOn, interop::Point anchor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rl::erode(*rlSrc, *rlDest, *rlKernel, bBoundaryOn != 0, cpp(anchor));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_getStructuringElement(int shape, interop::Size ksize, cv::Mat *outValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto result = cv::ximgproc::rl::getStructuringElement(shape, cpp(ksize));
     result.copyTo(*outValue);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_paint(cv::_InputOutputArray *image, cv::_InputArray *rlSrc, interop::Scalar value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rl::paint(*image, *rlSrc, cpp(value));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_isRLMorphologyPossible(cv::_InputArray *rlStructuringElement, int *outValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *outValue = cv::ximgproc::rl::isRLMorphologyPossible(*rlStructuringElement) ? 1 : 0;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_createRLEImage(interop::Point3i *runs, size_t runsLength, cv::_OutputArray *res, interop::Size size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     std::vector<cv::Point3i> runsVec(runsLength);
     for (size_t i = 0; i < runsLength; i++)
     {
         runsVec[i] = cpp(runs[i]);
     }
     cv::ximgproc::rl::createRLEImage(runsVec, *res, cpp(size));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_morphologyEx(
     cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, int op, cv::_InputArray *rlKernel,
     int bBoundaryOnForErosion, interop::Point anchor)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rl::morphologyEx(*rlSrc, *rlDest, op, *rlKernel, bBoundaryOnForErosion != 0, cpp(anchor));
-    END_WRAP
+    });
 }
 
 // weighted_median_filter.hpp
@@ -252,10 +252,10 @@ CVAPI(ExceptionStatus) ximgproc_weightedMedianFilter(
     cv::_InputArray* joint, cv::_InputArray* src, cv::_OutputArray* dst,
     int r, double sigma, int weightType, cv::Mat* mask)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::weightedMedianFilter(*joint, *src, *dst, r, sigma,
         static_cast<cv::ximgproc::WMFWeightType>(weightType), entity(mask));
-    END_WRAP
+    });
 }
 
 // (no NO_CONTRIB guard: kept in every profile for OpenCV 5)

--- a/src/OpenCvSharpExtern/ximgproc_EdgeBoxes.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeBoxes.h
@@ -13,35 +13,35 @@ CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getBoundingBoxes(
     cv::ximgproc::EdgeBoxes *obj, cv::_InputArray *edge_map, 
     cv::_InputArray *orientation_map, std::vector<cv::Rect> *boxes)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getBoundingBoxes(*edge_map, *orientation_map, *boxes);
-    END_WRAP
+    });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getAlpha(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { BEGIN_WRAP *returnValue = obj->getAlpha(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setAlpha(cv::ximgproc::EdgeBoxes *obj, float value)                 { BEGIN_WRAP obj->setAlpha(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getBeta(cv::ximgproc::EdgeBoxes *obj, float *returnValue)           { BEGIN_WRAP *returnValue = obj->getBeta(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setBeta(cv::ximgproc::EdgeBoxes *obj, float value)                  { BEGIN_WRAP obj->setBeta(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEta(cv::ximgproc::EdgeBoxes *obj, float *returnValue)            { BEGIN_WRAP *returnValue = obj->getEta(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEta(cv::ximgproc::EdgeBoxes *obj, float value)                   { BEGIN_WRAP obj->setEta(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMinScore(cv::ximgproc::EdgeBoxes *obj, float *returnValue)       { BEGIN_WRAP *returnValue = obj->getMinScore(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMinScore(cv::ximgproc::EdgeBoxes *obj, float value)              { BEGIN_WRAP obj->setMinScore(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMaxBoxes(cv::ximgproc::EdgeBoxes *obj, int *returnValue)         { BEGIN_WRAP *returnValue = obj->getMaxBoxes(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMaxBoxes(cv::ximgproc::EdgeBoxes *obj, int value)                { BEGIN_WRAP obj->setMaxBoxes(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEdgeMinMag(cv::ximgproc::EdgeBoxes *obj, float *returnValue)     { BEGIN_WRAP *returnValue = obj->getEdgeMinMag(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEdgeMinMag(cv::ximgproc::EdgeBoxes *obj, float value)            { BEGIN_WRAP obj->setEdgeMinMag(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEdgeMergeThr(cv::ximgproc::EdgeBoxes *obj, float *returnValue)   { BEGIN_WRAP *returnValue = obj->getEdgeMergeThr(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEdgeMergeThr(cv::ximgproc::EdgeBoxes *obj, float value)          { BEGIN_WRAP obj->setEdgeMergeThr(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getClusterMinMag(cv::ximgproc::EdgeBoxes *obj, float *returnValue)  { BEGIN_WRAP *returnValue = obj->getClusterMinMag(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setClusterMinMag(cv::ximgproc::EdgeBoxes *obj, float value)         { BEGIN_WRAP obj->setClusterMinMag(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMaxAspectRatio(cv::ximgproc::EdgeBoxes *obj, float *returnValue) { BEGIN_WRAP *returnValue = obj->getMaxAspectRatio(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMaxAspectRatio(cv::ximgproc::EdgeBoxes *obj, float value)        { BEGIN_WRAP obj->setMaxAspectRatio(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMinBoxArea(cv::ximgproc::EdgeBoxes *obj, float *returnValue)     { BEGIN_WRAP *returnValue = obj->getMinBoxArea(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMinBoxArea(cv::ximgproc::EdgeBoxes *obj, float value)            { BEGIN_WRAP obj->setMinBoxArea(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getGamma(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { BEGIN_WRAP *returnValue = obj->getGamma(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setGamma(cv::ximgproc::EdgeBoxes *obj, float value)                 { BEGIN_WRAP obj->setGamma(value); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getKappa(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { BEGIN_WRAP *returnValue = obj->getKappa(); END_WRAP }
-CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setKappa(cv::ximgproc::EdgeBoxes *obj, float value)                 { BEGIN_WRAP obj->setKappa(value); END_WRAP }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getAlpha(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { return cvTry([&] { *returnValue = obj->getAlpha(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setAlpha(cv::ximgproc::EdgeBoxes *obj, float value)                 { return cvTry([&] { obj->setAlpha(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getBeta(cv::ximgproc::EdgeBoxes *obj, float *returnValue)           { return cvTry([&] { *returnValue = obj->getBeta(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setBeta(cv::ximgproc::EdgeBoxes *obj, float value)                  { return cvTry([&] { obj->setBeta(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEta(cv::ximgproc::EdgeBoxes *obj, float *returnValue)            { return cvTry([&] { *returnValue = obj->getEta(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEta(cv::ximgproc::EdgeBoxes *obj, float value)                   { return cvTry([&] { obj->setEta(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMinScore(cv::ximgproc::EdgeBoxes *obj, float *returnValue)       { return cvTry([&] { *returnValue = obj->getMinScore(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMinScore(cv::ximgproc::EdgeBoxes *obj, float value)              { return cvTry([&] { obj->setMinScore(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMaxBoxes(cv::ximgproc::EdgeBoxes *obj, int *returnValue)         { return cvTry([&] { *returnValue = obj->getMaxBoxes(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMaxBoxes(cv::ximgproc::EdgeBoxes *obj, int value)                { return cvTry([&] { obj->setMaxBoxes(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEdgeMinMag(cv::ximgproc::EdgeBoxes *obj, float *returnValue)     { return cvTry([&] { *returnValue = obj->getEdgeMinMag(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEdgeMinMag(cv::ximgproc::EdgeBoxes *obj, float value)            { return cvTry([&] { obj->setEdgeMinMag(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getEdgeMergeThr(cv::ximgproc::EdgeBoxes *obj, float *returnValue)   { return cvTry([&] { *returnValue = obj->getEdgeMergeThr(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setEdgeMergeThr(cv::ximgproc::EdgeBoxes *obj, float value)          { return cvTry([&] { obj->setEdgeMergeThr(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getClusterMinMag(cv::ximgproc::EdgeBoxes *obj, float *returnValue)  { return cvTry([&] { *returnValue = obj->getClusterMinMag(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setClusterMinMag(cv::ximgproc::EdgeBoxes *obj, float value)         { return cvTry([&] { obj->setClusterMinMag(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMaxAspectRatio(cv::ximgproc::EdgeBoxes *obj, float *returnValue) { return cvTry([&] { *returnValue = obj->getMaxAspectRatio(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMaxAspectRatio(cv::ximgproc::EdgeBoxes *obj, float value)        { return cvTry([&] { obj->setMaxAspectRatio(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getMinBoxArea(cv::ximgproc::EdgeBoxes *obj, float *returnValue)     { return cvTry([&] { *returnValue = obj->getMinBoxArea(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setMinBoxArea(cv::ximgproc::EdgeBoxes *obj, float value)            { return cvTry([&] { obj->setMinBoxArea(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getGamma(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { return cvTry([&] { *returnValue = obj->getGamma(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setGamma(cv::ximgproc::EdgeBoxes *obj, float value)                 { return cvTry([&] { obj->setGamma(value); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getKappa(cv::ximgproc::EdgeBoxes *obj, float *returnValue)          { return cvTry([&] { *returnValue = obj->getKappa(); }); }
+CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setKappa(cv::ximgproc::EdgeBoxes *obj, float value)                 { return cvTry([&] { obj->setKappa(value); }); }
 
 
 CVAPI(ExceptionStatus) ximgproc_createEdgeBoxes(
@@ -49,24 +49,24 @@ CVAPI(ExceptionStatus) ximgproc_createEdgeBoxes(
     float clusterMinMag, float maxAspectRatio, float minBoxArea, float gamma, float kappa,
     cv::Ptr<cv::ximgproc::EdgeBoxes> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::createEdgeBoxes(alpha, beta, eta, minScore, maxBoxes, edgeMinMag, edgeMergeThr,
         clusterMinMag, maxAspectRatio, minBoxArea, gamma, kappa));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeBoxes_delete(cv::Ptr<cv::ximgproc::EdgeBoxes> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeBoxes_get(cv::Ptr<cv::ximgproc::EdgeBoxes> *ptr, cv::ximgproc::EdgeBoxes **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_EdgeDrawing.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeDrawing.h
@@ -33,106 +33,106 @@ struct CvEdgeDrawingParams
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeDrawing_delete(cv::Ptr<cv::ximgproc::EdgeDrawing> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeDrawing_get(
     cv::Ptr<cv::ximgproc::EdgeDrawing> *ptr, cv::ximgproc::EdgeDrawing **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createEdgeDrawing(
     cv::Ptr<cv::ximgproc::EdgeDrawing> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createEdgeDrawing();
     *returnValue = new cv::Ptr<cv::ximgproc::EdgeDrawing>(ptr);
-    END_WRAP
+    });
 }
 
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEdges(
     cv::ximgproc::EdgeDrawing *obj, cv::_InputArray *src)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectEdges(*src);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getEdgeImage(
     cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getEdgeImage(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getGradientImage(
     cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getGradientImage(*dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegments(
     cv::ximgproc::EdgeDrawing *obj,
     std::vector<std::vector<cv::Point>> *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSegments();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegmentIndicesOfLines(
     cv::ximgproc::EdgeDrawing *obj, std::vector<int> *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSegmentIndicesOfLines();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines(
     cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectLines(*lines);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines_vector(
     cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec4f> *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectLines(*lines);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses(
     cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *ellipses)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectEllipses(*ellipses);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses_vector(
     cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec6d> *ellipses)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectEllipses(*ellipses);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getParams(
     cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto &p = obj->params;
     returnValue->PFmode                      = p.PFmode ? 1 : 0;
     returnValue->EdgeDetectionOperator       = p.EdgeDetectionOperator;
@@ -147,13 +147,13 @@ CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getParams(
     returnValue->MaxDistanceBetweenTwoLines  = p.MaxDistanceBetweenTwoLines;
     returnValue->LineFitErrorThreshold       = p.LineFitErrorThreshold;
     returnValue->MaxErrorThreshold           = p.MaxErrorThreshold;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_setParams(
     cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *params)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::EdgeDrawing::Params p;
     p.PFmode                     = params->PFmode != 0;
     p.EdgeDetectionOperator      = params->EdgeDetectionOperator;
@@ -169,12 +169,12 @@ CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_setParams(
     p.LineFitErrorThreshold      = params->LineFitErrorThreshold;
     p.MaxErrorThreshold          = params->MaxErrorThreshold;
     obj->setParams(p);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_Params_default(CvEdgeDrawingParams *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::EdgeDrawing::Params p;
     returnValue->PFmode                     = p.PFmode ? 1 : 0;
     returnValue->EdgeDetectionOperator      = p.EdgeDetectionOperator;
@@ -189,7 +189,7 @@ CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_Params_default(CvEdgeDrawingParams *
     returnValue->MaxDistanceBetweenTwoLines = p.MaxDistanceBetweenTwoLines;
     returnValue->LineFitErrorThreshold      = p.LineFitErrorThreshold;
     returnValue->MaxErrorThreshold          = p.MaxErrorThreshold;
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_EdgeFilter.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeFilter.h
@@ -13,44 +13,44 @@
 CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_delete(
     cv::Ptr<cv::ximgproc::DTFilter>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_get(
     cv::Ptr<cv::ximgproc::DTFilter>* ptr, cv::ximgproc::DTFilter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_DTFilter_filter(
     cv::ximgproc::DTFilter* obj,
     cv::_InputArray *src, cv::_OutputArray *dst, int dDepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->filter(*src, *dst, dDepth);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createDTFilter(
     cv::_InputArray *guide, double sigmaSpatial, double sigmaColor, int mode, int numIters,
     cv::Ptr<cv::ximgproc::DTFilter>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createDTFilter(*guide, sigmaSpatial, sigmaColor, mode, numIters);
     *returnValue = new cv::Ptr<cv::ximgproc::DTFilter>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_dtFilter(
     cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, double sigmaSpatial, double sigmaColor, int mode, int numIters)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::dtFilter(*guide, *src, *dst, sigmaSpatial, sigmaColor, mode, numIters);
-    END_WRAP
+    });
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -59,44 +59,44 @@ CVAPI(ExceptionStatus) ximgproc_dtFilter(
 CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_delete(
     cv::Ptr<cv::ximgproc::GuidedFilter>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_get(
     cv::Ptr<cv::ximgproc::GuidedFilter>* ptr, cv::ximgproc::GuidedFilter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_GuidedFilter_filter(
     cv::ximgproc::GuidedFilter* obj,
     cv::_InputArray* src, cv::_OutputArray* dst, int dDepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->filter(*src, *dst, dDepth);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createGuidedFilter(
     cv::_InputArray* guide, int radius, double eps, 
     cv::Ptr<cv::ximgproc::GuidedFilter>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createGuidedFilter(*guide, radius, eps);
     *returnValue = new cv::Ptr<cv::ximgproc::GuidedFilter>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_guidedFilter(
     cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, int radius, double eps, int dDepth)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::guidedFilter(*guide, *src, *dst, radius, eps, dDepth);
-    END_WRAP
+    });
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -105,125 +105,125 @@ CVAPI(ExceptionStatus) ximgproc_guidedFilter(
 CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_delete(
     cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_get(
     cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* ptr, cv::ximgproc::AdaptiveManifoldFilter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_filter(
     cv::ximgproc::AdaptiveManifoldFilter* obj,
     cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray *joint)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->filter(*src, *dst, entity(joint));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_collectGarbage(
     cv::ximgproc::AdaptiveManifoldFilter* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->collectGarbage();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getSigmaS(cv::ximgproc::AdaptiveManifoldFilter* obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigmaS();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setSigmaS(cv::ximgproc::AdaptiveManifoldFilter* obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigmaS(val);
-    END_WRAP    
+    });    
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getSigmaR(cv::ximgproc::AdaptiveManifoldFilter* obj, double* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigmaR();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setSigmaR(cv::ximgproc::AdaptiveManifoldFilter* obj, double val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigmaR(val);
-    END_WRAP    
+    });    
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getTreeHeight(cv::ximgproc::AdaptiveManifoldFilter* obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getTreeHeight();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setTreeHeight(cv::ximgproc::AdaptiveManifoldFilter* obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setTreeHeight(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getPCAIterations(cv::ximgproc::AdaptiveManifoldFilter* obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getPCAIterations();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setPCAIterations(cv::ximgproc::AdaptiveManifoldFilter* obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setPCAIterations(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getAdjustOutliers(cv::ximgproc::AdaptiveManifoldFilter* obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getAdjustOutliers();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setAdjustOutliers(cv::ximgproc::AdaptiveManifoldFilter* obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setAdjustOutliers(val);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_getUseRNG(cv::ximgproc::AdaptiveManifoldFilter* obj, int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getUseRNG() ? 1 : 0;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setUseRNG(cv::ximgproc::AdaptiveManifoldFilter* obj, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setUseRNG(val != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createAMFilter(
     double sigma_s, double sigma_r, int adjust_outliers,
     cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createAMFilter(sigma_s, sigma_r, adjust_outliers != 0);
     *returnValue = new cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_amFilter(
     cv::_InputArray *joint, cv::_InputArray *src, cv::_OutputArray *dst, double sigma_s, double sigma_r, int adjust_outliers)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::amFilter(*joint, *src, *dst, sigma_s, sigma_r, adjust_outliers != 0);
-    END_WRAP
+    });
 }
 
 
@@ -231,23 +231,23 @@ CVAPI(ExceptionStatus) ximgproc_amFilter(
 
 CVAPI(ExceptionStatus) ximgproc_jointBilateralFilter(cv::_InputArray *joint, cv::_InputArray *src, cv::_OutputArray *dst, int d, double sigmaColor, double sigmaSpace, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::jointBilateralFilter(*joint, *src, *dst, d, sigmaColor, sigmaSpace, borderType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_bilateralTextureFilter(cv::_InputArray *src, cv::_OutputArray *dst, int fr, int numIter, double sigmaAlpha, double sigmaAvg)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::bilateralTextureFilter(*src, *dst, fr, numIter, sigmaAlpha, sigmaAvg);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rollingGuidanceFilter(cv::_InputArray *src, cv::_OutputArray *dst, int d, double sigmaColor, double sigmaSpace, int numOfIter, int borderType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::rollingGuidanceFilter(*src, *dst, d, sigmaColor, sigmaSpace, numOfIter, borderType);
-    END_WRAP
+    });
 }
 
 
@@ -257,46 +257,46 @@ CVAPI(ExceptionStatus) ximgproc_rollingGuidanceFilter(cv::_InputArray *src, cv::
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_delete(
     cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_get(
     cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* ptr, cv::ximgproc::FastBilateralSolverFilter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     * returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastBilateralSolverFilter_filter(
     cv::ximgproc::FastBilateralSolverFilter* obj,
     cv::_InputArray* src, cv::_InputArray *confidence, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->filter(*src, *confidence , *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createFastBilateralSolverFilter(
     cv::_InputArray *guide, double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, double max_tol,
     cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createFastBilateralSolverFilter(*guide, sigma_spatial, sigma_luma, sigma_chroma, lambda, num_iter, max_tol);
     *returnValue = new cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_fastBilateralSolverFilter(
     cv::_InputArray *guide, cv::_InputArray *src, cv::_InputArray *confidence, cv::_OutputArray *dst, 
     double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, double max_tol)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::fastBilateralSolverFilter(*guide, *src, *confidence, *dst,
         sigma_spatial, sigma_luma, sigma_chroma, lambda, num_iter, max_tol);
-    END_WRAP
+    });
 }
 
 
@@ -306,52 +306,52 @@ CVAPI(ExceptionStatus) ximgproc_fastBilateralSolverFilter(
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_delete(
     cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_get(
     cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* ptr, cv::ximgproc::FastGlobalSmootherFilter** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     * returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastGlobalSmootherFilter_filter(
     cv::ximgproc::FastGlobalSmootherFilter* obj,
     cv::_InputArray* src, cv::_OutputArray* dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->filter(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createFastGlobalSmootherFilter(
     cv::_InputArray *guide, double lambda, double sigma_color, double lambda_attenuation, int num_iter,
     cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createFastGlobalSmootherFilter(*guide, lambda, sigma_color, lambda_attenuation, num_iter);
     *returnValue = new cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_fastGlobalSmootherFilter(
     cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, double lambda, double sigma_color, double lambda_attenuation, int num_iter)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::fastGlobalSmootherFilter(*guide, *src, *dst,
         lambda, sigma_color, lambda_attenuation, num_iter);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_l0Smooth(cv::_InputArray *src, cv::_OutputArray *dst, double lambda, double kappa)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::ximgproc::l0Smooth(*src, *dst, lambda, kappa);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_FastLineDetector.h
+++ b/src/OpenCvSharpExtern/ximgproc_FastLineDetector.h
@@ -11,49 +11,49 @@
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_delete(
     cv::Ptr<cv::ximgproc::FastLineDetector> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_get(
     cv::Ptr<cv::ximgproc::FastLineDetector> *ptr, cv::ximgproc::FastLineDetector **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_detect_OutputArray(
     cv::ximgproc::FastLineDetector *obj, cv::_InputArray *image, cv::_OutputArray *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*image, *lines);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_detect_vector(
     cv::ximgproc::FastLineDetector *obj, cv::_InputArray *image, std::vector<cv::Vec4f> *lines)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detect(*image, *lines);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_drawSegments_InputArray(
     cv::ximgproc::FastLineDetector *obj, cv::_InputOutputArray *image, cv::_InputArray *lines, int draw_arrow)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->drawSegments(*image, *lines, draw_arrow != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_drawSegments_vector(
     cv::ximgproc::FastLineDetector *obj, cv::_InputOutputArray *image, std::vector<cv::Vec4f> *lines, int draw_arrow)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->drawSegments(*image, *lines, draw_arrow != 0);
-    END_WRAP
+    });
 }
 
 
@@ -61,11 +61,11 @@ CVAPI(ExceptionStatus) ximgproc_createFastLineDetector(
     int length_threshold, float distance_threshold, double canny_th1, double canny_th2, int canny_aperture_size, int do_merge,
     cv::Ptr<cv::ximgproc::FastLineDetector> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createFastLineDetector(
         length_threshold, distance_threshold, canny_th1, canny_th2, canny_aperture_size, do_merge != 0);
     *returnValue = new cv::Ptr<cv::ximgproc::FastLineDetector>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_RidgeDetectionFilter.h
+++ b/src/OpenCvSharpExtern/ximgproc_RidgeDetectionFilter.h
@@ -8,34 +8,34 @@ CVAPI(ExceptionStatus) ximgproc_RidgeDetectionFilter_create(
     int ddepth, int dx, int dy, int ksize, int out_dtype, double scale, double delta, int borderType,
     cv::Ptr<cv::ximgproc::RidgeDetectionFilter> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     auto obj = cv::ximgproc::RidgeDetectionFilter::create(
         ddepth, dx, dy, ksize, out_dtype, scale, delta, borderType);
     *returnValue = clone(obj);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(
     cv::ximgproc::RidgeDetectionFilter *obj,
     cv::_InputArray *_img, cv::_OutputArray *out)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getRidgeFilteredImage(*_img, *out);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_RidgeDetectionFilter_delete(cv::Ptr<cv::ximgproc::RidgeDetectionFilter> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_RidgeDetectionFilter_get(cv::Ptr<cv::ximgproc::RidgeDetectionFilter> *ptr, cv::ximgproc::RidgeDetectionFilter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_Segmentation.h
+++ b/src/OpenCvSharpExtern/ximgproc_Segmentation.h
@@ -13,71 +13,71 @@
 CVAPI(ExceptionStatus) ximgproc_segmentation_createGraphSegmentation(
     double sigma, float k, int min_size, cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createGraphSegmentation(sigma, k, min_size));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_GraphSegmentation_delete(cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_GraphSegmentation_get(
     cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *ptr, 
     cv::ximgproc::segmentation::GraphSegmentation **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_processImage(cv::ximgproc::segmentation::GraphSegmentation *obj, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->processImage(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_setSigma(cv::ximgproc::segmentation::GraphSegmentation *obj, double value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigma(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_getSigma(cv::ximgproc::segmentation::GraphSegmentation *obj, double *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigma();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_setK(cv::ximgproc::segmentation::GraphSegmentation *obj, float value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setK(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_getK(cv::ximgproc::segmentation::GraphSegmentation *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getK();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_setMinSize(cv::ximgproc::segmentation::GraphSegmentation *obj, int value)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setMinSize(value);
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_getMinSize(cv::ximgproc::segmentation::GraphSegmentation *obj, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getMinSize();
-    END_WRAP
+    });
 }
 
 
@@ -86,116 +86,116 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_getMinSize(cv::xi
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, cv::_InputArray *img, cv::_InputArray *regions, cv::_InputArray *sizes, int image_id)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setImage(*img, *regions, *sizes, image_id);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, int r1, int r2, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->get(r1, r2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, int r1, int r2)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->merge(r1, r2);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyColor(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyColor());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategySize(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategySize());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyTexture(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyTexture());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyFill(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyFill());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_delete(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_delete(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_delete(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_delete(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *ptr, 
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *ptr, 
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *ptr, 
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *ptr, 
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 
@@ -204,41 +204,41 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStra
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategyMultiple_addStrategy(
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple *obj, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *g, float weight)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addStrategy(*g, weight);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategyMultiple_clearStrategies(cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clearStrategies();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple0(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyMultiple());
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple1(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1, 
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(createSelectiveSearchSegmentationStrategyMultiple(*s1));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple2(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1, 
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2, 
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(createSelectiveSearchSegmentationStrategyMultiple(*s1, *s2));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple3(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1,
@@ -246,9 +246,9 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationSt
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s3, 
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyMultiple(*s1, *s2, *s3));
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple4(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1,
@@ -257,25 +257,25 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationSt
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s4, 
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyMultiple(*s1, *s2, *s3, *s4));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> *ptr, 
     cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 // SelectiveSearchSegmentation
@@ -283,108 +283,108 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStra
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::_InputArray *img)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setBaseImage(*img);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int k, float sigma)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->switchToSingleStrategy(k, sigma);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchFast(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int base_k, int inc_k, float sigma)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->switchToSelectiveSearchFast(base_k, inc_k, sigma);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchQuality(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int base_k, int inc_k, float sigma) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->switchToSelectiveSearchQuality(base_k, inc_k, sigma);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addImage(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::_InputArray *img)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addImage(*img);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clearImages();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *g)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addGraphSegmentation(*g);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearGraphSegmentations(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clearGraphSegmentations();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->addStrategy(*s);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->clearStrategies();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_process(
     cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, std::vector<cv::Rect> *rects) 
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->process(*rects);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentation(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentation> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentation());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentation_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentation> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentation_get(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentation> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentation **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_StructuredEdgeDetection.h
+++ b/src/OpenCvSharpExtern/ximgproc_StructuredEdgeDetection.h
@@ -12,32 +12,32 @@
 
 CVAPI(ExceptionStatus) ximgproc_createRFFeatureGetter(cv::Ptr<cv::ximgproc::RFFeatureGetter> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = clone(cv::ximgproc::createRFFeatureGetter());
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_RFFeatureGetter_delete(cv::Ptr<cv::ximgproc::RFFeatureGetter> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_RFFeatureGetter_get(cv::Ptr<cv::ximgproc::RFFeatureGetter> *ptr, cv::ximgproc::RFFeatureGetter **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_RFFeatureGetter_getFeatures(
     cv::ximgproc::RFFeatureGetter *obj, cv::Mat *src, cv::Mat *features,
     const int gnrmRad, const int gsmthRad, const int shrink, const int outNum, const int gradNum)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getFeatures(*src, *features, gnrmRad, gsmthRad, shrink, outNum, gradNum);
-    END_WRAP
+    });
 }
 
 
@@ -46,49 +46,49 @@ CVAPI(ExceptionStatus) ximgproc_RFFeatureGetter_getFeatures(
 CVAPI(ExceptionStatus) ximgproc_createStructuredEdgeDetection(
     const char *model, cv::Ptr<cv::ximgproc::RFFeatureGetter> *howToGetFeatures, cv::Ptr<cv::ximgproc::StructuredEdgeDetection> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (howToGetFeatures == nullptr)
         *returnValue = clone(cv::ximgproc::createStructuredEdgeDetection(model));
     else
         *returnValue = clone(cv::ximgproc::createStructuredEdgeDetection(model, *howToGetFeatures));
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_StructuredEdgeDetection_delete(cv::Ptr<cv::ximgproc::StructuredEdgeDetection> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_StructuredEdgeDetection_get(cv::Ptr<cv::ximgproc::StructuredEdgeDetection> *ptr, cv::ximgproc::StructuredEdgeDetection **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_detectEdges(cv::ximgproc::StructuredEdgeDetection *obj, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->detectEdges(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_computeOrientation(cv::ximgproc::StructuredEdgeDetection *obj, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->computeOrientation(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_edgesNms(cv::ximgproc::StructuredEdgeDetection *obj,
     cv::_InputArray *edge_image, cv::_InputArray *orientation_image, cv::_OutputArray *dst,
     int r, int s, float m, int isParallel)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->edgesNms(*edge_image, *orientation_image, *dst, r, s, m, isParallel != 0);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/ximgproc_SuperPixel.h
+++ b/src/OpenCvSharpExtern/ximgproc_SuperPixel.h
@@ -13,69 +13,69 @@
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_delete(
     cv::Ptr<cv::ximgproc::SuperpixelLSC>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_get(
     cv::Ptr<cv::ximgproc::SuperpixelLSC>* ptr, cv::ximgproc::SuperpixelLSC** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getNumberOfSuperpixels(
     cv::ximgproc::SuperpixelLSC* obj,
     int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_iterate(
     cv::ximgproc::SuperpixelLSC* obj, int num_iterations)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->iterate(num_iterations);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getLabels(
     cv::ximgproc::SuperpixelLSC* obj, cv::_OutputArray *labels_out)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabels(*labels_out);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getLabelContourMask(
     cv::ximgproc::SuperpixelLSC* obj,
     cv::_OutputArray *image, int thick_line)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabelContourMask(*image, thick_line != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_enforceLabelConnectivity(
     cv::ximgproc::SuperpixelLSC* obj,
     int min_element_size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->enforceLabelConnectivity(min_element_size);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelLSC(
     cv::_InputArray *image, int region_size, float ratio, cv::Ptr<cv::ximgproc::SuperpixelLSC>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createSuperpixelLSC(*image, region_size, ratio);
     *returnValue = new cv::Ptr<cv::ximgproc::SuperpixelLSC>(ptr);
-    END_WRAP
+    });
 }
 
 
@@ -84,51 +84,51 @@ CVAPI(ExceptionStatus) ximgproc_createSuperpixelLSC(
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_delete(
     cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_get(
     cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* ptr, cv::ximgproc::SuperpixelSEEDS** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(
     cv::ximgproc::SuperpixelSEEDS* obj,
     int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_iterate(
     cv::ximgproc::SuperpixelSEEDS* obj, cv::_InputArray *img, int num_iterations)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->iterate(*img, num_iterations);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getLabels(
     cv::ximgproc::SuperpixelSEEDS* obj, cv::_OutputArray* labels_out)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabels(*labels_out);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getLabelContourMask(
     cv::ximgproc::SuperpixelSEEDS* obj,
     cv::_OutputArray* image, int thick_line)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabelContourMask(*image, thick_line != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelSEEDS(
@@ -137,11 +137,11 @@ CVAPI(ExceptionStatus) ximgproc_createSuperpixelSEEDS(
     int histogram_bins, int double_step,
     cv::Ptr<cv::ximgproc::SuperpixelSEEDS>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createSuperpixelSEEDS(
         image_width, image_height, image_channels, num_superpixels, num_levels, prior, histogram_bins, double_step);
     *returnValue = new cv::Ptr<cv::ximgproc::SuperpixelSEEDS>(ptr);
-    END_WRAP
+    });
 }
 
 
@@ -150,71 +150,71 @@ CVAPI(ExceptionStatus) ximgproc_createSuperpixelSEEDS(
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_delete(
     cv::Ptr<cv::ximgproc::SuperpixelSLIC>* obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_get(
     cv::Ptr<cv::ximgproc::SuperpixelSLIC>* ptr, cv::ximgproc::SuperpixelSLIC** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getNumberOfSuperpixels(
     cv::ximgproc::SuperpixelSLIC* obj,
     int* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_iterate(
     cv::ximgproc::SuperpixelSLIC* obj, int num_iterations)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->iterate(num_iterations);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getLabels(
     cv::ximgproc::SuperpixelSLIC* obj, cv::_OutputArray* labels_out)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabels(*labels_out);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getLabelContourMask(
     cv::ximgproc::SuperpixelSLIC* obj,
     cv::_OutputArray* image, int thick_line)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->getLabelContourMask(*image, thick_line != 0);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
     cv::ximgproc::SuperpixelSLIC* obj,
     int min_element_size)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->enforceLabelConnectivity(min_element_size);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelSLIC(
     cv::_InputArray *image, int algorithm, int region_size, float ruler,
     cv::Ptr<cv::ximgproc::SuperpixelSLIC>** returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::ximgproc::createSuperpixelSLIC(
         *image, algorithm, region_size, ruler);
     *returnValue = new cv::Ptr<cv::ximgproc::SuperpixelSLIC>(ptr);
-    END_WRAP
+    });
 }
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xphoto.h
+++ b/src/OpenCvSharpExtern/xphoto.h
@@ -12,9 +12,9 @@
 
 CVAPI(ExceptionStatus) xphoto_inpaint(cv::Mat *src, cv::Mat *mask, cv::Mat *dst, int algorithm)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xphoto::inpaint(*src, *mask, *dst, static_cast<const cv::xphoto::InpaintTypes>(algorithm));
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -23,218 +23,218 @@ CVAPI(ExceptionStatus) xphoto_inpaint(cv::Mat *src, cv::Mat *mask, cv::Mat *dst,
 
 CVAPI(ExceptionStatus) xphoto_applyChannelGains(cv::_InputArray *src, cv::_OutputArray *dst, float gainB, float gainG, float gainR)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xphoto::applyChannelGains(*src, *dst, gainB, gainG, gainR);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_createGrayworldWB(cv::Ptr<cv::xphoto::GrayworldWB> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xphoto::createGrayworldWB();
     *returnValue = new cv::Ptr<cv::xphoto::GrayworldWB>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_Ptr_GrayworldWB_delete(cv::Ptr<cv::xphoto::GrayworldWB> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_Ptr_GrayworldWB_get(cv::Ptr<cv::xphoto::GrayworldWB>* ptr, cv::xphoto::GrayworldWB **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_GrayworldWB_balanceWhite(cv::xphoto::GrayworldWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->balanceWhite(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_GrayworldWB_SaturationThreshold_get(cv::xphoto::GrayworldWB* ptr, float* returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getSaturationThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_GrayworldWB_SaturationThreshold_set(cv::xphoto::GrayworldWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setSaturationThreshold(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_createLearningBasedWB(const char* path_to_model, cv::Ptr<cv::xphoto::LearningBasedWB> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const std::string str_path_to_model(path_to_model);
     const auto ptr = cv::xphoto::createLearningBasedWB(str_path_to_model);
     *returnValue = new cv::Ptr<cv::xphoto::LearningBasedWB>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_Ptr_LearningBasedWB_delete(cv::Ptr<cv::xphoto::LearningBasedWB> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_Ptr_LearningBasedWB_get(cv::Ptr<cv::xphoto::LearningBasedWB>* ptr, cv::xphoto::LearningBasedWB **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_balanceWhite(cv::xphoto::LearningBasedWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->balanceWhite(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_extractSimpleFeatures(cv::xphoto::LearningBasedWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->extractSimpleFeatures(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_RangeMaxVal_get(cv::xphoto::LearningBasedWB* ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getRangeMaxVal();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_RangeMaxVal_set(cv::xphoto::LearningBasedWB* ptr, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setRangeMaxVal(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_SaturationThreshold_get(cv::xphoto::LearningBasedWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getSaturationThreshold();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_SaturationThreshold_set(cv::xphoto::LearningBasedWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setSaturationThreshold(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_HistBinNum_get(cv::xphoto::LearningBasedWB* ptr, int *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getHistBinNum();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_LearningBasedWB_HistBinNum_set(cv::xphoto::LearningBasedWB* ptr, int val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setHistBinNum(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_createSimpleWB(cv::Ptr<cv::xphoto::SimpleWB> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto ptr = cv::xphoto::createSimpleWB();
     *returnValue = new cv::Ptr<cv::xphoto::SimpleWB>(ptr);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_Ptr_SimpleWB_delete(cv::Ptr<cv::xphoto::SimpleWB> *obj)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete obj;
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_Ptr_SimpleWB_get(cv::Ptr<cv::xphoto::SimpleWB>* ptr, cv::xphoto::SimpleWB **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_balanceWhite(cv::xphoto::SimpleWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->balanceWhite(*src, *dst);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_InputMax_get(cv::xphoto::SimpleWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getInputMax();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_SimpleWB_InputMax_set(cv::xphoto::SimpleWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setInputMax(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_InputMin_get(cv::xphoto::SimpleWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getInputMin();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_SimpleWB_InputMin_set(cv::xphoto::SimpleWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setInputMin(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_OutputMax_get(cv::xphoto::SimpleWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getOutputMax();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_SimpleWB_OutputMax_set(cv::xphoto::SimpleWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setOutputMax(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_OutputMin_get(cv::xphoto::SimpleWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getOutputMin();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_SimpleWB_OutputMin_set(cv::xphoto::SimpleWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setOutputMin(val);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_SimpleWB_P_get(cv::xphoto::SimpleWB* ptr, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->getP();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_SimpleWB_P_set(cv::xphoto::SimpleWB* ptr, float val)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     ptr->setP(val);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -257,11 +257,11 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising1(
     int step,
     int transformType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xphoto::bm3dDenoising(
         *src, *dstStep1, *dstStep2, h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
         groupSize, slidingStep, beta, normType, step, transformType);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
@@ -279,11 +279,11 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
     int step,
     int transformType)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xphoto::bm3dDenoising(
         *src, *dst, h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
         groupSize, slidingStep, beta, normType, step, transformType);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -292,9 +292,9 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
 
 CVAPI(ExceptionStatus) xphoto_dctDenoising(cv::Mat *src, cv::Mat *dst, const double sigma, const int psize)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     cv::xphoto::dctDenoising(*src, *dst, sigma, psize);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -304,12 +304,12 @@ CVAPI(ExceptionStatus) xphoto_dctDenoising(cv::Mat *src, cv::Mat *dst, const dou
 CVAPI(ExceptionStatus) xphoto_oilPainting(
     cv::_InputArray *src, cv::_OutputArray *dst, int size, int dynRatio, int code)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     if (code >= 0)
         cv::xphoto::oilPainting(*src, *dst, size, dynRatio, code);
     else
         cv::xphoto::oilPainting(*src, *dst, size, dynRatio);
-    END_WRAP
+    });
 }
 
 #pragma endregion
@@ -318,77 +318,77 @@ CVAPI(ExceptionStatus) xphoto_oilPainting(
 
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_getSaturation(cv::xphoto::TonemapDurand *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSaturation();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_setSaturation(cv::xphoto::TonemapDurand *obj, float saturation)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSaturation(saturation);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_getContrast(cv::xphoto::TonemapDurand *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getContrast();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_setContrast(cv::xphoto::TonemapDurand *obj, float contrast)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setContrast(contrast);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_getSigmaSpace(cv::xphoto::TonemapDurand *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigmaSpace();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_setSigmaSpace(cv::xphoto::TonemapDurand *obj, float sigma_space)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigmaSpace(sigma_space);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_getSigmaColor(cv::xphoto::TonemapDurand *obj, float *returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = obj->getSigmaColor();
-    END_WRAP
+    });
 }
 CVAPI(ExceptionStatus) xphoto_TonemapDurand_setSigmaColor(cv::xphoto::TonemapDurand *obj, float sigma_color)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     obj->setSigmaColor(sigma_color);
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_createTonemapDurand(
     float gamma, float contrast, float saturation, float sigma_space, float sigma_color, cv::Ptr<cv::xphoto::TonemapDurand> **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     const auto p = cv::xphoto::createTonemapDurand(gamma, contrast, saturation, sigma_space, sigma_color);
     *returnValue = clone(p);
-    END_WRAP  
+    });  
 }
 
 CVAPI(ExceptionStatus) xphoto_Ptr_TonemapDurand_delete(cv::Ptr<cv::xphoto::TonemapDurand> *ptr)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     delete ptr;
-    END_WRAP
+    });
 }
 
 CVAPI(ExceptionStatus) xphoto_Ptr_TonemapDurand_get(cv::Ptr<cv::xphoto::TonemapDurand> *ptr, cv::xphoto::TonemapDurand **returnValue)
 {
-    BEGIN_WRAP
+    return cvTry([&] {
     *returnValue = ptr->get();
-    END_WRAP
+    });
 }
 
 #pragma endregion


### PR DESCRIPTION
@
**Layer A of Phase 3** (#1938). Mechanical, behavior-preserving refactor — split out from the error-mechanism redesign (#1966) for reviewability.

## What

Replace the unbalanced-brace `BEGIN_WRAP` / `END_WRAP` macro pair with a single `cvTry([&]{ ... })` template wrapper, applied at every exported function body (**2986 sites across 109 headers**).

```cpp
// before
CVAPI(ExceptionStatus) core_norm1(...) { BEGIN_WRAP *returnValue = cv::norm(...); END_WRAP }
// after
CVAPI(ExceptionStatus) core_norm1(...) { return cvTry([&] { *returnValue = cv::norm(...); }); }
```

## Behavior preserved

`cvTry` keeps the macros exact per-platform semantics — **no observable change**:
- **Windows:** no `try`/`catch`; exceptions propagate as before.
- **Other:** body runs in `try`/`catch`, a caught `std::exception` is reported as `Occurred`.

The real unification of the error path (and `cvTry`s final body) lands in the stacked follow-up (#1966).

## Also

- Removed the now-obsolete `BEGIN_WRAP`/`END_WRAP` `StatementMacros` hints from `.clang-format` (balanced braces no longer need them).

Requires rebuilding `OpenCvSharpExtern`; verified on CI.
@