### PR TITLE
Remove InputArray collection blockers from StereoCalibrate/Rectify3Collinear

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -546,9 +546,9 @@ static partial class Cv2
     /// <param name="flags">Different flags that may be zero or a combination of the CalibrationFlag values</param>
     /// <returns></returns>
     public static double StereoCalibrate(
-        IEnumerable<InputArray> objectPoints,
-        IEnumerable<InputArray> imagePoints1,
-        IEnumerable<InputArray> imagePoints2,
+        IReadOnlyList<Mat> objectPoints,
+        IReadOnlyList<Mat> imagePoints1,
+        IReadOnlyList<Mat> imagePoints2,
         InputOutputArray cameraMatrix1, InputOutputArray distCoeffs1,
         InputOutputArray cameraMatrix2, InputOutputArray distCoeffs2,
         Size imageSize, OutputArray R,
@@ -614,90 +614,6 @@ static partial class Cv2
         T.Fix();
         E.Fix();
         F.Fix();
-
-        return ret;
-    }
-
-    /// <summary>
-    /// finds intrinsic and extrinsic parameters of a stereo camera
-    /// </summary>
-    /// <param name="objectPoints">Vector of vectors of the calibration pattern points.</param>
-    /// <param name="imagePoints1">Vector of vectors of the projections of the calibration pattern points, observed by the first camera.</param>
-    /// <param name="imagePoints2">Vector of vectors of the projections of the calibration pattern points, observed by the second camera.</param>
-    /// <param name="cameraMatrix1">Input/output first camera matrix</param>
-    /// <param name="distCoeffs1">Input/output vector of distortion coefficients (k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6]]) of 4, 5, or 8 elements. 
-    /// The output vector length depends on the flags.</param>
-    /// <param name="cameraMatrix2"> Input/output second camera matrix. The parameter is similar to cameraMatrix1 .</param>
-    /// <param name="distCoeffs2">Input/output lens distortion coefficients for the second camera. The parameter is similar to distCoeffs1 .</param>
-    /// <param name="imageSize">Size of the image used only to initialize intrinsic camera matrix.</param>
-    /// <param name="R">Output rotation matrix between the 1st and the 2nd camera coordinate systems.</param>
-    /// <param name="T">Output translation vector between the coordinate systems of the cameras.</param>
-    /// <param name="E">Output essential matrix.</param>
-    /// <param name="F">Output fundamental matrix.</param>
-    /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
-    /// <param name="flags">Different flags that may be zero or a combination of the CalibrationFlag values</param>
-    /// <returns></returns>
-    public static double StereoCalibrate(
-        IEnumerable<Mat> objectPoints,
-        IEnumerable<Mat> imagePoints1,
-        IEnumerable<Mat> imagePoints2,
-        Mat cameraMatrix1, Mat distCoeffs1,
-        Mat cameraMatrix2, Mat distCoeffs2,
-        Size imageSize, Mat R, Mat T, Mat E, Mat F,
-        CalibrationFlags flags = CalibrationFlags.FixIntrinsic,
-        TermCriteria? criteria = null)
-    {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints1 is null)
-            throw new ArgumentNullException(nameof(imagePoints1));
-        if (imagePoints2 is null)
-            throw new ArgumentNullException(nameof(imagePoints2));
-        if (cameraMatrix1 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix1));
-        if (distCoeffs1 is null)
-            throw new ArgumentNullException(nameof(distCoeffs1));
-        if (cameraMatrix2 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix2));
-        if (distCoeffs2 is null)
-            throw new ArgumentNullException(nameof(distCoeffs2));
-        if (R is null)
-            throw new ArgumentNullException(nameof(R));
-        if (T is null)
-            throw new ArgumentNullException(nameof(T));
-        if (E is null)
-            throw new ArgumentNullException(nameof(E));
-        if (F is null)
-            throw new ArgumentNullException(nameof(F));
-
-        var opPtrs = objectPoints.Select(x => x.CvPtr).ToArray();
-        var ip1Ptrs = imagePoints1.Select(x => x.CvPtr).ToArray();
-        var ip2Ptrs = imagePoints2.Select(x => x.CvPtr).ToArray();
-
-        var criteria0 = criteria.GetValueOrDefault(
-            new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, 1e-6));
-
-        NativeMethods.HandleException(
-            NativeMethods.calib_stereoCalibrate_Mat(
-                opPtrs, opPtrs.Length,
-                ip1Ptrs, ip1Ptrs.Length,
-                ip2Ptrs, ip2Ptrs.Length,
-                cameraMatrix1.CvPtr, distCoeffs1.CvPtr,
-                cameraMatrix2.CvPtr, distCoeffs2.CvPtr,
-                imageSize, R.CvPtr, T.CvPtr, E.CvPtr, F.CvPtr,
-                (int)flags, criteria0, out var ret));
-
-        GC.KeepAlive(objectPoints);
-        GC.KeepAlive(imagePoints1);
-        GC.KeepAlive(imagePoints2);
-        GC.KeepAlive(cameraMatrix1);
-        GC.KeepAlive(distCoeffs1);
-        GC.KeepAlive(cameraMatrix2);
-        GC.KeepAlive(distCoeffs2);
-        GC.KeepAlive(R);
-        GC.KeepAlive(T);
-        GC.KeepAlive(E);
-        GC.KeepAlive(F);
 
         return ret;
     }

--- a/src/OpenCvSharp/Cv2/Cv2_stereo.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_stereo.cs
@@ -413,7 +413,7 @@ static partial class Cv2
         InputArray cameraMatrix1, InputArray distCoeffs1,
         InputArray cameraMatrix2, InputArray distCoeffs2,
         InputArray cameraMatrix3, InputArray distCoeffs3,
-        IEnumerable<InputArray> imgpt1, IEnumerable<InputArray> imgpt3,
+        IReadOnlyList<Mat> imgpt1, IReadOnlyList<Mat> imgpt3,
         Size imageSize, InputArray R12, InputArray T12,
         InputArray R13, InputArray T13,
         OutputArray R1, OutputArray R2, OutputArray R3,

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
@@ -101,21 +101,6 @@ static partial class NativeMethods
         out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus calib_stereoCalibrate_Mat(
-        IntPtr[] objectPoints, int opSize,
-        IntPtr[] imagePoints1, int ip1Size,
-        IntPtr[] imagePoints2, int ip2Size,
-        IntPtr cameraMatrix1,
-        IntPtr distCoeffs1,
-        IntPtr cameraMatrix2,
-        IntPtr distCoeffs2,
-        Size imageSize,
-        IntPtr R, IntPtr T,
-        IntPtr E, IntPtr F,
-        int flags, TermCriteria criteria,
-        out double returnValue);
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial ExceptionStatus calib_stereoCalibrate_array(
         IntPtr[] objectPoints, int opSize1, int[] opSizes2,
         IntPtr[] imagePoints1, int ip1Size1, int[] ip1Sizes2,

--- a/src/OpenCvSharpExtern/calib.h
+++ b/src/OpenCvSharpExtern/calib.h
@@ -162,9 +162,9 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_vector(
 
 
 CVAPI(ExceptionStatus) calib_stereoCalibrate_InputArray(
-    cv::_InputArray **objectPoints, int opSize,
-    cv::_InputArray **imagePoints1, int ip1Size,
-    cv::_InputArray **imagePoints2, int ip2Size,
+    cv::Mat **objectPoints, int opSize,
+    cv::Mat **imagePoints1, int ip1Size,
+    cv::Mat **imagePoints2, int ip2Size,
     cv::_InputOutputArray *cameraMatrix1,
     cv::_InputOutputArray *distCoeffs1,
     cv::_InputOutputArray *cameraMatrix2,
@@ -172,39 +172,6 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_InputArray(
     interop::Size imageSize,
     cv::_OutputArray *R, cv::_OutputArray *T,
     cv::_OutputArray *E, cv::_OutputArray *F,
-    int flags, 
-    interop::TermCriteria criteria,
-    double *returnValue)
-{
-    return cvTry([&] {
-    std::vector<cv::Mat> objectPointsVec(opSize);
-    std::vector<cv::Mat> imagePoints1Vec(ip1Size);
-    std::vector<cv::Mat> imagePoints2Vec(ip2Size);
-    for (auto i = 0; i < opSize; i++)
-        objectPointsVec[i] = objectPoints[i]->getMat();
-    for (auto i = 0; i < ip1Size; i++)
-        imagePoints1Vec[i] = imagePoints1[i]->getMat();
-    for (auto i = 0; i < ip2Size; i++)
-        imagePoints2Vec[i] = imagePoints2[i]->getMat();
-
-    *returnValue = cv::stereoCalibrate(objectPointsVec, imagePoints1Vec, imagePoints2Vec,
-        *cameraMatrix1, *distCoeffs1,
-        *cameraMatrix2, *distCoeffs2,
-        cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
-    });
-}
-
-CVAPI(ExceptionStatus) calib_stereoCalibrate_Mat(
-    cv::Mat **objectPoints, int opSize,
-    cv::Mat **imagePoints1, int ip1Size,
-    cv::Mat **imagePoints2, int ip2Size,
-    cv::Mat *cameraMatrix1,
-    cv::Mat *distCoeffs1,
-    cv::Mat *cameraMatrix2,
-    cv::Mat *distCoeffs2,
-    interop::Size imageSize,
-    cv::Mat *R, cv::Mat *T,
-    cv::Mat *E, cv::Mat *F,
     int flags,
     interop::TermCriteria criteria,
     double *returnValue)
@@ -223,7 +190,7 @@ CVAPI(ExceptionStatus) calib_stereoCalibrate_Mat(
     *returnValue = cv::stereoCalibrate(objectPointsVec, imagePoints1Vec, imagePoints2Vec,
         *cameraMatrix1, *distCoeffs1,
         *cameraMatrix2, *distCoeffs2,
-        cpp(imageSize), *R, *T, *E, *F, flags, cpp(criteria));
+        cpp(imageSize), entity(R), entity(T), entity(E), entity(F), flags, cpp(criteria));
     });
 }
 

--- a/src/OpenCvSharpExtern/stereo.h
+++ b/src/OpenCvSharpExtern/stereo.h
@@ -95,8 +95,8 @@ CVAPI(ExceptionStatus) stereo_rectify3Collinear_InputArray(
     cv::_InputArray *cameraMatrix1, cv::_InputArray *distCoeffs1,
     cv::_InputArray *cameraMatrix2, cv::_InputArray *distCoeffs2,
     cv::_InputArray *cameraMatrix3, cv::_InputArray *distCoeffs3,
-    cv::_InputArray **imgpt1, int imgpt1Size,
-    cv::_InputArray **imgpt3, int imgpt3Size,
+    cv::Mat **imgpt1, int imgpt1Size,
+    cv::Mat **imgpt3, int imgpt3Size,
     interop::Size imageSize, cv::_InputArray *R12, cv::_InputArray *T12,
     cv::_InputArray *R13, cv::_InputArray *T13,
     cv::_OutputArray *R1, cv::_OutputArray *R2, cv::_OutputArray *R3,
@@ -109,9 +109,9 @@ CVAPI(ExceptionStatus) stereo_rectify3Collinear_InputArray(
     std::vector<cv::Mat> imgpt1Vec(imgpt1Size);
     std::vector<cv::Mat> imgpt3Vec(imgpt3Size);
     for (auto i = 0; i < imgpt1Size; i++)
-        imgpt1Vec[i] = imgpt1[i]->getMat();
+        imgpt1Vec[i] = *imgpt1[i];
     for (auto i = 0; i < imgpt3Size; i++)
-        imgpt3Vec[i] = imgpt3[i]->getMat();
+        imgpt3Vec[i] = *imgpt3[i];
     cv::Rect _roi1, _roi2;
 
     const auto ret = cv::rectify3Collinear(*cameraMatrix1, *distCoeffs1,

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -638,40 +638,6 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
     }
 
     [Fact]
-    public void StereoCalibrateByInputArray()
-    {
-        var patternSize = new Size(10, 7);
-
-        using var image = LoadImage("calibration/00.jpg");
-        Cv2.FindChessboardCorners(image, patternSize, out var cornerPoints);
-
-        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
-
-        using var opIA = InputArray.Create(objectPointsArray);
-        using var ip1IA = InputArray.Create(cornerPoints);
-        using var ip2IA = InputArray.Create(cornerPoints);
-
-        using var cameraMatrix1 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
-        using var distCoeffs1 = new Mat<double>();
-        using var cameraMatrix2 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
-        using var distCoeffs2 = new Mat<double>();
-        using var R = new Mat();
-        using var T = new Mat();
-        using var E = new Mat();
-        using var F = new Mat();
-
-        var rms = Cv2.StereoCalibrate(
-            new[] { opIA }, new[] { ip1IA }, new[] { ip2IA },
-            cameraMatrix1, distCoeffs1,
-            cameraMatrix2, distCoeffs2,
-            image.Size(), R, T, E, F,
-            CalibrationFlags.UseIntrinsicGuess);
-
-        Assert.False(double.IsNaN(rms));
-        Assert.False(double.IsInfinity(rms));
-    }
-
-    [Fact]
     public void StereoCalibrateByMat()
     {
         var patternSize = new Size(10, 7);
@@ -684,9 +650,9 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
         using var imagePoints = Mat<Point2f>.FromArray(cornerPoints);
         using var cameraMatrix1 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
-        using var distCoeffs1 = new Mat();
+        using var distCoeffs1 = new Mat<double>();
         using var cameraMatrix2 = Mat.EyeMat(3, 3, MatType.CV_64FC1);
-        using var distCoeffs2 = new Mat();
+        using var distCoeffs2 = new Mat<double>();
         using var R = new Mat();
         using var T = new Mat();
         using var E = new Mat();


### PR DESCRIPTION
Strategy ① (blocker removal) of #1976 — making `InputArray`/`OutputArray` allocation-free `ref struct`s. A `ref struct` cannot be a type argument of `IEnumerable<T>`, so the `IEnumerable<InputArray>` parameters must be removed before the type can be converted. This PR is mergeable on its own while the types are still classes.

## Changes

- **`Cv2.StereoCalibrate` (the `InputOutputArray`-based overload) and `Cv2.Rectify3Collinear`**: `IEnumerable<InputArray>` → `IReadOnlyList<Mat>` for the point-vector parameters, mirroring the existing `IEnumerable<Mat>` calibration overloads.
- **CS0121 resolution (owner-approved option A):** switching the vectors to `Mat` made the `InputOutputArray`-based `StereoCalibrate` overload collide with the all-`Mat` overload. The all-`Mat` overload is deleted and callers consolidate onto the flexible `InputArray`/`OutputArray` version; `Mat` args still bind via implicit conversion.
- **Native pointer-type fix:** `calib_stereoCalibrate_InputArray` / `stereo_rectify3Collinear_InputArray` took `cv::_InputArray**` for the vectors, but the managed side now passes `cv::Mat*` handles (a different C++ type — it compiles because both are `IntPtr`, but fails at runtime with *"Unknown/unsupported array type"*). Those vector parameters are changed to `cv::Mat**` (dereference instead of `getMat()`); the scalar args stay `_InputOutputArray*`/`_OutputArray*`. The now-unused `calib_stereoCalibrate_Mat` extern and its P/Invoke are dropped.
- **Tests:** removed `StereoCalibrateByInputArray` (it passed `InputArray[]`); kept `StereoCalibrateByMat`, fixing its empty `distCoeffs` to `Mat<double>` so the `_InputArray` path can infer the element type.

## Verification

Native rebuilt (`cmake --build src/build --config Release`). calib3d/stereo test suites: 31 passed, 1 skipped (pre-existing `FishEyeCalibrate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)