### PR TITLE
Unify native→managed error propagation; drop the managed error callback

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -3309,6 +3309,38 @@ public static partial class Cv2
         return stdString.ToString();
     }
 
+    // Roots the user-supplied delegate for the lifetime of the registration so it is not
+    // collected while OpenCV holds the native function pointer.
+    private static CvErrorCallback? userErrorHandler;
+
+    /// <summary>
+    /// Overrides OpenCV's native error handler.
+    /// </summary>
+    /// <param name="errorHandler">
+    /// The handler invoked by OpenCV when an error is raised, or <see langword="null"/> to
+    /// restore the default native handler (which simply mutes OpenCV's stderr output).
+    /// </param>
+    /// <remarks>
+    /// By default OpenCvSharp installs a native, managed-free handler; native errors are
+    /// surfaced as managed <see cref="OpenCVException"/>s regardless. Installing a managed
+    /// handler here is opt-in and reintroduces a managed delegate into the native error
+    /// path, which is not NativeAOT / trimming friendly.
+    /// </remarks>
+    public static void SetErrorHandler(CvErrorCallback? errorHandler)
+    {
+        userErrorHandler = errorHandler;
+
+        if (errorHandler is null)
+        {
+            NativeMethods.HandleException(NativeMethods.core_setSilentErrorHandler());
+            return;
+        }
+
+        var zero = IntPtr.Zero;
+        var prev = NativeMethods.redirectError(errorHandler, IntPtr.Zero, ref zero);
+        GC.KeepAlive(prev);
+    }
+
     /// <summary>
     /// Returns library version string.
     /// For example "3.4.1-dev".

--- a/src/OpenCvSharp/Internal/PInvoke/ExceptionHandler.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/ExceptionHandler.cs
@@ -1,79 +1,27 @@
-#if DOTNETCORE
-
 namespace OpenCvSharp.Internal;
 
 /// <summary>
-/// This static class defines one instance which than can be used by multiple threads to gather exception information from OpenCV
-/// Implemented as a singleton
+/// Surfaces the last native OpenCV exception as a managed exception.
 /// </summary>
+/// <remarks>
+/// Details are captured natively, on the calling thread, directly from the thrown C++
+/// exception (see the native cvTry / LastNativeException). No managed error callback is
+/// installed in the default path, so this is NativeAOT / trimming friendly.
+/// </remarks>
 public static class ExceptionHandler
 {
-    // ThreadLocal variables to save the exception for the current thread
-    private static readonly ThreadLocal<bool> exceptionHappened = new(false);
-    private static readonly ThreadLocal<ErrorCode> localStatus = new();
-    private static readonly ThreadLocal<string> localFuncName = new();
-    private static readonly ThreadLocal<string> localErrMsg = new();
-    private static readonly ThreadLocal<string> localFileName = new();
-    private static readonly ThreadLocal<int> localLine = new();
-
     /// <summary>
-    /// Callback function invoked by OpenCV when exception occurs 
-    /// Stores the information locally for every thread
-    /// </summary>
-    public static readonly CvErrorCallback ErrorHandlerCallback =
-        delegate (ErrorCode status, string funcName, string errMsg, string fileName, int line, IntPtr userData)
-        {
-            try
-            {
-                return 0;
-            }
-            finally
-            {
-                exceptionHappened.Value = true;
-                localStatus.Value = status;
-                localErrMsg.Value = errMsg;
-                localFileName.Value = fileName;
-                localLine.Value = line;
-                localFuncName.Value = funcName;
-            }
-        };
-
-    /// <summary>
-    /// Registers the callback function to OpenCV, so exception caught before the p/invoke boundary 
-    /// </summary>
-    public static void RegisterExceptionCallback()
-    {
-        IntPtr zero = IntPtr.Zero;
-        IntPtr ret = NativeMethods.redirectError(ErrorHandlerCallback, zero, ref zero);
-    }
-
-    /// <summary>
-    /// Throws appropriate exception if one happened
+    /// Throws an <see cref="OpenCVException"/> built from the per-thread native exception
+    /// record. Call only when an export reported <see cref="ExceptionStatus.Occurred"/>.
     /// </summary>
     public static void ThrowPossibleException()
     {
-        if (CheckForException())
-        {
-            throw new OpenCVException(
-                localStatus.Value,
-                localFuncName.Value ?? "",
-                localErrMsg.Value ?? "",
-                localFileName.Value ?? "",
-                localLine.Value);
-        }
-    }
+        using var func = new StdString();
+        using var file = new StdString();
+        using var message = new StdString();
 
-    /// <summary>
-    /// Returns a boolean which indicates if an exception occured for the current thread
-    /// Reading this value changes its state, so an exception is handled only once
-    /// </summary>
-    private static bool CheckForException()
-    {
-        var value = exceptionHappened.Value;
-        // reset exception value
-        exceptionHappened.Value = false;
-        return value;
+        NativeMethods.core_getLastException(out var code, out var line, func.CvPtr, file.CvPtr, message.CvPtr);
+
+        throw new OpenCVException((ErrorCode)code, func.ToString(), message.ToString(), file.ToString(), line);
     }
 }
-
-#endif

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
@@ -42,19 +42,15 @@ public static partial class NativeMethods
         LoadLibraries(WindowsLibraryLoader.Instance.AdditionalPaths);
     }
 
-#pragma warning disable CA1801
     public static void HandleException(ExceptionStatus status)
     {
-#if DOTNETCORE
-        // Check if there has been an exception
-        if (status == ExceptionStatus.Occurred /*&& IsUnix()*/) // thrown can be 1 when unix 
+        // The native wrapper caught an exception and reported it through the status
+        // return value (on every platform). Surface the recorded details as a managed exception.
+        if (status == ExceptionStatus.Occurred)
         {
             ExceptionHandler.ThrowPossibleException();
         }
-#else
-#endif
     }
-#pragma warning restore CA1801
 
     /// <summary>
     /// Load DLL files dynamically using Win32 LoadLibrary
@@ -69,9 +65,9 @@ public static partial class NativeMethods
 
         if (IsUnix())
         {
-#if DOTNETCORE
-            ExceptionHandler.RegisterExceptionCallback();
-#endif
+            // On *nix the native library is resolved by the OS loader; the P/Invoke below
+            // triggers the load and installs the default error handler.
+            InstallDefaultErrorHandler();
             return;
         }
 
@@ -85,10 +81,18 @@ public static partial class NativeMethods
         //*/
         WindowsLibraryLoader.Instance.LoadLibrary(DllExtern, ap);
 
-        // Redirection of error occurred in native library 
-        var zero = IntPtr.Zero;
-        var current = redirectError(ErrorHandlerThrowException, zero, ref zero);
-        GC.KeepAlive(current);
+        InstallDefaultErrorHandler();
+    }
+
+    /// <summary>
+    /// Installs the default native (managed-free) OpenCV error handler. It only mutes
+    /// OpenCV's stderr dump; error details are captured natively and surfaced as a managed
+    /// exception via <see cref="HandleException"/> on each call's returned status.
+    /// Use <see cref="OpenCvSharp.Cv2.SetErrorHandler"/> to override it.
+    /// </summary>
+    private static void InstallDefaultErrorHandler()
+    {
+        HandleException(core_setSilentErrorHandler());
     }
 
     /// <summary>
@@ -181,13 +185,6 @@ public static partial class NativeMethods
     {
         return RuntimeInformation.OSArchitecture == Architecture.Wasm;
     }
-
-    /// <summary>
-    /// Custom error handler to be thrown by OpenCV
-    /// </summary>
-    public static readonly CvErrorCallback ErrorHandlerThrowException =
-        // ReSharper disable once UnusedParameter.Local
-        (status, funcName, errMsg, fileName, line, userData) => throw new OpenCVException(status, funcName, errMsg, fileName, line);
 
     /// <summary>
     /// Custom error handler to ignore all OpenCV errors

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -19,8 +19,14 @@ static partial class NativeMethods
     public static partial int core_setBreakOnError(int flag);
 
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern IntPtr redirectError(CvErrorCallback errCallback, IntPtr userdata, ref IntPtr prevUserdata);    
- 
+    public static extern IntPtr redirectError(CvErrorCallback errCallback, IntPtr userdata, ref IntPtr prevUserdata);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_setSilentErrorHandler();
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_getLastException(out int code, out int line, IntPtr func, IntPtr file, IntPtr message);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_setNumThreads(int nthreads);
 

--- a/src/OpenCvSharp/OpenCvSharp.csproj
+++ b/src/OpenCvSharp/OpenCvSharp.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>TRACE;DOTNETCORE;</DefineConstants>
+    <DefineConstants>TRACE;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release-JP' ">

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -927,6 +927,40 @@ CVAPI(cv::ErrorCallback) redirectError(cv::ErrorCallback errCallback, void* user
     return cv::redirectError(errCallback, userdata, prevUserdata);
 }
 
+// Native, managed-free OpenCV error handler installed by default. It exists only to
+// suppress OpenCV's stderr dump (OpenCV prints to stderr only when no handler is set).
+// Error details are captured by cvTry from the thrown exception, not here.
+static int opencvsharp_silentErrorHandler(int /*status*/, const char* /*funcName*/,
+    const char* /*errMsg*/, const char* /*fileName*/, int /*line*/, void* /*userdata*/)
+{
+    return 0;
+}
+
+// Installs the default native silent error handler. Idempotent. Pass-through for the
+// managed default path and for restoring the default after Cv2.SetErrorHandler(null).
+CVAPI(ExceptionStatus) core_setSilentErrorHandler()
+{
+    return cvTry([&] {
+        cv::redirectError(opencvsharp_silentErrorHandler);
+    });
+}
+
+// Reads the per-thread record of the last exception caught at the export boundary
+// (see cvTry / LastNativeException). The managed side calls this after an export
+// returns ExceptionStatus::Occurred.
+CVAPI(ExceptionStatus) core_getLastException(
+    int* code, int* line, std::string* func, std::string* file, std::string* message)
+{
+    return cvTry([&] {
+    const auto& last = lastNativeException();
+    *code = last.code;
+    *line = last.line;
+    func->assign(last.func);
+    file->assign(last.file);
+    message->assign(last.message);
+    });
+}
+
 CVAPI(ExceptionStatus) core_setNumThreads(int nthreads)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/my_functions.h
+++ b/src/OpenCvSharpExtern/my_functions.h
@@ -129,34 +129,81 @@ static bool writeAllBytesWide(const char *utf8Path, const uchar *data, size_t si
 #endif
 
 
-// catch all exception
+// Status returned by every exported function: whether a C++ exception escaped its body.
 enum class ExceptionStatus : int { NotOccurred = 0, Occurred = 1 };
 
-// Runs an exported function body and reports whether a C++ exception escaped it via the
-// ExceptionStatus return value. This is a drop-in replacement for the former
-// BEGIN_WRAP / END_WRAP macros and preserves their exact, per-platform behavior:
-//   * Windows: no try/catch -- exceptions propagate as before (a managed exception thrown
-//     from the OpenCV error callback unwinds through native frames via SEH).
-//   * Other:   the body runs inside try/catch and a caught std::exception is reported as
-//     Occurred.
-// (A later change unifies these onto a single portable path.)
+// Per-thread record of the last C++ exception caught at the export boundary. Captured
+// directly from the thrown exception object -- no OpenCV error callback is involved -- so
+// the details are recorded on the very thread that ran the body and returns to managed
+// code. This stays correct even when cv::parallel_for_ rethrows a worker exception on the
+// calling thread. The managed side reads this via core_getLastException when an export
+// reports ExceptionStatus::Occurred.
+struct LastNativeException
+{
+    int code = 0;
+    int line = 0;
+    std::string func;
+    std::string file;
+    std::string message;
+};
+
+inline LastNativeException& lastNativeException()
+{
+    thread_local LastNativeException value;
+    return value;
+}
+
+// Runs an exported function body and converts any C++ exception into an ExceptionStatus
+// return value, uniformly on all platforms. Every catchable C++ exception is recorded into
+// the per-thread LastNativeException and reported as Occurred; the managed side turns that
+// into a managed OpenCVException (see NativeMethods.HandleException /
+// ExceptionHandler.ThrowPossibleException). Only non-C++ faults (SEH / SIGSEGV) pass
+// through -- catch(...) does not (and should not) mask those.
+//
+// This portable path replaces the former Windows-only scheme of throwing a managed
+// exception from the error callback through native frames, which is unsafe under
+// .NET Core / NativeAOT (the CLR cannot unwind native C++ frames reliably).
+//
+// Usage:
+//     CVAPI(ExceptionStatus) foo(int* out) { return cvTry([&] { *out = 42; }); }
 template <typename TFunc>
 ExceptionStatus cvTry(TFunc&& body)
 {
-#if defined WIN32 || defined _WIN32
-    body();
-    return ExceptionStatus::NotOccurred;
-#else
     try
     {
         body();
         return ExceptionStatus::NotOccurred;
     }
-    catch (const std::exception&)
+    catch (const cv::Exception& e)
     {
+        auto& last = lastNativeException();
+        last.code = e.code;
+        last.line = e.line;
+        last.func = e.func;
+        last.file = e.file;
+        last.message = e.err;
         return ExceptionStatus::Occurred;
     }
-#endif
+    catch (const std::exception& e)
+    {
+        auto& last = lastNativeException();
+        last.code = 0;
+        last.line = 0;
+        last.func.clear();
+        last.file.clear();
+        last.message = e.what() != nullptr ? e.what() : "";
+        return ExceptionStatus::Occurred;
+    }
+    catch (...)
+    {
+        auto& last = lastNativeException();
+        last.code = 0;
+        last.line = 0;
+        last.func.clear();
+        last.file.clear();
+        last.message = "Unknown C++ exception";
+        return ExceptionStatus::Occurred;
+    }
 }
 
 

--- a/test/OpenCvSharp.Tests/system/ExceptionTest.cs
+++ b/test/OpenCvSharp.Tests/system/ExceptionTest.cs
@@ -101,4 +101,51 @@ public class ExceptionTest : TestBase
         Assert.True(ex.Line > 0);
         Assert.Equal(ErrorCode.StsAssert, ex.Status);
     }
+
+    [Fact]
+    public void SetErrorHandlerInvokesCustomHandler()
+    {
+        var callCount = 0;
+        var capturedStatus = default(ErrorCode);
+        var capturedFunc = "";
+        var capturedMsg = "";
+
+        CvErrorCallback handler = (status, funcName, errMsg, fileName, line, userData) =>
+        {
+            callCount++;
+            capturedStatus = status;
+            capturedFunc = funcName;
+            capturedMsg = errMsg;
+            return 0;
+        };
+
+        try
+        {
+            Cv2.SetErrorHandler(handler);
+
+            using var img = new Mat(3, 3, MatType.CV_8UC1);
+            // Even with a custom handler installed, the error still surfaces as a managed exception.
+            Assert.Throws<OpenCVException>(() => Cv2.GaussianBlur(img, img, new Size(2, 2), 1));
+        }
+        finally
+        {
+            Cv2.SetErrorHandler(null); // restore the default native silent handler
+        }
+
+        Assert.True(callCount > 0);
+        Assert.Equal(ErrorCode.StsAssert, capturedStatus);
+        Assert.StartsWith("ksize.width > 0", capturedMsg, StringComparison.Ordinal);
+        Assert.False(string.IsNullOrEmpty(capturedFunc));
+    }
+
+    [Fact]
+    public void SetErrorHandlerNullRestoresDefault()
+    {
+        // Installing then clearing a handler must leave errors still surfacing as OpenCVException.
+        Cv2.SetErrorHandler((_, _, _, _, _, _) => 0);
+        Cv2.SetErrorHandler(null);
+
+        using var img = new Mat(3, 3, MatType.CV_8UC1);
+        Assert.Throws<OpenCVException>(() => Cv2.GaussianBlur(img, img, new Size(2, 2), 1));
+    }
 }


### PR DESCRIPTION
@
**Layer B of Phase 3** — closes #1966 (part of #1938). **Stacked on #1968** (review/merge that first; this PRs diff is only the mechanism change).

Replaces the split error mechanism — Windows: throw a managed exception from the OpenCV error callback *through native frames*; *nix: record into a managed `ThreadLocal` via the callback — with a single portable path on all platforms.

## Design

- **`cvTry`** now wraps each body in a three-tier `catch` (`cv::Exception` → `std::exception` → `...`) and records the caught exceptions details into a **per-thread native store**, captured directly from the thrown object. `catch(...)` guarantees any C++ exception is reported rather than crossing the P/Invoke boundary as `SEHException`; only non-C++ faults (SEH / `SIGSEGV`) pass through.
- **New exports:** `core_getLastException` (read the per-thread record) and `core_setSilentErrorHandler` (install a native, managed-free no-op handler that merely mutes OpenCVs stderr dump).
- **Managed:** `ExceptionHandler` builds `OpenCVException` from the native record; **no `CvErrorCallback` delegate is installed in the default path** (NativeAOT / trim friendly, removes a delegate from the #1941 set). `HandleException` simply throws on `Occurred`; the now-dead `DOTNETCORE` conditionals are removed.
- **Escape hatch:** `Cv2.SetErrorHandler(CvErrorCallback?)` — opt-in managed handler; `null` restores the native silent handler.

## Why its more correct

`cvTry` catches on the calling (P/Invoke) thread, so details are right even when `cv::parallel_for_` rethrows a worker exception there. The old callback-on-worker-thread + `ThreadLocal` scheme recorded on the wrong thread in that case.

## Notes

- stderr suppression: OpenCV only prints when no handler is registered, so the default native no-op handler mutes it without any managed delegate.
- Managed control of OpenCVs separate diagnostic logger (`cv::utils::logging`) is tracked independently in #1967.

Requires rebuilding `OpenCvSharpExtern`; native build + runtime behavior verified on CI.
@