### PR TITLE
Foundation: allocation-free InputArray/OutputArray ref structs (ArrayProxy proxy-POD path)

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_experimental.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_experimental.cs
@@ -1,0 +1,38 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// PROTOTYPE (issue: InputArray/OutputArray ref struct redesign).
+// One function wired through the ref-struct proxy path to prove the end-to-end design:
+// implicit Mat -> InputArrayRef/OutputArrayRef (stack, no alloc) -> extern receives handle+kind
+// -> native builds cv::_InputArray/_OutputArray on the stack. No managed/native _InputArray
+// object is allocated per call.
+static partial class Cv2
+{
+    /// <summary>
+    /// PROTOTYPE: Transposes a matrix through the allocation-free ref-struct proxy path.
+    /// </summary>
+    public static void TransposeRef(InputArrayRef src, OutputArrayRef dst)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_transpose_io(src.Handle, (int)src.Kind, dst.Handle, (int)dst.Kind));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
+    /// PROTOTYPE: Per-element addition through the ref-struct proxy path. Either operand may be a
+    /// Mat/UMat or a Scalar/double — scalars travel inline (no allocation).
+    /// </summary>
+    public static void AddRef(InputArrayRef src1, InputArrayRef src2, OutputArrayRef dst)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_add_io(
+                src1.Handle, (int)src1.Kind, src1.ScalarValue,
+                src2.Handle, (int)src2.Kind, src2.ScalarValue,
+                dst.Handle, (int)dst.Kind));
+        GC.KeepAlive(src1.Source);
+        GC.KeepAlive(src2.Source);
+        GC.KeepAlive(dst.Source);
+    }
+}

--- a/src/OpenCvSharp/Cv2/Cv2_experimental.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_experimental.cs
@@ -2,37 +2,45 @@ using OpenCvSharp.Internal;
 
 namespace OpenCvSharp;
 
-// PROTOTYPE (issue: InputArray/OutputArray ref struct redesign).
-// One function wired through the ref-struct proxy path to prove the end-to-end design:
-// implicit Mat -> InputArrayRef/OutputArrayRef (stack, no alloc) -> extern receives handle+kind
-// -> native builds cv::_InputArray/_OutputArray on the stack. No managed/native _InputArray
-// object is allocated per call.
+// FOUNDATION (issue: InputArray/OutputArray ref-struct redesign).
+// A few functions wired through the ref-struct proxy path to prove the end-to-end design:
+// implicit Mat/Scalar/... -> InputArrayRef/OutputArrayRef (stack, no alloc) -> extern receives an
+// ArrayProxy BY VALUE -> native rebuilds cv::_InputArray/_OutputArray on its stack. No managed or
+// native _InputArray object is allocated per call.
 static partial class Cv2
 {
     /// <summary>
-    /// PROTOTYPE: Transposes a matrix through the allocation-free ref-struct proxy path.
+    /// FOUNDATION: Transposes a matrix through the allocation-free ref-struct proxy path.
     /// </summary>
     public static void TransposeRef(InputArrayRef src, OutputArrayRef dst)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_transpose_io(src.Handle, (int)src.Kind, dst.Handle, (int)dst.Kind));
+            NativeMethods.core_transpose_io(src.Proxy, dst.Proxy));
         GC.KeepAlive(src.Source);
         GC.KeepAlive(dst.Source);
     }
 
     /// <summary>
-    /// PROTOTYPE: Per-element addition through the ref-struct proxy path. Either operand may be a
+    /// FOUNDATION: Per-element addition through the ref-struct proxy path. Either operand may be a
     /// Mat/UMat or a Scalar/double — scalars travel inline (no allocation).
     /// </summary>
     public static void AddRef(InputArrayRef src1, InputArrayRef src2, OutputArrayRef dst)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_add_io(
-                src1.Handle, (int)src1.Kind, src1.ScalarValue,
-                src2.Handle, (int)src2.Kind, src2.ScalarValue,
-                dst.Handle, (int)dst.Kind));
+            NativeMethods.core_add_io(src1.Proxy, src2.Proxy, dst.Proxy));
         GC.KeepAlive(src1.Source);
         GC.KeepAlive(src2.Source);
         GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
+    /// FOUNDATION: Copies the lower/upper half of a square matrix onto the other half, in place,
+    /// through the ref-struct proxy path (exercises the InputOutputArray proxy).
+    /// </summary>
+    public static void CompleteSymmRef(InputOutputArrayRef mtx, bool lowerToUpper = false)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_completeSymm_io(mtx.Proxy, lowerToUpper ? 1 : 0));
+        GC.KeepAlive(mtx.Source);
     }
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -317,18 +317,13 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_transpose(IntPtr src, IntPtr dst);
 
-    // PROTOTYPE: ref-struct proxy path. Receives handle + kind and builds cv::_InputArray /
-    // cv::_OutputArray on the native stack (no managed-side _InputArray allocation).
+    // FOUNDATION: ref-struct proxy path. Each array argument is an ArrayProxy passed BY VALUE; the
+    // native side rebuilds cv::_InputArray/_OutputArray on its stack (no managed _InputArray alloc).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_transpose_io(IntPtr src, int srcKind, IntPtr dst, int dstKind);
+    internal static partial ExceptionStatus core_transpose_io(ArrayProxy src, ArrayProxy dst);
 
-    // PROTOTYPE: scalar-aware ref-struct path. Scalar/double operands are passed by value (inline),
-    // so no _InputArray is allocated for them either.
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_add_io(
-        IntPtr src1, int kind1, Scalar scalar1,
-        IntPtr src2, int kind2, Scalar scalar2,
-        IntPtr dst, int dstKind);
+    internal static partial ExceptionStatus core_add_io(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_transform(IntPtr src, IntPtr dst, IntPtr m);
@@ -348,6 +343,10 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_completeSymm(IntPtr mtx, int lowerToUpper);
+
+    // FOUNDATION: ref-struct proxy path for an InputOutputArray argument.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_completeSymm_io(ArrayProxy mtx, int lowerToUpper);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_setIdentity(IntPtr mtx, Scalar s);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -317,6 +317,19 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_transpose(IntPtr src, IntPtr dst);
 
+    // PROTOTYPE: ref-struct proxy path. Receives handle + kind and builds cv::_InputArray /
+    // cv::_OutputArray on the native stack (no managed-side _InputArray allocation).
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_transpose_io(IntPtr src, int srcKind, IntPtr dst, int dstKind);
+
+    // PROTOTYPE: scalar-aware ref-struct path. Scalar/double operands are passed by value (inline),
+    // so no _InputArray is allocated for them either.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_add_io(
+        IntPtr src1, int kind1, Scalar scalar1,
+        IntPtr src2, int kind2, Scalar scalar2,
+        IntPtr dst, int dstKind);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_transform(IntPtr src, IntPtr dst, IntPtr m);
 

--- a/src/OpenCvSharp/Modules/core/InputArrayRef.cs
+++ b/src/OpenCvSharp/Modules/core/InputArrayRef.cs
@@ -117,6 +117,68 @@ public readonly ref struct InputArrayRef
     /// <summary>Wraps a <see cref="double"/> value (no allocation; travels inline as Scalar(d,0,0,0)).</summary>
     public static implicit operator InputArrayRef(double d) =>
         new(null, new ArrayProxy { Kind = (int)ArrayProxyKind.Double, Payload0 = d });
+
+    // cv depth constants for the inline Vec payload (cv::CV_8U .. CV_64F).
+    private const int DepthU8 = 0, DepthU16 = 2, DepthS16 = 3, DepthS32 = 4, DepthF32 = 5, DepthF64 = 6;
+
+    // Copies a fixed-length vector value into the inline payload (no allocation). The native side
+    // reads it back as (const T*)payload with VecLength elements; see fromInputProxy in my_types.h.
+    private static InputArrayRef FromVec<T>(T vec, int depth, int length) where T : unmanaged
+    {
+        var proxy = new ArrayProxy { Kind = (int)ArrayProxyKind.Vec, VecDepth = depth, VecLength = length };
+        var payload = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref proxy.Payload0, 6));
+        MemoryMarshal.Write(payload, in vec);
+        return new InputArrayRef(null, proxy);
+    }
+
+    /// <summary>Wraps a <see cref="Vec2b"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2b v) => FromVec(v, DepthU8, 2);
+    /// <summary>Wraps a <see cref="Vec3b"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3b v) => FromVec(v, DepthU8, 3);
+    /// <summary>Wraps a <see cref="Vec4b"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4b v) => FromVec(v, DepthU8, 4);
+    /// <summary>Wraps a <see cref="Vec6b"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6b v) => FromVec(v, DepthU8, 6);
+    /// <summary>Wraps a <see cref="Vec2s"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2s v) => FromVec(v, DepthS16, 2);
+    /// <summary>Wraps a <see cref="Vec3s"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3s v) => FromVec(v, DepthS16, 3);
+    /// <summary>Wraps a <see cref="Vec4s"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4s v) => FromVec(v, DepthS16, 4);
+    /// <summary>Wraps a <see cref="Vec6s"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6s v) => FromVec(v, DepthS16, 6);
+    /// <summary>Wraps a <see cref="Vec2w"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2w v) => FromVec(v, DepthU16, 2);
+    /// <summary>Wraps a <see cref="Vec3w"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3w v) => FromVec(v, DepthU16, 3);
+    /// <summary>Wraps a <see cref="Vec4w"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4w v) => FromVec(v, DepthU16, 4);
+    /// <summary>Wraps a <see cref="Vec6w"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6w v) => FromVec(v, DepthU16, 6);
+    /// <summary>Wraps a <see cref="Vec2i"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2i v) => FromVec(v, DepthS32, 2);
+    /// <summary>Wraps a <see cref="Vec3i"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3i v) => FromVec(v, DepthS32, 3);
+    /// <summary>Wraps a <see cref="Vec4i"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4i v) => FromVec(v, DepthS32, 4);
+    /// <summary>Wraps a <see cref="Vec6i"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6i v) => FromVec(v, DepthS32, 6);
+    /// <summary>Wraps a <see cref="Vec2f"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2f v) => FromVec(v, DepthF32, 2);
+    /// <summary>Wraps a <see cref="Vec3f"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3f v) => FromVec(v, DepthF32, 3);
+    /// <summary>Wraps a <see cref="Vec4f"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4f v) => FromVec(v, DepthF32, 4);
+    /// <summary>Wraps a <see cref="Vec6f"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6f v) => FromVec(v, DepthF32, 6);
+    /// <summary>Wraps a <see cref="Vec2d"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec2d v) => FromVec(v, DepthF64, 2);
+    /// <summary>Wraps a <see cref="Vec3d"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec3d v) => FromVec(v, DepthF64, 3);
+    /// <summary>Wraps a <see cref="Vec4d"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec4d v) => FromVec(v, DepthF64, 4);
+    /// <summary>Wraps a <see cref="Vec6d"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Vec6d v) => FromVec(v, DepthF64, 6);
 }
 
 /// <summary>

--- a/src/OpenCvSharp/Modules/core/InputArrayRef.cs
+++ b/src/OpenCvSharp/Modules/core/InputArrayRef.cs
@@ -1,16 +1,22 @@
+using System.Runtime.InteropServices;
+
 namespace OpenCvSharp;
 
-// PROTOTYPE (issue: InputArray/OutputArray ref struct redesign).
-// A handle-less, stack-only proxy that mirrors OpenCV's cv::_InputArray: it carries just a
-// native handle + a kind tag (and an inline Scalar for scalar operands). No native _InputArray
-// is allocated on the managed side; the extern boundary builds cv::_InputArray on the stack.
-// This makes the implicit-conversion temporaries (e.g. Cv2.Foo(mat, dst)) allocation-free and
-// removes the non-deterministic finalizer cleanup of the current class-based InputArray.
+// FOUNDATION for the InputArray/OutputArray ref-struct redesign (issue: allocation-free arrays).
 //
-// Named *Ref while prototyping to avoid colliding with the existing InputArray/OutputArray
-// classes; once proven on a few functions these replace them.
+// A handle-less, stack-only proxy that mirrors OpenCV's cv::_InputArray: it carries just a native
+// handle + a kind tag (and an inline payload for scalar/vector operands). No native _InputArray is
+// allocated on the managed side; the extern boundary receives the proxy BY VALUE and rebuilds a
+// cv::_InputArray/_OutputArray on its own stack (see fromInputProxy/fromOutputProxy in my_types.h).
+// This makes implicit-conversion temporaries (e.g. Cv2.Foo(mat, dst)) allocation-free and removes
+// the non-deterministic finalizer cleanup of the current class-based InputArray.
+//
+// Named *Ref while the class-based InputArray/OutputArray still exist; the big-bang migration
+// renames these over them. Scope (owner decision, "Option 1"): handle kinds (Mat/UMat/MatExpr) and
+// inline value kinds (Scalar/double/Vec). Array / Span / vector-of-Mat inputs are NOT carried here
+// (they get dedicated ReadOnlySpan / out Mat[] signatures), so a proxy never owns pinned memory.
 
-/// <summary>Kind of array a ref-struct proxy refers to.</summary>
+/// <summary>Kind of array a ref-struct proxy refers to. Must match the switch in my_types.h.</summary>
 public enum ArrayProxyKind
 {
     /// <summary>No array (cv::noArray()).</summary>
@@ -19,90 +25,160 @@ public enum ArrayProxyKind
     Mat = 1,
     /// <summary>A <see cref="UMat"/>.</summary>
     UMat = 2,
-    /// <summary>A <see cref="Scalar"/> value.</summary>
-    Scalar = 3,
-    /// <summary>A scalar <see cref="double"/> value.</summary>
-    Double = 4,
+    /// <summary>A <see cref="MatExpr"/> (materialized to a native cv::MatExpr).</summary>
+    MatExpr = 3,
+    /// <summary>A <see cref="Scalar"/> value (inline).</summary>
+    Scalar = 4,
+    /// <summary>A scalar <see cref="double"/> value (inline, as Scalar(d,0,0,0)).</summary>
+    Double = 5,
+    /// <summary>A small fixed-length vector value (inline).</summary>
+    Vec = 6,
 }
 
 /// <summary>
-/// PROTOTYPE stack-only input proxy (see file header).
+/// Blittable plain-old-data mirror of <c>interop::ArrayProxy</c> (my_types.h). Passed BY VALUE
+/// across the P/Invoke boundary; no field is a managed reference, so it marshals 1:1.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct ArrayProxy
+{
+    public IntPtr Handle;     // Mat/UMat/NativeMatExpr CvPtr for handle kinds; zero otherwise
+    public int Kind;          // ArrayProxyKind
+    public int VecDepth;      // Vec only: CV_8U..CV_64F element depth; otherwise 0
+    public int VecLength;     // Vec only: element count (2/3/4/6); otherwise 0
+    // Inline payload: Scalar (4 doubles) / double (1) / Vec (raw bytes, <= 48). 6 doubles == 48 bytes.
+    public double Payload0;
+    public double Payload1;
+    public double Payload2;
+    public double Payload3;
+    public double Payload4;
+    public double Payload5;
+
+    public static ArrayProxy FromScalar(in Scalar s) => new()
+    {
+        Handle = IntPtr.Zero,
+        Kind = (int)ArrayProxyKind.Scalar,
+        Payload0 = s.Val0,
+        Payload1 = s.Val1,
+        Payload2 = s.Val2,
+        Payload3 = s.Val3,
+    };
+}
+
+/// <summary>
+/// Stack-only input proxy (see file header). Carries a native handle or an inline value; building
+/// one allocates nothing on the managed heap.
 /// </summary>
 public readonly ref struct InputArrayRef
 {
-    // Keeps the source Mat/UMat alive across the native call (the struct only stores its raw handle).
+    // Keeps the source Mat/UMat/NativeMatExpr alive across the native call (the proxy stores only
+    // its raw handle).
     internal readonly object? Source;
-    internal readonly nint Handle;
-    internal readonly ArrayProxyKind Kind;
-    internal readonly Scalar ScalarValue;
+    internal readonly ArrayProxy Proxy;
 
-    private InputArrayRef(object? source, nint handle, ArrayProxyKind kind, Scalar scalar)
+    private InputArrayRef(object? source, ArrayProxy proxy)
     {
         Source = source;
-        Handle = handle;
-        Kind = kind;
-        ScalarValue = scalar;
+        Proxy = proxy;
     }
 
     /// <summary>Wraps a <see cref="Mat"/> (no allocation).</summary>
     public static implicit operator InputArrayRef(Mat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputArrayRef(mat, mat.CvPtr, ArrayProxyKind.Mat, default);
+        return new InputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
     }
 
     /// <summary>Wraps a <see cref="UMat"/> (no allocation).</summary>
     public static implicit operator InputArrayRef(UMat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputArrayRef(mat, mat.CvPtr, ArrayProxyKind.UMat, default);
+        return new InputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
     }
 
-    /// <summary>Wraps a <see cref="Scalar"/> value (no allocation).</summary>
-    public static implicit operator InputArrayRef(Scalar s) =>
-        new(null, 0, ArrayProxyKind.Scalar, s);
+    /// <summary>
+    /// Wraps a <see cref="MatExpr"/>. The expression is materialized into a native cv::MatExpr
+    /// (kept alive via <see cref="Source"/>), so this path is not allocation-free — matching the
+    /// inherent cost of feeding a lazy expression into an OpenCV call.
+    /// </summary>
+    public static implicit operator InputArrayRef(MatExpr expr)
+    {
+        ArgumentNullException.ThrowIfNull(expr);
+        var native = expr.Eval();
+        return new InputArrayRef(native, new ArrayProxy { Handle = native.CvPtr, Kind = (int)ArrayProxyKind.MatExpr });
+    }
 
-    /// <summary>Wraps a <see cref="double"/> value (no allocation).</summary>
+    /// <summary>Wraps a <see cref="Scalar"/> value (no allocation; travels inline).</summary>
+    public static implicit operator InputArrayRef(Scalar s) =>
+        new(null, ArrayProxy.FromScalar(s));
+
+    /// <summary>Wraps a <see cref="double"/> value (no allocation; travels inline as Scalar(d,0,0,0)).</summary>
     public static implicit operator InputArrayRef(double d) =>
-        new(null, 0, ArrayProxyKind.Double, new Scalar(d, 0, 0, 0));
+        new(null, new ArrayProxy { Kind = (int)ArrayProxyKind.Double, Payload0 = d });
 }
 
 /// <summary>
-/// PROTOTYPE stack-only output proxy (see file header). Single Mat/UMat output only — native
-/// writes through the referenced matrix directly, so no write-back (Fix/AssignResult) is needed.
+/// Stack-only output proxy (see file header). Single Mat/UMat output only — native writes through
+/// the referenced matrix directly, so no write-back (Fix/AssignResult) is needed.
 /// </summary>
 public readonly ref struct OutputArrayRef
 {
     internal readonly object? Source;
-    internal readonly nint Handle;
-    internal readonly ArrayProxyKind Kind;
+    internal readonly ArrayProxy Proxy;
 
-    private OutputArrayRef(object? source, nint handle, ArrayProxyKind kind)
+    private OutputArrayRef(object? source, ArrayProxy proxy)
     {
         Source = source;
-        Handle = handle;
-        Kind = kind;
+        Proxy = proxy;
     }
 
     /// <summary>Wraps a <see cref="Mat"/> output (no allocation).</summary>
     public static implicit operator OutputArrayRef(Mat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new OutputArrayRef(mat, mat.CvPtr, ArrayProxyKind.Mat);
+        return new OutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
     }
 
     /// <summary>Wraps a <see cref="UMat"/> output (no allocation).</summary>
     public static implicit operator OutputArrayRef(UMat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new OutputArrayRef(mat, mat.CvPtr, ArrayProxyKind.UMat);
+        return new OutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
+    }
+}
+
+/// <summary>
+/// Stack-only input/output proxy (see file header). Single Mat/UMat only; its read/write role is
+/// flag-dependent in OpenCV, so it is kept as one type (not split into in/out variants).
+/// </summary>
+public readonly ref struct InputOutputArrayRef
+{
+    internal readonly object? Source;
+    internal readonly ArrayProxy Proxy;
+
+    private InputOutputArrayRef(object? source, ArrayProxy proxy)
+    {
+        Source = source;
+        Proxy = proxy;
+    }
+
+    /// <summary>Wraps a <see cref="Mat"/> in/out target (no allocation).</summary>
+    public static implicit operator InputOutputArrayRef(Mat mat)
+    {
+        ArgumentNullException.ThrowIfNull(mat);
+        mat.ThrowIfDisposed();
+        return new InputOutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
+    }
+
+    /// <summary>Wraps a <see cref="UMat"/> in/out target (no allocation).</summary>
+    public static implicit operator InputOutputArrayRef(UMat mat)
+    {
+        ArgumentNullException.ThrowIfNull(mat);
+        mat.ThrowIfDisposed();
+        return new InputOutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
     }
 }

--- a/src/OpenCvSharp/Modules/core/InputArrayRef.cs
+++ b/src/OpenCvSharp/Modules/core/InputArrayRef.cs
@@ -1,0 +1,108 @@
+namespace OpenCvSharp;
+
+// PROTOTYPE (issue: InputArray/OutputArray ref struct redesign).
+// A handle-less, stack-only proxy that mirrors OpenCV's cv::_InputArray: it carries just a
+// native handle + a kind tag (and an inline Scalar for scalar operands). No native _InputArray
+// is allocated on the managed side; the extern boundary builds cv::_InputArray on the stack.
+// This makes the implicit-conversion temporaries (e.g. Cv2.Foo(mat, dst)) allocation-free and
+// removes the non-deterministic finalizer cleanup of the current class-based InputArray.
+//
+// Named *Ref while prototyping to avoid colliding with the existing InputArray/OutputArray
+// classes; once proven on a few functions these replace them.
+
+/// <summary>Kind of array a ref-struct proxy refers to.</summary>
+public enum ArrayProxyKind
+{
+    /// <summary>No array (cv::noArray()).</summary>
+    None = 0,
+    /// <summary>A <see cref="Mat"/>.</summary>
+    Mat = 1,
+    /// <summary>A <see cref="UMat"/>.</summary>
+    UMat = 2,
+    /// <summary>A <see cref="Scalar"/> value.</summary>
+    Scalar = 3,
+    /// <summary>A scalar <see cref="double"/> value.</summary>
+    Double = 4,
+}
+
+/// <summary>
+/// PROTOTYPE stack-only input proxy (see file header).
+/// </summary>
+public readonly ref struct InputArrayRef
+{
+    // Keeps the source Mat/UMat alive across the native call (the struct only stores its raw handle).
+    internal readonly object? Source;
+    internal readonly nint Handle;
+    internal readonly ArrayProxyKind Kind;
+    internal readonly Scalar ScalarValue;
+
+    private InputArrayRef(object? source, nint handle, ArrayProxyKind kind, Scalar scalar)
+    {
+        Source = source;
+        Handle = handle;
+        Kind = kind;
+        ScalarValue = scalar;
+    }
+
+    /// <summary>Wraps a <see cref="Mat"/> (no allocation).</summary>
+    public static implicit operator InputArrayRef(Mat mat)
+    {
+        if (mat is null)
+            throw new ArgumentNullException(nameof(mat));
+        mat.ThrowIfDisposed();
+        return new InputArrayRef(mat, mat.CvPtr, ArrayProxyKind.Mat, default);
+    }
+
+    /// <summary>Wraps a <see cref="UMat"/> (no allocation).</summary>
+    public static implicit operator InputArrayRef(UMat mat)
+    {
+        if (mat is null)
+            throw new ArgumentNullException(nameof(mat));
+        mat.ThrowIfDisposed();
+        return new InputArrayRef(mat, mat.CvPtr, ArrayProxyKind.UMat, default);
+    }
+
+    /// <summary>Wraps a <see cref="Scalar"/> value (no allocation).</summary>
+    public static implicit operator InputArrayRef(Scalar s) =>
+        new(null, 0, ArrayProxyKind.Scalar, s);
+
+    /// <summary>Wraps a <see cref="double"/> value (no allocation).</summary>
+    public static implicit operator InputArrayRef(double d) =>
+        new(null, 0, ArrayProxyKind.Double, new Scalar(d, 0, 0, 0));
+}
+
+/// <summary>
+/// PROTOTYPE stack-only output proxy (see file header). Single Mat/UMat output only — native
+/// writes through the referenced matrix directly, so no write-back (Fix/AssignResult) is needed.
+/// </summary>
+public readonly ref struct OutputArrayRef
+{
+    internal readonly object? Source;
+    internal readonly nint Handle;
+    internal readonly ArrayProxyKind Kind;
+
+    private OutputArrayRef(object? source, nint handle, ArrayProxyKind kind)
+    {
+        Source = source;
+        Handle = handle;
+        Kind = kind;
+    }
+
+    /// <summary>Wraps a <see cref="Mat"/> output (no allocation).</summary>
+    public static implicit operator OutputArrayRef(Mat mat)
+    {
+        if (mat is null)
+            throw new ArgumentNullException(nameof(mat));
+        mat.ThrowIfDisposed();
+        return new OutputArrayRef(mat, mat.CvPtr, ArrayProxyKind.Mat);
+    }
+
+    /// <summary>Wraps a <see cref="UMat"/> output (no allocation).</summary>
+    public static implicit operator OutputArrayRef(UMat mat)
+    {
+        if (mat is null)
+            throw new ArgumentNullException(nameof(mat));
+        mat.ThrowIfDisposed();
+        return new OutputArrayRef(mat, mat.CvPtr, ArrayProxyKind.UMat);
+    }
+}

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -563,63 +563,23 @@ CVAPI(ExceptionStatus) core_transpose(cv::_InputArray *src, cv::_OutputArray *ds
     });
 }
 
-// PROTOTYPE: ref-struct proxy path. Build cv::_InputArray / cv::_OutputArray on the stack from a
-// raw handle + kind tag, so the managed side never allocates a heap _InputArray per call.
-// kind: 1 = Mat, 2 = UMat (scalar kinds handled later by overloads taking interop::Scalar).
-static cv::_InputArray refToInputArray(void *handle, int kind)
-{
-    switch (kind)
-    {
-    case 1: return cv::_InputArray(*static_cast<cv::Mat *>(handle));
-    case 2: return cv::_InputArray(*static_cast<cv::UMat *>(handle));
-    default: return cv::noArray();
-    }
-}
-static cv::_OutputArray refToOutputArray(void *handle, int kind)
-{
-    switch (kind)
-    {
-    case 1: return cv::_OutputArray(*static_cast<cv::Mat *>(handle));
-    case 2: return cv::_OutputArray(*static_cast<cv::UMat *>(handle));
-    default: return cv::noArray();
-    }
-}
-
-CVAPI(ExceptionStatus) core_transpose_io(void *src, int srcKind, void *dst, int dstKind)
+// FOUNDATION: ref-struct proxy path. Each array argument arrives as an interop::ArrayProxy passed
+// BY VALUE; fromInputProxy()/fromOutputProxy() (in my_types.h) rebuild a cv::_InputArray /
+// _OutputArray on this stack frame, so the managed side never allocates a heap _InputArray per call.
+// Scalar-kind inputs reference a stack-local cv::Scalar scratch that must outlive the OpenCV call.
+CVAPI(ExceptionStatus) core_transpose_io(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::transpose(refToInputArray(src, srcKind), refToOutputArray(dst, dstKind));
+    cv::Scalar s;
+    cv::transpose(fromInputProxy(src, s), fromOutputProxy(dst));
     });
 }
 
-// Scalar-aware overload. For scalar kinds the cv::_InputArray references 'scalar', so the caller
-// must keep that cv::Scalar alive on its own stack for the duration of the OpenCV call.
-// kind: 1 = Mat, 2 = UMat, 3 = Scalar, 4 = Double.
-static cv::_InputArray refToInputArray(void *handle, int kind, const cv::Scalar &scalar)
-{
-    switch (kind)
-    {
-    case 1: return cv::_InputArray(*static_cast<cv::Mat *>(handle));
-    case 2: return cv::_InputArray(*static_cast<cv::UMat *>(handle));
-    case 3:
-    case 4: return cv::_InputArray(scalar);
-    default: return cv::noArray();
-    }
-}
-
-CVAPI(ExceptionStatus) core_add_io(
-    void *src1, int kind1, interop::Scalar scalar1,
-    void *src2, int kind2, interop::Scalar scalar2,
-    void *dst, int dstKind)
+CVAPI(ExceptionStatus) core_add_io(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    // Materialize scalars onto this stack frame so the _InputArray references stay valid.
-    const cv::Scalar s1 = cpp(scalar1);
-    const cv::Scalar s2 = cpp(scalar2);
-    cv::add(
-        refToInputArray(src1, kind1, s1),
-        refToInputArray(src2, kind2, s2),
-        refToOutputArray(dst, dstKind));
+    cv::Scalar s1, s2;
+    cv::add(fromInputProxy(src1, s1), fromInputProxy(src2, s2), fromOutputProxy(dst));
     });
 }
 
@@ -679,6 +639,14 @@ CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerTo
 {
     return cvTry([&] {
     cv::completeSymm(*mtx, lowerToUpper != 0);
+    });
+}
+
+// FOUNDATION: ref-struct proxy path for an _InputOutputArray argument (see core_transpose_io).
+CVAPI(ExceptionStatus) core_completeSymm_io(interop::ArrayProxy mtx, int lowerToUpper)
+{
+    return cvTry([&] {
+    cv::completeSymm(fromInputOutputProxy(mtx), lowerToUpper != 0);
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -563,6 +563,66 @@ CVAPI(ExceptionStatus) core_transpose(cv::_InputArray *src, cv::_OutputArray *ds
     });
 }
 
+// PROTOTYPE: ref-struct proxy path. Build cv::_InputArray / cv::_OutputArray on the stack from a
+// raw handle + kind tag, so the managed side never allocates a heap _InputArray per call.
+// kind: 1 = Mat, 2 = UMat (scalar kinds handled later by overloads taking interop::Scalar).
+static cv::_InputArray refToInputArray(void *handle, int kind)
+{
+    switch (kind)
+    {
+    case 1: return cv::_InputArray(*static_cast<cv::Mat *>(handle));
+    case 2: return cv::_InputArray(*static_cast<cv::UMat *>(handle));
+    default: return cv::noArray();
+    }
+}
+static cv::_OutputArray refToOutputArray(void *handle, int kind)
+{
+    switch (kind)
+    {
+    case 1: return cv::_OutputArray(*static_cast<cv::Mat *>(handle));
+    case 2: return cv::_OutputArray(*static_cast<cv::UMat *>(handle));
+    default: return cv::noArray();
+    }
+}
+
+CVAPI(ExceptionStatus) core_transpose_io(void *src, int srcKind, void *dst, int dstKind)
+{
+    return cvTry([&] {
+    cv::transpose(refToInputArray(src, srcKind), refToOutputArray(dst, dstKind));
+    });
+}
+
+// Scalar-aware overload. For scalar kinds the cv::_InputArray references 'scalar', so the caller
+// must keep that cv::Scalar alive on its own stack for the duration of the OpenCV call.
+// kind: 1 = Mat, 2 = UMat, 3 = Scalar, 4 = Double.
+static cv::_InputArray refToInputArray(void *handle, int kind, const cv::Scalar &scalar)
+{
+    switch (kind)
+    {
+    case 1: return cv::_InputArray(*static_cast<cv::Mat *>(handle));
+    case 2: return cv::_InputArray(*static_cast<cv::UMat *>(handle));
+    case 3:
+    case 4: return cv::_InputArray(scalar);
+    default: return cv::noArray();
+    }
+}
+
+CVAPI(ExceptionStatus) core_add_io(
+    void *src1, int kind1, interop::Scalar scalar1,
+    void *src2, int kind2, interop::Scalar scalar2,
+    void *dst, int dstKind)
+{
+    return cvTry([&] {
+    // Materialize scalars onto this stack frame so the _InputArray references stay valid.
+    const cv::Scalar s1 = cpp(scalar1);
+    const cv::Scalar s2 = cpp(scalar2);
+    cv::add(
+        refToInputArray(src1, kind1, s1),
+        refToInputArray(src2, kind2, s2),
+        refToOutputArray(dst, dstKind));
+    });
+}
+
 CVAPI(ExceptionStatus) core_transform(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *m)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -197,6 +197,24 @@ namespace interop
     typedef struct Vec4d { double val[4]; } Vec4d;
     typedef struct Vec6d { double val[6]; } Vec6d;
 
+    // Stack-only array proxy for the ref-struct InputArray/OutputArray redesign. It mirrors
+    // cv::_InputArray/_OutputArray (a kind tag + a pointer/inline payload) and is passed BY VALUE
+    // across the P/Invoke boundary, so the managed side never allocates a heap cv::_InputArray per
+    // call. The native side rebuilds a cv::_InputArray/_OutputArray on its own stack from these
+    // fields via fromInputProxy()/fromOutputProxy().
+    //
+    // For Scalar kinds the inline payload feeds a stack-local cv::Scalar (see fromInputProxy). For
+    // Vec kinds the cv::_InputArray references this struct's own `payload` storage; because the
+    // proxy is taken by value, the parameter copy stays valid for the duration of the OpenCV call.
+    struct ArrayProxy
+    {
+        void  *handle;     // cv::Mat*/cv::UMat*/cv::MatExpr* for handle kinds; null otherwise
+        int    kind;       // ArrayProxyKind: 0 None, 1 Mat, 2 UMat, 3 MatExpr, 4 Scalar, 5 Double, 6 Vec
+        int    vecDepth;   // Vec only: CV_8U..CV_64F element depth; otherwise 0
+        int    vecLength;  // Vec only: element count (2/3/4/6); otherwise 0
+        double payload[6]; // inline storage: Scalar (4 doubles) | double (1) | Vec (raw bytes, <= 48)
+    };
+
 } // namespace interop
 
 extern "C"
@@ -329,4 +347,71 @@ static interop::Moments c(const cv::Moments &m)
 static cv::Moments cpp(const interop::Moments &m)
 {
     return cv::Moments(m.m00, m.m10, m.m01, m.m20, m.m11, m.m02, m.m30, m.m21, m.m12, m.m03);
+}
+
+// -------------------------------------------------------------------------
+// interop::ArrayProxy -> cv::_InputArray / _OutputArray / _InputOutputArray
+//
+// These build the cv:: array proxy on the caller's stack from a by-value
+// interop::ArrayProxy, so no heap cv::_InputArray is allocated per call. Use
+// them at the head of a CVAPI body, e.g.:
+//
+//     CVAPI(...) foo(interop::ArrayProxy src, interop::ArrayProxy dst) {
+//         return cvTry([&] {
+//         cv::Scalar s; // scratch storage for scalar-kind inputs (see below)
+//         cv::bar(fromInputProxy(src, s), fromOutputProxy(dst));
+//         });
+//     }
+//
+// Scalar/Double inputs: cv::_InputArray references a cv::Scalar, so the caller
+// must keep `scalarScratch` alive for the whole OpenCV call (one scratch per
+// input that may be a scalar).
+// Vec inputs: cv::_InputArray references proxy.payload; the by-value parameter
+// copy stays valid for the call.
+// -------------------------------------------------------------------------
+static cv::_InputArray fromInputProxy(const interop::ArrayProxy &p, cv::Scalar &scalarScratch)
+{
+    switch (p.kind)
+    {
+    case 1: return cv::_InputArray(*static_cast<cv::Mat *>(p.handle));
+    case 2: return cv::_InputArray(*static_cast<cv::UMat *>(p.handle));
+    case 3: return cv::_InputArray(*static_cast<cv::MatExpr *>(p.handle));
+    case 4:
+    case 5:
+        scalarScratch = cv::Scalar(p.payload[0], p.payload[1], p.payload[2], p.payload[3]);
+        return cv::_InputArray(scalarScratch);
+    case 6:
+        switch (p.vecDepth)
+        {
+        case CV_8U:  return cv::_InputArray(reinterpret_cast<const uchar  *>(p.payload), p.vecLength);
+        case CV_8S:  return cv::_InputArray(reinterpret_cast<const schar  *>(p.payload), p.vecLength);
+        case CV_16U: return cv::_InputArray(reinterpret_cast<const ushort *>(p.payload), p.vecLength);
+        case CV_16S: return cv::_InputArray(reinterpret_cast<const short  *>(p.payload), p.vecLength);
+        case CV_32S: return cv::_InputArray(reinterpret_cast<const int    *>(p.payload), p.vecLength);
+        case CV_32F: return cv::_InputArray(reinterpret_cast<const float  *>(p.payload), p.vecLength);
+        case CV_64F: return cv::_InputArray(reinterpret_cast<const double *>(p.payload), p.vecLength);
+        default:     return cv::noArray();
+        }
+    default: return cv::noArray();
+    }
+}
+
+static cv::_OutputArray fromOutputProxy(const interop::ArrayProxy &p)
+{
+    switch (p.kind)
+    {
+    case 1: return cv::_OutputArray(*static_cast<cv::Mat *>(p.handle));
+    case 2: return cv::_OutputArray(*static_cast<cv::UMat *>(p.handle));
+    default: return cv::noArray();
+    }
+}
+
+static cv::_InputOutputArray fromInputOutputProxy(const interop::ArrayProxy &p)
+{
+    switch (p.kind)
+    {
+    case 1: return cv::_InputOutputArray(*static_cast<cv::Mat *>(p.handle));
+    case 2: return cv::_InputOutputArray(*static_cast<cv::UMat *>(p.handle));
+    default: return cv::noArray();
+    }
 }

--- a/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
+++ b/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
@@ -127,6 +127,36 @@ public class InputArrayRefTest : TestBase
     }
 
     [Fact]
+    public void TransposeRef_Vec_Matches()
+    {
+        var v = new Vec3d(1, 2, 3);
+
+        using var actual = new Mat();
+        Cv2.TransposeRef(v, actual);   // Vec3d -> InputArrayRef(Vec), travels inline
+
+        using var expected = new Mat();
+        Cv2.Transpose(v, expected);    // Vec3d -> class InputArray(Vec)
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void TransposeRef_Vec_IsAllocationFree()
+    {
+        var v = new Vec3d(1, 2, 3);
+        using var dst = new Mat();
+
+        Cv2.TransposeRef(v, dst); // warmup
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+            Cv2.TransposeRef(v, dst);
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
+
+    [Fact]
     public void CompleteSymmRef_Matches()
     {
         using var actual = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);

--- a/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
+++ b/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
@@ -1,0 +1,113 @@
+using OpenCvSharp.Tests;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Core;
+
+/// <summary>
+/// PROTOTYPE proof for the ref-struct InputArray/OutputArray redesign: one function
+/// (<see cref="Cv2.TransposeRef"/>) wired through the handle+kind proxy path. Verifies numeric
+/// correctness against the existing class-based path and, crucially, that repeated calls allocate
+/// nothing on the managed heap (the implicit-conversion temporaries live on the stack and the
+/// native _InputArray is built extern-side).
+/// </summary>
+public class InputArrayRefTest : TestBase
+{
+    private static Mat Float3x3(params float[] v)
+    {
+        var m = new Mat(3, 3, MatType.CV_32FC1);
+        m.SetArray(v);
+        return m;
+    }
+
+    [Fact]
+    public void TransposeRef_MatchesClassBasedTranspose()
+    {
+        using var src = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        using var actual = new Mat();
+        Cv2.TransposeRef(src, actual);   // Mat -> InputArrayRef/OutputArrayRef (ref struct)
+
+        using var expected = new Mat();
+        Cv2.Transpose(src, expected);    // existing class-based InputArray/OutputArray path
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void TransposeRef_IsAllocationFree()
+    {
+        using var src = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        using var dst = new Mat();
+
+        // Warm up JIT / one-time setup.
+        Cv2.TransposeRef(src, dst);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+            Cv2.TransposeRef(src, dst);
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
+
+    [Fact]
+    public void AddRef_MatPlusMat_Matches()
+    {
+        using var a = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        using var b = Float3x3(9, 8, 7, 6, 5, 4, 3, 2, 1);
+
+        using var actual = new Mat();
+        Cv2.AddRef(a, b, actual);
+
+        using var expected = new Mat();
+        Cv2.Add(a, b, expected);
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void AddRef_MatPlusScalar_Matches()
+    {
+        using var src = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        var s = new Scalar(10);
+
+        using var actual = new Mat();
+        Cv2.AddRef(src, s, actual);   // InputArrayRef(Scalar) — scalar travels inline
+
+        using var expected = new Mat();
+        Cv2.Add(src, s, expected);    // class path (Scalar -> InputArray)
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void AddRef_MatPlusDouble_Matches()
+    {
+        using var src = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        using var actual = new Mat();
+        Cv2.AddRef(src, 5.0, actual); // InputArrayRef(double)
+
+        using var expected = new Mat();
+        Cv2.Add(src, new Scalar(5.0), expected);
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void AddRef_MatPlusScalar_IsAllocationFree()
+    {
+        using var src = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        var s = new Scalar(10);
+        using var dst = new Mat();
+
+        Cv2.AddRef(src, s, dst); // warmup
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+            Cv2.AddRef(src, s, dst);
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
+}

--- a/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
+++ b/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
@@ -110,4 +110,46 @@ public class InputArrayRefTest : TestBase
 
         Assert.Equal(0, after - before);
     }
+
+    [Fact]
+    public void AddRef_MatPlusMatExpr_Matches()
+    {
+        using var a = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        using var b = Float3x3(9, 8, 7, 6, 5, 4, 3, 2, 1);
+
+        using var actual = new Mat();
+        Cv2.AddRef(a, a + b, actual);   // (a + b) is a MatExpr -> InputArrayRef(MatExpr)
+
+        using var expected = new Mat();
+        Cv2.Add(a, a + b, expected);    // class path (MatExpr -> InputArray)
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void CompleteSymmRef_Matches()
+    {
+        using var actual = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        Cv2.CompleteSymmRef(actual);    // InputOutputArrayRef (in-place)
+
+        using var expected = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        Cv2.CompleteSymm(expected);     // class InputOutputArray path
+
+        ImageEquals(expected, actual);
+    }
+
+    [Fact]
+    public void CompleteSymmRef_IsAllocationFree()
+    {
+        using var m = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        Cv2.CompleteSymmRef(m); // warmup
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+            Cv2.CompleteSymmRef(m);
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+    }
 }


### PR DESCRIPTION
Strategy ② (foundation) of #1976 — the complete, proven ref-struct `InputArray`/`OutputArray` types and the generic native converters that the big-bang migration (strategy ③) will build on. The class-based types are untouched; the new `*Ref` types coexist until the type flip.

Builds on the prototype spike (`8cb35b95`, included here as history); the foundation **redesigns** the prototype's per-argument `(handle, kind, scalar)` parameter explosion into a single by-value POD.

## Scope — "Option 1" (owner decision)

The proxies carry **handle kinds** (`Mat`/`UMat`/`MatExpr`) and **inline value kinds** (`Scalar`/`double`/`Vec`). Array / `Span` / vector-of-`Mat` inputs are deliberately **not** carried — they get dedicated `ReadOnlySpan` / `out Mat[]` signatures — so a proxy never owns pinned memory. (Unifying arrays onto `InputArray` is the later calib3d-modernization epic.)

## Design — proxy POD passed by value

Each array argument is a blittable `interop::ArrayProxy { handle, kind, vecDepth, vecLength, payload[6] }` (72 B on x64) passed **by value** across the P/Invoke boundary. The native side rebuilds `cv::_InputArray`/`_OutputArray`/`_InputOutputArray` on its own stack via `fromInputProxy()` / `fromOutputProxy()` / `fromInputOutputProxy()` (`my_types.h`).

- No heap `cv::_InputArray` is allocated per call.
- The managed side needs no pinning or `unsafe` address-taking.
- Extern signatures become a near-mechanical swap (`cv::_InputArray*` → `interop::ArrayProxy`) for strategy ③, instead of a 3× parameter explosion.
- Scalar kinds reference a caller-stack scratch `cv::Scalar` (no dangling); Vec kinds reference the by-value parameter copy's `payload`.

## What's here

- **`my_types.h`**: `interop::ArrayProxy` POD + `from{Input,Output,InputOutput}Proxy` converters.
- **`InputArrayRef.cs`**: `ArrayProxyKind`, the blittable `ArrayProxy`, and `readonly ref struct` `InputArrayRef` / `OutputArrayRef` / `InputOutputArrayRef` with allocation-free implicit conversions — input: `Mat`/`UMat`/`MatExpr`/`Scalar`/`double`/`Vec{2,3,4,6}{b,s,w,i,f,d}` (24); output & in/out: `Mat`/`UMat`. (`MatExpr` materializes a native `cv::MatExpr`, so that one path is not allocation-free — inherent.)
- **Proof functions** (`Cv2_experimental.cs`): `TransposeRef`, `AddRef`, `CompleteSymmRef` (exercises the in/out proxy), wired to `core_transpose_io` / `core_add_io` / `core_completeSymm_io`.

## Verification

`InputArrayRefTest` — 11 tests: numeric parity vs the class-based path **and** zero-allocation (1000-iteration loops allocate 0 bytes) for `Mat`, `Mat+Scalar`, `Mat+double`, `MatExpr`, `Vec`, and `InputOutputArray`. Native rebuilt; full `core` suite (344) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)