### PR TITLE
Migration: move externs to the ArrayProxy ABI (strategy 3)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -350,6 +350,16 @@ jobs:
           name: test-results-macos
           path: test/OpenCvSharp.Tests/bin/Release/net10.0/test-results.trx
 
+      # Safety net: on a crash/failure, upload the macOS crash reports (.ips) so a
+      # native fault can be diagnosed from the faulting backtrace without a re-run.
+      - name: Upload crash reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-arm64-crash-reports
+          path: ~/Library/Logs/DiagnosticReports/
+          if-no-files-found: ignore
+
   # ---------------------------------------------------------------------------
   # Create NuGet packages from the macOS-built binaries.
   # ---------------------------------------------------------------------------

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -2442,7 +2442,7 @@ public static partial class Cv2
         eigenvectors.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_eigen(src.CvPtr, eigenvalues.CvPtr, eigenvectors.CvPtr, out var ret));
+            NativeMethods.core_eigen(src.ToInputProxy(), eigenvalues.ToOutputProxy(), eigenvectors.ToOutputProxy(), out var ret));
 
         eigenvalues.Fix();
         eigenvectors.Fix();
@@ -2471,7 +2471,7 @@ public static partial class Cv2
         eigenvectors.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_eigenNonSymmetric(src.CvPtr, eigenvalues.CvPtr, eigenvectors.CvPtr));
+            NativeMethods.core_eigenNonSymmetric(src.ToInputProxy(), eigenvalues.ToOutputProxy(), eigenvectors.ToOutputProxy()));
 
         eigenvalues.Fix();
         eigenvectors.Fix();
@@ -2536,7 +2536,7 @@ public static partial class Cv2
 
         var ctypeValue = ctype.GetValueOrDefault(MatType.CV_64F);
         NativeMethods.HandleException(
-            NativeMethods.core_calcCovarMatrix_InputArray(samples.CvPtr, covar.CvPtr, mean.CvPtr, (int) flags, ctypeValue.Value));
+            NativeMethods.core_calcCovarMatrix_InputArray(samples.ToInputProxy(), covar.ToOutputProxy(), mean.ToInputOutputProxy(), (int) flags, ctypeValue.Value));
 
         GC.KeepAlive(samples);
         GC.KeepAlive(covar);
@@ -2568,7 +2568,7 @@ public static partial class Cv2
         eigenvectors.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCACompute(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, maxComponents));
+            NativeMethods.core_PCACompute(data.ToInputProxy(), mean.ToInputOutputProxy(), eigenvectors.ToOutputProxy(), maxComponents));
 
         GC.KeepAlive(data);
         mean.Fix();
@@ -2602,7 +2602,7 @@ public static partial class Cv2
         eigenvalues.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCACompute2(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, eigenvalues.CvPtr, maxComponents));
+            NativeMethods.core_PCACompute2(data.ToInputProxy(), mean.ToInputOutputProxy(), eigenvectors.ToOutputProxy(), eigenvalues.ToOutputProxy(), maxComponents));
 
         GC.KeepAlive(data);
         mean.Fix();
@@ -2633,7 +2633,7 @@ public static partial class Cv2
         eigenvectors.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCAComputeVar(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, retainedVariance));
+            NativeMethods.core_PCAComputeVar(data.ToInputProxy(), mean.ToInputOutputProxy(), eigenvectors.ToOutputProxy(), retainedVariance));
 
         GC.KeepAlive(data);
         GC.KeepAlive(mean);
@@ -2669,7 +2669,7 @@ public static partial class Cv2
         eigenvalues.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCAComputeVar2(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, eigenvalues.CvPtr, retainedVariance));
+            NativeMethods.core_PCAComputeVar2(data.ToInputProxy(), mean.ToInputOutputProxy(), eigenvectors.ToOutputProxy(), eigenvalues.ToOutputProxy(), retainedVariance));
 
         GC.KeepAlive(data);
         mean.Fix();
@@ -2701,7 +2701,7 @@ public static partial class Cv2
         result.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCAProject(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, result.CvPtr));
+            NativeMethods.core_PCAProject(data.ToInputProxy(), mean.ToInputProxy(), eigenvectors.ToInputProxy(), result.ToOutputProxy()));
 
         GC.KeepAlive(data);
         GC.KeepAlive(mean);
@@ -2734,7 +2734,7 @@ public static partial class Cv2
         result.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PCABackProject(data.CvPtr, mean.CvPtr, eigenvectors.CvPtr, result.CvPtr));
+            NativeMethods.core_PCABackProject(data.ToInputProxy(), mean.ToInputProxy(), eigenvectors.ToInputProxy(), result.ToOutputProxy()));
 
         GC.KeepAlive(data);
         GC.KeepAlive(mean);
@@ -2771,7 +2771,7 @@ public static partial class Cv2
         vt.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_SVDecomp(src.CvPtr, w.CvPtr, u.CvPtr, vt.CvPtr, (int) flags));
+            NativeMethods.core_SVDecomp(src.ToInputProxy(), w.ToOutputProxy(), u.ToOutputProxy(), vt.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(w);
@@ -2812,7 +2812,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_SVBackSubst(w.CvPtr, u.CvPtr, vt.CvPtr, rhs.CvPtr, dst.CvPtr));
+            NativeMethods.core_SVBackSubst(w.ToInputProxy(), u.ToInputProxy(), vt.ToInputProxy(), rhs.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(w);
         GC.KeepAlive(u);
@@ -2842,7 +2842,7 @@ public static partial class Cv2
         icovar.ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_Mahalanobis(v1.CvPtr, v2.CvPtr, icovar.CvPtr, out var ret));
+            NativeMethods.core_Mahalanobis(v1.ToInputProxy(), v2.ToInputProxy(), icovar.ToInputProxy(), out var ret));
 
         GC.KeepAlive(v1);
         GC.KeepAlive(v2);
@@ -2872,7 +2872,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_dft(src.CvPtr, dst.CvPtr, (int) flags, nonzeroRows));
+            NativeMethods.core_dft(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags, nonzeroRows));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2901,7 +2901,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_idft(src.CvPtr, dst.CvPtr, (int) flags, nonzeroRows));
+            NativeMethods.core_idft(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags, nonzeroRows));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2924,7 +2924,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_dct(src.CvPtr, dst.CvPtr, (int) flags));
+            NativeMethods.core_dct(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2947,7 +2947,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_idct(src.CvPtr, dst.CvPtr, (int) flags));
+            NativeMethods.core_idct(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2978,7 +2978,7 @@ public static partial class Cv2
         c.ThrowIfNotReady();
 
         NativeMethods.HandleException( 
-            NativeMethods.core_mulSpectrums(a.CvPtr, b.CvPtr, c.CvPtr, (int) flags, conjB ? 1 : 0));
+            NativeMethods.core_mulSpectrums(a.ToInputProxy(), b.ToInputProxy(), c.ToOutputProxy(), (int) flags, conjB ? 1 : 0));
 
         GC.KeepAlive(a);
         GC.KeepAlive(b);
@@ -3041,7 +3041,7 @@ public static partial class Cv2
         high.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_randu_InputArray(dst.CvPtr, low.CvPtr, high.CvPtr));
+            NativeMethods.core_randu_InputArray(dst.ToInputOutputProxy(), low.ToInputProxy(), high.ToInputProxy()));
 
         GC.KeepAlive(dst);
         GC.KeepAlive(low);
@@ -3064,7 +3064,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_randu_Scalar(dst.CvPtr, low, high));
+            NativeMethods.core_randu_Scalar(dst.ToInputOutputProxy(), low, high));
 
         GC.KeepAlive(dst);
         dst.Fix();
@@ -3091,7 +3091,7 @@ public static partial class Cv2
         stddev.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_randn_InputArray(dst.CvPtr, mean.CvPtr, stddev.CvPtr));
+            NativeMethods.core_randn_InputArray(dst.ToInputOutputProxy(), mean.ToInputProxy(), stddev.ToInputProxy()));
 
         GC.KeepAlive(dst);
         GC.KeepAlive(mean);
@@ -3113,7 +3113,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_randn_Scalar(dst.CvPtr, mean, stddev));
+            NativeMethods.core_randn_Scalar(dst.ToInputOutputProxy(), mean, stddev));
 
         GC.KeepAlive(dst);
         dst.Fix();
@@ -3132,7 +3132,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_randShuffle(dst.CvPtr, iterFactor, IntPtr.Zero));
+            NativeMethods.core_randShuffle(dst.ToInputOutputProxy(), iterFactor, IntPtr.Zero));
 
         GC.KeepAlive(dst);
         dst.Fix();
@@ -3154,7 +3154,7 @@ public static partial class Cv2
 
         var state = rng.State;
         NativeMethods.HandleException(
-            NativeMethods.core_randShuffle(dst.CvPtr, iterFactor, ref state));
+            NativeMethods.core_randShuffle(dst.ToInputOutputProxy(), iterFactor, ref state));
         rng = new RNG(state);
 
         GC.KeepAlive(dst);
@@ -3192,7 +3192,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_kmeans(
-                data.CvPtr, k, bestLabels.CvPtr, criteria, attempts, (int) flags, ToPtr(centers), out var ret));
+                data.ToInputProxy(), k, bestLabels.ToInputOutputProxy(), criteria, attempts, (int) flags, centers?.ToOutputProxy() ?? default, out var ret));
 
         bestLabels.Fix();
         centers?.Fix();

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -497,7 +497,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_meanStdDev_OutputArray(
-                src.CvPtr, mean.CvPtr, stddev.CvPtr, ToPtr(mask)));
+                src.ToInputProxy(), mean.ToOutputProxy(), stddev.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         mean.Fix();
         stddev.Fix();
@@ -525,7 +525,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_meanStdDev_Scalar(
-                src.CvPtr, out mean, out stddev, ToPtr(mask)));
+                src.ToInputProxy(), out mean, out stddev, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -546,7 +546,7 @@ public static partial class Cv2
         src1.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_norm1(src1.CvPtr, (int)normType, ToPtr(mask), out var ret));
+            NativeMethods.core_norm1(src1.ToInputProxy(), (int)normType, mask?.ToInputProxy() ?? default, out var ret));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(mask);
@@ -572,7 +572,7 @@ public static partial class Cv2
         src2.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_norm2(src1.CvPtr, src2.CvPtr, (int)normType, ToPtr(mask), out var ret));
+            NativeMethods.core_norm2(src1.ToInputProxy(), src2.ToInputProxy(), (int)normType, mask?.ToInputProxy() ?? default, out var ret));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -601,7 +601,7 @@ public static partial class Cv2
         src2.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_PSNR(src1.CvPtr, src2.CvPtr, r, out var ret));
+            NativeMethods.core_PSNR(src1.ToInputProxy(), src2.ToInputProxy(), r, out var ret));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -643,8 +643,8 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_batchDistance(
-                src1.CvPtr, src2.CvPtr, dist.CvPtr, dtype, nidx.CvPtr,
-                (int) normType, k, ToPtr(mask), update, crosscheck ? 1 : 0));
+                src1.ToInputProxy(), src2.ToInputProxy(), dist.ToOutputProxy(), dtype, nidx.ToOutputProxy(),
+                (int) normType, k, mask?.ToInputProxy() ?? default, update, crosscheck ? 1 : 0));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -682,7 +682,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_normalize(
-                src.CvPtr, dst.CvPtr, alpha, beta, (int)normType, dtype, ToPtr(mask)));
+                src.ToInputProxy(), dst.ToInputOutputProxy(), alpha, beta, (int)normType, dtype, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -708,7 +708,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_reduceArgMax(src.CvPtr, dst.CvPtr, axis, lastIndex));
+            NativeMethods.core_reduceArgMax(src.ToInputProxy(), dst.ToOutputProxy(), axis, lastIndex));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -733,7 +733,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_reduceArgMin(src.CvPtr, dst.CvPtr, axis, lastIndex));
+            NativeMethods.core_reduceArgMin(src.ToInputProxy(), dst.ToOutputProxy(), axis, lastIndex));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -753,7 +753,7 @@ public static partial class Cv2
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_minMaxLoc1(src.CvPtr, out minVal, out maxVal));
+            NativeMethods.core_minMaxLoc1(src.ToInputProxy(), out minVal, out maxVal));
 
         GC.KeepAlive(src);
     }
@@ -787,7 +787,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_minMaxLoc2(
-                src.CvPtr, out minVal, out maxVal, out minLoc, out maxLoc, ToPtr(mask)));
+                src.ToInputProxy(), out minVal, out maxVal, out minLoc, out maxLoc, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -806,7 +806,7 @@ public static partial class Cv2
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_minMaxIdx1(src.CvPtr, out minVal, out maxVal));
+            NativeMethods.core_minMaxIdx1(src.ToInputProxy(), out minVal, out maxVal));
 
         GC.KeepAlive(src);
     }
@@ -844,7 +844,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_minMaxIdx2(
-                src.CvPtr, out minVal, out maxVal, minIdx, maxIdx, ToPtr(mask)));
+                src.ToInputProxy(), out minVal, out maxVal, minIdx, maxIdx, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
     }
@@ -870,7 +870,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_reduce(src.CvPtr, dst.CvPtr, (int)dim, (int)rtype, dtype));
+            NativeMethods.core_reduce(src.ToInputProxy(), dst.ToOutputProxy(), (int)dim, (int)rtype, dtype));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -1003,7 +1003,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_extractChannel(src.CvPtr, dst.CvPtr, coi));
+            NativeMethods.core_extractChannel(src.ToInputProxy(), dst.ToOutputProxy(), coi));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1026,7 +1026,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_insertChannel(src.CvPtr, dst.CvPtr, coi));
+            NativeMethods.core_insertChannel(src.ToInputProxy(), dst.ToInputOutputProxy(), coi));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1075,7 +1075,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_rotate(src.CvPtr, dst.CvPtr, (int)rotateCode));
+            NativeMethods.core_rotate(src.ToInputProxy(), dst.ToOutputProxy(), (int)rotateCode));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -1098,7 +1098,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_repeat1(src.CvPtr, ny, nx, dst.CvPtr));
+            NativeMethods.core_repeat1(src.ToInputProxy(), ny, nx, dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1175,7 +1175,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_hconcat2(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_hconcat2(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1233,7 +1233,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_vconcat2(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_vconcat2(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -279,7 +279,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_scaleAdd(src1.CvPtr, alpha, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_scaleAdd(src1.ToInputProxy(), alpha, src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -311,7 +311,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_addWeighted(
-                src1.CvPtr, alpha, src2.CvPtr, beta, gamma, dst.CvPtr, dtype));
+                src1.ToInputProxy(), alpha, src2.ToInputProxy(), beta, gamma, dst.ToOutputProxy(), dtype));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -335,7 +335,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_convertScaleAbs(src.CvPtr, dst.CvPtr, alpha, beta));
+            NativeMethods.core_convertScaleAbs(src.ToInputProxy(), dst.ToOutputProxy(), alpha, beta));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -365,7 +365,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_LUT(src.CvPtr, lut.CvPtr, dst.CvPtr));
+            NativeMethods.core_LUT(src.ToInputProxy(), lut.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(lut);
@@ -407,7 +407,7 @@ public static partial class Cv2
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_sum(src.CvPtr, out var ret));
+            NativeMethods.core_sum(src.ToInputProxy(), out var ret));
 
         GC.KeepAlive(src);
         return ret;
@@ -425,7 +425,7 @@ public static partial class Cv2
         mtx.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_countNonZero(mtx.CvPtr, out var ret));
+            NativeMethods.core_countNonZero(mtx.ToInputProxy(), out var ret));
 
         GC.KeepAlive(mtx);
         return ret;
@@ -446,7 +446,7 @@ public static partial class Cv2
         idx.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_findNonZero(src.CvPtr, idx.CvPtr));
+            NativeMethods.core_findNonZero(src.ToInputProxy(), idx.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(idx);
@@ -467,7 +467,7 @@ public static partial class Cv2
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_mean(src.CvPtr, ToPtr(mask), out var ret));
+            NativeMethods.core_mean(src.ToInputProxy(), mask?.ToInputProxy() ?? default, out var ret));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -1149,7 +1149,7 @@ public static partial class Cv2
         }
 
         NativeMethods.HandleException(
-            NativeMethods.core_hconcat1(srcPtr, (uint) srcArray.Length, dst.CvPtr));
+            NativeMethods.core_hconcat1(srcPtr, (uint) srcArray.Length, dst.ToOutputProxy()));
 
         GC.KeepAlive(srcArray);
         GC.KeepAlive(dst);
@@ -1207,7 +1207,7 @@ public static partial class Cv2
         }
 
         NativeMethods.HandleException(
-            NativeMethods.core_vconcat1(srcPtr, (uint)srcArray.Length, dst.CvPtr));
+            NativeMethods.core_vconcat1(srcPtr, (uint)srcArray.Length, dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2171,7 +2171,7 @@ public static partial class Cv2
         mtx.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_completeSymm(mtx.CvPtr, lowerToUpper ? 1 : 0));
+            NativeMethods.core_completeSymm(mtx.ToInputOutputProxy(), lowerToUpper ? 1 : 0));
 
         GC.KeepAlive(mtx);
         mtx.Fix();
@@ -3588,7 +3588,7 @@ public static partial class Cv2
 
         using var buf = new StdString();
         NativeMethods.HandleException(
-            NativeMethods.core_format(mtx.CvPtr, (int) format, buf.CvPtr));
+            NativeMethods.core_format(mtx.ToInputProxy(), (int) format, buf.CvPtr));
         GC.KeepAlive(mtx);
         return buf.ToString();
     }

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -10,6 +10,10 @@ namespace OpenCvSharp;
 
 public static partial class Cv2
 {
+    // Above this count, collect Mat handles into a heap IntPtr[] instead of stackalloc, to bound
+    // stack usage when passing a variable-length vector-of-Mat to the native cv::Mat** ABI.
+    private const int MaxStackAllocHandles = 32;
+
     #region core.hpp
 
     /// <summary>
@@ -882,33 +886,30 @@ public static partial class Cv2
     /// </summary>
     /// <param name="mv"></param>
     /// <param name="dst"></param>
-    public static void Merge(Mat[] mv, Mat dst)
+    public static void Merge(ReadOnlySpan<Mat> mv, Mat dst)
     {
-        if (mv is null)
-            throw new ArgumentNullException(nameof(mv));
         if (mv.Length == 0)
             throw new ArgumentException("mv is empty", nameof(mv));
         if (dst is null)
             throw new ArgumentNullException(nameof(dst));
-        foreach (var m in mv)
+
+        Span<IntPtr> handles = mv.Length <= MaxStackAllocHandles
+            ? stackalloc IntPtr[mv.Length]
+            : new IntPtr[mv.Length];
+        for (var i = 0; i < mv.Length; i++)
         {
-            if (m is null)
-                throw new ArgumentException("mv contains null element");
+            var m = mv[i] ?? throw new ArgumentException("mv contains null element");
             m.ThrowIfDisposed();
+            handles[i] = m.CvPtr;
         }
 
         dst.ThrowIfDisposed();
 
-        var mvPtr = new IntPtr[mv.Length];
-        for (var i = 0; i < mv.Length; i++)
-        {
-            mvPtr[i] = mv[i].CvPtr;
-        }
-
         NativeMethods.HandleException(
-            NativeMethods.core_merge(mvPtr, (uint)mvPtr.Length, dst.CvPtr));
+            NativeMethods.core_merge(handles, (uint)mv.Length, dst.CvPtr));
 
-        GC.KeepAlive(mv);
+        foreach (var m in mv)
+            GC.KeepAlive(m);
         GC.KeepAlive(dst);
     }
 
@@ -951,12 +952,8 @@ public static partial class Cv2
     /// <param name="src"></param>
     /// <param name="dst"></param>
     /// <param name="fromTo"></param>
-    public static void MixChannels(Mat[] src, Mat[] dst, int[] fromTo)
+    public static void MixChannels(ReadOnlySpan<Mat> src, ReadOnlySpan<Mat> dst, int[] fromTo)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
         if (fromTo is null)
             throw new ArgumentNullException(nameof(fromTo));
         if (src.Length == 0)
@@ -965,8 +962,9 @@ public static partial class Cv2
             throw new ArgumentException("Length == 0", nameof(dst));
         if (fromTo.Length == 0 || fromTo.Length % 2 != 0)
             throw new ArgumentException("Invalid length", nameof(fromTo));
-        var srcPtr = new IntPtr[src.Length];
-        var dstPtr = new IntPtr[dst.Length];
+
+        Span<IntPtr> srcPtr = src.Length <= MaxStackAllocHandles ? stackalloc IntPtr[src.Length] : new IntPtr[src.Length];
+        Span<IntPtr> dstPtr = dst.Length <= MaxStackAllocHandles ? stackalloc IntPtr[dst.Length] : new IntPtr[dst.Length];
         for (var i = 0; i < src.Length; i++)
         {
             src[i].ThrowIfDisposed();
@@ -983,8 +981,10 @@ public static partial class Cv2
                 srcPtr, (uint)src.Length, dstPtr, (uint)dst.Length,
                 fromTo, (uint)(fromTo.Length / 2)));
 
-        GC.KeepAlive(src);
-        GC.KeepAlive(dst);
+        foreach (var m in src)
+            GC.KeepAlive(m);
+        foreach (var m in dst)
+            GC.KeepAlive(m);
     }
 
     /// <summary>
@@ -1130,28 +1130,27 @@ public static partial class Cv2
     /// </summary>
     /// <param name="src">input array or vector of matrices. all of the matrices must have the same number of rows and the same depth.</param>
     /// <param name="dst">output array. It has the same number of rows and depth as the src, and the sum of cols of the src.</param>
-    [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
-    public static void HConcat(IEnumerable<Mat> src, OutputArray dst)
+    public static void HConcat(ReadOnlySpan<Mat> src, OutputArray dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
         if (dst is null)
             throw new ArgumentNullException(nameof(dst));
-
-        var srcArray = src as Mat[] ?? src.ToArray();
-        if (srcArray.Length == 0)
+        if (src.Length == 0)
             throw new ArgumentException("src is empty", nameof(src));
-        var srcPtr = new IntPtr[srcArray.Length];
-        for (var i = 0; i < srcArray.Length; i++)
+
+        Span<IntPtr> srcPtr = src.Length <= MaxStackAllocHandles
+            ? stackalloc IntPtr[src.Length]
+            : new IntPtr[src.Length];
+        for (var i = 0; i < src.Length; i++)
         {
-            srcArray[i].ThrowIfDisposed();
-            srcPtr[i] = srcArray[i].CvPtr;
+            src[i].ThrowIfDisposed();
+            srcPtr[i] = src[i].CvPtr;
         }
 
         NativeMethods.HandleException(
-            NativeMethods.core_hconcat1(srcPtr, (uint) srcArray.Length, dst.ToOutputProxy()));
+            NativeMethods.core_hconcat1(srcPtr, (uint) src.Length, dst.ToOutputProxy()));
 
-        GC.KeepAlive(srcArray);
+        foreach (var m in src)
+            GC.KeepAlive(m);
         GC.KeepAlive(dst);
         dst.Fix();
     }
@@ -1188,28 +1187,27 @@ public static partial class Cv2
     /// </summary>
     /// <param name="src">input array or vector of matrices. all of the matrices must have the same number of cols and the same depth.</param>
     /// <param name="dst">output array. It has the same number of cols and depth as the src, and the sum of rows of the src.</param>
-    [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
-    public static void VConcat(IEnumerable<Mat> src, OutputArray dst)
+    public static void VConcat(ReadOnlySpan<Mat> src, OutputArray dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
         if (dst is null)
             throw new ArgumentNullException(nameof(dst));
-
-        var srcArray = src as Mat[] ?? src.ToArray();
-        if (srcArray.Length == 0)
+        if (src.Length == 0)
             throw new ArgumentException("src.Count == 0", nameof(src));
-        var srcPtr = new IntPtr[srcArray.Length];
-        for (var i = 0; i < srcArray.Length; i++)
+
+        Span<IntPtr> srcPtr = src.Length <= MaxStackAllocHandles
+            ? stackalloc IntPtr[src.Length]
+            : new IntPtr[src.Length];
+        for (var i = 0; i < src.Length; i++)
         {
-            srcArray[i].ThrowIfDisposed();
-            srcPtr[i] = srcArray[i].CvPtr;
+            src[i].ThrowIfDisposed();
+            srcPtr[i] = src[i].CvPtr;
         }
 
         NativeMethods.HandleException(
-            NativeMethods.core_vconcat1(srcPtr, (uint)srcArray.Length, dst.ToOutputProxy()));
+            NativeMethods.core_vconcat1(srcPtr, (uint)src.Length, dst.ToOutputProxy()));
 
-        GC.KeepAlive(src);
+        foreach (var m in src)
+            GC.KeepAlive(m);
         GC.KeepAlive(dst);
         dst.Fix();
     }
@@ -2490,24 +2488,28 @@ public static partial class Cv2
     /// <param name="flags">operation flags - see CovarFlags.</param>
     /// <param name="ctype">type of the matrixl; it equals 'CV_64F' by default.</param>
     public static void CalcCovarMatrix(
-        Mat[] samples, Mat covar, Mat mean,
+        ReadOnlySpan<Mat> samples, Mat covar, Mat mean,
         CovarFlags flags, MatType? ctype = null)
     {
-        if (samples is null)
-            throw new ArgumentNullException(nameof(samples));
         if (covar is null)
             throw new ArgumentNullException(nameof(covar));
         if (mean is null)
             throw new ArgumentNullException(nameof(mean));
         covar.ThrowIfDisposed();
         mean.ThrowIfDisposed();
-        var samplesPtr = samples.Select(x => x.CvPtr).ToArray();
+
+        Span<IntPtr> samplesPtr = samples.Length <= MaxStackAllocHandles
+            ? stackalloc IntPtr[samples.Length]
+            : new IntPtr[samples.Length];
+        for (var i = 0; i < samples.Length; i++)
+            samplesPtr[i] = samples[i].CvPtr;
 
         var ctypeValue = ctype.GetValueOrDefault(MatType.CV_64F);
         NativeMethods.HandleException(
             NativeMethods.core_calcCovarMatrix_Mat(samplesPtr, samples.Length, covar.CvPtr, mean.CvPtr, (int) flags, ctypeValue.Value));
 
-        GC.KeepAlive(samples);
+        foreach (var m in samples)
+            GC.KeepAlive(m);
         GC.KeepAlive(covar);
         GC.KeepAlive(mean);
     }

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -1889,7 +1889,7 @@ public static partial class Cv2
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_checkRange(src.CvPtr, quiet ? 1 : 0, out pos, minVal, maxVal, out var ret));
+            NativeMethods.core_checkRange(src.ToInputProxy(), quiet ? 1 : 0, out pos, minVal, maxVal, out var ret));
         GC.KeepAlive(src);
         return ret != 0;
     }
@@ -1906,7 +1906,7 @@ public static partial class Cv2
         a.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.core_patchNaNs(a.CvPtr, val));
+            NativeMethods.core_patchNaNs(a.ToInputOutputProxy(), val));
 
         GC.KeepAlive(a);
     }
@@ -1939,7 +1939,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_gemm(src1.CvPtr, src2.CvPtr, alpha, src3.CvPtr, gamma, dst.CvPtr, (int) flags));
+            NativeMethods.core_gemm(src1.ToInputProxy(), src2.ToInputProxy(), alpha, src3.ToInputProxy(), gamma, dst.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1975,7 +1975,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.core_mulTransposed(src.CvPtr, dst.CvPtr, aTa ? 1 : 0, ToPtr(delta), scale, dtype));
+            NativeMethods.core_mulTransposed(src.ToInputProxy(), dst.ToOutputProxy(), aTa ? 1 : 0, delta?.ToInputProxy() ?? default, scale, dtype));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2025,7 +2025,7 @@ public static partial class Cv2
         m.ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_transform(src.CvPtr, dst.CvPtr, m.CvPtr));
+            NativeMethods.core_transform(src.ToInputProxy(), dst.ToOutputProxy(), m.ToInputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2053,7 +2053,7 @@ public static partial class Cv2
         m.ThrowIfDisposed();
             
         NativeMethods.HandleException(
-            NativeMethods.core_perspectiveTransform(src.CvPtr, dst.CvPtr, m.CvPtr));
+            NativeMethods.core_perspectiveTransform(src.ToInputProxy(), dst.ToOutputProxy(), m.ToInputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2190,7 +2190,7 @@ public static partial class Cv2
 
         var s0 = s.GetValueOrDefault(new Scalar(1));
         NativeMethods.HandleException(
-            NativeMethods.core_setIdentity(mtx.CvPtr, s0));
+            NativeMethods.core_setIdentity(mtx.ToInputOutputProxy(), s0));
 
         GC.KeepAlive(mtx);
         mtx.Fix();
@@ -2208,7 +2208,7 @@ public static partial class Cv2
         mtx.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_determinant(mtx.CvPtr, out var ret));
+            NativeMethods.core_determinant(mtx.ToInputProxy(), out var ret));
 
         GC.KeepAlive(mtx);
         return ret;
@@ -2226,7 +2226,7 @@ public static partial class Cv2
         mtx.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_trace(mtx.CvPtr, out var ret));
+            NativeMethods.core_trace(mtx.ToInputProxy(), out var ret));
 
         GC.KeepAlive(mtx);
         return ret;
@@ -2250,7 +2250,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_invert(src.CvPtr, dst.CvPtr, (int) flags, out var ret));
+            NativeMethods.core_invert(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags, out var ret));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2280,7 +2280,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_solve(src1.CvPtr, src2.CvPtr, dst.CvPtr, (int) flags, out var ret));
+            NativeMethods.core_solve(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), (int) flags, out var ret));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -2315,7 +2315,7 @@ public static partial class Cv2
         z.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_solveLP(func.CvPtr, constr.CvPtr, z.CvPtr, out var ret));
+            NativeMethods.core_solveLP(func.ToInputProxy(), constr.ToInputProxy(), z.ToOutputProxy(), out var ret));
 
         GC.KeepAlive(func);
         GC.KeepAlive(constr);
@@ -2339,7 +2339,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_sort(src.CvPtr, dst.CvPtr, (int) flags));
+            NativeMethods.core_sort(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2362,7 +2362,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_sortIdx(src.CvPtr, dst.CvPtr, (int) flags));
+            NativeMethods.core_sortIdx(src.ToInputProxy(), dst.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2385,7 +2385,7 @@ public static partial class Cv2
         roots.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_solveCubic(coeffs.CvPtr, roots.CvPtr, out var ret));
+            NativeMethods.core_solveCubic(coeffs.ToInputProxy(), roots.ToOutputProxy(), out var ret));
 
         GC.KeepAlive(coeffs);
         GC.KeepAlive(roots);
@@ -2410,7 +2410,7 @@ public static partial class Cv2
         roots.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_solvePoly(coeffs.CvPtr, roots.CvPtr, maxIters, out var ret));
+            NativeMethods.core_solvePoly(coeffs.ToInputProxy(), roots.ToOutputProxy(), maxIters, out var ret));
 
         GC.KeepAlive(coeffs);
         GC.KeepAlive(roots);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -81,7 +81,8 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_add(
-                src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask), dtype));
+                src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(),
+                mask?.ToInputProxy() ?? default, dtype));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -1995,7 +1995,7 @@ public static partial class Cv2
             
 
         NativeMethods.HandleException(
-            NativeMethods.core_transpose(src.CvPtr, dst.CvPtr));
+            NativeMethods.core_transpose(src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -1261,7 +1261,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_bitwise_and(src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.core_bitwise_and(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1289,7 +1289,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_bitwise_or(src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.core_bitwise_or(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1318,7 +1318,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_bitwise_xor(src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.core_bitwise_xor(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1343,7 +1343,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_bitwise_not(src.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.core_bitwise_not(src.ToInputProxy(), dst.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1508,7 +1508,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_min1(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_min1(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1583,7 +1583,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_max1(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_max1(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -52,7 +52,7 @@ public static partial class Cv2
         var value0 = value.GetValueOrDefault(new Scalar());
         NativeMethods.HandleException(
             NativeMethods.core_copyMakeBorder(
-                src.CvPtr, dst.CvPtr, top, bottom, left, right, (int)borderType, value0));
+                src.ToInputProxy(), dst.ToOutputProxy(), top, bottom, left, right, (int)borderType, value0));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -1051,7 +1051,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_flip(src.CvPtr, dst.CvPtr, (int) flipCode));
+            NativeMethods.core_flip(src.ToInputProxy(), dst.ToOutputProxy(), (int) flipCode));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -1396,7 +1396,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_copyTo(src.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.core_copyTo(src.ToInputProxy(), dst.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1427,7 +1427,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_inRange_InputArray(src.CvPtr, lowerb.CvPtr, upperb.CvPtr, dst.CvPtr));
+            NativeMethods.core_inRange_InputArray(src.ToInputProxy(), lowerb.ToInputProxy(), upperb.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(lowerb);
@@ -1453,7 +1453,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_inRange_Scalar(src.CvPtr, lowerb, upperb, dst.CvPtr));
+            NativeMethods.core_inRange_Scalar(src.ToInputProxy(), lowerb, upperb, dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1481,7 +1481,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_compare(src1.CvPtr, src2.CvPtr, dst.CvPtr, (int) cmpop));
+            NativeMethods.core_compare(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), (int) cmpop));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1654,7 +1654,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_sqrt(src.CvPtr, dst.CvPtr));
+            NativeMethods.core_sqrt(src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1677,7 +1677,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_pow_Mat(src.CvPtr, power, dst.CvPtr));
+            NativeMethods.core_pow_Mat(src.ToInputProxy(), power, dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1699,7 +1699,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_exp_Mat(src.CvPtr, dst.CvPtr));
+            NativeMethods.core_exp_Mat(src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1721,7 +1721,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_log_Mat(src.CvPtr, dst.CvPtr));
+            NativeMethods.core_log_Mat(src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1755,7 +1755,7 @@ public static partial class Cv2
         y.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.core_polarToCart(magnitude.CvPtr, angle.CvPtr, x.CvPtr, y.CvPtr, angleInDegrees ? 1 : 0));
+            NativeMethods.core_polarToCart(magnitude.ToInputProxy(), angle.ToInputProxy(), x.ToOutputProxy(), y.ToOutputProxy(), angleInDegrees ? 1 : 0));
 
         GC.KeepAlive(magnitude);
         GC.KeepAlive(angle);
@@ -1791,7 +1791,7 @@ public static partial class Cv2
         angle.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_cartToPolar(x.CvPtr, y.CvPtr, magnitude.CvPtr, angle.CvPtr, angleInDegrees ? 1 : 0));
+            NativeMethods.core_cartToPolar(x.ToInputProxy(), y.ToInputProxy(), magnitude.ToOutputProxy(), angle.ToOutputProxy(), angleInDegrees ? 1 : 0));
 
         GC.KeepAlive(x);
         GC.KeepAlive(y);
@@ -1821,7 +1821,7 @@ public static partial class Cv2
         angle.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_phase(x.CvPtr, y.CvPtr, angle.CvPtr, angleInDegrees ? 1 : 0));
+            NativeMethods.core_phase(x.ToInputProxy(), y.ToInputProxy(), angle.ToOutputProxy(), angleInDegrees ? 1 : 0));
 
         GC.KeepAlive(x);
         GC.KeepAlive(y);
@@ -1848,7 +1848,7 @@ public static partial class Cv2
         magnitude.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_magnitude_Mat(x.CvPtr, y.CvPtr, magnitude.CvPtr));
+            NativeMethods.core_magnitude_Mat(x.ToInputProxy(), y.ToInputProxy(), magnitude.ToOutputProxy()));
 
         GC.KeepAlive(x);
         GC.KeepAlive(y);

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -113,7 +113,8 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_subtract_InputArray2(
-                src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask), dtype));
+                src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(),
+                mask?.ToInputProxy() ?? default, dtype));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -141,7 +142,8 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_subtract_InputArrayScalar(
-                src1.CvPtr, src2, dst.CvPtr, ToPtr(mask), dtype));
+                src1.ToInputProxy(), src2, dst.ToOutputProxy(),
+                mask?.ToInputProxy() ?? default, dtype));
 
         GC.KeepAlive(src1);
         dst.Fix();
@@ -168,7 +170,8 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_subtract_ScalarInputArray(
-                src1, src2.CvPtr, dst.CvPtr, ToPtr(mask), dtype));
+                src1, src2.ToInputProxy(), dst.ToOutputProxy(),
+                mask?.ToInputProxy() ?? default, dtype));
 
         GC.KeepAlive(src2);
         dst.Fix();
@@ -197,7 +200,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_multiply(
-                src1.CvPtr, src2.CvPtr, dst.CvPtr, scale, dtype));
+                src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), scale, dtype));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -226,7 +229,7 @@ public static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.core_divide2(
-                src1.CvPtr, src2.CvPtr, dst.CvPtr, scale, dtype?.Value ?? -1));
+                src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), scale, dtype?.Value ?? -1));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -250,7 +253,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.core_divide1(scale, src2.CvPtr, dst.CvPtr, dtype));
+            NativeMethods.core_divide1(scale, src2.ToInputProxy(), dst.ToOutputProxy(), dtype));
 
         GC.KeepAlive(src2);
         dst.Fix();
@@ -1367,7 +1370,7 @@ public static partial class Cv2
         dst.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.core_absdiff(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+            NativeMethods.core_absdiff(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);

--- a/src/OpenCvSharp/Cv2/Cv2_experimental.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_experimental.cs
@@ -27,7 +27,7 @@ static partial class Cv2
     public static void AddRef(InputArrayRef src1, InputArrayRef src2, OutputArrayRef dst)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_add_io(src1.Proxy, src2.Proxy, dst.Proxy));
+            NativeMethods.core_add(src1.Proxy, src2.Proxy, dst.Proxy, default, -1));
         GC.KeepAlive(src1.Source);
         GC.KeepAlive(src2.Source);
         GC.KeepAlive(dst.Source);

--- a/src/OpenCvSharp/Cv2/Cv2_experimental.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_experimental.cs
@@ -15,7 +15,7 @@ static partial class Cv2
     public static void TransposeRef(InputArrayRef src, OutputArrayRef dst)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_transpose_io(src.Proxy, dst.Proxy));
+            NativeMethods.core_transpose(src.Proxy, dst.Proxy));
         GC.KeepAlive(src.Source);
         GC.KeepAlive(dst.Source);
     }

--- a/src/OpenCvSharp/Cv2/Cv2_experimental.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_experimental.cs
@@ -40,7 +40,7 @@ static partial class Cv2
     public static void CompleteSymmRef(InputOutputArrayRef mtx, bool lowerToUpper = false)
     {
         NativeMethods.HandleException(
-            NativeMethods.core_completeSymm_io(mtx.Proxy, lowerToUpper ? 1 : 0));
+            NativeMethods.core_completeSymm(mtx.Proxy, lowerToUpper ? 1 : 0));
         GC.KeepAlive(mtx.Source);
     }
 }

--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -58,7 +58,7 @@ static partial class Cv2
         var ktype0 = ktype.GetValueOrDefault(MatType.CV_32F);
         NativeMethods.HandleException(
             NativeMethods.imgproc_getDerivKernels(
-                kx.CvPtr, ky.CvPtr, dx, dy, ksize, normalize ? 1 : 0, ktype0));
+                kx.ToOutputProxy(), ky.ToOutputProxy(), dx, dy, ksize, normalize ? 1 : 0, ktype0));
         GC.KeepAlive(kx);
         GC.KeepAlive(ky);
         kx.Fix();
@@ -135,7 +135,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_medianBlur(src.CvPtr, dst.CvPtr, ksize));
+            NativeMethods.imgproc_medianBlur(src.ToInputProxy(), dst.ToOutputProxy(), ksize));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -167,7 +167,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_GaussianBlur(src.CvPtr, dst.CvPtr, ksize, sigmaX, sigmaY, borderType, (int)hint));
+            NativeMethods.imgproc_GaussianBlur(src.ToInputProxy(), dst.ToOutputProxy(), ksize, sigmaX, sigmaY, borderType, (int)hint));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -200,7 +200,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_bilateralFilter(src.CvPtr, dst.CvPtr, d, sigmaColor, sigmaSpace, borderType));
+            NativeMethods.imgproc_bilateralFilter(src.ToInputProxy(), dst.ToOutputProxy(), d, sigmaColor, sigmaSpace, borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -231,7 +231,7 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_boxFilter(src.CvPtr, dst.CvPtr, ddepth, ksize, anchor0, normalize ? 1 : 0, borderType));
+            NativeMethods.imgproc_boxFilter(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, ksize, anchor0, normalize ? 1 : 0, borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -268,7 +268,7 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_sqrBoxFilter(src.CvPtr, dst.CvPtr, ddepth, ksize, anchor0, normalize ? 1 : 0, borderType));
+            NativeMethods.imgproc_sqrBoxFilter(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, ksize, anchor0, normalize ? 1 : 0, borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -296,7 +296,7 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_blur(src.CvPtr, dst.CvPtr, ksize, anchor0, (int)borderType));
+            NativeMethods.imgproc_blur(src.ToInputProxy(), dst.ToOutputProxy(), ksize, anchor0, (int)borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -334,7 +334,7 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_filter2D(src.CvPtr, dst.CvPtr, ddepth, kernel.CvPtr, anchor0, delta, (int)borderType));
+            NativeMethods.imgproc_filter2D(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, kernel.ToInputProxy(), anchor0, delta, (int)borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -364,7 +364,7 @@ static partial class Cv2
         var p = @params ?? new Filter2DParams();
         NativeMethods.HandleException(
             NativeMethods.imgproc_filter2Dp(
-                src.CvPtr, dst.CvPtr, kernel.CvPtr,
+                src.ToInputProxy(), dst.ToOutputProxy(), kernel.ToInputProxy(),
                 p.AnchorX, p.AnchorY, (int)p.BorderType, p.BorderValue, p.Ddepth, p.Scale, p.Shift));
 
         GC.KeepAlive(src);
@@ -404,8 +404,8 @@ static partial class Cv2
             
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_sepFilter2D(src.CvPtr, dst.CvPtr, ddepth,
-                kernelX.CvPtr, kernelY.CvPtr, anchor0, delta, (int) borderType));
+            NativeMethods.imgproc_sepFilter2D(src.ToInputProxy(), dst.ToOutputProxy(), ddepth,
+                kernelX.ToInputProxy(), kernelY.ToInputProxy(), anchor0, delta, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -439,7 +439,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_Sobel(src.CvPtr, dst.CvPtr, ddepth, xorder, yorder,
+            NativeMethods.imgproc_Sobel(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, xorder, yorder,
                 ksize, scale, delta, (int) borderType));
 
         GC.KeepAlive(src);
@@ -469,7 +469,7 @@ static partial class Cv2
         dy.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_spatialGradient(src.CvPtr, dx.CvPtr, dy.CvPtr, ksize, (int)borderType));
+            NativeMethods.imgproc_spatialGradient(src.ToInputProxy(), dx.ToOutputProxy(), dy.ToOutputProxy(), ksize, (int)borderType));
 
         GC.KeepAlive(src);
         dx.Fix();
@@ -499,7 +499,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_Scharr(src.CvPtr, dst.CvPtr, ddepth, xorder, yorder,
+            NativeMethods.imgproc_Scharr(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, xorder, yorder,
                 scale, delta, (int) borderType));
 
         GC.KeepAlive(src);
@@ -530,7 +530,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_Laplacian(src.CvPtr, dst.CvPtr, ddepth, ksize, scale, delta, (int) borderType));
+            NativeMethods.imgproc_Laplacian(src.ToInputProxy(), dst.ToOutputProxy(), ddepth, ksize, scale, delta, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -557,7 +557,7 @@ static partial class Cv2
         edges.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_Canny1(src.CvPtr, edges.CvPtr, threshold1, threshold2, apertureSize, L2gradient ? 1 : 0));
+            NativeMethods.imgproc_Canny1(src.ToInputProxy(), edges.ToOutputProxy(), threshold1, threshold2, apertureSize, L2gradient ? 1 : 0));
 
         GC.KeepAlive(src);
         GC.KeepAlive(edges);
@@ -590,7 +590,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_Canny2(
-                dx.CvPtr, dy.CvPtr, edges.CvPtr, threshold1, threshold2, L2gradient ? 1 : 0));
+                dx.ToInputProxy(), dy.ToInputProxy(), edges.ToOutputProxy(), threshold1, threshold2, L2gradient ? 1 : 0));
 
         GC.KeepAlive(dx);
         GC.KeepAlive(dy);
@@ -620,7 +620,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cornerMinEigenVal(src.CvPtr, dst.CvPtr, blockSize, ksize, (int) borderType));
+            NativeMethods.imgproc_cornerMinEigenVal(src.ToInputProxy(), dst.ToOutputProxy(), blockSize, ksize, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -653,7 +653,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cornerHarris(src.CvPtr, dst.CvPtr, blockSize, ksize, k, (int)borderType));
+            NativeMethods.imgproc_cornerHarris(src.ToInputProxy(), dst.ToOutputProxy(), blockSize, ksize, k, (int)borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -680,7 +680,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cornerEigenValsAndVecs(src.CvPtr, dst.CvPtr, blockSize, ksize, (int) borderType));
+            NativeMethods.imgproc_cornerEigenValsAndVecs(src.ToInputProxy(), dst.ToOutputProxy(), blockSize, ksize, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -705,7 +705,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_preCornerDetect(src.CvPtr, dst.CvPtr, ksize, (int) borderType));
+            NativeMethods.imgproc_preCornerDetect(src.ToInputProxy(), dst.ToOutputProxy(), ksize, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -740,7 +740,7 @@ static partial class Cv2
 
         using var vector = new StdVector<Point2f>(inputCornersCopy);
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cornerSubPix(image.CvPtr, vector.CvPtr, winSize, zeroZone, criteria));
+            NativeMethods.imgproc_cornerSubPix(image.ToInputProxy(), vector.CvPtr, winSize, zeroZone, criteria));
         GC.KeepAlive(image);
         return vector.ToArray();
     }
@@ -773,9 +773,9 @@ static partial class Cv2
         src.ThrowIfDisposed();
 
         using var vector = new StdVector<Point2f>();
-        var maskPtr = ToPtr(mask);
+        var maskPtr = mask?.ToInputProxy() ?? default;
         NativeMethods.HandleException(
-            NativeMethods.imgproc_goodFeaturesToTrack(src.CvPtr, vector.CvPtr, maxCorners, qualityLevel,
+            NativeMethods.imgproc_goodFeaturesToTrack(src.ToInputProxy(), vector.CvPtr, maxCorners, qualityLevel,
                 minDistance, maskPtr, blockSize, useHarrisDetector ? 1 : 0, k));
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -802,7 +802,7 @@ static partial class Cv2
 
         using var vec = new StdVector<Vec2f>();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_HoughLines(image.CvPtr, vec.CvPtr, rho, theta, threshold, srn, stn));
+            NativeMethods.imgproc_HoughLines(image.ToInputProxy(), vec.CvPtr, rho, theta, threshold, srn, stn));
         GC.KeepAlive(image);
         return vec.ToArray<LineSegmentPolar>();
     }
@@ -826,7 +826,7 @@ static partial class Cv2
         image.ThrowIfDisposed();
         using var vec = new StdVector<Vec4i>();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_HoughLinesP(image.CvPtr, vec.CvPtr, rho, theta, threshold, minLineLength, maxLineGap));
+            NativeMethods.imgproc_HoughLinesP(image.ToInputProxy(), vec.CvPtr, rho, theta, threshold, minLineLength, maxLineGap));
         GC.KeepAlive(image);
         return vec.ToArray<LineSegmentPoint>();
     }
@@ -859,7 +859,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_HoughLinesPointSet(
-                point.CvPtr, lines.CvPtr, linesMax, threshold, minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep));
+                point.ToInputProxy(), lines.ToOutputProxy(), linesMax, threshold, minRho, maxRho, rhoStep, minTheta, maxTheta, thetaStep));
 
         GC.KeepAlive(point);
         lines.Fix();
@@ -886,7 +886,7 @@ static partial class Cv2
         image.ThrowIfDisposed();
         using var vec = new StdVector<Vec3f>();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_HoughCircles(image.CvPtr, vec.CvPtr, (int) method, dp, minDist, param1,
+            NativeMethods.imgproc_HoughCircles(image.ToInputProxy(), vec.CvPtr, (int) method, dp, minDist, param1,
                 param2, minRadius, maxRadius));
         GC.KeepAlive(image);
         return vec.ToArray<CircleSegment>();
@@ -925,9 +925,9 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         var borderValue0 = borderValue.GetValueOrDefault(MorphologyDefaultBorderValue());
-        var elementPtr = ToPtr(element);
+        var elementPtr = element?.ToInputProxy() ?? default;
         NativeMethods.HandleException(
-            NativeMethods.imgproc_dilate(src.CvPtr, dst.CvPtr, elementPtr, anchor0, iterations, (int) borderType, borderValue0));
+            NativeMethods.imgproc_dilate(src.ToInputProxy(), dst.ToOutputProxy(), elementPtr, anchor0, iterations, (int) borderType, borderValue0));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -959,9 +959,9 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         var borderValue0 = borderValue.GetValueOrDefault(MorphologyDefaultBorderValue());
-        var elementPtr = ToPtr(element);
+        var elementPtr = element?.ToInputProxy() ?? default;
         NativeMethods.HandleException(
-            NativeMethods.imgproc_erode(src.CvPtr, dst.CvPtr, elementPtr, anchor0, iterations, (int) borderType, borderValue0));
+            NativeMethods.imgproc_erode(src.ToInputProxy(), dst.ToOutputProxy(), elementPtr, anchor0, iterations, (int) borderType, borderValue0));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -995,9 +995,9 @@ static partial class Cv2
 
         var anchor0 = anchor.GetValueOrDefault(new Point(-1, -1));
         var borderValue0 = borderValue.GetValueOrDefault(MorphologyDefaultBorderValue());
-        var elementPtr = ToPtr(element);
+        var elementPtr = element?.ToInputProxy() ?? default;
         NativeMethods.HandleException(
-            NativeMethods.imgproc_morphologyEx(src.CvPtr, dst.CvPtr, (int) op, elementPtr, anchor0, iterations,
+            NativeMethods.imgproc_morphologyEx(src.ToInputProxy(), dst.ToOutputProxy(), (int) op, elementPtr, anchor0, iterations,
                 (int) borderType, borderValue0));
 
         GC.KeepAlive(src);
@@ -1031,7 +1031,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_resize(src.CvPtr, dst.CvPtr, dsize, fx, fy, (int) interpolation));
+            NativeMethods.imgproc_resize(src.ToInputProxy(), dst.ToOutputProxy(), dsize, fx, fy, (int) interpolation));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1069,7 +1069,7 @@ static partial class Cv2
 
         var borderValue0 = borderValue.GetValueOrDefault(Scalar.All(0));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_warpAffine(src.CvPtr, dst.CvPtr, m.CvPtr, dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
+            NativeMethods.imgproc_warpAffine(src.ToInputProxy(), dst.ToOutputProxy(), m.ToInputProxy(), dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1108,7 +1108,7 @@ static partial class Cv2
         var borderValue0 = borderValue.GetValueOrDefault(Scalar.All(0));
         NativeMethods.HandleException(
             NativeMethods.imgproc_warpPerspective_MisInputArray(
-                src.CvPtr, dst.CvPtr, m.CvPtr, dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
+                src.ToInputProxy(), dst.ToOutputProxy(), m.ToInputProxy(), dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1149,7 +1149,7 @@ static partial class Cv2
         var mSpan = MemoryMarshal.CreateReadOnlySpan(ref m[0, 0], m.Length);
         NativeMethods.HandleException(
             NativeMethods.imgproc_warpPerspective_MisArray(
-                src.CvPtr, dst.CvPtr, mSpan, mRow, mCol, dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
+                src.ToInputProxy(), dst.ToOutputProxy(), mSpan, mRow, mCol, dsize, (int) flags, (int) borderMode, borderValue0, (int)hint));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1189,7 +1189,7 @@ static partial class Cv2
 
         var borderValue0 = borderValue.GetValueOrDefault(Scalar.All(0));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_remap(src.CvPtr, dst.CvPtr, map1.CvPtr, map2.CvPtr, (int) interpolation,
+            NativeMethods.imgproc_remap(src.ToInputProxy(), dst.ToOutputProxy(), map1.ToInputProxy(), map2.ToInputProxy(), (int) interpolation,
                 (int) borderMode, borderValue0, (int)hint));
 
         GC.KeepAlive(src);
@@ -1224,7 +1224,7 @@ static partial class Cv2
         dstmap2.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_convertMaps(map1.CvPtr, map2.CvPtr, dstmap1.CvPtr, dstmap2.CvPtr, dstmap1Type,
+            NativeMethods.imgproc_convertMaps(map1.ToInputProxy(), map2.ToInputProxy(), dstmap1.ToOutputProxy(), dstmap2.ToOutputProxy(), dstmap1Type,
                 nnInterpolation ? 1 : 0));
 
         GC.KeepAlive(map1);
@@ -1263,7 +1263,7 @@ static partial class Cv2
         m.ThrowIfDisposed();
         im.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_invertAffineTransform(m.CvPtr, im.CvPtr));
+            NativeMethods.imgproc_invertAffineTransform(m.ToInputProxy(), im.ToOutputProxy()));
         GC.KeepAlive(m);
         GC.KeepAlive(im);
         im.Fix();
@@ -1308,7 +1308,7 @@ static partial class Cv2
         dst.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_getPerspectiveTransform2(src.CvPtr, dst.CvPtr, out var retMat));
+            NativeMethods.imgproc_getPerspectiveTransform2(src.ToInputProxy(), dst.ToInputProxy(), out var retMat));
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
         return new Mat(retMat);
@@ -1353,7 +1353,7 @@ static partial class Cv2
         dst.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_getAffineTransform2(src.CvPtr, dst.CvPtr, out var retMat));
+            NativeMethods.imgproc_getAffineTransform2(src.ToInputProxy(), dst.ToInputProxy(), out var retMat));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1380,7 +1380,7 @@ static partial class Cv2
         patch.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_getRectSubPix(image.CvPtr, patchSize, center, patch.CvPtr, patchType));
+            NativeMethods.imgproc_getRectSubPix(image.ToInputProxy(), patchSize, center, patch.ToOutputProxy(), patchType));
 
         GC.KeepAlive(image);
         GC.KeepAlive(patch);
@@ -1415,7 +1415,7 @@ static partial class Cv2
 
         int flags = (int)interpolationFlags | (int)warpPolarMode;
         NativeMethods.HandleException(
-            NativeMethods.imgproc_warpPolar(src.CvPtr, dst.CvPtr, dsize, center, maxRadius, flags));
+            NativeMethods.imgproc_warpPolar(src.ToInputProxy(), dst.ToOutputProxy(), dsize, center, maxRadius, flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1440,7 +1440,7 @@ static partial class Cv2
         sum.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_integral1(src.CvPtr, sum.CvPtr, sdepth?.Value ?? -1));
+            NativeMethods.imgproc_integral1(src.ToInputProxy(), sum.ToOutputProxy(), sdepth?.Value ?? -1));
 
         GC.KeepAlive(src);
         GC.KeepAlive(sum);
@@ -1468,7 +1468,7 @@ static partial class Cv2
         sqsum.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_integral2(src.CvPtr, sum.CvPtr, sqsum.CvPtr, sdepth?.Value ?? -1));
+            NativeMethods.imgproc_integral2(src.ToInputProxy(), sum.ToOutputProxy(), sqsum.ToOutputProxy(), sdepth?.Value ?? -1));
 
         GC.KeepAlive(src);
         GC.KeepAlive(sum);
@@ -1505,7 +1505,7 @@ static partial class Cv2
         tilted.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_integral3(src.CvPtr, sum.CvPtr, sqsum.CvPtr, tilted.CvPtr, sdepth?.Value ?? -1, sqdepth?.Value ?? -1));
+            NativeMethods.imgproc_integral3(src.ToInputProxy(), sum.ToOutputProxy(), sqsum.ToOutputProxy(), tilted.ToOutputProxy(), sdepth?.Value ?? -1, sqdepth?.Value ?? -1));
 
         GC.KeepAlive(src);
         GC.KeepAlive(sum);
@@ -1532,7 +1532,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_accumulate(src.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.imgproc_accumulate(src.ToInputProxy(), dst.ToInputOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1556,7 +1556,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_accumulateSquare(src.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.imgproc_accumulateSquare(src.ToInputProxy(), dst.ToInputOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1584,7 +1584,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_accumulateProduct(src1.CvPtr, src2.CvPtr, dst.CvPtr, ToPtr(mask)));
+            NativeMethods.imgproc_accumulateProduct(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToInputOutputProxy(), mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1610,7 +1610,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_accumulateWeighted(src.CvPtr, dst.CvPtr, alpha, ToPtr(mask)));
+            NativeMethods.imgproc_accumulateWeighted(src.ToInputProxy(), dst.ToInputOutputProxy(), alpha, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1646,7 +1646,7 @@ static partial class Cv2
         window.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_phaseCorrelate(src1.CvPtr, src2.CvPtr, window.CvPtr, out response, out var ret));
+            NativeMethods.imgproc_phaseCorrelate(src1.ToInputProxy(), src2.ToInputProxy(), window.ToInputProxy(), out response, out var ret));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -1667,7 +1667,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_createHanningWindow(dst.CvPtr, winSize, type));
+            NativeMethods.imgproc_createHanningWindow(dst.ToOutputProxy(), winSize, type));
 
         GC.KeepAlive(dst);
         dst.Fix();
@@ -1692,7 +1692,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_threshold(src.CvPtr, dst.CvPtr, thresh, maxval, (int)type, out var ret));
+            NativeMethods.imgproc_threshold(src.ToInputProxy(), dst.ToOutputProxy(), thresh, maxval, (int)type, out var ret));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1722,7 +1722,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_adaptiveThreshold(src.CvPtr, dst.CvPtr, maxValue, (int) adaptiveMethod, (int)thresholdType, blockSize, c));
+            NativeMethods.imgproc_adaptiveThreshold(src.ToInputProxy(), dst.ToOutputProxy(), maxValue, (int) adaptiveMethod, (int)thresholdType, blockSize, c));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1748,7 +1748,7 @@ static partial class Cv2
 
         var dstSize0 = dstSize.GetValueOrDefault(new Size());
         NativeMethods.HandleException(
-            NativeMethods.imgproc_pyrDown(src.CvPtr, dst.CvPtr, dstSize0, (int) borderType));
+            NativeMethods.imgproc_pyrDown(src.ToInputProxy(), dst.ToOutputProxy(), dstSize0, (int) borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1772,7 +1772,7 @@ static partial class Cv2
         src.ThrowIfDisposed();
         dst.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_buildPyramid(src.CvPtr, dst.CvPtr, maxlevel,(int)borderType));
+            NativeMethods.imgproc_buildPyramid(src.ToInputProxy(), dst.CvPtr, maxlevel,(int)borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1797,7 +1797,7 @@ static partial class Cv2
 
         var dstSize0 = dstSize.GetValueOrDefault(new Size());
         NativeMethods.HandleException(
-            NativeMethods.imgproc_pyrUp(src.CvPtr, dst.CvPtr, dstSize0, (int)borderType));
+            NativeMethods.imgproc_pyrUp(src.ToInputProxy(), dst.ToOutputProxy(), dstSize0, (int)borderType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -1862,7 +1862,7 @@ static partial class Cv2
         {
             NativeMethods.HandleException(
                 NativeMethods.imgproc_calcHist(
-                    imagesPtr, images.Length, channels, ToPtr(mask), hist.CvPtr,
+                    imagesPtr, images.Length, channels, mask?.ToInputProxy() ?? default, hist.ToOutputProxy(),
                     dims, histSize, rangesPtr.GetPointer(), uniform ? 1 : 0, accumulate ? 1 : 0));
         }
         GC.KeepAlive(images);
@@ -1902,8 +1902,8 @@ static partial class Cv2
         using (var rangesPtr = new ArrayAddress2<float>(rangesFloat))
         {
             NativeMethods.HandleException(
-                NativeMethods.imgproc_calcBackProject(imagesPtr, images.Length, channels, hist.CvPtr,
-                    backProject.CvPtr, rangesPtr.GetPointer(), uniform ? 1 : 0));
+                NativeMethods.imgproc_calcBackProject(imagesPtr, images.Length, channels, hist.ToInputProxy(),
+                    backProject.ToOutputProxy(), rangesPtr.GetPointer(), uniform ? 1 : 0));
         }
         GC.KeepAlive(images);
         GC.KeepAlive(hist);
@@ -1928,7 +1928,7 @@ static partial class Cv2
         h2.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_compareHist(h1.CvPtr, h2.CvPtr, (int)method, out var ret));
+            NativeMethods.imgproc_compareHist(h1.ToInputProxy(), h2.ToInputProxy(), (int)method, out var ret));
 
         GC.KeepAlive(h1);
         GC.KeepAlive(h2);
@@ -1950,7 +1950,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_equalizeHist(src.CvPtr, dst.CvPtr));
+            NativeMethods.imgproc_equalizeHist(src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2065,8 +2065,8 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_EMD(
-                signature1.CvPtr, signature2.CvPtr, (int) distType, ToPtr(cost),
-                out lowerBound, ToPtr(flow), out var ret));
+                signature1.ToInputProxy(), signature2.ToInputProxy(), (int) distType, cost?.ToInputProxy() ?? default,
+                out lowerBound, flow?.ToOutputProxy() ?? default, out var ret));
 
         GC.KeepAlive(signature1);
         GC.KeepAlive(signature2);
@@ -2092,7 +2092,7 @@ static partial class Cv2
         markers.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_watershed(image.CvPtr, markers.CvPtr));
+            NativeMethods.imgproc_watershed(image.ToInputProxy(), markers.ToInputOutputProxy()));
 
         GC.KeepAlive(image);
         GC.KeepAlive(markers);
@@ -2121,7 +2121,7 @@ static partial class Cv2
         var termcrit0 = termcrit.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 5, 1));
         NativeMethods.HandleException(
-            NativeMethods.imgproc_pyrMeanShiftFiltering(src.CvPtr, dst.CvPtr, sp, sr, maxLevel, termcrit0));
+            NativeMethods.imgproc_pyrMeanShiftFiltering(src.ToInputProxy(), dst.ToOutputProxy(), sp, sr, maxLevel, termcrit0));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2161,8 +2161,8 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_grabCut(
-                img.CvPtr, mask.CvPtr, rect,
-                bgdModel.CvPtr, fgdModel.CvPtr, iterCount, (int) mode));
+                img.ToInputProxy(), mask.ToInputOutputProxy(), rect,
+                bgdModel.ToInputOutputProxy(), fgdModel.ToInputOutputProxy(), iterCount, (int) mode));
 
         GC.KeepAlive(img);
         GC.KeepAlive(mask);
@@ -2205,7 +2205,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_distanceTransformWithLabels(
-                src.CvPtr, dst.CvPtr, labels.CvPtr, (int) distanceType, (int) maskSize, (int) labelType));
+                src.ToInputProxy(), dst.ToOutputProxy(), labels.ToOutputProxy(), (int) distanceType, (int) maskSize, (int) labelType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2240,7 +2240,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_distanceTransform(src.CvPtr, dst.CvPtr, (int) distanceType, (int) maskSize, dstType));
+            NativeMethods.imgproc_distanceTransform(src.ToInputProxy(), dst.ToOutputProxy(), (int) distanceType, (int) maskSize, dstType));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2300,7 +2300,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_floodFill1(
-                image.CvPtr, seedPoint, newVal, out rect,
+                image.ToInputOutputProxy(), seedPoint, newVal, out rect,
                 loDiff0, upDiff0, (int)flags, out var ret));
 
         GC.KeepAlive(image);
@@ -2375,7 +2375,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_floodFill2(
-                image.CvPtr, mask.CvPtr, seedPoint,
+                image.ToInputOutputProxy(), mask.ToInputOutputProxy(), seedPoint,
                 newVal, out rect, loDiff0, upDiff0, (int)flags, out var ret));
 
         GC.KeepAlive(image);
@@ -2414,7 +2414,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_blendLinear(src1.CvPtr, src2.CvPtr, weights1.CvPtr, weights2.CvPtr, dst.CvPtr));
+            NativeMethods.imgproc_blendLinear(src1.ToInputProxy(), src2.ToInputProxy(), weights1.ToInputProxy(), weights2.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -2441,7 +2441,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cvtColor(src.CvPtr, dst.CvPtr, (int) code, dstCn, (int)hint));
+            NativeMethods.imgproc_cvtColor(src.ToInputProxy(), dst.ToOutputProxy(), (int) code, dstCn, (int)hint));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2478,7 +2478,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_cvtColorTwoPlane(src1.CvPtr, src2.CvPtr, dst.CvPtr, (int)code, (int)hint));
+            NativeMethods.imgproc_cvtColorTwoPlane(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy(), (int)code, (int)hint));
 
         GC.KeepAlive(src1);
         GC.KeepAlive(src2);
@@ -2524,7 +2524,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_demosaicing(src.CvPtr, dst.CvPtr, (int)code, dstCn));
+            NativeMethods.imgproc_demosaicing(src.ToInputProxy(), dst.ToOutputProxy(), (int)code, dstCn));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -2620,7 +2620,7 @@ static partial class Cv2
         mask?.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_matchTemplate(image.CvPtr, templ.CvPtr, result.CvPtr, (int) method, ToPtr(mask)));
+            NativeMethods.imgproc_matchTemplate(image.ToInputProxy(), templ.ToInputProxy(), result.ToOutputProxy(), (int) method, mask?.ToInputProxy() ?? default));
 
         GC.KeepAlive(image);
         GC.KeepAlive(templ);
@@ -2659,7 +2659,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_connectedComponentsWithAlgorithm(
-                image.CvPtr, labels.CvPtr, (int)connectivity, ltype, (int)ccltype, out var ret));
+                image.ToInputProxy(), labels.ToOutputProxy(), (int)connectivity, ltype, (int)ccltype, out var ret));
 
         GC.KeepAlive(image);
         GC.KeepAlive(labels);
@@ -2708,7 +2708,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_connectedComponents(
-                image.CvPtr, labels.CvPtr, (int)connectivity, ltype, out var ret));
+                image.ToInputProxy(), labels.ToOutputProxy(), (int)connectivity, ltype, out var ret));
 
         GC.KeepAlive(image);
         GC.KeepAlive(labels);
@@ -2781,7 +2781,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_connectedComponentsWithStatsWithAlgorithm(
-                image.CvPtr, labels.CvPtr, stats.CvPtr, centroids.CvPtr, (int)connectivity, ltype, (int)ccltype, out var ret));
+                image.ToInputProxy(), labels.ToOutputProxy(), stats.ToOutputProxy(), centroids.ToOutputProxy(), (int)connectivity, ltype, (int)ccltype, out var ret));
 
         GC.KeepAlive(image);
         GC.KeepAlive(labels);
@@ -2855,7 +2855,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_connectedComponentsWithStats(
-                image.CvPtr, labels.CvPtr, stats.CvPtr, centroids.CvPtr, (int) connectivity, ltype, out var ret));
+                image.ToInputProxy(), labels.ToOutputProxy(), stats.ToOutputProxy(), centroids.ToOutputProxy(), (int) connectivity, ltype, out var ret));
 
         GC.KeepAlive(image);
         GC.KeepAlive(labels);
@@ -2937,7 +2937,7 @@ static partial class Cv2
         using var hierarchyVec = new StdVector<Vec4i>();
         NativeMethods.HandleException(
             NativeMethods.imgproc_findContours1_vector(
-                image.CvPtr, contoursVec.CvPtr, hierarchyVec.CvPtr, (int) mode, (int) method, offset0));
+                image.ToInputProxy(), contoursVec.CvPtr, hierarchyVec.CvPtr, (int) mode, (int) method, offset0));
 
         contours = contoursVec.ToArray();
         var hierarchyOrg = hierarchyVec.ToArray();
@@ -2975,7 +2975,7 @@ static partial class Cv2
         var offset0 = offset.GetValueOrDefault(new Point());
         using var contoursVec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_findContours1_OutputArray(image.CvPtr, contoursVec.CvPtr, hierarchy.CvPtr, (int) mode, (int) method, offset0));
+            NativeMethods.imgproc_findContours1_OutputArray(image.ToInputProxy(), contoursVec.CvPtr, hierarchy.ToOutputProxy(), (int) mode, (int) method, offset0));
 
         contours = contoursVec.ToArray();
 
@@ -3005,7 +3005,7 @@ static partial class Cv2
         var offset0 = offset.GetValueOrDefault(new Point());
         using var contoursVec = new VectorOfVectorPoint();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_findContours2_vector(image.CvPtr, contoursVec.CvPtr, (int) mode, (int) method, offset0));
+            NativeMethods.imgproc_findContours2_vector(image.ToInputProxy(), contoursVec.CvPtr, (int) mode, (int) method, offset0));
         GC.KeepAlive(image);
 
         return contoursVec.ToArray();
@@ -3029,7 +3029,7 @@ static partial class Cv2
         using var contoursVec = new VectorOfVectorPoint();
         using var hierarchyVec = new StdVector<Vec4i>();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_findContoursLinkRuns1(image.CvPtr, contoursVec.CvPtr, hierarchyVec.CvPtr));
+            NativeMethods.imgproc_findContoursLinkRuns1(image.ToInputProxy(), contoursVec.CvPtr, hierarchyVec.CvPtr));
 
         contours = contoursVec.ToArray();
         hierarchy = hierarchyVec.ToArray().Select(HierarchyIndex.FromVec4i).ToArray();
@@ -3049,7 +3049,7 @@ static partial class Cv2
 
         using var contoursVec = new VectorOfVectorPoint();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_findContoursLinkRuns2(image.CvPtr, contoursVec.CvPtr));
+            NativeMethods.imgproc_findContoursLinkRuns2(image.ToInputProxy(), contoursVec.CvPtr));
 
         contours = contoursVec.ToArray();
         GC.KeepAlive(image);
@@ -3076,7 +3076,7 @@ static partial class Cv2
         var offset0 = offset.GetValueOrDefault(new Point());
         using var contoursVec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_findContours2_OutputArray(image.CvPtr, contoursVec.CvPtr, (int)mode, (int)method, offset0));
+            NativeMethods.imgproc_findContours2_OutputArray(image.ToInputProxy(), contoursVec.CvPtr, (int)mode, (int)method, offset0));
         GC.KeepAlive(image);
 
         return contoursVec.ToArray<Mat<Point>>();
@@ -3103,7 +3103,7 @@ static partial class Cv2
         approxCurve.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_approxPolyDP_InputArray(curve.CvPtr, approxCurve.CvPtr, epsilon, closed ? 1 : 0));
+            NativeMethods.imgproc_approxPolyDP_InputArray(curve.ToInputProxy(), approxCurve.ToOutputProxy(), epsilon, closed ? 1 : 0));
 
         GC.KeepAlive(curve);
         GC.KeepAlive(approxCurve);
@@ -3169,7 +3169,7 @@ static partial class Cv2
         curve.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_arcLength_InputArray(curve.CvPtr, closed ? 1 : 0, out var ret));
+            NativeMethods.imgproc_arcLength_InputArray(curve.ToInputProxy(), closed ? 1 : 0, out var ret));
         GC.KeepAlive(curve);
         return ret;
     }
@@ -3220,7 +3220,7 @@ static partial class Cv2
         curve.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_boundingRect_InputArray(curve.CvPtr, out var ret));
+            NativeMethods.imgproc_boundingRect_InputArray(curve.ToInputProxy(), out var ret));
         GC.KeepAlive(curve);
         return ret;
     }
@@ -3270,7 +3270,7 @@ static partial class Cv2
         contour.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_contourArea_InputArray(contour.CvPtr, oriented ? 1 : 0, out var ret));
+            NativeMethods.imgproc_contourArea_InputArray(contour.ToInputProxy(), oriented ? 1 : 0, out var ret));
         GC.KeepAlive(contour);
         return ret;
     }
@@ -3321,7 +3321,7 @@ static partial class Cv2
         points.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_minAreaRect_InputArray(points.CvPtr, out var ret));
+            NativeMethods.imgproc_minAreaRect_InputArray(points.ToInputProxy(), out var ret));
         GC.KeepAlive(points);
         return ret;
     }
@@ -3375,7 +3375,7 @@ static partial class Cv2
         points.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_boxPoints_OutputArray(box, points.CvPtr));
+            NativeMethods.imgproc_boxPoints_OutputArray(box, points.ToOutputProxy()));
         points.Fix();
     }
 
@@ -3408,7 +3408,7 @@ static partial class Cv2
             throw new ArgumentNullException(nameof(points));
         points.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.imgproc_minEnclosingCircle_InputArray(points.CvPtr, out center, out radius));
+            NativeMethods.imgproc_minEnclosingCircle_InputArray(points.ToInputProxy(), out center, out radius));
         GC.KeepAlive(points);
     }
 
@@ -3458,7 +3458,7 @@ static partial class Cv2
         triangle.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_minEnclosingTriangle_InputOutputArray(points.CvPtr, triangle.CvPtr, out var ret));
+            NativeMethods.imgproc_minEnclosingTriangle_InputOutputArray(points.ToInputProxy(), triangle.ToOutputProxy(), out var ret));
 
         GC.KeepAlive(points);
         triangle.Fix();
@@ -3525,7 +3525,7 @@ static partial class Cv2
             throw new ArgumentNullException(nameof(contour2));
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_matchShapes_InputArray(contour1.CvPtr, contour2.CvPtr, (int)method, parameter, out var ret));
+            NativeMethods.imgproc_matchShapes_InputArray(contour1.ToInputProxy(), contour2.ToInputProxy(), (int)method, parameter, out var ret));
 
         GC.KeepAlive(contour1);
         GC.KeepAlive(contour2);
@@ -3581,7 +3581,7 @@ static partial class Cv2
         hull.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_convexHull_InputArray(points.CvPtr, hull.CvPtr, clockwise ? 1 : 0, returnPoints ? 1 : 0));
+            NativeMethods.imgproc_convexHull_InputArray(points.ToInputProxy(), hull.ToOutputProxy(), clockwise ? 1 : 0, returnPoints ? 1 : 0));
 
         GC.KeepAlive(points);
         GC.KeepAlive(hull);
@@ -3709,7 +3709,7 @@ static partial class Cv2
         convexityDefects.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_convexityDefects_InputArray(contour.CvPtr, convexHull.CvPtr, convexityDefects.CvPtr));
+            NativeMethods.imgproc_convexityDefects_InputArray(contour.ToInputProxy(), convexHull.ToInputProxy(), convexityDefects.ToOutputProxy()));
 
         GC.KeepAlive(contour);
         GC.KeepAlive(convexHull);
@@ -3791,7 +3791,7 @@ static partial class Cv2
         contour.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_isContourConvex_InputArray(contour.CvPtr, out var ret));
+            NativeMethods.imgproc_isContourConvex_InputArray(contour.ToInputProxy(), out var ret));
 
         GC.KeepAlive(contour);
         return ret != 0;
@@ -3853,7 +3853,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_intersectConvexConvex_InputArray(
-                p1.CvPtr, p2.CvPtr, p12.CvPtr, handleNested ? 1 : 0, out var ret));
+                p1.ToInputProxy(), p2.ToInputProxy(), p12.ToOutputProxy(), handleNested ? 1 : 0, out var ret));
 
         GC.KeepAlive(p1);
         GC.KeepAlive(p2);
@@ -3931,7 +3931,7 @@ static partial class Cv2
         points.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_fitEllipse_InputArray(points.CvPtr, out var ret));
+            NativeMethods.imgproc_fitEllipse_InputArray(points.ToInputProxy(), out var ret));
 
         GC.KeepAlive(points);
         return ret;
@@ -3985,7 +3985,7 @@ static partial class Cv2
         points.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_fitEllipseAMS_InputArray(points.CvPtr, out var ret));
+            NativeMethods.imgproc_fitEllipseAMS_InputArray(points.ToInputProxy(), out var ret));
 
         GC.KeepAlive(points);
         return ret;
@@ -4047,7 +4047,7 @@ static partial class Cv2
         points.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_fitEllipseDirect_InputArray(points.CvPtr, out var ret));
+            NativeMethods.imgproc_fitEllipseDirect_InputArray(points.ToInputProxy(), out var ret));
 
         GC.KeepAlive(points);
         return ret;
@@ -4123,7 +4123,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_fitLine_InputArray(
-                points.CvPtr, line.CvPtr, (int) distType, param, reps, aeps));
+                points.ToInputProxy(), line.ToOutputProxy(), (int) distType, param, reps, aeps));
 
         GC.KeepAlive(points);
         GC.KeepAlive(line);
@@ -4244,7 +4244,7 @@ static partial class Cv2
         contour.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.imgproc_pointPolygonTest_InputArray(
-                contour.CvPtr, pt, measureDist ? 1 : 0, out var ret));
+                contour.ToInputProxy(), pt, measureDist ? 1 : 0, out var ret));
         GC.KeepAlive(contour);
         return ret;
     }
@@ -4311,7 +4311,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_rotatedRectangleIntersection_OutputArray(
-                rect1, rect2, intersectingRegion.CvPtr, out var ret));
+                rect1, rect2, intersectingRegion.ToOutputProxy(), out var ret));
 
         GC.KeepAlive(intersectingRegion);
         intersectingRegion.Fix();
@@ -4360,7 +4360,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_applyColorMap1(src.CvPtr, dst.CvPtr, (int) colormap));
+            NativeMethods.imgproc_applyColorMap1(src.ToInputProxy(), dst.ToOutputProxy(), (int) colormap));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -4386,7 +4386,7 @@ static partial class Cv2
         userColor.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_applyColorMap2(src.CvPtr, dst.CvPtr, userColor.CvPtr));
+            NativeMethods.imgproc_applyColorMap2(src.ToInputProxy(), dst.ToOutputProxy(), userColor.ToInputProxy()));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -4432,7 +4432,7 @@ static partial class Cv2
         img.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_line(img.CvPtr, pt1, pt2, color, thickness, (int) lineType, shift));
+            NativeMethods.imgproc_line(img.ToInputOutputProxy(), pt1, pt2, color, thickness, (int) lineType, shift));
 
         img.Fix();
         GC.KeepAlive(img);
@@ -4466,7 +4466,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_arrowedLine(
-                img.CvPtr, pt1, pt2, color, thickness, (int) lineType, shift, tipLength));
+                img.ToInputOutputProxy(), pt1, pt2, color, thickness, (int) lineType, shift, tipLength));
 
         GC.KeepAlive(img);
         img.Fix();
@@ -4491,7 +4491,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_rectangle_InputOutputArray_Point(
-                img.CvPtr, pt1, pt2, color, thickness, (int) lineType, shift));
+                img.ToInputOutputProxy(), pt1, pt2, color, thickness, (int) lineType, shift));
 
         img.Fix();
         GC.KeepAlive(img);
@@ -4516,7 +4516,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_rectangle_InputOutputArray_Rect(
-                img.CvPtr, rect, color, thickness, (int) lineType, shift));
+                img.ToInputOutputProxy(), rect, color, thickness, (int) lineType, shift));
         img.Fix();
         GC.KeepAlive(img);
     }
@@ -4600,7 +4600,7 @@ static partial class Cv2
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_circle(img.CvPtr, center, radius, color, thickness, (int) lineType, shift));
+            NativeMethods.imgproc_circle(img.ToInputOutputProxy(), center, radius, color, thickness, (int) lineType, shift));
         img.Fix();
         GC.KeepAlive(img);
     }
@@ -4628,7 +4628,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_ellipse1(
-                img.CvPtr, center, axes, angle, startAngle, endAngle, color, thickness, (int) lineType, shift));
+                img.ToInputOutputProxy(), center, axes, angle, startAngle, endAngle, color, thickness, (int) lineType, shift));
 
         img.Fix();
         GC.KeepAlive(img);
@@ -4650,7 +4650,7 @@ static partial class Cv2
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_ellipse2(img.CvPtr, box, color, thickness, (int) lineType));
+            NativeMethods.imgproc_ellipse2(img.ToInputOutputProxy(), box, color, thickness, (int) lineType));
         img.Fix();
         GC.KeepAlive(img);
     }
@@ -4678,7 +4678,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_drawMarker(
-                img.CvPtr, position, color, (int)markerType, markerSize, thickness, (int)lineType));
+                img.ToInputOutputProxy(), position, color, (int)markerType, markerSize, thickness, (int)lineType));
 
         img.Fix();
         GC.KeepAlive(img);
@@ -4726,7 +4726,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_fillConvexPoly_InputOutputArray(
-                img.CvPtr, pts.CvPtr, color, (int) lineType, shift));
+                img.ToInputOutputProxy(), pts.ToInputProxy(), color, (int) lineType, shift));
         GC.KeepAlive(img);
         GC.KeepAlive(pts);
     }
@@ -4795,7 +4795,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_fillPoly_InputOutputArray(
-                img.CvPtr, pts.CvPtr, color, (int) lineType, shift, offset0));
+                img.ToInputOutputProxy(), pts.ToInputProxy(), color, (int) lineType, shift, offset0));
         GC.KeepAlive(img);
         GC.KeepAlive(pts);
         img.Fix();
@@ -4868,7 +4868,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_polylines_InputOutputArray(
-                img.CvPtr, pts.CvPtr, isClosed ? 1 : 0, color, thickness, (int) lineType, shift));
+                img.ToInputOutputProxy(), pts.ToInputProxy(), isClosed ? 1 : 0, color, thickness, (int) lineType, shift));
         GC.KeepAlive(img);
         img.Fix();
         GC.KeepAlive(pts);
@@ -4916,7 +4916,7 @@ static partial class Cv2
             {
                 NativeMethods.HandleException(
                     NativeMethods.imgproc_drawContours_vector(
-                        image.CvPtr, contoursPtr.GetPointer(), contoursArray.Length, contourSize2,
+                        image.ToInputOutputProxy(), contoursPtr.GetPointer(), contoursArray.Length, contourSize2,
                         contourIdx, color, thickness, (int) lineType, IntPtr.Zero, 0, maxLevel, offset0));
             }
             else
@@ -4924,7 +4924,7 @@ static partial class Cv2
                 var hierarchyVecs = hierarchy.Select(hi => hi.ToVec4i()).ToArray();
                 NativeMethods.HandleException(
                     NativeMethods.imgproc_drawContours_vector(
-                        image.CvPtr, contoursPtr.GetPointer(), contoursArray.Length, contourSize2,
+                        image.ToInputOutputProxy(), contoursPtr.GetPointer(), contoursArray.Length, contourSize2,
                         contourIdx, color, thickness, (int) lineType, hierarchyVecs, hierarchyVecs.Length, maxLevel, offset0));
             }
         }
@@ -4955,7 +4955,7 @@ static partial class Cv2
         Scalar color,
         int thickness = 1,
         LineTypes lineType = LineTypes.Link8,
-        Mat? hierarchy = null,
+        InputArray? hierarchy = null,
         int maxLevel = int.MaxValue,
         Point? offset = null)
     {
@@ -4970,8 +4970,8 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_drawContours_InputArray(
-                image.CvPtr, contoursPtr, contoursPtr.Length,
-                contourIdx, color, thickness, (int) lineType, ToPtr(hierarchy), maxLevel, offset0));
+                image.ToInputOutputProxy(), contoursPtr, contoursPtr.Length,
+                contourIdx, color, thickness, (int) lineType, hierarchy?.ToInputProxy() ?? default, maxLevel, offset0));
         image.Fix();
         GC.KeepAlive(image);
         GC.KeepAlive(contours);
@@ -5072,7 +5072,7 @@ static partial class Cv2
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.imgproc_putText(img.CvPtr, text, org, (int) fontFace, fontScale, color,
+            NativeMethods.imgproc_putText(img.ToInputOutputProxy(), text, org, (int) fontFace, fontScale, color,
                 thickness, (int) lineType, bottomLeftOrigin ? 1 : 0));
 
         img.Fix();
@@ -5143,7 +5143,7 @@ static partial class Cv2
         var w = wrap ?? new Range(0, 0);
         NativeMethods.HandleException(
             NativeMethods.imgproc_putText_FontFace(
-                img.CvPtr, text, org, color, fontFace.CvPtr, size, weight, (int)flags, w.Start, w.End, out var ret));
+                img.ToInputOutputProxy(), text, org, color, fontFace.CvPtr, size, weight, (int)flags, w.Start, w.End, out var ret));
 
         img.Fix();
         GC.KeepAlive(img);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -201,14 +201,14 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_reduce(InputArrayProxy src, OutputArrayProxy dst, int dim, int rtype, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_merge([MarshalAs(UnmanagedType.LPArray)] IntPtr[] mv, uint count, IntPtr dst);
+    internal static partial ExceptionStatus core_merge(ReadOnlySpan<IntPtr> mv, uint count, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_split(IntPtr src, IntPtr mv);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_mixChannels(IntPtr[] src, uint nsrcs,
-        IntPtr[] dst, uint ndsts, int[] fromTo, uint npairs);
+    internal static partial ExceptionStatus core_mixChannels(ReadOnlySpan<IntPtr> src, uint nsrcs,
+        ReadOnlySpan<IntPtr> dst, uint ndsts, int[] fromTo, uint npairs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_extractChannel(InputArrayProxy src, OutputArrayProxy dst, int coi);
@@ -228,12 +228,12 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_repeat2(IntPtr src, int ny, int nx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_hconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_hconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_hconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_vconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_vconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_vconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
@@ -377,7 +377,7 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_eigenNonSymmetric(InputArrayProxy src, OutputArrayProxy eigenvalues, OutputArrayProxy eigenvectors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_calcCovarMatrix_Mat([MarshalAs(UnmanagedType.LPArray)] IntPtr[] samples,
+    internal static partial ExceptionStatus core_calcCovarMatrix_Mat(ReadOnlySpan<IntPtr> samples,
         int nsamples, IntPtr covar, IntPtr mean, int flags, int ctype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_calcCovarMatrix_InputArray(InputArrayProxy samples, OutputArrayProxy covar,

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -84,7 +84,7 @@ static partial class NativeMethods
         
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_format(IntPtr mtx, int fmt, IntPtr buf);
+    internal static partial ExceptionStatus core_format(InputArrayProxy mtx, int fmt, IntPtr buf);
 
     #endregion
 
@@ -228,12 +228,12 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_repeat2(IntPtr src, int ny, int nx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_hconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, IntPtr dst);
+    internal static partial ExceptionStatus core_hconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_hconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_vconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, IntPtr dst);
+    internal static partial ExceptionStatus core_vconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_vconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
@@ -329,20 +329,16 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_perspectiveTransform_Mat(IntPtr src, IntPtr dst, IntPtr m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_perspectiveTransform_Point2f(IntPtr src, int srcLength, IntPtr dst, int dstLength, IntPtr m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point2f(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_perspectiveTransform_Point2d(IntPtr src, int srcLength, IntPtr dst, int dstLength, IntPtr m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point2d(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_perspectiveTransform_Point3f(IntPtr src, int srcLength, IntPtr dst, int dstLength, IntPtr m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point3f(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_perspectiveTransform_Point3d(IntPtr src, int srcLength, IntPtr dst, int dstLength, IntPtr m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point3d(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_completeSymm(IntPtr mtx, int lowerToUpper);
-
-    // FOUNDATION: ref-struct proxy path for an InputOutputArray argument.
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_completeSymm_io(InputOutputArrayProxy mtx, int lowerToUpper);
+    internal static partial ExceptionStatus core_completeSymm(InputOutputArrayProxy mtx, int lowerToUpper);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_setIdentity(InputOutputArrayProxy mtx, Scalar s);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -153,52 +153,52 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_mean(InputArrayProxy src, InputArrayProxy mask, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_meanStdDev_OutputArray(
-        IntPtr src, IntPtr mean, IntPtr stddev, IntPtr mask);
+    internal static partial ExceptionStatus core_meanStdDev_OutputArray(
+        InputArrayProxy src, OutputArrayProxy mean, OutputArrayProxy stddev, InputArrayProxy mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_meanStdDev_Scalar(
-        IntPtr src, out Scalar mean, out Scalar stddev, IntPtr mask);
+    internal static partial ExceptionStatus core_meanStdDev_Scalar(
+        InputArrayProxy src, out Scalar mean, out Scalar stddev, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_norm1(
-        IntPtr src1, int normType, IntPtr mask, out double returnValue);
+    internal static partial ExceptionStatus core_norm1(
+        InputArrayProxy src1, int normType, InputArrayProxy mask, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_norm2(
-        IntPtr src1, IntPtr src2, int normType, IntPtr mask, out double returnValue);
+    internal static partial ExceptionStatus core_norm2(
+        InputArrayProxy src1, InputArrayProxy src2, int normType, InputArrayProxy mask, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PSNR(IntPtr src1, IntPtr src2, double r, out double returnValue);
+    internal static partial ExceptionStatus core_PSNR(InputArrayProxy src1, InputArrayProxy src2, double r, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_batchDistance(IntPtr src1, IntPtr src2,
-        IntPtr dist, int dtype, IntPtr nidx,
-        int normType, int k, IntPtr mask,
+    internal static partial ExceptionStatus core_batchDistance(InputArrayProxy src1, InputArrayProxy src2,
+        OutputArrayProxy dist, int dtype, OutputArrayProxy nidx,
+        int normType, int k, InputArrayProxy mask,
         int update, int crosscheck);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_normalize(IntPtr src, IntPtr dst, double alpha, double beta,
-        int normType, int dtype, IntPtr mask);
+    internal static partial ExceptionStatus core_normalize(InputArrayProxy src, InputOutputArrayProxy dst, double alpha, double beta,
+        int normType, int dtype, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_reduceArgMax(IntPtr src, IntPtr dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
+    internal static partial ExceptionStatus core_reduceArgMax(InputArrayProxy src, OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_reduceArgMin(IntPtr src, IntPtr dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
+    internal static partial ExceptionStatus core_reduceArgMin(InputArrayProxy src, OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_minMaxLoc1(IntPtr src, out double minVal, out double maxVal);
+    internal static partial ExceptionStatus core_minMaxLoc1(InputArrayProxy src, out double minVal, out double maxVal);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_minMaxLoc2(IntPtr src, out double minVal, out double maxVal,
-        out Point minLoc, out Point maxLoc, IntPtr mask);
+    internal static partial ExceptionStatus core_minMaxLoc2(InputArrayProxy src, out double minVal, out double maxVal,
+        out Point minLoc, out Point maxLoc, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_minMaxIdx1(IntPtr src, out double minVal, out double maxVal);
+    internal static partial ExceptionStatus core_minMaxIdx1(InputArrayProxy src, out double minVal, out double maxVal);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_minMaxIdx2(IntPtr src, out double minVal, out double maxVal,
-        [MarshalAs(UnmanagedType.LPArray), Out] int[] minIdx, [MarshalAs(UnmanagedType.LPArray), Out] int[] maxIdx, IntPtr mask);
+    internal static partial ExceptionStatus core_minMaxIdx2(InputArrayProxy src, out double minVal, out double maxVal,
+        [MarshalAs(UnmanagedType.LPArray), Out] int[] minIdx, [MarshalAs(UnmanagedType.LPArray), Out] int[] maxIdx, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_reduce(IntPtr src, IntPtr dst, int dim, int rtype, int dtype);
+    internal static partial ExceptionStatus core_reduce(InputArrayProxy src, OutputArrayProxy dst, int dim, int rtype, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_merge([MarshalAs(UnmanagedType.LPArray)] IntPtr[] mv, uint count, IntPtr dst);
@@ -211,31 +211,31 @@ static partial class NativeMethods
         IntPtr[] dst, uint ndsts, int[] fromTo, uint npairs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_extractChannel(IntPtr src, IntPtr dst, int coi);
+    internal static partial ExceptionStatus core_extractChannel(InputArrayProxy src, OutputArrayProxy dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_insertChannel(IntPtr src, IntPtr dst, int coi);
+    internal static partial ExceptionStatus core_insertChannel(InputArrayProxy src, InputOutputArrayProxy dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_flip(InputArrayProxy src, OutputArrayProxy dst, int flipCode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_rotate(IntPtr src, IntPtr dst, int rotateCode);
+    internal static partial ExceptionStatus core_rotate(InputArrayProxy src, OutputArrayProxy dst, int rotateCode);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_repeat1(IntPtr src, int ny, int nx, IntPtr dst);
+    internal static partial ExceptionStatus core_repeat1(InputArrayProxy src, int ny, int nx, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_repeat2(IntPtr src, int ny, int nx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_hconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_hconcat2(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus core_hconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_vconcat1([MarshalAs(UnmanagedType.LPArray)] IntPtr[] src, uint nsrc, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_vconcat2(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus core_vconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_bitwise_and(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -128,29 +128,29 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_divide2(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_scaleAdd(IntPtr src1, double alpha, IntPtr src2,IntPtr dst);
+    internal static partial ExceptionStatus core_scaleAdd(ArrayProxy src1, double alpha, ArrayProxy src2, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_addWeighted(IntPtr src1, double alpha, IntPtr src2,
-        double beta, double gamma, IntPtr dst, int dtype);
+    internal static partial ExceptionStatus core_addWeighted(ArrayProxy src1, double alpha, ArrayProxy src2,
+        double beta, double gamma, ArrayProxy dst, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_convertScaleAbs(IntPtr src, IntPtr dst, double alpha, double beta);
+    internal static partial ExceptionStatus core_convertScaleAbs(ArrayProxy src, ArrayProxy dst, double alpha, double beta);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_LUT(IntPtr src, IntPtr lut, IntPtr dst);
+    internal static partial ExceptionStatus core_LUT(ArrayProxy src, ArrayProxy lut, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_sum(IntPtr src, out Scalar returnValue);
+    internal static partial ExceptionStatus core_sum(ArrayProxy src, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_countNonZero(IntPtr src, out int returnValue);
+    internal static partial ExceptionStatus core_countNonZero(ArrayProxy src, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_findNonZero(IntPtr src, IntPtr idx);
+    internal static partial ExceptionStatus core_findNonZero(ArrayProxy src, ArrayProxy idx);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_mean(IntPtr src, IntPtr mask, out Scalar returnValue);
+    internal static partial ExceptionStatus core_mean(ArrayProxy src, ArrayProxy mask, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_meanStdDev_OutputArray(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -303,16 +303,16 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_magnitude_Mat(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy magnitude);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_checkRange(IntPtr a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);
-        
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_patchNaNs(IntPtr a, double val);
+    internal static partial ExceptionStatus core_checkRange(InputArrayProxy a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_gemm(IntPtr src1, IntPtr src2, double alpha, IntPtr src3, double gamma, IntPtr dst, int flags);
+    internal static partial ExceptionStatus core_patchNaNs(InputOutputArrayProxy a, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_mulTransposed(IntPtr src, IntPtr dst, int aTa, IntPtr delta, double scale, int dtype);
+    internal static partial ExceptionStatus core_gemm(InputArrayProxy src1, InputArrayProxy src2, double alpha, InputArrayProxy src3, double gamma, OutputArrayProxy dst, int flags);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_mulTransposed(InputArrayProxy src, OutputArrayProxy dst, int aTa, InputArrayProxy delta, double scale, int dtype);
 
     // MIGRATION (issue #1976, strategy 3): array arguments are ArrayProxy passed BY VALUE; the native
     // side rebuilds cv::_InputArray/_OutputArray on its stack. One signature serves both the ref-struct
@@ -322,10 +322,10 @@ static partial class NativeMethods
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_transform(IntPtr src, IntPtr dst, IntPtr m);
+    internal static partial ExceptionStatus core_transform(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_perspectiveTransform(IntPtr src, IntPtr dst, IntPtr m);
+    internal static partial ExceptionStatus core_perspectiveTransform(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_perspectiveTransform_Mat(IntPtr src, IntPtr dst, IntPtr m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -345,34 +345,34 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_completeSymm_io(InputOutputArrayProxy mtx, int lowerToUpper);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_setIdentity(IntPtr mtx, Scalar s);
+    internal static partial ExceptionStatus core_setIdentity(InputOutputArrayProxy mtx, Scalar s);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_determinant(IntPtr mtx, out double returnValue);
+    internal static partial ExceptionStatus core_determinant(InputArrayProxy mtx, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_trace(IntPtr mtx, out Scalar returnValue);
+    internal static partial ExceptionStatus core_trace(InputArrayProxy mtx, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_invert(IntPtr src, IntPtr dst, int flags, out double returnValue);
+    internal static partial ExceptionStatus core_invert(InputArrayProxy src, OutputArrayProxy dst, int flags, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_solve(IntPtr src1, IntPtr src2, IntPtr dst, int flags, out int returnValue);
-        
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_solveLP(IntPtr func, IntPtr constr, IntPtr z, out int returnValue);
-        
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_sort(IntPtr src, IntPtr dst, int flags);
+    internal static partial ExceptionStatus core_solve(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_sortIdx(IntPtr src, IntPtr dst, int flags);
+    internal static partial ExceptionStatus core_solveLP(InputArrayProxy func, InputArrayProxy constr, OutputArrayProxy z, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_solveCubic(IntPtr coeffs, IntPtr roots, out int returnValue);
+    internal static partial ExceptionStatus core_sort(InputArrayProxy src, OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_solvePoly(IntPtr coeffs, IntPtr roots, int maxIters, out double returnValue);
+    internal static partial ExceptionStatus core_sortIdx(InputArrayProxy src, OutputArrayProxy dst, int flags);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_solveCubic(InputArrayProxy coeffs, OutputArrayProxy roots, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_solvePoly(InputArrayProxy coeffs, OutputArrayProxy roots, int maxIters, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_eigen(IntPtr src, IntPtr eigenvalues, IntPtr eigenvectors, out int returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -84,7 +84,7 @@ static partial class NativeMethods
         
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_format(InputArrayProxy mtx, int fmt, IntPtr buf);
+    internal static partial ExceptionStatus core_format(in InputArrayProxy mtx, int fmt, IntPtr buf);
 
     #endregion
 
@@ -104,101 +104,101 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_copyMakeBorder(
-        InputArrayProxy src, OutputArrayProxy dst, int top, int bottom, int left, int right, int borderType, Scalar value);
+        in InputArrayProxy src, in OutputArrayProxy dst, int top, int bottom, int left, int right, int borderType, Scalar value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_add(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
+    internal static partial ExceptionStatus core_add(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_InputArray2(
-        InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
+        in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_InputArrayScalar(
-        InputArrayProxy src1, Scalar src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
+        in InputArrayProxy src1, Scalar src2, in OutputArrayProxy dst, in InputArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_ScalarInputArray(
-        Scalar src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
+        Scalar src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_multiply(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_multiply(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_divide1(double scale, InputArrayProxy src2, OutputArrayProxy dst, int dtype);
+    internal static partial ExceptionStatus core_divide1(double scale, in InputArrayProxy src2, in OutputArrayProxy dst, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_divide2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_divide2(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_scaleAdd(InputArrayProxy src1, double alpha, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_scaleAdd(in InputArrayProxy src1, double alpha, in InputArrayProxy src2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_addWeighted(InputArrayProxy src1, double alpha, InputArrayProxy src2,
-        double beta, double gamma, OutputArrayProxy dst, int dtype);
+    internal static partial ExceptionStatus core_addWeighted(in InputArrayProxy src1, double alpha, in InputArrayProxy src2,
+        double beta, double gamma, in OutputArrayProxy dst, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_convertScaleAbs(InputArrayProxy src, OutputArrayProxy dst, double alpha, double beta);
+    internal static partial ExceptionStatus core_convertScaleAbs(in InputArrayProxy src, in OutputArrayProxy dst, double alpha, double beta);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_LUT(InputArrayProxy src, InputArrayProxy lut, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_LUT(in InputArrayProxy src, in InputArrayProxy lut, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sum(InputArrayProxy src, out Scalar returnValue);
+    internal static partial ExceptionStatus core_sum(in InputArrayProxy src, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_countNonZero(InputArrayProxy src, out int returnValue);
+    internal static partial ExceptionStatus core_countNonZero(in InputArrayProxy src, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_findNonZero(InputArrayProxy src, OutputArrayProxy idx);
+    internal static partial ExceptionStatus core_findNonZero(in InputArrayProxy src, in OutputArrayProxy idx);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_mean(InputArrayProxy src, InputArrayProxy mask, out Scalar returnValue);
+    internal static partial ExceptionStatus core_mean(in InputArrayProxy src, in InputArrayProxy mask, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_meanStdDev_OutputArray(
-        InputArrayProxy src, OutputArrayProxy mean, OutputArrayProxy stddev, InputArrayProxy mask);
+        in InputArrayProxy src, in OutputArrayProxy mean, in OutputArrayProxy stddev, in InputArrayProxy mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_meanStdDev_Scalar(
-        InputArrayProxy src, out Scalar mean, out Scalar stddev, InputArrayProxy mask);
+        in InputArrayProxy src, out Scalar mean, out Scalar stddev, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_norm1(
-        InputArrayProxy src1, int normType, InputArrayProxy mask, out double returnValue);
+        in InputArrayProxy src1, int normType, in InputArrayProxy mask, out double returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_norm2(
-        InputArrayProxy src1, InputArrayProxy src2, int normType, InputArrayProxy mask, out double returnValue);
+        in InputArrayProxy src1, in InputArrayProxy src2, int normType, in InputArrayProxy mask, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PSNR(InputArrayProxy src1, InputArrayProxy src2, double r, out double returnValue);
+    internal static partial ExceptionStatus core_PSNR(in InputArrayProxy src1, in InputArrayProxy src2, double r, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_batchDistance(InputArrayProxy src1, InputArrayProxy src2,
-        OutputArrayProxy dist, int dtype, OutputArrayProxy nidx,
-        int normType, int k, InputArrayProxy mask,
+    internal static partial ExceptionStatus core_batchDistance(in InputArrayProxy src1, in InputArrayProxy src2,
+        in OutputArrayProxy dist, int dtype, in OutputArrayProxy nidx,
+        int normType, int k, in InputArrayProxy mask,
         int update, int crosscheck);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_normalize(InputArrayProxy src, InputOutputArrayProxy dst, double alpha, double beta,
-        int normType, int dtype, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_normalize(in InputArrayProxy src, in InputOutputArrayProxy dst, double alpha, double beta,
+        int normType, int dtype, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_reduceArgMax(InputArrayProxy src, OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
+    internal static partial ExceptionStatus core_reduceArgMax(in InputArrayProxy src, in OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_reduceArgMin(InputArrayProxy src, OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
+    internal static partial ExceptionStatus core_reduceArgMin(in InputArrayProxy src, in OutputArrayProxy dst, int axis, [MarshalAs(UnmanagedType.U1)] bool lastIndex);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_minMaxLoc1(InputArrayProxy src, out double minVal, out double maxVal);
+    internal static partial ExceptionStatus core_minMaxLoc1(in InputArrayProxy src, out double minVal, out double maxVal);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_minMaxLoc2(InputArrayProxy src, out double minVal, out double maxVal,
-        out Point minLoc, out Point maxLoc, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_minMaxLoc2(in InputArrayProxy src, out double minVal, out double maxVal,
+        out Point minLoc, out Point maxLoc, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_minMaxIdx1(InputArrayProxy src, out double minVal, out double maxVal);
+    internal static partial ExceptionStatus core_minMaxIdx1(in InputArrayProxy src, out double minVal, out double maxVal);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_minMaxIdx2(InputArrayProxy src, out double minVal, out double maxVal,
-        [MarshalAs(UnmanagedType.LPArray), Out] int[] minIdx, [MarshalAs(UnmanagedType.LPArray), Out] int[] maxIdx, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_minMaxIdx2(in InputArrayProxy src, out double minVal, out double maxVal,
+        [MarshalAs(UnmanagedType.LPArray), Out] int[] minIdx, [MarshalAs(UnmanagedType.LPArray), Out] int[] maxIdx, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_reduce(InputArrayProxy src, OutputArrayProxy dst, int dim, int rtype, int dtype);
+    internal static partial ExceptionStatus core_reduce(in InputArrayProxy src, in OutputArrayProxy dst, int dim, int rtype, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_merge(ReadOnlySpan<IntPtr> mv, uint count, IntPtr dst);
@@ -211,217 +211,217 @@ static partial class NativeMethods
         ReadOnlySpan<IntPtr> dst, uint ndsts, int[] fromTo, uint npairs);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_extractChannel(InputArrayProxy src, OutputArrayProxy dst, int coi);
+    internal static partial ExceptionStatus core_extractChannel(in InputArrayProxy src, in OutputArrayProxy dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_insertChannel(InputArrayProxy src, InputOutputArrayProxy dst, int coi);
+    internal static partial ExceptionStatus core_insertChannel(in InputArrayProxy src, in InputOutputArrayProxy dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_flip(InputArrayProxy src, OutputArrayProxy dst, int flipCode);
+    internal static partial ExceptionStatus core_flip(in InputArrayProxy src, in OutputArrayProxy dst, int flipCode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_rotate(InputArrayProxy src, OutputArrayProxy dst, int rotateCode);
+    internal static partial ExceptionStatus core_rotate(in InputArrayProxy src, in OutputArrayProxy dst, int rotateCode);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_repeat1(InputArrayProxy src, int ny, int nx, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_repeat1(in InputArrayProxy src, int ny, int nx, in OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_repeat2(IntPtr src, int ny, int nx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_hconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_hconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, in OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_hconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_hconcat2(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_vconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_vconcat1(ReadOnlySpan<IntPtr> src, uint nsrc, in OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_vconcat2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_vconcat2(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_and(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_and(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_or(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_or(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_xor(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_xor(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_not(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_not(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_absdiff(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_absdiff(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_copyTo(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus core_copyTo(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_inRange_InputArray(InputArrayProxy src, InputArrayProxy lowerb, InputArrayProxy upperb, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_inRange_InputArray(in InputArrayProxy src, in InputArrayProxy lowerb, in InputArrayProxy upperb, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_inRange_Scalar(InputArrayProxy src, Scalar lowerb, Scalar upperb, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_inRange_Scalar(in InputArrayProxy src, Scalar lowerb, Scalar upperb, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_compare(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int cmpop);
+    internal static partial ExceptionStatus core_compare(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, int cmpop);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_min1(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_min1(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_max1(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_max1(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_max_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_max_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sqrt(InputArrayProxy src, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_sqrt(in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_pow_Mat(InputArrayProxy src, double power, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_pow_Mat(in InputArrayProxy src, double power, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_exp_Mat(InputArrayProxy src, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_exp_Mat(in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_log_Mat(InputArrayProxy src, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_log_Mat(in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_polarToCart(InputArrayProxy magnitude, InputArrayProxy angle, OutputArrayProxy x, OutputArrayProxy y, int angleInDegrees);
+    internal static partial ExceptionStatus core_polarToCart(in InputArrayProxy magnitude, in InputArrayProxy angle, in OutputArrayProxy x, in OutputArrayProxy y, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_cartToPolar(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy magnitude, OutputArrayProxy angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_cartToPolar(in InputArrayProxy x, in InputArrayProxy y, in OutputArrayProxy magnitude, in OutputArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_phase(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_phase(in InputArrayProxy x, in InputArrayProxy y, in OutputArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_magnitude_Mat(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy magnitude);
+    internal static partial ExceptionStatus core_magnitude_Mat(in InputArrayProxy x, in InputArrayProxy y, in OutputArrayProxy magnitude);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_checkRange(InputArrayProxy a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);
+    internal static partial ExceptionStatus core_checkRange(in InputArrayProxy a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_patchNaNs(InputOutputArrayProxy a, double val);
+    internal static partial ExceptionStatus core_patchNaNs(in InputOutputArrayProxy a, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_gemm(InputArrayProxy src1, InputArrayProxy src2, double alpha, InputArrayProxy src3, double gamma, OutputArrayProxy dst, int flags);
+    internal static partial ExceptionStatus core_gemm(in InputArrayProxy src1, in InputArrayProxy src2, double alpha, in InputArrayProxy src3, double gamma, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_mulTransposed(InputArrayProxy src, OutputArrayProxy dst, int aTa, InputArrayProxy delta, double scale, int dtype);
+    internal static partial ExceptionStatus core_mulTransposed(in InputArrayProxy src, in OutputArrayProxy dst, int aTa, in InputArrayProxy delta, double scale, int dtype);
 
     // MIGRATION (issue #1976, strategy 3): array arguments are ArrayProxy passed BY VALUE; the native
     // side rebuilds cv::_InputArray/_OutputArray on its stack. One signature serves both the ref-struct
     // path (optimized kinds) and the still-class path (Raw kinds wrapping an existing cv::_InputArray*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_transpose(InputArrayProxy src, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_transpose(in InputArrayProxy src, in OutputArrayProxy dst);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_transform(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m);
+    internal static partial ExceptionStatus core_transform(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy m);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_perspectiveTransform(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m);
+    internal static partial ExceptionStatus core_perspectiveTransform(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_perspectiveTransform_Mat(IntPtr src, IntPtr dst, IntPtr m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_perspectiveTransform_Point2f(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point2f(IntPtr src, int srcLength, IntPtr dst, int dstLength, in InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_perspectiveTransform_Point2d(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point2d(IntPtr src, int srcLength, IntPtr dst, int dstLength, in InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_perspectiveTransform_Point3f(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point3f(IntPtr src, int srcLength, IntPtr dst, int dstLength, in InputArrayProxy m);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_perspectiveTransform_Point3d(IntPtr src, int srcLength, IntPtr dst, int dstLength, InputArrayProxy m);
+    internal static partial ExceptionStatus core_perspectiveTransform_Point3d(IntPtr src, int srcLength, IntPtr dst, int dstLength, in InputArrayProxy m);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_completeSymm(InputOutputArrayProxy mtx, int lowerToUpper);
+    internal static partial ExceptionStatus core_completeSymm(in InputOutputArrayProxy mtx, int lowerToUpper);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_setIdentity(InputOutputArrayProxy mtx, Scalar s);
+    internal static partial ExceptionStatus core_setIdentity(in InputOutputArrayProxy mtx, Scalar s);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_determinant(InputArrayProxy mtx, out double returnValue);
+    internal static partial ExceptionStatus core_determinant(in InputArrayProxy mtx, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_trace(InputArrayProxy mtx, out Scalar returnValue);
+    internal static partial ExceptionStatus core_trace(in InputArrayProxy mtx, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_invert(InputArrayProxy src, OutputArrayProxy dst, int flags, out double returnValue);
+    internal static partial ExceptionStatus core_invert(in InputArrayProxy src, in OutputArrayProxy dst, int flags, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_solve(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int flags, out int returnValue);
+    internal static partial ExceptionStatus core_solve(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_solveLP(InputArrayProxy func, InputArrayProxy constr, OutputArrayProxy z, out int returnValue);
+    internal static partial ExceptionStatus core_solveLP(in InputArrayProxy func, in InputArrayProxy constr, in OutputArrayProxy z, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sort(InputArrayProxy src, OutputArrayProxy dst, int flags);
+    internal static partial ExceptionStatus core_sort(in InputArrayProxy src, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sortIdx(InputArrayProxy src, OutputArrayProxy dst, int flags);
+    internal static partial ExceptionStatus core_sortIdx(in InputArrayProxy src, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_solveCubic(InputArrayProxy coeffs, OutputArrayProxy roots, out int returnValue);
+    internal static partial ExceptionStatus core_solveCubic(in InputArrayProxy coeffs, in OutputArrayProxy roots, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_solvePoly(InputArrayProxy coeffs, OutputArrayProxy roots, int maxIters, out double returnValue);
+    internal static partial ExceptionStatus core_solvePoly(in InputArrayProxy coeffs, in OutputArrayProxy roots, int maxIters, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_eigen(InputArrayProxy src, OutputArrayProxy eigenvalues, OutputArrayProxy eigenvectors, out int returnValue);
+    internal static partial ExceptionStatus core_eigen(in InputArrayProxy src, in OutputArrayProxy eigenvalues, in OutputArrayProxy eigenvectors, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_eigenNonSymmetric(InputArrayProxy src, OutputArrayProxy eigenvalues, OutputArrayProxy eigenvectors);
+    internal static partial ExceptionStatus core_eigenNonSymmetric(in InputArrayProxy src, in OutputArrayProxy eigenvalues, in OutputArrayProxy eigenvectors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_calcCovarMatrix_Mat(ReadOnlySpan<IntPtr> samples,
         int nsamples, IntPtr covar, IntPtr mean, int flags, int ctype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_calcCovarMatrix_InputArray(InputArrayProxy samples, OutputArrayProxy covar,
-        InputOutputArrayProxy mean, int flags, int ctype);
+    internal static partial ExceptionStatus core_calcCovarMatrix_InputArray(in InputArrayProxy samples, in OutputArrayProxy covar,
+        in InputOutputArrayProxy mean, int flags, int ctype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCACompute(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, int maxComponents);
+    internal static partial ExceptionStatus core_PCACompute(in InputArrayProxy data, in InputOutputArrayProxy mean, in OutputArrayProxy eigenvectors, int maxComponents);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCACompute2(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, OutputArrayProxy eigenvalues, int maxComponents);
+    internal static partial ExceptionStatus core_PCACompute2(in InputArrayProxy data, in InputOutputArrayProxy mean, in OutputArrayProxy eigenvectors, in OutputArrayProxy eigenvalues, int maxComponents);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCAComputeVar(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, double retainedVariance);
+    internal static partial ExceptionStatus core_PCAComputeVar(in InputArrayProxy data, in InputOutputArrayProxy mean, in OutputArrayProxy eigenvectors, double retainedVariance);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCAComputeVar2(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, OutputArrayProxy eigenvalues, double retainedVariance);
+    internal static partial ExceptionStatus core_PCAComputeVar2(in InputArrayProxy data, in InputOutputArrayProxy mean, in OutputArrayProxy eigenvectors, in OutputArrayProxy eigenvalues, double retainedVariance);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCAProject(InputArrayProxy data, InputArrayProxy mean, InputArrayProxy eigenvectors, OutputArrayProxy result);
+    internal static partial ExceptionStatus core_PCAProject(in InputArrayProxy data, in InputArrayProxy mean, in InputArrayProxy eigenvectors, in OutputArrayProxy result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_PCABackProject(InputArrayProxy data, InputArrayProxy mean, InputArrayProxy eigenvectors, OutputArrayProxy result);
+    internal static partial ExceptionStatus core_PCABackProject(in InputArrayProxy data, in InputArrayProxy mean, in InputArrayProxy eigenvectors, in OutputArrayProxy result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_SVDecomp(InputArrayProxy src, OutputArrayProxy w, OutputArrayProxy u, OutputArrayProxy vt, int flags);
+    internal static partial ExceptionStatus core_SVDecomp(in InputArrayProxy src, in OutputArrayProxy w, in OutputArrayProxy u, in OutputArrayProxy vt, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_SVBackSubst(InputArrayProxy w, InputArrayProxy u, InputArrayProxy vt, InputArrayProxy rhs, OutputArrayProxy dst);
+    internal static partial ExceptionStatus core_SVBackSubst(in InputArrayProxy w, in InputArrayProxy u, in InputArrayProxy vt, in InputArrayProxy rhs, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_Mahalanobis(InputArrayProxy v1, InputArrayProxy v2, InputArrayProxy icovar, out double returnValue);
+    internal static partial ExceptionStatus core_Mahalanobis(in InputArrayProxy v1, in InputArrayProxy v2, in InputArrayProxy icovar, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_dft(InputArrayProxy src, OutputArrayProxy dst, int flags, int nonzeroRows);
+    internal static partial ExceptionStatus core_dft(in InputArrayProxy src, in OutputArrayProxy dst, int flags, int nonzeroRows);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_idft(InputArrayProxy src, OutputArrayProxy dst, int flags, int nonzeroRows);
+    internal static partial ExceptionStatus core_idft(in InputArrayProxy src, in OutputArrayProxy dst, int flags, int nonzeroRows);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_dct(InputArrayProxy src, OutputArrayProxy dst, int flags);
+    internal static partial ExceptionStatus core_dct(in InputArrayProxy src, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_idct(InputArrayProxy src, OutputArrayProxy dst, int flags);
+    internal static partial ExceptionStatus core_idct(in InputArrayProxy src, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_mulSpectrums(InputArrayProxy a, InputArrayProxy b, OutputArrayProxy c, int flags, int conjB);
+    internal static partial ExceptionStatus core_mulSpectrums(in InputArrayProxy a, in InputArrayProxy b, in OutputArrayProxy c, int flags, int conjB);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_getOptimalDFTSize(int vecsize, out int returnValue);
@@ -432,24 +432,24 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_theRNG_set(ulong returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randu_InputArray(InputOutputArrayProxy dst, InputArrayProxy low, InputArrayProxy high);
+    internal static partial ExceptionStatus core_randu_InputArray(in InputOutputArrayProxy dst, in InputArrayProxy low, in InputArrayProxy high);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randu_Scalar(InputOutputArrayProxy dst, Scalar low, Scalar high);
+    internal static partial ExceptionStatus core_randu_Scalar(in InputOutputArrayProxy dst, Scalar low, Scalar high);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randn_InputArray(InputOutputArrayProxy dst, InputArrayProxy mean, InputArrayProxy stddev);
+    internal static partial ExceptionStatus core_randn_InputArray(in InputOutputArrayProxy dst, in InputArrayProxy mean, in InputArrayProxy stddev);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randn_Scalar(InputOutputArrayProxy dst, Scalar mean, Scalar stddev);
+    internal static partial ExceptionStatus core_randn_Scalar(in InputOutputArrayProxy dst, Scalar mean, Scalar stddev);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randShuffle(InputOutputArrayProxy dst, double iterFactor, ref ulong rng);
+    internal static partial ExceptionStatus core_randShuffle(in InputOutputArrayProxy dst, double iterFactor, ref ulong rng);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_randShuffle(InputOutputArrayProxy dst, double iterFactor, IntPtr rng);
+    internal static partial ExceptionStatus core_randShuffle(in InputOutputArrayProxy dst, double iterFactor, IntPtr rng);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_kmeans(
-        InputArrayProxy data, int k, InputOutputArrayProxy bestLabels,
-        TermCriteria criteria, int attempts, int flags, OutputArrayProxy centers,
+        in InputArrayProxy data, int k, in InputOutputArrayProxy bestLabels,
+        TermCriteria criteria, int attempts, int flags, in OutputArrayProxy centers,
         out double returnValue);
 
     #region base.hpp

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -107,7 +107,7 @@ static partial class NativeMethods
         IntPtr src, IntPtr dst, int top, int bottom, int left, int right, int borderType, Scalar value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_add(IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask, int dtype);
+    internal static partial ExceptionStatus core_add(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_subtract_InputArray2(
@@ -320,8 +320,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_transpose(ArrayProxy src, ArrayProxy dst);
 
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_add_io(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_transform(IntPtr src, IntPtr dst, IntPtr m);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -110,22 +110,22 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_add(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_subtract_InputArray2(
-        IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask, int dtype);
+    internal static partial ExceptionStatus core_subtract_InputArray2(
+        ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_subtract_InputArrayScalar(
-        IntPtr src1, Scalar src2, IntPtr dst, IntPtr mask, int dtype);
+    internal static partial ExceptionStatus core_subtract_InputArrayScalar(
+        ArrayProxy src1, Scalar src2, ArrayProxy dst, ArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_subtract_ScalarInputArray(
-        Scalar src1, IntPtr src2, IntPtr dst, IntPtr mask, int dtype);
+    internal static partial ExceptionStatus core_subtract_ScalarInputArray(
+        Scalar src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_multiply(IntPtr src1, IntPtr src2, IntPtr dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_multiply(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_divide1(double scale, IntPtr src2, IntPtr dst, int dtype);
+    internal static partial ExceptionStatus core_divide1(double scale, ArrayProxy src2, ArrayProxy dst, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_divide2(IntPtr src1, IntPtr src2, IntPtr dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_divide2(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_scaleAdd(IntPtr src1, double alpha, IntPtr src2,IntPtr dst);
@@ -250,7 +250,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_bitwise_not(IntPtr src, IntPtr dst, IntPtr mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_absdiff(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus core_absdiff(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_copyTo(IntPtr src, IntPtr dst, IntPtr mask);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -314,13 +314,11 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_mulTransposed(IntPtr src, IntPtr dst, int aTa, IntPtr delta, double scale, int dtype);
 
+    // MIGRATION (issue #1976, strategy 3): array arguments are ArrayProxy passed BY VALUE; the native
+    // side rebuilds cv::_InputArray/_OutputArray on its stack. One signature serves both the ref-struct
+    // path (optimized kinds) and the still-class path (Raw kinds wrapping an existing cv::_InputArray*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_transpose(IntPtr src, IntPtr dst);
-
-    // FOUNDATION: ref-struct proxy path. Each array argument is an ArrayProxy passed BY VALUE; the
-    // native side rebuilds cv::_InputArray/_OutputArray on its stack (no managed _InputArray alloc).
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_transpose_io(ArrayProxy src, ArrayProxy dst);
+    internal static partial ExceptionStatus core_transpose(ArrayProxy src, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_add_io(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -375,57 +375,57 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_solvePoly(InputArrayProxy coeffs, OutputArrayProxy roots, int maxIters, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_eigen(IntPtr src, IntPtr eigenvalues, IntPtr eigenvectors, out int returnValue);
+    internal static partial ExceptionStatus core_eigen(InputArrayProxy src, OutputArrayProxy eigenvalues, OutputArrayProxy eigenvectors, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_eigenNonSymmetric(IntPtr src, IntPtr eigenvalues, IntPtr eigenvectors);
+    internal static partial ExceptionStatus core_eigenNonSymmetric(InputArrayProxy src, OutputArrayProxy eigenvalues, OutputArrayProxy eigenvectors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_calcCovarMatrix_Mat([MarshalAs(UnmanagedType.LPArray)] IntPtr[] samples, 
+    public static partial ExceptionStatus core_calcCovarMatrix_Mat([MarshalAs(UnmanagedType.LPArray)] IntPtr[] samples,
         int nsamples, IntPtr covar, IntPtr mean, int flags, int ctype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_calcCovarMatrix_InputArray(IntPtr samples, IntPtr covar,
-        IntPtr mean, int flags, int ctype);
+    internal static partial ExceptionStatus core_calcCovarMatrix_InputArray(InputArrayProxy samples, OutputArrayProxy covar,
+        InputOutputArrayProxy mean, int flags, int ctype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCACompute(IntPtr data, IntPtr mean, IntPtr eigenvectors, int maxComponents);
+    internal static partial ExceptionStatus core_PCACompute(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, int maxComponents);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCACompute2(IntPtr data, IntPtr mean, IntPtr eigenvectors, IntPtr eigenvalues, int maxComponents);
+    internal static partial ExceptionStatus core_PCACompute2(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, OutputArrayProxy eigenvalues, int maxComponents);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCAComputeVar(IntPtr data, IntPtr mean, IntPtr eigenvectors, double retainedVariance);
+    internal static partial ExceptionStatus core_PCAComputeVar(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, double retainedVariance);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCAComputeVar2(IntPtr data, IntPtr mean, IntPtr eigenvectors, IntPtr eigenvalues, double retainedVariance);
+    internal static partial ExceptionStatus core_PCAComputeVar2(InputArrayProxy data, InputOutputArrayProxy mean, OutputArrayProxy eigenvectors, OutputArrayProxy eigenvalues, double retainedVariance);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCAProject(IntPtr data, IntPtr mean, IntPtr eigenvectors, IntPtr result);
+    internal static partial ExceptionStatus core_PCAProject(InputArrayProxy data, InputArrayProxy mean, InputArrayProxy eigenvectors, OutputArrayProxy result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_PCABackProject(IntPtr data, IntPtr mean, IntPtr eigenvectors, IntPtr result);
+    internal static partial ExceptionStatus core_PCABackProject(InputArrayProxy data, InputArrayProxy mean, InputArrayProxy eigenvectors, OutputArrayProxy result);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVDecomp(IntPtr src, IntPtr w, IntPtr u, IntPtr vt, int flags);
+    internal static partial ExceptionStatus core_SVDecomp(InputArrayProxy src, OutputArrayProxy w, OutputArrayProxy u, OutputArrayProxy vt, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_SVBackSubst(IntPtr w, IntPtr u, IntPtr vt, IntPtr rhs, IntPtr dst);
+    internal static partial ExceptionStatus core_SVBackSubst(InputArrayProxy w, InputArrayProxy u, InputArrayProxy vt, InputArrayProxy rhs, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Mahalanobis(IntPtr v1, IntPtr v2, IntPtr icovar, out double returnValue);
+    internal static partial ExceptionStatus core_Mahalanobis(InputArrayProxy v1, InputArrayProxy v2, InputArrayProxy icovar, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_dft(IntPtr src, IntPtr dst, int flags, int nonzeroRows);
+    internal static partial ExceptionStatus core_dft(InputArrayProxy src, OutputArrayProxy dst, int flags, int nonzeroRows);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_idft(IntPtr src, IntPtr dst, int flags, int nonzeroRows);
+    internal static partial ExceptionStatus core_idft(InputArrayProxy src, OutputArrayProxy dst, int flags, int nonzeroRows);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_dct(IntPtr src, IntPtr dst, int flags);
+    internal static partial ExceptionStatus core_dct(InputArrayProxy src, OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_idct(IntPtr src, IntPtr dst, int flags);
+    internal static partial ExceptionStatus core_idct(InputArrayProxy src, OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_mulSpectrums(IntPtr a, IntPtr b, IntPtr c, int flags, int conjB);
+    internal static partial ExceptionStatus core_mulSpectrums(InputArrayProxy a, InputArrayProxy b, OutputArrayProxy c, int flags, int conjB);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_getOptimalDFTSize(int vecsize, out int returnValue);
@@ -436,24 +436,24 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_theRNG_set(ulong returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randu_InputArray(IntPtr dst, IntPtr low, IntPtr high);
+    internal static partial ExceptionStatus core_randu_InputArray(InputOutputArrayProxy dst, InputArrayProxy low, InputArrayProxy high);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randu_Scalar(IntPtr dst, Scalar low, Scalar high);
+    internal static partial ExceptionStatus core_randu_Scalar(InputOutputArrayProxy dst, Scalar low, Scalar high);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randn_InputArray(IntPtr dst, IntPtr mean, IntPtr stddev);
+    internal static partial ExceptionStatus core_randn_InputArray(InputOutputArrayProxy dst, InputArrayProxy mean, InputArrayProxy stddev);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randn_Scalar(IntPtr dst, Scalar mean, Scalar stddev);
+    internal static partial ExceptionStatus core_randn_Scalar(InputOutputArrayProxy dst, Scalar mean, Scalar stddev);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randShuffle(IntPtr dst, double iterFactor, ref ulong rng);
+    internal static partial ExceptionStatus core_randShuffle(InputOutputArrayProxy dst, double iterFactor, ref ulong rng);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_randShuffle(IntPtr dst, double iterFactor, IntPtr rng);
-        
+    internal static partial ExceptionStatus core_randShuffle(InputOutputArrayProxy dst, double iterFactor, IntPtr rng);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_kmeans(
-        IntPtr data, int k, IntPtr bestLabels,
-        TermCriteria criteria, int attempts, int flags, IntPtr centers,
+    internal static partial ExceptionStatus core_kmeans(
+        InputArrayProxy data, int k, InputOutputArrayProxy bestLabels,
+        TermCriteria criteria, int attempts, int flags, OutputArrayProxy centers,
         out double returnValue);
 
     #region base.hpp

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -103,8 +103,8 @@ static partial class NativeMethods
         int p, int len, int borderType, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_copyMakeBorder(
-        IntPtr src, IntPtr dst, int top, int bottom, int left, int right, int borderType, Scalar value);
+    internal static partial ExceptionStatus core_copyMakeBorder(
+        ArrayProxy src, ArrayProxy dst, int top, int bottom, int left, int right, int borderType, Scalar value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_add(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
@@ -217,7 +217,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_insertChannel(IntPtr src, IntPtr dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_flip(IntPtr src, IntPtr dst, int flipCode);
+    internal static partial ExceptionStatus core_flip(ArrayProxy src, ArrayProxy dst, int flipCode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_rotate(IntPtr src, IntPtr dst, int rotateCode);
@@ -253,16 +253,16 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_absdiff(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_copyTo(IntPtr src, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus core_copyTo(ArrayProxy src, ArrayProxy dst, ArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_inRange_InputArray(IntPtr src, IntPtr lowerb, IntPtr upperb, IntPtr dst);
+    internal static partial ExceptionStatus core_inRange_InputArray(ArrayProxy src, ArrayProxy lowerb, ArrayProxy upperb, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_inRange_Scalar(IntPtr src, Scalar lowerb, Scalar upperb, IntPtr dst);
+    internal static partial ExceptionStatus core_inRange_Scalar(ArrayProxy src, Scalar lowerb, Scalar upperb, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_compare(IntPtr src1, IntPtr src2, IntPtr dst, int cmpop);
+    internal static partial ExceptionStatus core_compare(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, int cmpop);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_min1(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
@@ -279,28 +279,28 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_max_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_sqrt(IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus core_sqrt(ArrayProxy src, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_pow_Mat(IntPtr src, double power, IntPtr dst);
+    internal static partial ExceptionStatus core_pow_Mat(ArrayProxy src, double power, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_exp_Mat(IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus core_exp_Mat(ArrayProxy src, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_log_Mat(IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus core_log_Mat(ArrayProxy src, ArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_polarToCart(IntPtr magnitude, IntPtr angle, IntPtr x, IntPtr y, int angleInDegrees);
+    internal static partial ExceptionStatus core_polarToCart(ArrayProxy magnitude, ArrayProxy angle, ArrayProxy x, ArrayProxy y, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_cartToPolar(IntPtr x, IntPtr y, IntPtr magnitude, IntPtr angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_cartToPolar(ArrayProxy x, ArrayProxy y, ArrayProxy magnitude, ArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_phase(IntPtr x, IntPtr y, IntPtr angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_phase(ArrayProxy x, ArrayProxy y, ArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_magnitude_Mat(IntPtr x, IntPtr y, IntPtr magnitude);
+    internal static partial ExceptionStatus core_magnitude_Mat(ArrayProxy x, ArrayProxy y, ArrayProxy magnitude);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_checkRange(IntPtr a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -238,16 +238,16 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_vconcat2(IntPtr src1, IntPtr src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_bitwise_and(IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus core_bitwise_and(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_bitwise_or(IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus core_bitwise_or(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_bitwise_xor(IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus core_bitwise_xor(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_bitwise_not(IntPtr src, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus core_bitwise_not(ArrayProxy src, ArrayProxy dst, ArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_absdiff(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
@@ -265,14 +265,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_compare(IntPtr src1, IntPtr src2, IntPtr dst, int cmpop);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_min1(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus core_min1(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_max1(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus core_max1(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_max_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -104,53 +104,53 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_copyMakeBorder(
-        ArrayProxy src, ArrayProxy dst, int top, int bottom, int left, int right, int borderType, Scalar value);
+        InputArrayProxy src, OutputArrayProxy dst, int top, int bottom, int left, int right, int borderType, Scalar value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_add(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
+    internal static partial ExceptionStatus core_add(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_InputArray2(
-        ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
+        InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_InputArrayScalar(
-        ArrayProxy src1, Scalar src2, ArrayProxy dst, ArrayProxy mask, int dtype);
+        InputArrayProxy src1, Scalar src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_subtract_ScalarInputArray(
-        Scalar src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask, int dtype);
+        Scalar src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_multiply(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_multiply(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_divide1(double scale, ArrayProxy src2, ArrayProxy dst, int dtype);
+    internal static partial ExceptionStatus core_divide1(double scale, InputArrayProxy src2, OutputArrayProxy dst, int dtype);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_divide2(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, double scale, int dtype);
+    internal static partial ExceptionStatus core_divide2(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, double scale, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_scaleAdd(ArrayProxy src1, double alpha, ArrayProxy src2, ArrayProxy dst);
+    internal static partial ExceptionStatus core_scaleAdd(InputArrayProxy src1, double alpha, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_addWeighted(ArrayProxy src1, double alpha, ArrayProxy src2,
-        double beta, double gamma, ArrayProxy dst, int dtype);
+    internal static partial ExceptionStatus core_addWeighted(InputArrayProxy src1, double alpha, InputArrayProxy src2,
+        double beta, double gamma, OutputArrayProxy dst, int dtype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_convertScaleAbs(ArrayProxy src, ArrayProxy dst, double alpha, double beta);
+    internal static partial ExceptionStatus core_convertScaleAbs(InputArrayProxy src, OutputArrayProxy dst, double alpha, double beta);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_LUT(ArrayProxy src, ArrayProxy lut, ArrayProxy dst);
+    internal static partial ExceptionStatus core_LUT(InputArrayProxy src, InputArrayProxy lut, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sum(ArrayProxy src, out Scalar returnValue);
+    internal static partial ExceptionStatus core_sum(InputArrayProxy src, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_countNonZero(ArrayProxy src, out int returnValue);
+    internal static partial ExceptionStatus core_countNonZero(InputArrayProxy src, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_findNonZero(ArrayProxy src, ArrayProxy idx);
+    internal static partial ExceptionStatus core_findNonZero(InputArrayProxy src, OutputArrayProxy idx);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_mean(ArrayProxy src, ArrayProxy mask, out Scalar returnValue);
+    internal static partial ExceptionStatus core_mean(InputArrayProxy src, InputArrayProxy mask, out Scalar returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_meanStdDev_OutputArray(
@@ -217,7 +217,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_insertChannel(IntPtr src, IntPtr dst, int coi);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_flip(ArrayProxy src, ArrayProxy dst, int flipCode);
+    internal static partial ExceptionStatus core_flip(InputArrayProxy src, OutputArrayProxy dst, int flipCode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_rotate(IntPtr src, IntPtr dst, int rotateCode);
@@ -238,69 +238,69 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_vconcat2(IntPtr src1, IntPtr src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_and(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_and(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_or(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_or(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_xor(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, ArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_xor(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_bitwise_not(ArrayProxy src, ArrayProxy dst, ArrayProxy mask);
+    internal static partial ExceptionStatus core_bitwise_not(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_absdiff(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
+    internal static partial ExceptionStatus core_absdiff(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_copyTo(ArrayProxy src, ArrayProxy dst, ArrayProxy mask);
+    internal static partial ExceptionStatus core_copyTo(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_inRange_InputArray(ArrayProxy src, ArrayProxy lowerb, ArrayProxy upperb, ArrayProxy dst);
+    internal static partial ExceptionStatus core_inRange_InputArray(InputArrayProxy src, InputArrayProxy lowerb, InputArrayProxy upperb, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_inRange_Scalar(ArrayProxy src, Scalar lowerb, Scalar upperb, ArrayProxy dst);
+    internal static partial ExceptionStatus core_inRange_Scalar(InputArrayProxy src, Scalar lowerb, Scalar upperb, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_compare(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst, int cmpop);
+    internal static partial ExceptionStatus core_compare(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int cmpop);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_min1(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
+    internal static partial ExceptionStatus core_min1(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_min_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_max1(ArrayProxy src1, ArrayProxy src2, ArrayProxy dst);
+    internal static partial ExceptionStatus core_max1(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_max_MatMat(IntPtr src1, IntPtr src2, IntPtr dst);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_max_MatDouble(IntPtr src1, double src2, IntPtr dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_sqrt(ArrayProxy src, ArrayProxy dst);
+    internal static partial ExceptionStatus core_sqrt(InputArrayProxy src, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_pow_Mat(ArrayProxy src, double power, ArrayProxy dst);
+    internal static partial ExceptionStatus core_pow_Mat(InputArrayProxy src, double power, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_exp_Mat(ArrayProxy src, ArrayProxy dst);
+    internal static partial ExceptionStatus core_exp_Mat(InputArrayProxy src, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_log_Mat(ArrayProxy src, ArrayProxy dst);
+    internal static partial ExceptionStatus core_log_Mat(InputArrayProxy src, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_polarToCart(ArrayProxy magnitude, ArrayProxy angle, ArrayProxy x, ArrayProxy y, int angleInDegrees);
+    internal static partial ExceptionStatus core_polarToCart(InputArrayProxy magnitude, InputArrayProxy angle, OutputArrayProxy x, OutputArrayProxy y, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_cartToPolar(ArrayProxy x, ArrayProxy y, ArrayProxy magnitude, ArrayProxy angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_cartToPolar(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy magnitude, OutputArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_phase(ArrayProxy x, ArrayProxy y, ArrayProxy angle, int angleInDegrees);
+    internal static partial ExceptionStatus core_phase(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy angle, int angleInDegrees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_magnitude_Mat(ArrayProxy x, ArrayProxy y, ArrayProxy magnitude);
+    internal static partial ExceptionStatus core_magnitude_Mat(InputArrayProxy x, InputArrayProxy y, OutputArrayProxy magnitude);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_checkRange(IntPtr a, int quiet, out Point pos, double minVal, double maxVal, out int returnValue);
@@ -318,7 +318,7 @@ static partial class NativeMethods
     // side rebuilds cv::_InputArray/_OutputArray on its stack. One signature serves both the ref-struct
     // path (optimized kinds) and the still-class path (Raw kinds wrapping an existing cv::_InputArray*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_transpose(ArrayProxy src, ArrayProxy dst);
+    internal static partial ExceptionStatus core_transpose(InputArrayProxy src, OutputArrayProxy dst);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -342,7 +342,7 @@ static partial class NativeMethods
 
     // FOUNDATION: ref-struct proxy path for an InputOutputArray argument.
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_completeSymm_io(ArrayProxy mtx, int lowerToUpper);
+    internal static partial ExceptionStatus core_completeSymm_io(InputOutputArrayProxy mtx, int lowerToUpper);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_setIdentity(IntPtr mtx, Scalar s);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Classes.cs
@@ -60,7 +60,7 @@ static partial class NativeMethods
     #region RNG
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_RNG_fill(ref ulong state, IntPtr mat, int distType, IntPtr a, IntPtr b, int saturateRange);
+    internal static partial ExceptionStatus core_RNG_fill(ref ulong state, InputOutputArrayProxy mat, int distType, InputArrayProxy a, InputArrayProxy b, int saturateRange);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_RNG_gaussian(ref ulong state, double sigma, out double returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -18,7 +18,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_getDerivKernels(
-        OutputArrayProxy kx, OutputArrayProxy ky, int dx, int dy, int ksize, int normalize, MatType ktype);
+        in OutputArrayProxy kx, in OutputArrayProxy ky, int dx, int dy, int ksize, int normalize, MatType ktype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getGaborKernel(Size ksize, double sigma, double theta, double lambd,
@@ -28,326 +28,326 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_getStructuringElement(int shape, Size ksize, Point anchor, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_medianBlur(InputArrayProxy src, OutputArrayProxy dst, int ksize);
+    internal static partial ExceptionStatus imgproc_medianBlur(in InputArrayProxy src, in OutputArrayProxy dst, int ksize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_GaussianBlur(InputArrayProxy src, OutputArrayProxy dst, Size ksize, double sigmaX,
+    internal static partial ExceptionStatus imgproc_GaussianBlur(in InputArrayProxy src, in OutputArrayProxy dst, Size ksize, double sigmaX,
         double sigmaY, BorderTypes borderType, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_bilateralFilter(InputArrayProxy src, OutputArrayProxy dst, int d, double sigmaColor,
+    internal static partial ExceptionStatus imgproc_bilateralFilter(in InputArrayProxy src, in OutputArrayProxy dst, int d, double sigmaColor,
         double sigmaSpace, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_boxFilter(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
+    internal static partial ExceptionStatus imgproc_boxFilter(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
         int normalize, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_sqrBoxFilter(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
+    internal static partial ExceptionStatus imgproc_sqrBoxFilter(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
         int normalize, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_blur(InputArrayProxy src, OutputArrayProxy dst, Size ksize, Point anchor, int borderType);
+    internal static partial ExceptionStatus imgproc_blur(in InputArrayProxy src, in OutputArrayProxy dst, Size ksize, Point anchor, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_filter2D(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, InputArrayProxy kernel, Point anchor,
+    internal static partial ExceptionStatus imgproc_filter2D(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth, in InputArrayProxy kernel, Point anchor,
         double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_filter2Dp(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel,
+    internal static partial ExceptionStatus imgproc_filter2Dp(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy kernel,
         int anchorX, int anchorY, int borderType, Scalar borderValue, int ddepth, double scale, double shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_sepFilter2D(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, InputArrayProxy kernelX,
-        InputArrayProxy kernelY, Point anchor, double delta, int borderType);
+    internal static partial ExceptionStatus imgproc_sepFilter2D(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth, in InputArrayProxy kernelX,
+        in InputArrayProxy kernelY, Point anchor, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_Sobel(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Sobel(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth,
         int dx, int dy, int ksize, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_spatialGradient(
-        InputArrayProxy src, OutputArrayProxy dx, OutputArrayProxy dy, int ksize, int borderType);
+        in InputArrayProxy src, in OutputArrayProxy dx, in OutputArrayProxy dy, int ksize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_Scharr(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Scharr(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth,
         int dx, int dy, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_Laplacian(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Laplacian(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth,
         int ksize, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_Canny1(
-        InputArrayProxy src, OutputArrayProxy edges, double threshold1, double threshold2, int apertureSize, int l2Gradient);
+        in InputArrayProxy src, in OutputArrayProxy edges, double threshold1, double threshold2, int apertureSize, int l2Gradient);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_Canny2(
-        InputArrayProxy dx, InputArrayProxy dy, OutputArrayProxy edges, double threshold1, double threshold2, int l2Gradient);
+        in InputArrayProxy dx, in InputArrayProxy dy, in OutputArrayProxy edges, double threshold1, double threshold2, int l2Gradient);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cornerMinEigenVal(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerMinEigenVal(in InputArrayProxy src, in OutputArrayProxy dst, int blockSize, int ksize,
         int borderType);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cornerHarris(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerHarris(in InputArrayProxy src, in OutputArrayProxy dst, int blockSize, int ksize,
         double  k, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cornerEigenValsAndVecs(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerEigenValsAndVecs(in InputArrayProxy src, in OutputArrayProxy dst, int blockSize, int ksize,
         int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_preCornerDetect(InputArrayProxy src, OutputArrayProxy dst, int ksize, int borderType);
+    internal static partial ExceptionStatus imgproc_preCornerDetect(in InputArrayProxy src, in OutputArrayProxy dst, int ksize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cornerSubPix(InputArrayProxy image, IntPtr corners,
+    internal static partial ExceptionStatus imgproc_cornerSubPix(in InputArrayProxy image, IntPtr corners,
         Size winSize, Size zeroZone, TermCriteria criteria);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_goodFeaturesToTrack(InputArrayProxy src, IntPtr corners,
-        int maxCorners, double qualityLevel, double minDistance, InputArrayProxy mask, int blockSize, int useHarrisDetector,
+    internal static partial ExceptionStatus imgproc_goodFeaturesToTrack(in InputArrayProxy src, IntPtr corners,
+        int maxCorners, double qualityLevel, double minDistance, in InputArrayProxy mask, int blockSize, int useHarrisDetector,
         double k);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_HoughLines(InputArrayProxy src, IntPtr lines,
+    internal static partial ExceptionStatus imgproc_HoughLines(in InputArrayProxy src, IntPtr lines,
         double rho, double theta, int threshold, double srn, double stn);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_HoughLinesP(InputArrayProxy src, IntPtr lines,
+    internal static partial ExceptionStatus imgproc_HoughLinesP(in InputArrayProxy src, IntPtr lines,
         double rho, double theta, int threshold, double minLineLength, double maxLineG);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_HoughLinesPointSet(
-        InputArrayProxy point, OutputArrayProxy lines, int linesMax, int threshold,
+        in InputArrayProxy point, in OutputArrayProxy lines, int linesMax, int threshold,
         double minRho, double maxRho, double rhoStep,
         double minTheta, double maxTheta, double thetaStep);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_HoughCircles(InputArrayProxy src, IntPtr circles,
+    internal static partial ExceptionStatus imgproc_HoughCircles(in InputArrayProxy src, IntPtr circles,
         int method, double dp, double minDist, double param1, double param2, int minRadius, int maxRadius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_erode(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel, Point anchor, int iterations,
+    internal static partial ExceptionStatus imgproc_erode(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy kernel, Point anchor, int iterations,
         int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_dilate(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel, Point anchor, int iterations,
+    internal static partial ExceptionStatus imgproc_dilate(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy kernel, Point anchor, int iterations,
         int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_morphologyEx(InputArrayProxy src, OutputArrayProxy dst, int op, InputArrayProxy kernel, Point anchor,
+    internal static partial ExceptionStatus imgproc_morphologyEx(in InputArrayProxy src, in OutputArrayProxy dst, int op, in InputArrayProxy kernel, Point anchor,
         int iterations, int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_resize(InputArrayProxy src, OutputArrayProxy dst, Size dsize, double fx, double fy,
+    internal static partial ExceptionStatus imgproc_resize(in InputArrayProxy src, in OutputArrayProxy dst, Size dsize, double fx, double fy,
         int interpolation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_warpAffine(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m, Size dsize, int flags,
+    internal static partial ExceptionStatus imgproc_warpAffine(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy m, Size dsize, int flags,
         int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_warpPerspective_MisInputArray(
-        InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m, Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
+        in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy m, Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
 
     // The 3x3 matrix is a contiguous, blittable float[,]; pass it as a (pinned) ReadOnlySpan with the
     // dimensions kept as separate ints, so source-generated marshalling can handle it (native takes float*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_warpPerspective_MisArray(
-        InputArrayProxy src, OutputArrayProxy dst, ReadOnlySpan<float> m, int mRow, int mCol,
+        in InputArrayProxy src, in OutputArrayProxy dst, ReadOnlySpan<float> m, int mRow, int mCol,
         Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_remap(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy map1, InputArrayProxy map2, int interpolation,
+    internal static partial ExceptionStatus imgproc_remap(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy map1, in InputArrayProxy map2, int interpolation,
         int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_convertMaps(InputArrayProxy map1, InputArrayProxy map2, OutputArrayProxy dstmap1, OutputArrayProxy dstmap2,
+    internal static partial ExceptionStatus imgproc_convertMaps(in InputArrayProxy map1, in InputArrayProxy map2, in OutputArrayProxy dstmap1, in OutputArrayProxy dstmap2,
         MatType dstmap1Type, int nninterpolation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getRotationMatrix2D(Point2f center, double angle, double scale, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_invertAffineTransform(InputArrayProxy m, OutputArrayProxy im);
+    internal static partial ExceptionStatus imgproc_invertAffineTransform(in InputArrayProxy m, in OutputArrayProxy im);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getPerspectiveTransform1(Point2f[] src, Point2f[] dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_getPerspectiveTransform2(InputArrayProxy src, InputArrayProxy dst, out IntPtr returnValue);
+    internal static partial ExceptionStatus imgproc_getPerspectiveTransform2(in InputArrayProxy src, in InputArrayProxy dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getAffineTransform1(Point2f[] src, Point2f[] dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_getAffineTransform2(InputArrayProxy src, InputArrayProxy dst, out IntPtr returnValue);
+    internal static partial ExceptionStatus imgproc_getAffineTransform2(in InputArrayProxy src, in InputArrayProxy dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_getRectSubPix(InputArrayProxy image, Size patchSize, Point2f center, OutputArrayProxy patch,
+    internal static partial ExceptionStatus imgproc_getRectSubPix(in InputArrayProxy image, Size patchSize, Point2f center, in OutputArrayProxy patch,
         int patchType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_warpPolar(
-        InputArrayProxy src, OutputArrayProxy dst, Size dsize, Point2f center, double maxRadius, int flags);
+        in InputArrayProxy src, in OutputArrayProxy dst, Size dsize, Point2f center, double maxRadius, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_integral1(InputArrayProxy src, OutputArrayProxy sum, int sdepth);
+    internal static partial ExceptionStatus imgproc_integral1(in InputArrayProxy src, in OutputArrayProxy sum, int sdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_integral2(InputArrayProxy src, OutputArrayProxy sum, OutputArrayProxy sqsum, int sdepth);
+    internal static partial ExceptionStatus imgproc_integral2(in InputArrayProxy src, in OutputArrayProxy sum, in OutputArrayProxy sqsum, int sdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_integral3(InputArrayProxy src, OutputArrayProxy sum, OutputArrayProxy sqsum, OutputArrayProxy tilted, int sdepth, int sqdepth);
+    internal static partial ExceptionStatus imgproc_integral3(in InputArrayProxy src, in OutputArrayProxy sum, in OutputArrayProxy sqsum, in OutputArrayProxy tilted, int sdepth, int sqdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_accumulate(InputArrayProxy src, InputOutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus imgproc_accumulate(in InputArrayProxy src, in InputOutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_accumulateSquare(InputArrayProxy src, InputOutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus imgproc_accumulateSquare(in InputArrayProxy src, in InputOutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_accumulateProduct(InputArrayProxy src1, InputArrayProxy src2, InputOutputArrayProxy dst, InputArrayProxy mask);
+    internal static partial ExceptionStatus imgproc_accumulateProduct(in InputArrayProxy src1, in InputArrayProxy src2, in InputOutputArrayProxy dst, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_accumulateWeighted(InputArrayProxy src, InputOutputArrayProxy dst, double alpha, InputArrayProxy mask);
+    internal static partial ExceptionStatus imgproc_accumulateWeighted(in InputArrayProxy src, in InputOutputArrayProxy dst, double alpha, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_phaseCorrelate(InputArrayProxy src1, InputArrayProxy src2, InputArrayProxy window, 
+    internal static partial ExceptionStatus imgproc_phaseCorrelate(in InputArrayProxy src1, in InputArrayProxy src2, in InputArrayProxy window, 
         out double response, out Point2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_createHanningWindow(OutputArrayProxy dst, Size winSize, MatType type);
+    internal static partial ExceptionStatus imgproc_createHanningWindow(in OutputArrayProxy dst, Size winSize, MatType type);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_threshold(InputArrayProxy src, OutputArrayProxy dst, double thresh, double maxval, int type, out double returnValue);
+    internal static partial ExceptionStatus imgproc_threshold(in InputArrayProxy src, in OutputArrayProxy dst, double thresh, double maxval, int type, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_adaptiveThreshold(InputArrayProxy src, OutputArrayProxy dst,
+    internal static partial ExceptionStatus imgproc_adaptiveThreshold(in InputArrayProxy src, in OutputArrayProxy dst,
         double maxValue, int adaptiveMethod, int thresholdType, int blockSize, double c);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_pyrDown(InputArrayProxy src, OutputArrayProxy dst, Size dstsize, int borderType);
+    internal static partial ExceptionStatus imgproc_pyrDown(in InputArrayProxy src, in OutputArrayProxy dst, Size dstsize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_buildPyramid(InputArrayProxy src, IntPtr dst, int maxlevel, int borderType);
+    internal static partial ExceptionStatus imgproc_buildPyramid(in InputArrayProxy src, IntPtr dst, int maxlevel, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_pyrUp(InputArrayProxy src, OutputArrayProxy dst, Size dstsize, int borderType);
+    internal static partial ExceptionStatus imgproc_pyrUp(in InputArrayProxy src, in OutputArrayProxy dst, Size dstsize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_calcHist(IntPtr[] images, int nimages,
-        int[] channels, InputArrayProxy mask, OutputArrayProxy hist, int dims, int[] histSize,
+        int[] channels, in InputArrayProxy mask, in OutputArrayProxy hist, int dims, int[] histSize,
         IntPtr[] ranges, int uniform, int accumulate);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_calcBackProject(IntPtr[] images, int nimages,
-        int[] channels, InputArrayProxy hist, OutputArrayProxy backProject, IntPtr[] ranges, int uniform);
+        int[] channels, in InputArrayProxy hist, in OutputArrayProxy backProject, IntPtr[] ranges, int uniform);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_compareHist(InputArrayProxy h1, InputArrayProxy h2, int method, out double returnValue);
+    internal static partial ExceptionStatus imgproc_compareHist(in InputArrayProxy h1, in InputArrayProxy h2, int method, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_equalizeHist(InputArrayProxy src, OutputArrayProxy dst);
+    internal static partial ExceptionStatus imgproc_equalizeHist(in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_EMD(InputArrayProxy signature1, InputArrayProxy signature2,
-        int distType, InputArrayProxy cost, out float lowerBound, OutputArrayProxy flow, out float returnValue);
+    internal static partial ExceptionStatus imgproc_EMD(in InputArrayProxy signature1, in InputArrayProxy signature2,
+        int distType, in InputArrayProxy cost, out float lowerBound, in OutputArrayProxy flow, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_watershed(InputArrayProxy image, InputOutputArrayProxy markers);
+    internal static partial ExceptionStatus imgproc_watershed(in InputArrayProxy image, in InputOutputArrayProxy markers);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_pyrMeanShiftFiltering(InputArrayProxy src, OutputArrayProxy dst,
+    internal static partial ExceptionStatus imgproc_pyrMeanShiftFiltering(in InputArrayProxy src, in OutputArrayProxy dst,
         double sp, double sr, int maxLevel, TermCriteria termcrit);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_grabCut(InputArrayProxy img, InputOutputArrayProxy mask, Rect rect,
-        InputOutputArrayProxy bgdModel, InputOutputArrayProxy fgdModel,
+    internal static partial ExceptionStatus imgproc_grabCut(in InputArrayProxy img, in InputOutputArrayProxy mask, Rect rect,
+        in InputOutputArrayProxy bgdModel, in InputOutputArrayProxy fgdModel,
         int iterCount, int mode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_distanceTransformWithLabels(InputArrayProxy src, OutputArrayProxy dst, OutputArrayProxy labels,
+    internal static partial ExceptionStatus imgproc_distanceTransformWithLabels(in InputArrayProxy src, in OutputArrayProxy dst, in OutputArrayProxy labels,
         int distanceType, int maskSize, int labelType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_distanceTransform(InputArrayProxy src, OutputArrayProxy dst,
+    internal static partial ExceptionStatus imgproc_distanceTransform(in InputArrayProxy src, in OutputArrayProxy dst,
         int distanceType, int maskSize, int dstType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_floodFill1(InputOutputArrayProxy image,
+    internal static partial ExceptionStatus imgproc_floodFill1(in InputOutputArrayProxy image,
         Point seedPoint, Scalar newVal, out Rect rect,
         Scalar loDiff, Scalar upDiff, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_floodFill2(InputOutputArrayProxy image, InputOutputArrayProxy mask,
+    internal static partial ExceptionStatus imgproc_floodFill2(in InputOutputArrayProxy image, in InputOutputArrayProxy mask,
         Point seedPoint, Scalar newVal, out Rect rect,
         Scalar loDiff, Scalar upDiff, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_blendLinear(
-        InputArrayProxy src1, InputArrayProxy src2, InputArrayProxy weights1, InputArrayProxy weights2, OutputArrayProxy dst);
+        in InputArrayProxy src1, in InputArrayProxy src2, in InputArrayProxy weights1, in InputArrayProxy weights2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cvtColor(InputArrayProxy src, OutputArrayProxy dst, int code, int dstCn, int hint);
+    internal static partial ExceptionStatus imgproc_cvtColor(in InputArrayProxy src, in OutputArrayProxy dst, int code, int dstCn, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_cvtColorTwoPlane(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int code, int hint);
+    internal static partial ExceptionStatus imgproc_cvtColorTwoPlane(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst, int code, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_demosaicing(InputArrayProxy src, OutputArrayProxy dst, int code, int dstCn);
+    internal static partial ExceptionStatus imgproc_demosaicing(in InputArrayProxy src, in OutputArrayProxy dst, int code, int dstCn);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_moments(InputArrayProxy arr, int binaryImage, out Moments.NativeStruct returnValue);
+    internal static partial ExceptionStatus imgproc_moments(in InputArrayProxy arr, int binaryImage, out Moments.NativeStruct returnValue);
 
     //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     //public static extern ExceptionStatus imgproc_HuMoments(ref Moments.NativeStruct moments, [MarshalAs(UnmanagedType.LPArray)] double[] hu);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_matchTemplate(
-        InputArrayProxy image, InputArrayProxy templ, OutputArrayProxy result, int method, InputArrayProxy mask);
+        in InputArrayProxy image, in InputArrayProxy templ, in OutputArrayProxy result, int method, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_connectedComponentsWithAlgorithm(
-        InputArrayProxy image, OutputArrayProxy labels, int connectivity, MatType ltype, int ccltype, out int returnValue);
+        in InputArrayProxy image, in OutputArrayProxy labels, int connectivity, MatType ltype, int ccltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_connectedComponents(
-        InputArrayProxy image, OutputArrayProxy labels, int connectivity, MatType ltype, out int returnValue);
+        in InputArrayProxy image, in OutputArrayProxy labels, int connectivity, MatType ltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_connectedComponentsWithStatsWithAlgorithm(
-        InputArrayProxy image, OutputArrayProxy labels, OutputArrayProxy stats, OutputArrayProxy centroids, int connectivity, MatType ltype, int ccltype, out int returnValue);
+        in InputArrayProxy image, in OutputArrayProxy labels, in OutputArrayProxy stats, in OutputArrayProxy centroids, int connectivity, MatType ltype, int ccltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_connectedComponentsWithStats(
-        InputArrayProxy image, OutputArrayProxy labels, OutputArrayProxy stats, OutputArrayProxy centroids, int connectivity, MatType ltype, out int returnValue);
+        in InputArrayProxy image, in OutputArrayProxy labels, in OutputArrayProxy stats, in OutputArrayProxy centroids, int connectivity, MatType ltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContours1_vector(InputArrayProxy image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours1_vector(in InputArrayProxy image, IntPtr contours,
         IntPtr hierarchy, int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContours1_OutputArray(InputArrayProxy image, IntPtr contours,
-        OutputArrayProxy hierarchy, int mode, int method, Point offset);
+    internal static partial ExceptionStatus imgproc_findContours1_OutputArray(in InputArrayProxy image, IntPtr contours,
+        in OutputArrayProxy hierarchy, int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContours2_vector(InputArrayProxy image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours2_vector(in InputArrayProxy image, IntPtr contours,
         int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContours2_OutputArray(InputArrayProxy image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours2_OutputArray(in InputArrayProxy image, IntPtr contours,
         int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContoursLinkRuns1(InputArrayProxy image, IntPtr contours, IntPtr hierarchy);
+    internal static partial ExceptionStatus imgproc_findContoursLinkRuns1(in InputArrayProxy image, IntPtr contours, IntPtr hierarchy);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_findContoursLinkRuns2(InputArrayProxy image, IntPtr contours);
+    internal static partial ExceptionStatus imgproc_findContoursLinkRuns2(in InputArrayProxy image, IntPtr contours);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_approxPolyDP_InputArray(InputArrayProxy curve, OutputArrayProxy approxCurve,
+    internal static partial ExceptionStatus imgproc_approxPolyDP_InputArray(in InputArrayProxy curve, in OutputArrayProxy approxCurve,
         double epsilon, int closed);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -359,7 +359,7 @@ static partial class NativeMethods
         IntPtr approxCurve, double epsilon, int closed);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_arcLength_InputArray(InputArrayProxy curve, int closed, out double returnValue);
+    internal static partial ExceptionStatus imgproc_arcLength_InputArray(in InputArrayProxy curve, int closed, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_arcLength_Point(Point[] curve, int curveLength, int closed, out double returnValue);
@@ -368,7 +368,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_arcLength_Point2f(Point2f[] curve, int curveLength, int closed, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_boundingRect_InputArray(InputArrayProxy curve, out Rect returnValue);
+    internal static partial ExceptionStatus imgproc_boundingRect_InputArray(in InputArrayProxy curve, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_boundingRect_Point(Point[] curve, int curveLength, out Rect returnValue);
@@ -377,7 +377,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_boundingRect_Point2f(Point2f[] curve, int curveLength, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_contourArea_InputArray(InputArrayProxy contour, int oriented, out double returnValue);
+    internal static partial ExceptionStatus imgproc_contourArea_InputArray(in InputArrayProxy contour, int oriented, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_contourArea_Point(
@@ -388,7 +388,7 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPArray)] Point2f[] contour, int contourLength, int oriented, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_minAreaRect_InputArray(InputArrayProxy points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_minAreaRect_InputArray(in InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_minAreaRect_Point(
@@ -399,13 +399,13 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPArray)] Point2f[] points, int pointsLength, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_boxPoints_OutputArray(RotatedRect box, OutputArrayProxy points);
+    internal static partial ExceptionStatus imgproc_boxPoints_OutputArray(RotatedRect box, in OutputArrayProxy points);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_boxPoints_Point2f(RotatedRect box, [MarshalAs(UnmanagedType.LPArray), Out] Point2f[] points);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_minEnclosingCircle_InputArray(InputArrayProxy points, out Point2f center,
+    internal static partial ExceptionStatus imgproc_minEnclosingCircle_InputArray(in InputArrayProxy points, out Point2f center,
         out float radius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -417,7 +417,7 @@ static partial class NativeMethods
         out Point2f center, out float radius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_minEnclosingTriangle_InputOutputArray(InputArrayProxy points, OutputArrayProxy triangle, out double returnValue);
+    internal static partial ExceptionStatus imgproc_minEnclosingTriangle_InputOutputArray(in InputArrayProxy points, in OutputArrayProxy triangle, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_minEnclosingTriangle_Point(
@@ -429,14 +429,14 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_matchShapes_InputArray(
-        InputArrayProxy contour1, InputArrayProxy contour2, int method, double parameter, out double returnValue);
+        in InputArrayProxy contour1, in InputArrayProxy contour2, int method, double parameter, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_matchShapes_Point(
         Point[] contour1, int contour1Length, Point[] contour2, int contour2Length, int method, double parameter, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_convexHull_InputArray(InputArrayProxy points, OutputArrayProxy hull,
+    internal static partial ExceptionStatus imgproc_convexHull_InputArray(in InputArrayProxy points, in OutputArrayProxy hull,
         int clockwise, int returnPoints);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -456,8 +456,8 @@ static partial class NativeMethods
         IntPtr hull, int clockwise);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_convexityDefects_InputArray(InputArrayProxy contour, InputArrayProxy convexHull,
-        OutputArrayProxy convexityDefects);
+    internal static partial ExceptionStatus imgproc_convexityDefects_InputArray(in InputArrayProxy contour, in InputArrayProxy convexHull,
+        in OutputArrayProxy convexityDefects);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_convexityDefects_Point(Point[] contour, int contourLength, int[] convexHull,
@@ -468,7 +468,7 @@ static partial class NativeMethods
         int[] convexHull, int convexHullLength, IntPtr convexityDefects);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_isContourConvex_InputArray(InputArrayProxy contour, out int returnValue);
+    internal static partial ExceptionStatus imgproc_isContourConvex_InputArray(in InputArrayProxy contour, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_isContourConvex_Point(Point[] contour, int contourLength, out int returnValue);
@@ -477,8 +477,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_isContourConvex_Point2f(Point2f[] contour, int contourLength, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_intersectConvexConvex_InputArray(InputArrayProxy p1, InputArrayProxy p2,
-        OutputArrayProxy p12, int handleNested, out float returnValue);
+    internal static partial ExceptionStatus imgproc_intersectConvexConvex_InputArray(in InputArrayProxy p1, in InputArrayProxy p2,
+        in OutputArrayProxy p12, int handleNested, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_intersectConvexConvex_Point(Point[] p1, int p1Length, Point[] p2,
@@ -489,7 +489,7 @@ static partial class NativeMethods
         int p2Length, IntPtr p12, int handleNested, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_fitEllipse_InputArray(InputArrayProxy points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipse_InputArray(in InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipse_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -499,7 +499,7 @@ static partial class NativeMethods
 
     // Not exported
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_fitEllipseAMS_InputArray(InputArrayProxy points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipseAMS_InputArray(in InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipseAMS_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -509,7 +509,7 @@ static partial class NativeMethods
 
     // Not exported
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_fitEllipseDirect_InputArray(InputArrayProxy points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipseDirect_InputArray(in InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipseDirect_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -518,7 +518,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_fitEllipseDirect_Point2f(Point2f[] points, int pointsLength, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_fitLine_InputArray(InputArrayProxy points, OutputArrayProxy line,
+    internal static partial ExceptionStatus imgproc_fitLine_InputArray(in InputArrayProxy points, in OutputArrayProxy line,
         int distType, double param, double reps, double aeps);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -540,7 +540,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_pointPolygonTest_InputArray(
-        InputArrayProxy contour, Point2f pt, int measureDist, out double returnValue);
+        in InputArrayProxy contour, Point2f pt, int measureDist, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_pointPolygonTest_Point(Point[] contour, int contourLength, Point2f pt,
@@ -552,34 +552,34 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_rotatedRectangleIntersection_OutputArray(
-        RotatedRect rect1, RotatedRect rect2, OutputArrayProxy intersectingRegion, out int returnValue);
+        RotatedRect rect1, RotatedRect rect2, in OutputArrayProxy intersectingRegion, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_rotatedRectangleIntersection_vector(
         RotatedRect rect1, RotatedRect rect2, IntPtr intersectingRegion, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_applyColorMap1(InputArrayProxy src, OutputArrayProxy dst, int colormap);
+    internal static partial ExceptionStatus imgproc_applyColorMap1(in InputArrayProxy src, in OutputArrayProxy dst, int colormap);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_applyColorMap2(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy userColor);
+    internal static partial ExceptionStatus imgproc_applyColorMap2(in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy userColor);
 
     #region Drawing
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_line(
-        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
+        in InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_arrowedLine(
-        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift, double tipLength);
+        in InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift, double tipLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Point(
-        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
+        in InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Rect(
-        InputOutputArrayProxy img, Rect rect, Scalar color, int thickness, int lineType, int shift);
+        in InputOutputArrayProxy img, Rect rect, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_rectangle_Mat_Point(
@@ -589,21 +589,21 @@ static partial class NativeMethods
         IntPtr img, Rect rect, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_circle(InputOutputArrayProxy img, Point center, int radius, Scalar color, int thickness,
+    internal static partial ExceptionStatus imgproc_circle(in InputOutputArrayProxy img, Point center, int radius, Scalar color, int thickness,
         int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_ellipse1(
-        InputOutputArrayProxy img, Point center, Size axes,
+        in InputOutputArrayProxy img, Point center, Size axes,
         double angle, double startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_ellipse2(
-        InputOutputArrayProxy img, RotatedRect box, Scalar color, int thickness, int lineType);
+        in InputOutputArrayProxy img, RotatedRect box, Scalar color, int thickness, int lineType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_drawMarker(
-        InputOutputArrayProxy img, Point position, Scalar color, int markerType, int markerSize, int thickness, int lineType);
+        in InputOutputArrayProxy img, Point position, Scalar color, int markerType, int markerSize, int thickness, int lineType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fillConvexPoly_Mat(
@@ -611,7 +611,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_fillConvexPoly_InputOutputArray(
-        InputOutputArrayProxy img, InputArrayProxy points, Scalar color, int lineType, int shift);
+        in InputOutputArrayProxy img, in InputArrayProxy points, Scalar color, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fillPoly_Mat(
@@ -620,7 +620,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_fillPoly_InputOutputArray(
-        InputOutputArrayProxy img, InputArrayProxy pts, Scalar color, int lineType, int shift, Point offset);
+        in InputOutputArrayProxy img, in InputArrayProxy pts, Scalar color, int lineType, int shift, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_polylines_Mat(
@@ -629,25 +629,25 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_polylines_InputOutputArray(
-        InputOutputArrayProxy img, InputArrayProxy pts, int isClosed, Scalar color, int thickness, int lineType, int shift);
+        in InputOutputArrayProxy img, in InputArrayProxy pts, int isClosed, Scalar color, int thickness, int lineType, int shift);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_drawContours_vector(InputOutputArrayProxy image,
+    internal static partial ExceptionStatus imgproc_drawContours_vector(in InputOutputArrayProxy image,
         IntPtr[] contours, int contoursSize1, int[] contoursSize2,
         int contourIdx, Scalar color, int thickness, int lineType,
         Vec4i[] hierarchy, int hiearchyLength, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_drawContours_vector(InputOutputArrayProxy image,
+    internal static partial ExceptionStatus imgproc_drawContours_vector(in InputOutputArrayProxy image,
         IntPtr[] contours, int contoursSize1, int[] contoursSize2,
         int contourIdx, Scalar color, int thickness, int lineType,
         IntPtr hierarchy, int hiearchyLength, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_drawContours_InputArray(InputOutputArrayProxy image,
+    internal static partial ExceptionStatus imgproc_drawContours_InputArray(in InputOutputArrayProxy image,
         IntPtr[] contours, int contoursLength,
         int contourIdx, Scalar color, int thickness, int lineType,
-        InputArrayProxy hierarchy, int maxLevel, Point offset);
+        in InputArrayProxy hierarchy, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_clipLine1(Size imgSize, ref Point pt1, ref Point pt2, out int returnValue);
@@ -664,7 +664,7 @@ static partial class NativeMethods
         Point2d center, Size2d axes, int angle, int arcStart, int arcEnd, int delta, IntPtr pts);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_putText(InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPStr)] string text, Point org,
+    internal static partial ExceptionStatus imgproc_putText(in InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPStr)] string text, Point org,
         int fontFace, double fontScale, Scalar color,
         int thickness, int lineType, int bottomLeftOrigin);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -17,8 +17,8 @@ static partial class NativeMethods
         int ksize, double sigma, MatType ktype, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_getDerivKernels(
-        IntPtr kx, IntPtr ky, int dx, int dy, int ksize, int normalize, MatType ktype);
+    internal static partial ExceptionStatus imgproc_getDerivKernels(
+        OutputArrayProxy kx, OutputArrayProxy ky, int dx, int dy, int ksize, int normalize, MatType ktype);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getGaborKernel(Size ksize, double sigma, double theta, double lambd,
@@ -28,326 +28,326 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_getStructuringElement(int shape, Size ksize, Point anchor, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_medianBlur(IntPtr src, IntPtr dst, int ksize);
+    internal static partial ExceptionStatus imgproc_medianBlur(InputArrayProxy src, OutputArrayProxy dst, int ksize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_GaussianBlur(IntPtr src, IntPtr dst, Size ksize, double sigmaX,
+    internal static partial ExceptionStatus imgproc_GaussianBlur(InputArrayProxy src, OutputArrayProxy dst, Size ksize, double sigmaX,
         double sigmaY, BorderTypes borderType, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_bilateralFilter(IntPtr src, IntPtr dst, int d, double sigmaColor,
+    internal static partial ExceptionStatus imgproc_bilateralFilter(InputArrayProxy src, OutputArrayProxy dst, int d, double sigmaColor,
         double sigmaSpace, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_boxFilter(IntPtr src, IntPtr dst, MatType ddepth, Size ksize, Point anchor,
+    internal static partial ExceptionStatus imgproc_boxFilter(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
         int normalize, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_sqrBoxFilter(IntPtr src, IntPtr dst, MatType ddepth, Size ksize, Point anchor,
+    internal static partial ExceptionStatus imgproc_sqrBoxFilter(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, Size ksize, Point anchor,
         int normalize, BorderTypes borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_blur(IntPtr src, IntPtr dst, Size ksize, Point anchor, int borderType);
+    internal static partial ExceptionStatus imgproc_blur(InputArrayProxy src, OutputArrayProxy dst, Size ksize, Point anchor, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_filter2D(IntPtr src, IntPtr dst, MatType ddepth, IntPtr kernel, Point anchor,
+    internal static partial ExceptionStatus imgproc_filter2D(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, InputArrayProxy kernel, Point anchor,
         double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_filter2Dp(IntPtr src, IntPtr dst, IntPtr kernel,
+    internal static partial ExceptionStatus imgproc_filter2Dp(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel,
         int anchorX, int anchorY, int borderType, Scalar borderValue, int ddepth, double scale, double shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_sepFilter2D(IntPtr src, IntPtr dst, MatType ddepth, IntPtr kernelX,
-        IntPtr kernelY, Point anchor, double delta, int borderType);
+    internal static partial ExceptionStatus imgproc_sepFilter2D(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth, InputArrayProxy kernelX,
+        InputArrayProxy kernelY, Point anchor, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_Sobel(IntPtr src, IntPtr dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Sobel(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
         int dx, int dy, int ksize, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_spatialGradient(
-        IntPtr src, IntPtr dx, IntPtr dy, int ksize, int borderType);
+    internal static partial ExceptionStatus imgproc_spatialGradient(
+        InputArrayProxy src, OutputArrayProxy dx, OutputArrayProxy dy, int ksize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_Scharr(IntPtr src, IntPtr dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Scharr(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
         int dx, int dy, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_Laplacian(IntPtr src, IntPtr dst, MatType ddepth,
+    internal static partial ExceptionStatus imgproc_Laplacian(InputArrayProxy src, OutputArrayProxy dst, MatType ddepth,
         int ksize, double scale, double delta, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_Canny1(
-        IntPtr src, IntPtr edges, double threshold1, double threshold2, int apertureSize, int l2Gradient);
+    internal static partial ExceptionStatus imgproc_Canny1(
+        InputArrayProxy src, OutputArrayProxy edges, double threshold1, double threshold2, int apertureSize, int l2Gradient);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_Canny2(
-        IntPtr dx, IntPtr dy, IntPtr edges, double threshold1, double threshold2, int l2Gradient);
+    internal static partial ExceptionStatus imgproc_Canny2(
+        InputArrayProxy dx, InputArrayProxy dy, OutputArrayProxy edges, double threshold1, double threshold2, int l2Gradient);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cornerMinEigenVal(IntPtr src, IntPtr dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerMinEigenVal(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
         int borderType);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cornerHarris(IntPtr src, IntPtr dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerHarris(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
         double  k, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cornerEigenValsAndVecs(IntPtr src, IntPtr dst, int blockSize, int ksize,
+    internal static partial ExceptionStatus imgproc_cornerEigenValsAndVecs(InputArrayProxy src, OutputArrayProxy dst, int blockSize, int ksize,
         int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_preCornerDetect(IntPtr src, IntPtr dst, int ksize, int borderType);
+    internal static partial ExceptionStatus imgproc_preCornerDetect(InputArrayProxy src, OutputArrayProxy dst, int ksize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cornerSubPix(IntPtr image, IntPtr corners,
+    internal static partial ExceptionStatus imgproc_cornerSubPix(InputArrayProxy image, IntPtr corners,
         Size winSize, Size zeroZone, TermCriteria criteria);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_goodFeaturesToTrack(IntPtr src, IntPtr corners,
-        int maxCorners, double qualityLevel, double minDistance, IntPtr mask, int blockSize, int useHarrisDetector,
+    internal static partial ExceptionStatus imgproc_goodFeaturesToTrack(InputArrayProxy src, IntPtr corners,
+        int maxCorners, double qualityLevel, double minDistance, InputArrayProxy mask, int blockSize, int useHarrisDetector,
         double k);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_HoughLines(IntPtr src, IntPtr lines,
+    internal static partial ExceptionStatus imgproc_HoughLines(InputArrayProxy src, IntPtr lines,
         double rho, double theta, int threshold, double srn, double stn);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_HoughLinesP(IntPtr src, IntPtr lines,
+    internal static partial ExceptionStatus imgproc_HoughLinesP(InputArrayProxy src, IntPtr lines,
         double rho, double theta, int threshold, double minLineLength, double maxLineG);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_HoughLinesPointSet(
-        IntPtr point, IntPtr lines, int linesMax, int threshold,
+    internal static partial ExceptionStatus imgproc_HoughLinesPointSet(
+        InputArrayProxy point, OutputArrayProxy lines, int linesMax, int threshold,
         double minRho, double maxRho, double rhoStep,
         double minTheta, double maxTheta, double thetaStep);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_HoughCircles(IntPtr src, IntPtr circles,
+    internal static partial ExceptionStatus imgproc_HoughCircles(InputArrayProxy src, IntPtr circles,
         int method, double dp, double minDist, double param1, double param2, int minRadius, int maxRadius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_erode(IntPtr src, IntPtr dst, IntPtr kernel, Point anchor, int iterations,
+    internal static partial ExceptionStatus imgproc_erode(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel, Point anchor, int iterations,
         int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_dilate(IntPtr src, IntPtr dst, IntPtr kernel, Point anchor, int iterations,
+    internal static partial ExceptionStatus imgproc_dilate(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy kernel, Point anchor, int iterations,
         int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_morphologyEx(IntPtr src, IntPtr dst, int op, IntPtr kernel, Point anchor,
+    internal static partial ExceptionStatus imgproc_morphologyEx(InputArrayProxy src, OutputArrayProxy dst, int op, InputArrayProxy kernel, Point anchor,
         int iterations, int borderType, Scalar borderValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_resize(IntPtr src, IntPtr dst, Size dsize, double fx, double fy,
+    internal static partial ExceptionStatus imgproc_resize(InputArrayProxy src, OutputArrayProxy dst, Size dsize, double fx, double fy,
         int interpolation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_warpAffine(IntPtr src, IntPtr dst, IntPtr m, Size dsize, int flags,
+    internal static partial ExceptionStatus imgproc_warpAffine(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m, Size dsize, int flags,
         int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_warpPerspective_MisInputArray(
-        IntPtr src, IntPtr dst, IntPtr m, Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
+    internal static partial ExceptionStatus imgproc_warpPerspective_MisInputArray(
+        InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy m, Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
 
     // The 3x3 matrix is a contiguous, blittable float[,]; pass it as a (pinned) ReadOnlySpan with the
     // dimensions kept as separate ints, so source-generated marshalling can handle it (native takes float*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_warpPerspective_MisArray(
-        IntPtr src, IntPtr dst, ReadOnlySpan<float> m, int mRow, int mCol,
+    internal static partial ExceptionStatus imgproc_warpPerspective_MisArray(
+        InputArrayProxy src, OutputArrayProxy dst, ReadOnlySpan<float> m, int mRow, int mCol,
         Size dsize, int flags, int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_remap(IntPtr src, IntPtr dst, IntPtr map1, IntPtr map2, int interpolation,
+    internal static partial ExceptionStatus imgproc_remap(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy map1, InputArrayProxy map2, int interpolation,
         int borderMode, Scalar borderValue, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_convertMaps(IntPtr map1, IntPtr map2, IntPtr dstmap1, IntPtr dstmap2,
+    internal static partial ExceptionStatus imgproc_convertMaps(InputArrayProxy map1, InputArrayProxy map2, OutputArrayProxy dstmap1, OutputArrayProxy dstmap2,
         MatType dstmap1Type, int nninterpolation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getRotationMatrix2D(Point2f center, double angle, double scale, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_invertAffineTransform(IntPtr m, IntPtr im);
+    internal static partial ExceptionStatus imgproc_invertAffineTransform(InputArrayProxy m, OutputArrayProxy im);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getPerspectiveTransform1(Point2f[] src, Point2f[] dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_getPerspectiveTransform2(IntPtr src, IntPtr dst, out IntPtr returnValue);
+    internal static partial ExceptionStatus imgproc_getPerspectiveTransform2(InputArrayProxy src, InputArrayProxy dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_getAffineTransform1(Point2f[] src, Point2f[] dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_getAffineTransform2(IntPtr src, IntPtr dst, out IntPtr returnValue);
+    internal static partial ExceptionStatus imgproc_getAffineTransform2(InputArrayProxy src, InputArrayProxy dst, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_getRectSubPix(IntPtr image, Size patchSize, Point2f center, IntPtr patch,
+    internal static partial ExceptionStatus imgproc_getRectSubPix(InputArrayProxy image, Size patchSize, Point2f center, OutputArrayProxy patch,
         int patchType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_warpPolar(
-        IntPtr src, IntPtr dst, Size dsize, Point2f center, double maxRadius, int flags);
+    internal static partial ExceptionStatus imgproc_warpPolar(
+        InputArrayProxy src, OutputArrayProxy dst, Size dsize, Point2f center, double maxRadius, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_integral1(IntPtr src, IntPtr sum, int sdepth);
+    internal static partial ExceptionStatus imgproc_integral1(InputArrayProxy src, OutputArrayProxy sum, int sdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_integral2(IntPtr src, IntPtr sum, IntPtr sqsum, int sdepth);
+    internal static partial ExceptionStatus imgproc_integral2(InputArrayProxy src, OutputArrayProxy sum, OutputArrayProxy sqsum, int sdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_integral3(IntPtr src, IntPtr sum, IntPtr sqsum, IntPtr tilted, int sdepth, int sqdepth);
+    internal static partial ExceptionStatus imgproc_integral3(InputArrayProxy src, OutputArrayProxy sum, OutputArrayProxy sqsum, OutputArrayProxy tilted, int sdepth, int sqdepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_accumulate(IntPtr src, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus imgproc_accumulate(InputArrayProxy src, InputOutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_accumulateSquare(IntPtr src, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus imgproc_accumulateSquare(InputArrayProxy src, InputOutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_accumulateProduct(IntPtr src1, IntPtr src2, IntPtr dst, IntPtr mask);
+    internal static partial ExceptionStatus imgproc_accumulateProduct(InputArrayProxy src1, InputArrayProxy src2, InputOutputArrayProxy dst, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_accumulateWeighted(IntPtr src, IntPtr dst, double alpha, IntPtr mask);
+    internal static partial ExceptionStatus imgproc_accumulateWeighted(InputArrayProxy src, InputOutputArrayProxy dst, double alpha, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_phaseCorrelate(IntPtr src1, IntPtr src2, IntPtr window, 
+    internal static partial ExceptionStatus imgproc_phaseCorrelate(InputArrayProxy src1, InputArrayProxy src2, InputArrayProxy window, 
         out double response, out Point2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_createHanningWindow(IntPtr dst, Size winSize, MatType type);
+    internal static partial ExceptionStatus imgproc_createHanningWindow(OutputArrayProxy dst, Size winSize, MatType type);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_threshold(IntPtr src, IntPtr dst, double thresh, double maxval, int type, out double returnValue);
+    internal static partial ExceptionStatus imgproc_threshold(InputArrayProxy src, OutputArrayProxy dst, double thresh, double maxval, int type, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_adaptiveThreshold(IntPtr src, IntPtr dst,
+    internal static partial ExceptionStatus imgproc_adaptiveThreshold(InputArrayProxy src, OutputArrayProxy dst,
         double maxValue, int adaptiveMethod, int thresholdType, int blockSize, double c);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_pyrDown(IntPtr src, IntPtr dst, Size dstsize, int borderType);
+    internal static partial ExceptionStatus imgproc_pyrDown(InputArrayProxy src, OutputArrayProxy dst, Size dstsize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_buildPyramid(IntPtr src, IntPtr dst, int maxlevel, int borderType);
+    internal static partial ExceptionStatus imgproc_buildPyramid(InputArrayProxy src, IntPtr dst, int maxlevel, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_pyrUp(IntPtr src, IntPtr dst, Size dstsize, int borderType);
+    internal static partial ExceptionStatus imgproc_pyrUp(InputArrayProxy src, OutputArrayProxy dst, Size dstsize, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_calcHist(IntPtr[] images, int nimages,
-        int[] channels, IntPtr mask, IntPtr hist, int dims, int[] histSize,
+    internal static partial ExceptionStatus imgproc_calcHist(IntPtr[] images, int nimages,
+        int[] channels, InputArrayProxy mask, OutputArrayProxy hist, int dims, int[] histSize,
         IntPtr[] ranges, int uniform, int accumulate);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_calcBackProject(IntPtr[] images, int nimages,
-        int[] channels, IntPtr hist, IntPtr backProject, IntPtr[] ranges, int uniform);
+    internal static partial ExceptionStatus imgproc_calcBackProject(IntPtr[] images, int nimages,
+        int[] channels, InputArrayProxy hist, OutputArrayProxy backProject, IntPtr[] ranges, int uniform);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_compareHist(IntPtr h1, IntPtr h2, int method, out double returnValue);
+    internal static partial ExceptionStatus imgproc_compareHist(InputArrayProxy h1, InputArrayProxy h2, int method, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_equalizeHist(IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus imgproc_equalizeHist(InputArrayProxy src, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_EMD(IntPtr signature1, IntPtr signature2,
-        int distType, IntPtr cost, out float lowerBound, IntPtr flow, out float returnValue);
+    internal static partial ExceptionStatus imgproc_EMD(InputArrayProxy signature1, InputArrayProxy signature2,
+        int distType, InputArrayProxy cost, out float lowerBound, OutputArrayProxy flow, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_watershed(IntPtr image, IntPtr markers);
+    internal static partial ExceptionStatus imgproc_watershed(InputArrayProxy image, InputOutputArrayProxy markers);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_pyrMeanShiftFiltering(IntPtr src, IntPtr dst,
+    internal static partial ExceptionStatus imgproc_pyrMeanShiftFiltering(InputArrayProxy src, OutputArrayProxy dst,
         double sp, double sr, int maxLevel, TermCriteria termcrit);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_grabCut(IntPtr img, IntPtr mask, Rect rect,
-        IntPtr bgdModel, IntPtr fgdModel,
+    internal static partial ExceptionStatus imgproc_grabCut(InputArrayProxy img, InputOutputArrayProxy mask, Rect rect,
+        InputOutputArrayProxy bgdModel, InputOutputArrayProxy fgdModel,
         int iterCount, int mode);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_distanceTransformWithLabels(IntPtr src, IntPtr dst, IntPtr labels,
+    internal static partial ExceptionStatus imgproc_distanceTransformWithLabels(InputArrayProxy src, OutputArrayProxy dst, OutputArrayProxy labels,
         int distanceType, int maskSize, int labelType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_distanceTransform(IntPtr src, IntPtr dst,
+    internal static partial ExceptionStatus imgproc_distanceTransform(InputArrayProxy src, OutputArrayProxy dst,
         int distanceType, int maskSize, int dstType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_floodFill1(IntPtr image,
+    internal static partial ExceptionStatus imgproc_floodFill1(InputOutputArrayProxy image,
         Point seedPoint, Scalar newVal, out Rect rect,
         Scalar loDiff, Scalar upDiff, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_floodFill2(IntPtr image, IntPtr mask,
+    internal static partial ExceptionStatus imgproc_floodFill2(InputOutputArrayProxy image, InputOutputArrayProxy mask,
         Point seedPoint, Scalar newVal, out Rect rect,
         Scalar loDiff, Scalar upDiff, int flags, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_blendLinear(
-        IntPtr src1, IntPtr src2, IntPtr weights1, IntPtr weights2, IntPtr dst);
+    internal static partial ExceptionStatus imgproc_blendLinear(
+        InputArrayProxy src1, InputArrayProxy src2, InputArrayProxy weights1, InputArrayProxy weights2, OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cvtColor(IntPtr src, IntPtr dst, int code, int dstCn, int hint);
+    internal static partial ExceptionStatus imgproc_cvtColor(InputArrayProxy src, OutputArrayProxy dst, int code, int dstCn, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_cvtColorTwoPlane(IntPtr src1, IntPtr src2, IntPtr dst, int code, int hint);
+    internal static partial ExceptionStatus imgproc_cvtColorTwoPlane(InputArrayProxy src1, InputArrayProxy src2, OutputArrayProxy dst, int code, int hint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_demosaicing(IntPtr src, IntPtr dst, int code, int dstCn);
+    internal static partial ExceptionStatus imgproc_demosaicing(InputArrayProxy src, OutputArrayProxy dst, int code, int dstCn);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_moments(IntPtr arr, int binaryImage, out Moments.NativeStruct returnValue);
+    internal static partial ExceptionStatus imgproc_moments(InputArrayProxy arr, int binaryImage, out Moments.NativeStruct returnValue);
 
     //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     //public static extern ExceptionStatus imgproc_HuMoments(ref Moments.NativeStruct moments, [MarshalAs(UnmanagedType.LPArray)] double[] hu);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_matchTemplate(
-        IntPtr image, IntPtr templ, IntPtr result, int method, IntPtr mask);
+    internal static partial ExceptionStatus imgproc_matchTemplate(
+        InputArrayProxy image, InputArrayProxy templ, OutputArrayProxy result, int method, InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_connectedComponentsWithAlgorithm(
-        IntPtr image, IntPtr labels, int connectivity, MatType ltype, int ccltype, out int returnValue);
+    internal static partial ExceptionStatus imgproc_connectedComponentsWithAlgorithm(
+        InputArrayProxy image, OutputArrayProxy labels, int connectivity, MatType ltype, int ccltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_connectedComponents(
-        IntPtr image, IntPtr labels, int connectivity, MatType ltype, out int returnValue);
+    internal static partial ExceptionStatus imgproc_connectedComponents(
+        InputArrayProxy image, OutputArrayProxy labels, int connectivity, MatType ltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_connectedComponentsWithStatsWithAlgorithm(
-        IntPtr image, IntPtr labels, IntPtr stats, IntPtr centroids, int connectivity, MatType ltype, int ccltype, out int returnValue);
+    internal static partial ExceptionStatus imgproc_connectedComponentsWithStatsWithAlgorithm(
+        InputArrayProxy image, OutputArrayProxy labels, OutputArrayProxy stats, OutputArrayProxy centroids, int connectivity, MatType ltype, int ccltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_connectedComponentsWithStats(
-        IntPtr image, IntPtr labels, IntPtr stats, IntPtr centroids, int connectivity, MatType ltype, out int returnValue);
+    internal static partial ExceptionStatus imgproc_connectedComponentsWithStats(
+        InputArrayProxy image, OutputArrayProxy labels, OutputArrayProxy stats, OutputArrayProxy centroids, int connectivity, MatType ltype, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContours1_vector(IntPtr image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours1_vector(InputArrayProxy image, IntPtr contours,
         IntPtr hierarchy, int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContours1_OutputArray(IntPtr image, IntPtr contours,
-        IntPtr hierarchy, int mode, int method, Point offset);
+    internal static partial ExceptionStatus imgproc_findContours1_OutputArray(InputArrayProxy image, IntPtr contours,
+        OutputArrayProxy hierarchy, int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContours2_vector(IntPtr image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours2_vector(InputArrayProxy image, IntPtr contours,
         int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContours2_OutputArray(IntPtr image, IntPtr contours,
+    internal static partial ExceptionStatus imgproc_findContours2_OutputArray(InputArrayProxy image, IntPtr contours,
         int mode, int method, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContoursLinkRuns1(IntPtr image, IntPtr contours, IntPtr hierarchy);
+    internal static partial ExceptionStatus imgproc_findContoursLinkRuns1(InputArrayProxy image, IntPtr contours, IntPtr hierarchy);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_findContoursLinkRuns2(IntPtr image, IntPtr contours);
+    internal static partial ExceptionStatus imgproc_findContoursLinkRuns2(InputArrayProxy image, IntPtr contours);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_approxPolyDP_InputArray(IntPtr curve, IntPtr approxCurve,
+    internal static partial ExceptionStatus imgproc_approxPolyDP_InputArray(InputArrayProxy curve, OutputArrayProxy approxCurve,
         double epsilon, int closed);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -359,7 +359,7 @@ static partial class NativeMethods
         IntPtr approxCurve, double epsilon, int closed);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_arcLength_InputArray(IntPtr curve, int closed, out double returnValue);
+    internal static partial ExceptionStatus imgproc_arcLength_InputArray(InputArrayProxy curve, int closed, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_arcLength_Point(Point[] curve, int curveLength, int closed, out double returnValue);
@@ -368,7 +368,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_arcLength_Point2f(Point2f[] curve, int curveLength, int closed, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_boundingRect_InputArray(IntPtr curve, out Rect returnValue);
+    internal static partial ExceptionStatus imgproc_boundingRect_InputArray(InputArrayProxy curve, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_boundingRect_Point(Point[] curve, int curveLength, out Rect returnValue);
@@ -377,7 +377,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_boundingRect_Point2f(Point2f[] curve, int curveLength, out Rect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_contourArea_InputArray(IntPtr contour, int oriented, out double returnValue);
+    internal static partial ExceptionStatus imgproc_contourArea_InputArray(InputArrayProxy contour, int oriented, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_contourArea_Point(
@@ -388,7 +388,7 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPArray)] Point2f[] contour, int contourLength, int oriented, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_minAreaRect_InputArray(IntPtr points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_minAreaRect_InputArray(InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_minAreaRect_Point(
@@ -399,13 +399,13 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPArray)] Point2f[] points, int pointsLength, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_boxPoints_OutputArray(RotatedRect box, IntPtr points);
+    internal static partial ExceptionStatus imgproc_boxPoints_OutputArray(RotatedRect box, OutputArrayProxy points);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_boxPoints_Point2f(RotatedRect box, [MarshalAs(UnmanagedType.LPArray), Out] Point2f[] points);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_minEnclosingCircle_InputArray(IntPtr points, out Point2f center,
+    internal static partial ExceptionStatus imgproc_minEnclosingCircle_InputArray(InputArrayProxy points, out Point2f center,
         out float radius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -417,7 +417,7 @@ static partial class NativeMethods
         out Point2f center, out float radius);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_minEnclosingTriangle_InputOutputArray(IntPtr points, IntPtr triangle, out double returnValue);
+    internal static partial ExceptionStatus imgproc_minEnclosingTriangle_InputOutputArray(InputArrayProxy points, OutputArrayProxy triangle, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_minEnclosingTriangle_Point(
@@ -428,15 +428,15 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPArray), In] Point2f[] points, int pointsLength, IntPtr triangle, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_matchShapes_InputArray(
-        IntPtr contour1, IntPtr contour2, int method, double parameter, out double returnValue);
+    internal static partial ExceptionStatus imgproc_matchShapes_InputArray(
+        InputArrayProxy contour1, InputArrayProxy contour2, int method, double parameter, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_matchShapes_Point(
         Point[] contour1, int contour1Length, Point[] contour2, int contour2Length, int method, double parameter, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_convexHull_InputArray(IntPtr points, IntPtr hull,
+    internal static partial ExceptionStatus imgproc_convexHull_InputArray(InputArrayProxy points, OutputArrayProxy hull,
         int clockwise, int returnPoints);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -456,8 +456,8 @@ static partial class NativeMethods
         IntPtr hull, int clockwise);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_convexityDefects_InputArray(IntPtr contour, IntPtr convexHull,
-        IntPtr convexityDefects);
+    internal static partial ExceptionStatus imgproc_convexityDefects_InputArray(InputArrayProxy contour, InputArrayProxy convexHull,
+        OutputArrayProxy convexityDefects);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_convexityDefects_Point(Point[] contour, int contourLength, int[] convexHull,
@@ -468,7 +468,7 @@ static partial class NativeMethods
         int[] convexHull, int convexHullLength, IntPtr convexityDefects);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_isContourConvex_InputArray(IntPtr contour, out int returnValue);
+    internal static partial ExceptionStatus imgproc_isContourConvex_InputArray(InputArrayProxy contour, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_isContourConvex_Point(Point[] contour, int contourLength, out int returnValue);
@@ -477,8 +477,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_isContourConvex_Point2f(Point2f[] contour, int contourLength, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_intersectConvexConvex_InputArray(IntPtr p1, IntPtr p2,
-        IntPtr p12, int handleNested, out float returnValue);
+    internal static partial ExceptionStatus imgproc_intersectConvexConvex_InputArray(InputArrayProxy p1, InputArrayProxy p2,
+        OutputArrayProxy p12, int handleNested, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_intersectConvexConvex_Point(Point[] p1, int p1Length, Point[] p2,
@@ -489,7 +489,7 @@ static partial class NativeMethods
         int p2Length, IntPtr p12, int handleNested, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fitEllipse_InputArray(IntPtr points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipse_InputArray(InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipse_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -499,7 +499,7 @@ static partial class NativeMethods
 
     // Not exported
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fitEllipseAMS_InputArray(IntPtr points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipseAMS_InputArray(InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipseAMS_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -509,7 +509,7 @@ static partial class NativeMethods
 
     // Not exported
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fitEllipseDirect_InputArray(IntPtr points, out RotatedRect returnValue);
+    internal static partial ExceptionStatus imgproc_fitEllipseDirect_InputArray(InputArrayProxy points, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fitEllipseDirect_Point(Point[] points, int pointsLength, out RotatedRect returnValue);
@@ -518,7 +518,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_fitEllipseDirect_Point2f(Point2f[] points, int pointsLength, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fitLine_InputArray(IntPtr points, IntPtr line,
+    internal static partial ExceptionStatus imgproc_fitLine_InputArray(InputArrayProxy points, OutputArrayProxy line,
         int distType, double param, double reps, double aeps);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -539,8 +539,8 @@ static partial class NativeMethods
         int distType, double param, double reps, double aeps);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_pointPolygonTest_InputArray(
-        IntPtr contour, Point2f pt, int measureDist, out double returnValue);
+    internal static partial ExceptionStatus imgproc_pointPolygonTest_InputArray(
+        InputArrayProxy contour, Point2f pt, int measureDist, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_pointPolygonTest_Point(Point[] contour, int contourLength, Point2f pt,
@@ -551,35 +551,35 @@ static partial class NativeMethods
         Point2f pt, int measureDist, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_rotatedRectangleIntersection_OutputArray(
-        RotatedRect rect1, RotatedRect rect2, IntPtr intersectingRegion, out int returnValue);
+    internal static partial ExceptionStatus imgproc_rotatedRectangleIntersection_OutputArray(
+        RotatedRect rect1, RotatedRect rect2, OutputArrayProxy intersectingRegion, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_rotatedRectangleIntersection_vector(
         RotatedRect rect1, RotatedRect rect2, IntPtr intersectingRegion, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_applyColorMap1(IntPtr src, IntPtr dst, int colormap);
+    internal static partial ExceptionStatus imgproc_applyColorMap1(InputArrayProxy src, OutputArrayProxy dst, int colormap);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_applyColorMap2(IntPtr src, IntPtr dst, IntPtr userColor);
+    internal static partial ExceptionStatus imgproc_applyColorMap2(InputArrayProxy src, OutputArrayProxy dst, InputArrayProxy userColor);
 
     #region Drawing
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_line(
-        IntPtr img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
+    internal static partial ExceptionStatus imgproc_line(
+        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_arrowedLine(
-        IntPtr img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift, double tipLength);
+    internal static partial ExceptionStatus imgproc_arrowedLine(
+        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift, double tipLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Point(
-        IntPtr img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
+    internal static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Point(
+        InputOutputArrayProxy img, Point pt1, Point pt2, Scalar color, int thickness, int lineType, int shift);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Rect(
-        IntPtr img, Rect rect, Scalar color, int thickness, int lineType, int shift);
+    internal static partial ExceptionStatus imgproc_rectangle_InputOutputArray_Rect(
+        InputOutputArrayProxy img, Rect rect, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_rectangle_Mat_Point(
@@ -589,29 +589,29 @@ static partial class NativeMethods
         IntPtr img, Rect rect, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_circle(IntPtr img, Point center, int radius, Scalar color, int thickness,
+    internal static partial ExceptionStatus imgproc_circle(InputOutputArrayProxy img, Point center, int radius, Scalar color, int thickness,
         int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_ellipse1(
-        IntPtr img, Point center, Size axes,
+    internal static partial ExceptionStatus imgproc_ellipse1(
+        InputOutputArrayProxy img, Point center, Size axes,
         double angle, double startAngle, double endAngle, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_ellipse2(
-        IntPtr img, RotatedRect box, Scalar color, int thickness, int lineType);
+    internal static partial ExceptionStatus imgproc_ellipse2(
+        InputOutputArrayProxy img, RotatedRect box, Scalar color, int thickness, int lineType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_drawMarker(
-        IntPtr img, Point position, Scalar color, int markerType, int markerSize, int thickness, int lineType);
+    internal static partial ExceptionStatus imgproc_drawMarker(
+        InputOutputArrayProxy img, Point position, Scalar color, int markerType, int markerSize, int thickness, int lineType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fillConvexPoly_Mat(
         IntPtr img, Point[] pts, int npts, Scalar color, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fillConvexPoly_InputOutputArray(
-        IntPtr img, IntPtr points, Scalar color, int lineType, int shift);
+    internal static partial ExceptionStatus imgproc_fillConvexPoly_InputOutputArray(
+        InputOutputArrayProxy img, InputArrayProxy points, Scalar color, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_fillPoly_Mat(
@@ -619,8 +619,8 @@ static partial class NativeMethods
         Scalar color, int lineType, int shift, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_fillPoly_InputOutputArray(
-        IntPtr img, IntPtr pts, Scalar color, int lineType, int shift, Point offset);
+    internal static partial ExceptionStatus imgproc_fillPoly_InputOutputArray(
+        InputOutputArrayProxy img, InputArrayProxy pts, Scalar color, int lineType, int shift, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_polylines_Mat(
@@ -628,26 +628,26 @@ static partial class NativeMethods
         int ncontours, int isClosed, Scalar color, int thickness, int lineType, int shift);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_polylines_InputOutputArray(
-        IntPtr img, IntPtr pts, int isClosed, Scalar color, int thickness, int lineType, int shift);
+    internal static partial ExceptionStatus imgproc_polylines_InputOutputArray(
+        InputOutputArrayProxy img, InputArrayProxy pts, int isClosed, Scalar color, int thickness, int lineType, int shift);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_drawContours_vector(IntPtr image,
+    internal static partial ExceptionStatus imgproc_drawContours_vector(InputOutputArrayProxy image,
         IntPtr[] contours, int contoursSize1, int[] contoursSize2,
         int contourIdx, Scalar color, int thickness, int lineType,
         Vec4i[] hierarchy, int hiearchyLength, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_drawContours_vector(IntPtr image,
+    internal static partial ExceptionStatus imgproc_drawContours_vector(InputOutputArrayProxy image,
         IntPtr[] contours, int contoursSize1, int[] contoursSize2,
         int contourIdx, Scalar color, int thickness, int lineType,
         IntPtr hierarchy, int hiearchyLength, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_drawContours_InputArray(IntPtr image,
+    internal static partial ExceptionStatus imgproc_drawContours_InputArray(InputOutputArrayProxy image,
         IntPtr[] contours, int contoursLength,
         int contourIdx, Scalar color, int thickness, int lineType,
-        IntPtr hierarchy, int maxLevel, Point offset);
+        InputArrayProxy hierarchy, int maxLevel, Point offset);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_clipLine1(Size imgSize, ref Point pt1, ref Point pt2, out int returnValue);
@@ -664,7 +664,7 @@ static partial class NativeMethods
         Point2d center, Size2d axes, int angle, int arcStart, int arcEnd, int delta, IntPtr pts);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_putText(IntPtr img, [MarshalAs(UnmanagedType.LPStr)] string text, Point org,
+    internal static partial ExceptionStatus imgproc_putText(InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPStr)] string text, Point org,
         int fontFace, double fontScale, Scalar color,
         int thickness, int lineType, int bottomLeftOrigin);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
@@ -56,8 +56,8 @@ static partial class NativeMethods
     // putText / getTextSize with FontFace (text is UTF-8 for full Unicode support)
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus imgproc_putText_FontFace(
-        IntPtr img, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org, Scalar color,
+    internal static partial ExceptionStatus imgproc_putText_FontFace(
+        InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org, Scalar color,
         IntPtr fface, int size, int weight, int flags, int wrapStart, int wrapEnd, out Point returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_FontFace.cs
@@ -57,7 +57,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_putText_FontFace(
-        InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org, Scalar color,
+        in InputOutputArrayProxy img, [MarshalAs(UnmanagedType.LPUTF8Str)] string text, Point org, Scalar color,
         IntPtr fface, int size, int weight, int flags, int wrapStart, int wrapEnd, out Point returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -28,7 +28,7 @@ public class InputArray : CvObject
     // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_InputArray* as an
     // ArrayProxy so externs can move to the ArrayProxy ABI one module at a time while InputArray is
     // still a class. The caller must keep this object alive across the native call (GC.KeepAlive).
-    internal ArrayProxy ToInputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputArray };
+    internal InputArrayProxy ToInputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputArray };
 
     #region Init & Disposal
 

--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -25,6 +25,11 @@ public class InputArray : CvObject
     // ReSharper restore InconsistentNaming
 #pragma warning restore 1591
 
+    // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_InputArray* as an
+    // ArrayProxy so externs can move to the ArrayProxy ABI one module at a time while InputArray is
+    // still a class. The caller must keep this object alive across the native call (GC.KeepAlive).
+    internal ArrayProxy ToInputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputArray };
+
     #region Init & Disposal
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/core/InputArrayRef.cs
+++ b/src/OpenCvSharp/Modules/core/InputArrayRef.cs
@@ -33,6 +33,18 @@ public enum ArrayProxyKind
     Double = 5,
     /// <summary>A small fixed-length vector value (inline).</summary>
     Vec = 6,
+
+    // Migration scaffold: a proxy that wraps an existing native cv::_InputArray*/_OutputArray*/
+    // _InputOutputArray* (the handle of a class-based InputArray/OutputArray/InputOutputArray).
+    // Lets externs move to the ArrayProxy ABI one module at a time while the class types still
+    // exist; the native side just dereferences the handle. Removed once the type flip is complete.
+
+    /// <summary>An existing native cv::_InputArray* (class-based <see cref="InputArray"/>).</summary>
+    RawInputArray = 7,
+    /// <summary>An existing native cv::_OutputArray* (class-based <see cref="OutputArray"/>).</summary>
+    RawOutputArray = 8,
+    /// <summary>An existing native cv::_InputOutputArray* (class-based <see cref="InputOutputArray"/>).</summary>
+    RawInputOutputArray = 9,
 }
 
 /// <summary>

--- a/src/OpenCvSharp/Modules/core/InputArrayRef.cs
+++ b/src/OpenCvSharp/Modules/core/InputArrayRef.cs
@@ -48,11 +48,12 @@ public enum ArrayProxyKind
 }
 
 /// <summary>
-/// Blittable plain-old-data mirror of <c>interop::ArrayProxy</c> (my_types.h). Passed BY VALUE
-/// across the P/Invoke boundary; no field is a managed reference, so it marshals 1:1.
+/// Blittable plain-old-data mirror of <c>interop::InputArrayProxy</c> (my_types.h). Passed BY VALUE
+/// across the P/Invoke boundary; no field is a managed reference, so it marshals 1:1. Only inputs
+/// can be a Scalar/Vec value, so this is the only proxy that carries the inline payload.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-internal struct ArrayProxy
+internal struct InputArrayProxy
 {
     public IntPtr Handle;     // Mat/UMat/NativeMatExpr CvPtr for handle kinds; zero otherwise
     public int Kind;          // ArrayProxyKind
@@ -66,7 +67,7 @@ internal struct ArrayProxy
     public double Payload4;
     public double Payload5;
 
-    public static ArrayProxy FromScalar(in Scalar s) => new()
+    public static InputArrayProxy FromScalar(in Scalar s) => new()
     {
         Handle = IntPtr.Zero,
         Kind = (int)ArrayProxyKind.Scalar,
@@ -78,6 +79,27 @@ internal struct ArrayProxy
 }
 
 /// <summary>
+/// Blittable mirror of <c>interop::OutputArrayProxy</c> (my_types.h). An output is always a
+/// Mat/UMat (or a raw native handle), so it only needs a handle + kind — no inline payload.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct OutputArrayProxy
+{
+    public IntPtr Handle;     // Mat/UMat CvPtr, or a cv::_OutputArray* for the Raw kind
+    public int Kind;          // ArrayProxyKind
+}
+
+/// <summary>
+/// Blittable mirror of <c>interop::InputOutputArrayProxy</c> (my_types.h). Handle + kind only.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct InputOutputArrayProxy
+{
+    public IntPtr Handle;     // Mat/UMat CvPtr, or a cv::_InputOutputArray* for the Raw kind
+    public int Kind;          // ArrayProxyKind
+}
+
+/// <summary>
 /// Stack-only input proxy (see file header). Carries a native handle or an inline value; building
 /// one allocates nothing on the managed heap.
 /// </summary>
@@ -86,9 +108,9 @@ public readonly ref struct InputArrayRef
     // Keeps the source Mat/UMat/NativeMatExpr alive across the native call (the proxy stores only
     // its raw handle).
     internal readonly object? Source;
-    internal readonly ArrayProxy Proxy;
+    internal readonly InputArrayProxy Proxy;
 
-    private InputArrayRef(object? source, ArrayProxy proxy)
+    private InputArrayRef(object? source, InputArrayProxy proxy)
     {
         Source = source;
         Proxy = proxy;
@@ -99,7 +121,7 @@ public readonly ref struct InputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
+        return new InputArrayRef(mat, new InputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
     }
 
     /// <summary>Wraps a <see cref="UMat"/> (no allocation).</summary>
@@ -107,7 +129,7 @@ public readonly ref struct InputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
+        return new InputArrayRef(mat, new InputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
     }
 
     /// <summary>
@@ -119,16 +141,16 @@ public readonly ref struct InputArrayRef
     {
         ArgumentNullException.ThrowIfNull(expr);
         var native = expr.Eval();
-        return new InputArrayRef(native, new ArrayProxy { Handle = native.CvPtr, Kind = (int)ArrayProxyKind.MatExpr });
+        return new InputArrayRef(native, new InputArrayProxy { Handle = native.CvPtr, Kind = (int)ArrayProxyKind.MatExpr });
     }
 
     /// <summary>Wraps a <see cref="Scalar"/> value (no allocation; travels inline).</summary>
     public static implicit operator InputArrayRef(Scalar s) =>
-        new(null, ArrayProxy.FromScalar(s));
+        new(null, InputArrayProxy.FromScalar(s));
 
     /// <summary>Wraps a <see cref="double"/> value (no allocation; travels inline as Scalar(d,0,0,0)).</summary>
     public static implicit operator InputArrayRef(double d) =>
-        new(null, new ArrayProxy { Kind = (int)ArrayProxyKind.Double, Payload0 = d });
+        new(null, new InputArrayProxy { Kind = (int)ArrayProxyKind.Double, Payload0 = d });
 
     // cv depth constants for the inline Vec payload (cv::CV_8U .. CV_64F).
     private const int DepthU8 = 0, DepthU16 = 2, DepthS16 = 3, DepthS32 = 4, DepthF32 = 5, DepthF64 = 6;
@@ -137,7 +159,7 @@ public readonly ref struct InputArrayRef
     // reads it back as (const T*)payload with VecLength elements; see fromInputProxy in my_types.h.
     private static InputArrayRef FromVec<T>(T vec, int depth, int length) where T : unmanaged
     {
-        var proxy = new ArrayProxy { Kind = (int)ArrayProxyKind.Vec, VecDepth = depth, VecLength = length };
+        var proxy = new InputArrayProxy { Kind = (int)ArrayProxyKind.Vec, VecDepth = depth, VecLength = length };
         var payload = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref proxy.Payload0, 6));
         MemoryMarshal.Write(payload, in vec);
         return new InputArrayRef(null, proxy);
@@ -200,9 +222,9 @@ public readonly ref struct InputArrayRef
 public readonly ref struct OutputArrayRef
 {
     internal readonly object? Source;
-    internal readonly ArrayProxy Proxy;
+    internal readonly OutputArrayProxy Proxy;
 
-    private OutputArrayRef(object? source, ArrayProxy proxy)
+    private OutputArrayRef(object? source, OutputArrayProxy proxy)
     {
         Source = source;
         Proxy = proxy;
@@ -213,7 +235,7 @@ public readonly ref struct OutputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new OutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
+        return new OutputArrayRef(mat, new OutputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
     }
 
     /// <summary>Wraps a <see cref="UMat"/> output (no allocation).</summary>
@@ -221,7 +243,7 @@ public readonly ref struct OutputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new OutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
+        return new OutputArrayRef(mat, new OutputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
     }
 }
 
@@ -232,9 +254,9 @@ public readonly ref struct OutputArrayRef
 public readonly ref struct InputOutputArrayRef
 {
     internal readonly object? Source;
-    internal readonly ArrayProxy Proxy;
+    internal readonly InputOutputArrayProxy Proxy;
 
-    private InputOutputArrayRef(object? source, ArrayProxy proxy)
+    private InputOutputArrayRef(object? source, InputOutputArrayProxy proxy)
     {
         Source = source;
         Proxy = proxy;
@@ -245,7 +267,7 @@ public readonly ref struct InputOutputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputOutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
+        return new InputOutputArrayRef(mat, new InputOutputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.Mat });
     }
 
     /// <summary>Wraps a <see cref="UMat"/> in/out target (no allocation).</summary>
@@ -253,6 +275,6 @@ public readonly ref struct InputOutputArrayRef
     {
         ArgumentNullException.ThrowIfNull(mat);
         mat.ThrowIfDisposed();
-        return new InputOutputArrayRef(mat, new ArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
+        return new InputOutputArrayRef(mat, new InputOutputArrayProxy { Handle = mat.CvPtr, Kind = (int)ArrayProxyKind.UMat });
     }
 }

--- a/src/OpenCvSharp/Modules/core/InputOutputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputOutputArray.cs
@@ -12,7 +12,7 @@ public class InputOutputArray : OutputArray
     // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_InputOutputArray*
     // as an ArrayProxy so externs taking _InputOutputArray* can move to the ArrayProxy ABI one module
     // at a time. The caller must keep this object alive across the native call (GC.KeepAlive).
-    internal ArrayProxy ToInputOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputOutputArray };
+    internal InputOutputArrayProxy ToInputOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputOutputArray };
 
     /// <summary>
     /// Constructor

--- a/src/OpenCvSharp/Modules/core/InputOutputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputOutputArray.cs
@@ -9,6 +9,11 @@ namespace OpenCvSharp;
 /// </summary>
 public class InputOutputArray : OutputArray
 {
+    // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_InputOutputArray*
+    // as an ArrayProxy so externs taking _InputOutputArray* can move to the ArrayProxy ABI one module
+    // at a time. The caller must keep this object alive across the native call (GC.KeepAlive).
+    internal ArrayProxy ToInputOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawInputOutputArray };
+
     /// <summary>
     /// Constructor
     /// </summary>

--- a/src/OpenCvSharp/Modules/core/OutputArray.cs
+++ b/src/OpenCvSharp/Modules/core/OutputArray.cs
@@ -16,7 +16,7 @@ public class OutputArray : CvObject
     // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_OutputArray* as an
     // ArrayProxy so externs can move to the ArrayProxy ABI one module at a time while OutputArray is
     // still a class. The caller must keep this object alive across the native call (GC.KeepAlive).
-    internal ArrayProxy ToOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawOutputArray };
+    internal OutputArrayProxy ToOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawOutputArray };
 
     #region Init & Disposal
 

--- a/src/OpenCvSharp/Modules/core/OutputArray.cs
+++ b/src/OpenCvSharp/Modules/core/OutputArray.cs
@@ -13,6 +13,11 @@ public class OutputArray : CvObject
 {
     private readonly object obj;
 
+    // Migration scaffold (issue #1976, strategy 3): wraps this class's native cv::_OutputArray* as an
+    // ArrayProxy so externs can move to the ArrayProxy ABI one module at a time while OutputArray is
+    // still a class. The caller must keep this object alive across the native call (GC.KeepAlive).
+    internal ArrayProxy ToOutputProxy() => new() { Handle = CvPtr, Kind = (int)ArrayProxyKind.RawOutputArray };
+
     #region Init & Disposal
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/core/RNG.cs
+++ b/src/OpenCvSharp/Modules/core/RNG.cs
@@ -287,7 +287,7 @@ public struct RNG : IEquatable<RNG>
         b.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.core_RNG_fill(ref state, mat.CvPtr, (int) distType, a.CvPtr, b.CvPtr, saturateRange ? 1 : 0));
+            NativeMethods.core_RNG_fill(ref state, mat.ToInputOutputProxy(), (int) distType, a.ToInputProxy(), b.ToInputProxy(), saturateRange ? 1 : 0));
 
         mat.Fix();
         GC.KeepAlive(mat);

--- a/src/OpenCvSharp/Modules/imgproc/Moments.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Moments.cs
@@ -150,7 +150,7 @@ public class Moments
     private void InitializeFromInputArray(InputArray array, bool binaryImage)
     {
         NativeMethods.HandleException(
-            NativeMethods.imgproc_moments(array.CvPtr, binaryImage ? 1 : 0, out var m));
+            NativeMethods.imgproc_moments(array.ToInputProxy(), binaryImage ? 1 : 0, out var m));
         GC.KeepAlive(array);
         Initialize(m.m00, m.m10, m.m01, m.m20, m.m11, m.m02, m.m30, m.m21, m.m12, m.m03);
     }

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -24,333 +24,333 @@ CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, in
 }
 
 CVAPI(ExceptionStatus) core_copyMakeBorder(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int top, int bottom, int left, int right,
     int borderType,
     interop::Scalar value)
 {
     return cvTry([&] {
-        cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
+        cv::copyMakeBorder(InProxy(*src), OutProxy(*dst), top, bottom, left, right, borderType, cpp(value));
     });
 }
 
 CVAPI(ExceptionStatus) core_add(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
     int dtype)
 {
     return cvTry([&] {
-        cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::add(InProxy(*src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask), dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_subtract_InputArray2(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
     int dtype)
 {
     return cvTry([&] {
-        cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(InProxy(*src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
-    interop::InputArrayProxy src1,
+    const interop::InputArrayProxy* src1,
     interop::Scalar src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
     int dtype)
 {
     return cvTry([&] {
-        cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(InProxy(*src1), cpp(src2), OutProxy(*dst), InProxy(*mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
     interop::Scalar src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
     int dtype)
 {
     return cvTry([&] {
-        cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(cpp(src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask), dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_multiply(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
     double scale,
     int dtype)
 {
     return cvTry([&] {
-        cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
+        cv::multiply(InProxy(*src1), InProxy(*src2), OutProxy(*dst), scale, dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide1(
     double scale,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
     int dtype)
 {
     return cvTry([&] {
-        cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
+        cv::divide(scale, InProxy(*src2), OutProxy(*dst), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide2(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
     double scale,
     int dtype)
 {
     return cvTry([&] {
-        cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
+        cv::divide(InProxy(*src1), InProxy(*src2), OutProxy(*dst), scale, dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_scaleAdd(
-    interop::InputArrayProxy src1,
+    const interop::InputArrayProxy* src1,
     double alpha,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
+        cv::scaleAdd(InProxy(*src1), alpha, InProxy(*src2), OutProxy(*dst));
     });
 }
 CVAPI(ExceptionStatus) core_addWeighted(
-    interop::InputArrayProxy src1,
+    const interop::InputArrayProxy* src1,
     double alpha,
-    interop::InputArrayProxy src2,
+    const interop::InputArrayProxy* src2,
     double beta,
     double gamma,
-    interop::OutputArrayProxy dst,
+    const interop::OutputArrayProxy* dst,
     int dtype)
 {
     return cvTry([&] {
-        cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
+        cv::addWeighted(InProxy(*src1), alpha, InProxy(*src2), beta, gamma, OutProxy(*dst), dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_convertScaleAbs(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     double alpha,
     double beta)
 {
     return cvTry([&] {
-        cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
+        cv::convertScaleAbs(InProxy(*src), OutProxy(*dst), alpha, beta);
     });
 }
 
 CVAPI(ExceptionStatus) core_LUT(
-    interop::InputArrayProxy src,
-    interop::InputArrayProxy lut,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* lut,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
+        cv::LUT(InProxy(*src), InProxy(*lut), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_sum(interop::InputArrayProxy src, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_sum(const interop::InputArrayProxy* src, interop::Scalar* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::sum(InProxy(src)));
+        *returnValue = c(cv::sum(InProxy(*src)));
     });
 }
 
-CVAPI(ExceptionStatus) core_countNonZero(interop::InputArrayProxy src, int* returnValue)
+CVAPI(ExceptionStatus) core_countNonZero(const interop::InputArrayProxy* src, int* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::countNonZero(InProxy(src));
+        *returnValue = cv::countNonZero(InProxy(*src));
     });
 }
 
-CVAPI(ExceptionStatus) core_findNonZero(interop::InputArrayProxy src, interop::OutputArrayProxy idx)
+CVAPI(ExceptionStatus) core_findNonZero(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* idx)
 {
     return cvTry([&] {
-        cv::findNonZero(InProxy(src), OutProxy(idx));
+        cv::findNonZero(InProxy(*src), OutProxy(*idx));
     });
 }
 
 CVAPI(ExceptionStatus) core_mean(
-    interop::InputArrayProxy src,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* mask,
     interop::Scalar* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
+        *returnValue = c(cv::mean(InProxy(*src), InProxy(*mask)));
     });
 }
 
 CVAPI(ExceptionStatus) core_meanStdDev_OutputArray(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy mean,
-    interop::OutputArrayProxy stddev,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* mean,
+    const interop::OutputArrayProxy* stddev,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::meanStdDev(InProxy(src), OutProxy(mean), OutProxy(stddev), InProxy(mask));
+        cv::meanStdDev(InProxy(*src), OutProxy(*mean), OutProxy(*stddev), InProxy(*mask));
     });
 }
 CVAPI(ExceptionStatus) core_meanStdDev_Scalar(
-    interop::InputArrayProxy src,
+    const interop::InputArrayProxy* src,
     interop::Scalar* mean,
     interop::Scalar* stddev,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
         cv::Scalar mean0, stddev0;
-        cv::meanStdDev(InProxy(src), mean0, stddev0, InProxy(mask));
+        cv::meanStdDev(InProxy(*src), mean0, stddev0, InProxy(*mask));
         *mean = c(mean0);
         *stddev = c(stddev0);
     });
 }
 
 CVAPI(ExceptionStatus) core_norm1(
-    interop::InputArrayProxy src1,
+    const interop::InputArrayProxy* src1,
     int normType,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* mask,
     double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::norm(InProxy(src1), normType, InProxy(mask));
+        *returnValue = cv::norm(InProxy(*src1), normType, InProxy(*mask));
     });
 }
 CVAPI(ExceptionStatus) core_norm2(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
     int normType,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* mask,
     double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::norm(InProxy(src1), InProxy(src2), normType, InProxy(mask));
+        *returnValue = cv::norm(InProxy(*src1), InProxy(*src2), normType, InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_PSNR(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
     double R,
     double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::PSNR(InProxy(src1), InProxy(src2), R);
+        *returnValue = cv::PSNR(InProxy(*src1), InProxy(*src2), R);
     });
 }
 
 CVAPI(ExceptionStatus) core_batchDistance(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dist,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dist,
     int dtype,
-    interop::OutputArrayProxy nidx,
+    const interop::OutputArrayProxy* nidx,
     int normType,
     int K,
-    interop::InputArrayProxy mask,
+    const interop::InputArrayProxy* mask,
     int update,
     int crosscheck)
 {
     return cvTry([&] {
         cv::batchDistance(
-            InProxy(src1), InProxy(src2), OutProxy(dist), dtype, OutProxy(nidx), normType, K, InProxy(mask), update, crosscheck != 0);
+            InProxy(*src1), InProxy(*src2), OutProxy(*dist), dtype, OutProxy(*nidx), normType, K, InProxy(*mask), update, crosscheck != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_normalize(
-    interop::InputArrayProxy src,
-    interop::InputOutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dst,
     double alpha,
     double beta,
     int normType,
     int dtype,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::normalize(InProxy(src), IoProxy(dst), alpha, beta, normType, dtype, InProxy(mask));
+        cv::normalize(InProxy(*src), IoProxy(*dst), alpha, beta, normType, dtype, InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_reduceArgMax(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int axis,
     bool lastIndex)
 {
     return cvTry([&] {
-        cv::reduceArgMax(InProxy(src), OutProxy(dst), axis, lastIndex);
+        cv::reduceArgMax(InProxy(*src), OutProxy(*dst), axis, lastIndex);
     });
 }
 
 CVAPI(ExceptionStatus) core_reduceArgMin(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int axis,
     bool lastIndex)
 {
     return cvTry([&] {
-        cv::reduceArgMin(InProxy(src), OutProxy(dst), axis, lastIndex);
+        cv::reduceArgMin(InProxy(*src), OutProxy(*dst), axis, lastIndex);
     });
 }
 
-CVAPI(ExceptionStatus) core_minMaxLoc1(interop::InputArrayProxy src, double* minVal, double* maxVal)
+CVAPI(ExceptionStatus) core_minMaxLoc1(const interop::InputArrayProxy* src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-        cv::minMaxLoc(InProxy(src), minVal, maxVal);
+        cv::minMaxLoc(InProxy(*src), minVal, maxVal);
     });
 }
 CVAPI(ExceptionStatus) core_minMaxLoc2(
-    interop::InputArrayProxy src,
+    const interop::InputArrayProxy* src,
     double* minVal,
     double* maxVal,
     interop::Point* minLoc,
     interop::Point* maxLoc,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
         cv::Point minLoc0, maxLoc0;
-        cv::minMaxLoc(InProxy(src), minVal, maxVal, &minLoc0, &maxLoc0, InProxy(mask));
+        cv::minMaxLoc(InProxy(*src), minVal, maxVal, &minLoc0, &maxLoc0, InProxy(*mask));
         *minLoc = c(minLoc0);
         *maxLoc = c(maxLoc0);
     });
 }
 
-CVAPI(ExceptionStatus) core_minMaxIdx1(interop::InputArrayProxy src, double* minVal, double* maxVal)
+CVAPI(ExceptionStatus) core_minMaxIdx1(const interop::InputArrayProxy* src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-        cv::minMaxIdx(InProxy(src), minVal, maxVal);
+        cv::minMaxIdx(InProxy(*src), minVal, maxVal);
     });
 }
 CVAPI(ExceptionStatus) core_minMaxIdx2(
-    interop::InputArrayProxy src,
+    const interop::InputArrayProxy* src,
     double* minVal,
     double* maxVal,
     int* minIdx,
     int* maxIdx,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::minMaxIdx(InProxy(src), minVal, maxVal, minIdx, maxIdx, InProxy(mask));
+        cv::minMaxIdx(InProxy(*src), minVal, maxVal, minIdx, maxIdx, InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_reduce(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int dim,
     int rtype,
     int dtype)
 {
     return cvTry([&] {
-        cv::reduce(InProxy(src), OutProxy(dst), dim, rtype, dtype);
+        cv::reduce(InProxy(*src), OutProxy(*dst), dim, rtype, dtype);
     });
 }
 
@@ -386,42 +386,42 @@ CVAPI(ExceptionStatus) core_mixChannels(cv::Mat** src, uint32_t nsrcs, cv::Mat**
     });
 }
 
-CVAPI(ExceptionStatus) core_extractChannel(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int coi)
+CVAPI(ExceptionStatus) core_extractChannel(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int coi)
 {
     return cvTry([&] {
-        cv::extractChannel(InProxy(src), OutProxy(dst), coi);
+        cv::extractChannel(InProxy(*src), OutProxy(*dst), coi);
     });
 }
 
-CVAPI(ExceptionStatus) core_insertChannel(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, int coi)
+CVAPI(ExceptionStatus) core_insertChannel(const interop::InputArrayProxy* src, const interop::InputOutputArrayProxy* dst, int coi)
 {
     return cvTry([&] {
-        cv::insertChannel(InProxy(src), IoProxy(dst), coi);
+        cv::insertChannel(InProxy(*src), IoProxy(*dst), coi);
     });
 }
 
-CVAPI(ExceptionStatus) core_flip(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flipCode)
+CVAPI(ExceptionStatus) core_flip(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flipCode)
 {
     return cvTry([&] {
-        cv::flip(InProxy(src), OutProxy(dst), flipCode);
+        cv::flip(InProxy(*src), OutProxy(*dst), flipCode);
     });
 }
 
-CVAPI(ExceptionStatus) core_rotate(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int rotateCode)
+CVAPI(ExceptionStatus) core_rotate(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int rotateCode)
 {
     return cvTry([&] {
-        cv::rotate(InProxy(src), OutProxy(dst), rotateCode);
+        cv::rotate(InProxy(*src), OutProxy(*dst), rotateCode);
     });
 }
 
 CVAPI(ExceptionStatus) core_repeat1(
-    interop::InputArrayProxy src,
+    const interop::InputArrayProxy* src,
     int ny,
     int nx,
-    interop::OutputArrayProxy dst)
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::repeat(InProxy(src), ny, nx, OutProxy(dst));
+        cv::repeat(InProxy(*src), ny, nx, OutProxy(*dst));
     });
 }
 CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** returnValue)
@@ -432,134 +432,134 @@ CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** retu
     });
 }
 
-CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
         std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
         for (uint32_t i = 0; i < nsrc; i++)
             srcVec[i] = *(src[i]);
-        cv::hconcat(&srcVec[0], nsrc, OutProxy(dst));
+        cv::hconcat(&srcVec[0], nsrc, OutProxy(*dst));
     });
 }
-CVAPI(ExceptionStatus) core_hconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_hconcat2(const interop::InputArrayProxy* src1, const interop::InputArrayProxy* src2, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::hconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::hconcat(InProxy(*src1), InProxy(*src2), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
         std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
         for (uint32_t i = 0; i < nsrc; i++)
             srcVec[i] = *(src[i]);
-        cv::vconcat(&srcVec[0], nsrc, OutProxy(dst));
+        cv::vconcat(&srcVec[0], nsrc, OutProxy(*dst));
     });
 }
-CVAPI(ExceptionStatus) core_vconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_vconcat2(const interop::InputArrayProxy* src1, const interop::InputArrayProxy* src2, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::vconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::vconcat(InProxy(*src1), InProxy(*src2), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_bitwise_and(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_and(InProxy(*src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_or(InProxy(*src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_xor(InProxy(*src1), InProxy(*src2), OutProxy(*dst), InProxy(*mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
+        cv::bitwise_not(InProxy(*src), OutProxy(*dst), InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_absdiff(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::absdiff(InProxy(*src1), InProxy(*src2), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_copyTo(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy mask)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
+        cv::copyTo(InProxy(*src), OutProxy(*dst), InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_inRange_InputArray(
-    interop::InputArrayProxy src,
-    interop::InputArrayProxy lowerb,
-    interop::InputArrayProxy upperb,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* lowerb,
+    const interop::InputArrayProxy* upperb,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
+        cv::inRange(InProxy(*src), InProxy(*lowerb), InProxy(*upperb), OutProxy(*dst));
     });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
-    interop::InputArrayProxy src,
+    const interop::InputArrayProxy* src,
     interop::Scalar lowerb,
     interop::Scalar upperb,
-    interop::OutputArrayProxy dst)
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
+        cv::inRange(InProxy(*src), cpp(lowerb), cpp(upperb), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_compare(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
     int cmpop)
 {
     return cvTry([&] {
-        cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
+        cv::compare(InProxy(*src1), InProxy(*src2), OutProxy(*dst), cmpop);
     });
 }
 
 CVAPI(ExceptionStatus) core_min1(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
         // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
@@ -567,9 +567,9 @@ CVAPI(ExceptionStatus) core_min1(
         // over dangling temporaries -> heap corruption, plus C4834). Binding to named cv::_InputArray
         // lvalues forces the void min(InputArray,InputArray,OutputArray) overload.
         cv::Scalar s1, s2;
-        const cv::_InputArray a = fromInputProxy(src1, s1);
-        const cv::_InputArray b = fromInputProxy(src2, s2);
-        cv::_OutputArray d = fromOutputProxy(dst);
+        const cv::_InputArray a = fromInputProxy(*src1, s1);
+        const cv::_InputArray b = fromInputProxy(*src2, s2);
+        cv::_OutputArray d = fromOutputProxy(*dst);
         cv::min(a, b, d);
     });
 }
@@ -587,17 +587,17 @@ CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* d
 }
 
 CVAPI(ExceptionStatus) core_max1(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
         // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
         // instead of the [[nodiscard]] MatExpr max(Mat,Mat).
         cv::Scalar s1, s2;
-        const cv::_InputArray a = fromInputProxy(src1, s1);
-        const cv::_InputArray b = fromInputProxy(src2, s2);
-        cv::_OutputArray d = fromOutputProxy(dst);
+        const cv::_InputArray a = fromInputProxy(*src1, s1);
+        const cv::_InputArray b = fromInputProxy(*src2, s2);
+        cv::_OutputArray d = fromOutputProxy(*dst);
         cv::max(a, b, d);
     });
 }
@@ -614,81 +614,81 @@ CVAPI(ExceptionStatus) core_max_MatDouble(cv::Mat *src1, double src2, cv::Mat *d
     });
 }
 
-CVAPI(ExceptionStatus) core_sqrt(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_sqrt(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::sqrt(InProxy(src), OutProxy(dst));
+        cv::sqrt(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_pow_Mat(interop::InputArrayProxy src, double power, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_pow_Mat(const interop::InputArrayProxy* src, double power, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::pow(InProxy(src), power, OutProxy(dst));
+        cv::pow(InProxy(*src), power, OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_exp_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_exp_Mat(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::exp(InProxy(src), OutProxy(dst));
+        cv::exp(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_log_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_log_Mat(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::log(InProxy(src), OutProxy(dst));
+        cv::log(InProxy(*src), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_polarToCart(
-    interop::InputArrayProxy magnitude,
-    interop::InputArrayProxy angle,
-    interop::OutputArrayProxy x,
-    interop::OutputArrayProxy y,
+    const interop::InputArrayProxy* magnitude,
+    const interop::InputArrayProxy* angle,
+    const interop::OutputArrayProxy* x,
+    const interop::OutputArrayProxy* y,
     int angleInDegrees)
 {
     return cvTry([&] {
-        cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
+        cv::polarToCart(InProxy(*magnitude), InProxy(*angle), OutProxy(*x), OutProxy(*y), angleInDegrees != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_cartToPolar(
-    interop::InputArrayProxy x,
-    interop::InputArrayProxy y,
-    interop::OutputArrayProxy magnitude,
-    interop::OutputArrayProxy angle,
+    const interop::InputArrayProxy* x,
+    const interop::InputArrayProxy* y,
+    const interop::OutputArrayProxy* magnitude,
+    const interop::OutputArrayProxy* angle,
     int angleInDegrees)
 {
     return cvTry([&] {
-        cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
+        cv::cartToPolar(InProxy(*x), InProxy(*y), OutProxy(*magnitude), OutProxy(*angle), angleInDegrees != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_phase(
-    interop::InputArrayProxy x,
-    interop::InputArrayProxy y,
-    interop::OutputArrayProxy angle,
+    const interop::InputArrayProxy* x,
+    const interop::InputArrayProxy* y,
+    const interop::OutputArrayProxy* angle,
     int angleInDegrees)
 {
     return cvTry([&] {
-        cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
+        cv::phase(InProxy(*x), InProxy(*y), OutProxy(*angle), angleInDegrees != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_magnitude_Mat(
-    interop::InputArrayProxy x,
-    interop::InputArrayProxy y,
-    interop::OutputArrayProxy magnitude)
+    const interop::InputArrayProxy* x,
+    const interop::InputArrayProxy* y,
+    const interop::OutputArrayProxy* magnitude)
 {
     return cvTry([&] {
-        cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));
+        cv::magnitude(InProxy(*x), InProxy(*y), OutProxy(*magnitude));
     });
 }
 
 CVAPI(ExceptionStatus) core_checkRange(
-    interop::InputArrayProxy a,
+    const interop::InputArrayProxy* a,
     int quiet,
     interop::Point* pos,
     double minVal,
@@ -697,42 +697,42 @@ CVAPI(ExceptionStatus) core_checkRange(
 {
     return cvTry([&] {
         cv::Point pos0;
-        *returnValue = cv::checkRange(InProxy(a), quiet != 0, &pos0, minVal, maxVal);
+        *returnValue = cv::checkRange(InProxy(*a), quiet != 0, &pos0, minVal, maxVal);
         *pos = c(pos0);
     });
 }
 
-CVAPI(ExceptionStatus) core_patchNaNs(interop::InputOutputArrayProxy a, double val)
+CVAPI(ExceptionStatus) core_patchNaNs(const interop::InputOutputArrayProxy* a, double val)
 {
     return cvTry([&] {
-        cv::patchNaNs(IoProxy(a), val);
+        cv::patchNaNs(IoProxy(*a), val);
     });
 }
 
 CVAPI(ExceptionStatus) core_gemm(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
     double alpha,
-    interop::InputArrayProxy src3,
+    const interop::InputArrayProxy* src3,
     double gamma,
-    interop::OutputArrayProxy dst,
+    const interop::OutputArrayProxy* dst,
     int flags)
 {
     return cvTry([&] {
-        cv::gemm(InProxy(src1), InProxy(src2), alpha, InProxy(src3), gamma, OutProxy(dst), flags);
+        cv::gemm(InProxy(*src1), InProxy(*src2), alpha, InProxy(*src3), gamma, OutProxy(*dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_mulTransposed(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int aTa,
-    interop::InputArrayProxy delta,
+    const interop::InputArrayProxy* delta,
     double scale,
     int dtype)
 {
     return cvTry([&] {
-        cv::mulTransposed(InProxy(src), OutProxy(dst), aTa != 0, InProxy(delta), scale, dtype);
+        cv::mulTransposed(InProxy(*src), OutProxy(*dst), aTa != 0, InProxy(*delta), scale, dtype);
     });
 }
 
@@ -741,30 +741,30 @@ CVAPI(ExceptionStatus) core_mulTransposed(
 // The InProxy/OutProxy/IoProxy views (my_types.h) rebuild cv::_InputArray/_OutputArray on this stack
 // frame. The same signature serves both the ref-struct path (optimized kinds, zero managed alloc) and
 // the still-class path (Raw kinds that wrap an existing cv::_InputArray*).
-CVAPI(ExceptionStatus) core_transpose(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_transpose(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::transpose(InProxy(src), OutProxy(dst));
+        cv::transpose(InProxy(*src), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_transform(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy m)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
-        cv::transform(InProxy(src), OutProxy(dst), InProxy(m));
+        cv::transform(InProxy(*src), OutProxy(*dst), InProxy(*m));
     });
 }
 
 CVAPI(ExceptionStatus) core_perspectiveTransform(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
-    interop::InputArrayProxy m)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
-        cv::perspectiveTransform(InProxy(src), OutProxy(dst), InProxy(m));
+        cv::perspectiveTransform(InProxy(*src), OutProxy(*dst), InProxy(*m));
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst, cv::Mat *m)
@@ -773,151 +773,151 @@ CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst,
         cv::perspectiveTransform(*src, *dst, *m);
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, interop::InputArrayProxy m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
         const std::vector<cv::Point2f> srcVector(src, src + srcLength);
         std::vector<cv::Point2f> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(*m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, interop::InputArrayProxy m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
         const std::vector<cv::Point2d> srcVector(src, src + srcLength);
         std::vector<cv::Point2d> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(*m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, interop::InputArrayProxy m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
         const std::vector<cv::Point3f> srcVector(src, src + srcLength);
         std::vector<cv::Point3f> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(*m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, interop::InputArrayProxy m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, const interop::InputArrayProxy* m)
 {
     return cvTry([&] {
         const std::vector<cv::Point3d> srcVector(src, src + srcLength);
         std::vector<cv::Point3d> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(*m));
     });
 }
 
-CVAPI(ExceptionStatus) core_completeSymm(interop::InputOutputArrayProxy mtx, int lowerToUpper)
+CVAPI(ExceptionStatus) core_completeSymm(const interop::InputOutputArrayProxy* mtx, int lowerToUpper)
 {
     return cvTry([&] {
-        cv::completeSymm(IoProxy(mtx), lowerToUpper != 0);
+        cv::completeSymm(IoProxy(*mtx), lowerToUpper != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_setIdentity(interop::InputOutputArrayProxy mtx, interop::Scalar s)
+CVAPI(ExceptionStatus) core_setIdentity(const interop::InputOutputArrayProxy* mtx, interop::Scalar s)
 {
     return cvTry([&] {
-        cv::setIdentity(IoProxy(mtx), cpp(s));
+        cv::setIdentity(IoProxy(*mtx), cpp(s));
     });
 }
 
-CVAPI(ExceptionStatus) core_determinant(interop::InputArrayProxy mtx, double *returnValue)
+CVAPI(ExceptionStatus) core_determinant(const interop::InputArrayProxy* mtx, double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::determinant(InProxy(mtx));
+        *returnValue = cv::determinant(InProxy(*mtx));
     });
 }
 
-CVAPI(ExceptionStatus) core_trace(interop::InputArrayProxy mtx, interop::Scalar *returnValue)
+CVAPI(ExceptionStatus) core_trace(const interop::InputArrayProxy* mtx, interop::Scalar *returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::trace(InProxy(mtx)));
+        *returnValue = c(cv::trace(InProxy(*mtx)));
     });
 }
 
 CVAPI(ExceptionStatus) core_invert(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     int flags,
     double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::invert(InProxy(src), OutProxy(dst), flags);
+        *returnValue = cv::invert(InProxy(*src), OutProxy(*dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_solve(
-    interop::InputArrayProxy src1,
-    interop::InputArrayProxy src2,
-    interop::OutputArrayProxy dst,
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
     int flags,
     int *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::solve(InProxy(src1), InProxy(src2), OutProxy(dst), flags);
+        *returnValue = cv::solve(InProxy(*src1), InProxy(*src2), OutProxy(*dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_solveLP(
-    interop::InputArrayProxy Func,
-    interop::InputArrayProxy Constr,
-    interop::OutputArrayProxy z,
+    const interop::InputArrayProxy* Func,
+    const interop::InputArrayProxy* Constr,
+    const interop::OutputArrayProxy* z,
     int *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::solveLP(InProxy(Func), InProxy(Constr), OutProxy(z));
+        *returnValue = cv::solveLP(InProxy(*Func), InProxy(*Constr), OutProxy(*z));
     });
 }
 
-CVAPI(ExceptionStatus) core_sort(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+CVAPI(ExceptionStatus) core_sort(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags)
 {
     return cvTry([&] {
-        cv::sort(InProxy(src), OutProxy(dst), flags);
+        cv::sort(InProxy(*src), OutProxy(*dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_sortIdx(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+CVAPI(ExceptionStatus) core_sortIdx(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags)
 {
     return cvTry([&] {
-        cv::sortIdx(InProxy(src), OutProxy(dst), flags);
+        cv::sortIdx(InProxy(*src), OutProxy(*dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_solveCubic(interop::InputArrayProxy coeffs, interop::OutputArrayProxy roots, int *returnValue)
+CVAPI(ExceptionStatus) core_solveCubic(const interop::InputArrayProxy* coeffs, const interop::OutputArrayProxy* roots, int *returnValue)
 {
     return cvTry([&] {
-        *returnValue =  cv::solveCubic(InProxy(coeffs), OutProxy(roots));
+        *returnValue =  cv::solveCubic(InProxy(*coeffs), OutProxy(*roots));
     });
 }
 
 CVAPI(ExceptionStatus) core_solvePoly(
-    interop::InputArrayProxy coeffs,
-    interop::OutputArrayProxy roots,
+    const interop::InputArrayProxy* coeffs,
+    const interop::OutputArrayProxy* roots,
     int maxIters,
     double *returnValue)
 {
     return cvTry([&] {
-        *returnValue =  cv::solvePoly(InProxy(coeffs), OutProxy(roots), maxIters);
+        *returnValue =  cv::solvePoly(InProxy(*coeffs), OutProxy(*roots), maxIters);
     });
 }
 
 CVAPI(ExceptionStatus) core_eigen(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy eigenvalues,
-    interop::OutputArrayProxy eigenvectors,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* eigenvalues,
+    const interop::OutputArrayProxy* eigenvectors,
     int *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::eigen(InProxy(src), OutProxy(eigenvalues), OutProxy(eigenvectors)) ? 1 : 0;
+        *returnValue = cv::eigen(InProxy(*src), OutProxy(*eigenvalues), OutProxy(*eigenvectors)) ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) core_eigenNonSymmetric(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy eigenvalues,
-    interop::OutputArrayProxy eigenvectors)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* eigenvalues,
+    const interop::OutputArrayProxy* eigenvectors)
 {
     return cvTry([&] {
-        cv::eigenNonSymmetric(InProxy(src), OutProxy(eigenvalues), OutProxy(eigenvectors));
+        cv::eigenNonSymmetric(InProxy(*src), OutProxy(*eigenvalues), OutProxy(*eigenvectors));
     });
 }
 
@@ -933,154 +933,154 @@ CVAPI(ExceptionStatus) core_calcCovarMatrix_Mat(cv::Mat **samples, int nsamples,
     });
 }
 CVAPI(ExceptionStatus) core_calcCovarMatrix_InputArray(
-    interop::InputArrayProxy samples,
-    interop::OutputArrayProxy covar,
-    interop::InputOutputArrayProxy mean,
+    const interop::InputArrayProxy* samples,
+    const interop::OutputArrayProxy* covar,
+    const interop::InputOutputArrayProxy* mean,
     int flags,
     int ctype)
 {
     return cvTry([&] {
-        cv::calcCovarMatrix(InProxy(samples), OutProxy(covar), IoProxy(mean), flags, ctype);
+        cv::calcCovarMatrix(InProxy(*samples), OutProxy(*covar), IoProxy(*mean), flags, ctype);
     });
 }
 
 CVAPI(ExceptionStatus) core_PCACompute(
-    interop::InputArrayProxy data,
-    interop::InputOutputArrayProxy mean,
-    interop::OutputArrayProxy eigenvectors,
+    const interop::InputArrayProxy* data,
+    const interop::InputOutputArrayProxy* mean,
+    const interop::OutputArrayProxy* eigenvectors,
     int maxComponents)
 {
     return cvTry([&] {
-        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), maxComponents);
+        cv::PCACompute(InProxy(*data), IoProxy(*mean), OutProxy(*eigenvectors), maxComponents);
     });
 }
 CVAPI(ExceptionStatus) core_PCACompute2(
-    interop::InputArrayProxy data,
-    interop::InputOutputArrayProxy mean,
-    interop::OutputArrayProxy eigenvectors,
-    interop::OutputArrayProxy eigenvalues,
+    const interop::InputArrayProxy* data,
+    const interop::InputOutputArrayProxy* mean,
+    const interop::OutputArrayProxy* eigenvectors,
+    const interop::OutputArrayProxy* eigenvalues,
     int maxComponents)
 {
     return cvTry([&] {
-        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), OutProxy(eigenvalues), maxComponents);
+        cv::PCACompute(InProxy(*data), IoProxy(*mean), OutProxy(*eigenvectors), OutProxy(*eigenvalues), maxComponents);
     });
 }
 
 CVAPI(ExceptionStatus) core_PCAComputeVar(
-    interop::InputArrayProxy data,
-    interop::InputOutputArrayProxy mean,
-    interop::OutputArrayProxy eigenvectors,
+    const interop::InputArrayProxy* data,
+    const interop::InputOutputArrayProxy* mean,
+    const interop::OutputArrayProxy* eigenvectors,
     double retainedVariance)
 {
     return cvTry([&] {
-        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), retainedVariance);
+        cv::PCACompute(InProxy(*data), IoProxy(*mean), OutProxy(*eigenvectors), retainedVariance);
     });
 }
 CVAPI(ExceptionStatus) core_PCAComputeVar2(
-    interop::InputArrayProxy data,
-    interop::InputOutputArrayProxy mean,
-    interop::OutputArrayProxy eigenvectors,
-    interop::OutputArrayProxy eigenvalues,
+    const interop::InputArrayProxy* data,
+    const interop::InputOutputArrayProxy* mean,
+    const interop::OutputArrayProxy* eigenvectors,
+    const interop::OutputArrayProxy* eigenvalues,
     double retainedVariance)
 {
     return cvTry([&] {
-        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), OutProxy(eigenvalues), retainedVariance);
+        cv::PCACompute(InProxy(*data), IoProxy(*mean), OutProxy(*eigenvectors), OutProxy(*eigenvalues), retainedVariance);
     });
 }
 
 CVAPI(ExceptionStatus) core_PCAProject(
-    interop::InputArrayProxy data,
-    interop::InputArrayProxy mean,
-    interop::InputArrayProxy eigenvectors,
-    interop::OutputArrayProxy result)
+    const interop::InputArrayProxy* data,
+    const interop::InputArrayProxy* mean,
+    const interop::InputArrayProxy* eigenvectors,
+    const interop::OutputArrayProxy* result)
 {
     return cvTry([&] {
-        cv::PCAProject(InProxy(data), InProxy(mean), InProxy(eigenvectors), OutProxy(result));
+        cv::PCAProject(InProxy(*data), InProxy(*mean), InProxy(*eigenvectors), OutProxy(*result));
     });
 }
 CVAPI(ExceptionStatus) core_PCABackProject(
-    interop::InputArrayProxy data,
-    interop::InputArrayProxy mean,
-    interop::InputArrayProxy eigenvectors,
-    interop::OutputArrayProxy result)
+    const interop::InputArrayProxy* data,
+    const interop::InputArrayProxy* mean,
+    const interop::InputArrayProxy* eigenvectors,
+    const interop::OutputArrayProxy* result)
 {
     return cvTry([&] {
-        cv::PCABackProject(InProxy(data), InProxy(mean), InProxy(eigenvectors), OutProxy(result));
+        cv::PCABackProject(InProxy(*data), InProxy(*mean), InProxy(*eigenvectors), OutProxy(*result));
     });
 }
 
 CVAPI(ExceptionStatus) core_SVDecomp(
-    interop::InputArrayProxy src,
-    interop::OutputArrayProxy w,
-    interop::OutputArrayProxy u,
-    interop::OutputArrayProxy vt,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* w,
+    const interop::OutputArrayProxy* u,
+    const interop::OutputArrayProxy* vt,
     int flags)
 {
     return cvTry([&] {
-        cv::SVDecomp(InProxy(src), OutProxy(w), OutProxy(u), OutProxy(vt), flags);
+        cv::SVDecomp(InProxy(*src), OutProxy(*w), OutProxy(*u), OutProxy(*vt), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_SVBackSubst(
-    interop::InputArrayProxy w,
-    interop::InputArrayProxy u,
-    interop::InputArrayProxy vt,
-    interop::InputArrayProxy rhs,
-    interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* w,
+    const interop::InputArrayProxy* u,
+    const interop::InputArrayProxy* vt,
+    const interop::InputArrayProxy* rhs,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::SVBackSubst(InProxy(w), InProxy(u), InProxy(vt), InProxy(rhs), OutProxy(dst));
+        cv::SVBackSubst(InProxy(*w), InProxy(*u), InProxy(*vt), InProxy(*rhs), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_Mahalanobis(
-    interop::InputArrayProxy v1,
-    interop::InputArrayProxy v2,
-    interop::InputArrayProxy icovar,
+    const interop::InputArrayProxy* v1,
+    const interop::InputArrayProxy* v2,
+    const interop::InputArrayProxy* icovar,
     double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::Mahalanobis(InProxy(v1), InProxy(v2), InProxy(icovar));
+        *returnValue = cv::Mahalanobis(InProxy(*v1), InProxy(*v2), InProxy(*icovar));
     });
 }
 
-CVAPI(ExceptionStatus) core_dft(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags, int nonzeroRows)
+CVAPI(ExceptionStatus) core_dft(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-        cv::dft(InProxy(src), OutProxy(dst), flags, nonzeroRows);
+        cv::dft(InProxy(*src), OutProxy(*dst), flags, nonzeroRows);
     });
 }
 
-CVAPI(ExceptionStatus) core_idft(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags, int nonzeroRows)
+CVAPI(ExceptionStatus) core_idft(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-        cv::idft(InProxy(src), OutProxy(dst), flags, nonzeroRows);
+        cv::idft(InProxy(*src), OutProxy(*dst), flags, nonzeroRows);
     });
 }
 
-CVAPI(ExceptionStatus) core_dct(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+CVAPI(ExceptionStatus) core_dct(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags)
 {
     return cvTry([&] {
-        cv::dct(InProxy(src), OutProxy(dst), flags);
+        cv::dct(InProxy(*src), OutProxy(*dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_idct(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+CVAPI(ExceptionStatus) core_idct(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int flags)
 {
     return cvTry([&] {
-        cv::idct(InProxy(src), OutProxy(dst), flags);
+        cv::idct(InProxy(*src), OutProxy(*dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_mulSpectrums(
-    interop::InputArrayProxy a,
-    interop::InputArrayProxy b,
-    interop::OutputArrayProxy c,
+    const interop::InputArrayProxy* a,
+    const interop::InputArrayProxy* b,
+    const interop::OutputArrayProxy* c,
     int flags,
     int conjB)
 {
     return cvTry([&] {
-        cv::mulSpectrums(InProxy(a), InProxy(b), OutProxy(c), flags, conjB != 0);
+        cv::mulSpectrums(InProxy(*a), InProxy(*b), OutProxy(*c), flags, conjB != 0);
     });
 }
 
@@ -1106,56 +1106,56 @@ CVAPI(ExceptionStatus) core_theRNG_set(uint64 value)
     });
 }
 
-CVAPI(ExceptionStatus) core_randu_InputArray(interop::InputOutputArrayProxy dst, interop::InputArrayProxy low, interop::InputArrayProxy high)
+CVAPI(ExceptionStatus) core_randu_InputArray(const interop::InputOutputArrayProxy* dst, const interop::InputArrayProxy* low, const interop::InputArrayProxy* high)
 {
     return cvTry([&] {
-        cv::randu(IoProxy(dst), InProxy(low), InProxy(high));
+        cv::randu(IoProxy(*dst), InProxy(*low), InProxy(*high));
     });
 }
-CVAPI(ExceptionStatus) core_randu_Scalar(interop::InputOutputArrayProxy dst, interop::Scalar low, interop::Scalar high)
+CVAPI(ExceptionStatus) core_randu_Scalar(const interop::InputOutputArrayProxy* dst, interop::Scalar low, interop::Scalar high)
 {
     return cvTry([&] {
-        cv::randu(IoProxy(dst), cpp(low), cpp(high));
-    });
-}
-
-CVAPI(ExceptionStatus) core_randn_InputArray(interop::InputOutputArrayProxy dst, interop::InputArrayProxy mean, interop::InputArrayProxy stddev)
-{
-    return cvTry([&] {
-        cv::randn(IoProxy(dst), InProxy(mean), InProxy(stddev));
-    });
-}
-CVAPI(ExceptionStatus) core_randn_Scalar(interop::InputOutputArrayProxy dst, interop::Scalar mean, interop::Scalar stddev)
-{
-    return cvTry([&] {
-        cv::randn(IoProxy(dst), cpp(mean), cpp(stddev));
+        cv::randu(IoProxy(*dst), cpp(low), cpp(high));
     });
 }
 
-CVAPI(ExceptionStatus) core_randShuffle(interop::InputOutputArrayProxy dst, double iterFactor, uint64 *rng)
+CVAPI(ExceptionStatus) core_randn_InputArray(const interop::InputOutputArrayProxy* dst, const interop::InputArrayProxy* mean, const interop::InputArrayProxy* stddev)
+{
+    return cvTry([&] {
+        cv::randn(IoProxy(*dst), InProxy(*mean), InProxy(*stddev));
+    });
+}
+CVAPI(ExceptionStatus) core_randn_Scalar(const interop::InputOutputArrayProxy* dst, interop::Scalar mean, interop::Scalar stddev)
+{
+    return cvTry([&] {
+        cv::randn(IoProxy(*dst), cpp(mean), cpp(stddev));
+    });
+}
+
+CVAPI(ExceptionStatus) core_randShuffle(const interop::InputOutputArrayProxy* dst, double iterFactor, uint64 *rng)
 {
     return cvTry([&] {
         cv::RNG rng0;
         if (rng != nullptr)
             rng0.state = *rng;
-        cv::randShuffle(IoProxy(dst), iterFactor, &rng0);
+        cv::randShuffle(IoProxy(*dst), iterFactor, &rng0);
         if (rng != nullptr)
             *rng = rng0.state;
     });
 }
 
 CVAPI(ExceptionStatus) core_kmeans(
-    interop::InputArrayProxy data,
+    const interop::InputArrayProxy* data,
     int k,
-    interop::InputOutputArrayProxy bestLabels,
+    const interop::InputOutputArrayProxy* bestLabels,
     interop::TermCriteria criteria,
     int attempts,
     int flags,
-    interop::OutputArrayProxy centers,
+    const interop::OutputArrayProxy* centers,
     double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::kmeans(InProxy(data), k, IoProxy(bestLabels), cpp(criteria), attempts, flags, OutProxy(centers));
+        *returnValue = cv::kmeans(InProxy(*data), k, IoProxy(*bestLabels), cpp(criteria), attempts, flags, OutProxy(*centers));
     });
 }
 
@@ -1345,10 +1345,10 @@ CVAPI(ExceptionStatus) core_useOptimized(int *returnValue)
     });
 }
 
-CVAPI(ExceptionStatus) core_format(interop::InputArrayProxy mtx, int fmt, std::string *buf)
+CVAPI(ExceptionStatus) core_format(const interop::InputArrayProxy* mtx, int fmt, std::string *buf)
 {
     return cvTry([&] {
-        const auto formatted = cv::format(InProxy(mtx), static_cast<cv::Formatter::FormatType>(fmt));
+        const auto formatted = cv::format(InProxy(*mtx), static_cast<cv::Formatter::FormatType>(fmt));
 
         std::stringstream s;
         s << formatted;
@@ -1380,15 +1380,15 @@ CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *ret
 
 CVAPI(ExceptionStatus) core_RNG_fill(
     uint64 *state,
-    interop::InputOutputArrayProxy mat,
+    const interop::InputOutputArrayProxy* mat,
     int distType,
-    interop::InputArrayProxy a,
-    interop::InputArrayProxy b,
+    const interop::InputArrayProxy* a,
+    const interop::InputArrayProxy* b,
     int saturateRange)
 {
     return cvTry([&] {
         cv::RNG rng(*state);
-        rng.fill(IoProxy(mat), distType, InProxy(a), InProxy(b), saturateRange != 0);
+        rng.fill(IoProxy(*mat), distType, InProxy(*a), InProxy(*b), saturateRange != 0);
         *state = rng.state;
     });
 }

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -24,7 +24,11 @@ CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, in
 }
 
 CVAPI(ExceptionStatus) core_copyMakeBorder(
-    interop::InputArrayProxy src, interop::OutputArrayProxy dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int top, int bottom, int left, int right,
+    int borderType,
+    interop::Scalar value)
 {
     return cvTry([&] {
     cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
@@ -32,7 +36,11 @@ CVAPI(ExceptionStatus) core_copyMakeBorder(
 }
 
 CVAPI(ExceptionStatus) core_add(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask,
+    int dtype)
 {
     return cvTry([&] {
     cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
@@ -40,21 +48,33 @@ CVAPI(ExceptionStatus) core_add(
 }
 
 CVAPI(ExceptionStatus) core_subtract_InputArray2(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask,
+    int dtype)
 {
     return cvTry([&] {
     cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
-    interop::InputArrayProxy src1, interop::Scalar src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1,
+    interop::Scalar src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask,
+    int dtype)
 {
     return cvTry([&] {
     cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
-    interop::Scalar src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
+    interop::Scalar src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask,
+    int dtype)
 {
     return cvTry([&] {
     cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
@@ -62,49 +82,77 @@ CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
 }
 
 CVAPI(ExceptionStatus) core_multiply(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, double scale, int dtype)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    double scale,
+    int dtype)
 {
     return cvTry([&] {
     cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide1(
-    double scale, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int dtype)
+    double scale,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    int dtype)
 {
     return cvTry([&] {
     cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide2(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, double scale, int dtype)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    double scale,
+    int dtype)
 {
     return cvTry([&] {
     cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 
-CVAPI(ExceptionStatus) core_scaleAdd(interop::InputArrayProxy src1, double alpha, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_scaleAdd(
+    interop::InputArrayProxy src1,
+    double alpha,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
     });
 }
-CVAPI(ExceptionStatus) core_addWeighted(interop::InputArrayProxy src1, double alpha, interop::InputArrayProxy src2,
-                             double beta, double gamma, interop::OutputArrayProxy dst, int dtype)
+CVAPI(ExceptionStatus) core_addWeighted(
+    interop::InputArrayProxy src1,
+    double alpha,
+    interop::InputArrayProxy src2,
+    double beta,
+    double gamma,
+    interop::OutputArrayProxy dst,
+    int dtype)
 {
     return cvTry([&] {
     cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
     });
 }
 
-CVAPI(ExceptionStatus) core_convertScaleAbs(interop::InputArrayProxy src, interop::OutputArrayProxy dst, double alpha, double beta)
+CVAPI(ExceptionStatus) core_convertScaleAbs(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    double alpha,
+    double beta)
 {
     return cvTry([&] {
     cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
     });
 }
 
-CVAPI(ExceptionStatus) core_LUT(interop::InputArrayProxy src, interop::InputArrayProxy lut, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_LUT(
+    interop::InputArrayProxy src,
+    interop::InputArrayProxy lut,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
@@ -132,7 +180,10 @@ CVAPI(ExceptionStatus) core_findNonZero(interop::InputArrayProxy src, interop::O
     });
 }
 
-CVAPI(ExceptionStatus) core_mean(interop::InputArrayProxy src, interop::InputArrayProxy mask, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_mean(
+    interop::InputArrayProxy src,
+    interop::InputArrayProxy mask,
+    interop::Scalar* returnValue)
 {
     return cvTry([&] {
     *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
@@ -362,28 +413,39 @@ CVAPI(ExceptionStatus) core_vconcat2(cv::_InputArray* src1, cv::_InputArray* src
 }
 
 CVAPI(ExceptionStatus) core_bitwise_and(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
-    interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
@@ -391,14 +453,19 @@ CVAPI(ExceptionStatus) core_bitwise_not(
 }
 
 CVAPI(ExceptionStatus) core_absdiff(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_copyTo(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) core_copyTo(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
@@ -406,14 +473,20 @@ CVAPI(ExceptionStatus) core_copyTo(interop::InputArrayProxy src, interop::Output
 }
 
 CVAPI(ExceptionStatus) core_inRange_InputArray(
-    interop::InputArrayProxy src, interop::InputArrayProxy lowerb, interop::InputArrayProxy upperb, interop::OutputArrayProxy dst)
+    interop::InputArrayProxy src,
+    interop::InputArrayProxy lowerb,
+    interop::InputArrayProxy upperb,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
-    interop::InputArrayProxy src, interop::Scalar lowerb, interop::Scalar upperb, interop::OutputArrayProxy dst)
+    interop::InputArrayProxy src,
+    interop::Scalar lowerb,
+    interop::Scalar upperb,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
@@ -421,14 +494,20 @@ CVAPI(ExceptionStatus) core_inRange_Scalar(
 }
 
 CVAPI(ExceptionStatus) core_compare(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int cmpop)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    int cmpop)
 {
     return cvTry([&] {
     cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
     });
 }
 
-CVAPI(ExceptionStatus) core_min1(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_min1(
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
@@ -455,7 +534,10 @@ CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* d
     });
 }
 
-CVAPI(ExceptionStatus) core_max1(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) core_max1(
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
@@ -508,30 +590,45 @@ CVAPI(ExceptionStatus) core_log_Mat(interop::InputArrayProxy src, interop::Outpu
     });
 }
 
-CVAPI(ExceptionStatus) core_polarToCart(interop::InputArrayProxy magnitude, interop::InputArrayProxy angle,
-    interop::OutputArrayProxy x, interop::OutputArrayProxy y, int angleInDegrees)
+CVAPI(ExceptionStatus) core_polarToCart(
+    interop::InputArrayProxy magnitude,
+    interop::InputArrayProxy angle,
+    interop::OutputArrayProxy x,
+    interop::OutputArrayProxy y,
+    int angleInDegrees)
 {
     return cvTry([&] {
     cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_cartToPolar(interop::InputArrayProxy x, interop::InputArrayProxy y,
-    interop::OutputArrayProxy magnitude, interop::OutputArrayProxy angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_cartToPolar(
+    interop::InputArrayProxy x,
+    interop::InputArrayProxy y,
+    interop::OutputArrayProxy magnitude,
+    interop::OutputArrayProxy angle,
+    int angleInDegrees)
 {
     return cvTry([&] {
     cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_phase(interop::InputArrayProxy x, interop::InputArrayProxy y, interop::OutputArrayProxy angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_phase(
+    interop::InputArrayProxy x,
+    interop::InputArrayProxy y,
+    interop::OutputArrayProxy angle,
+    int angleInDegrees)
 {
     return cvTry([&] {
     cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_magnitude_Mat(interop::InputArrayProxy x, interop::InputArrayProxy y, interop::OutputArrayProxy magnitude)
+CVAPI(ExceptionStatus) core_magnitude_Mat(
+    interop::InputArrayProxy x,
+    interop::InputArrayProxy y,
+    interop::OutputArrayProxy magnitude)
 {
     return cvTry([&] {
     cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -19,7 +19,7 @@ CVAPI(interop::RotatedRect) core_RotatedRect_byThreeVertexPoints(
 CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::borderInterpolate(p, len, borderType);
+        *returnValue = cv::borderInterpolate(p, len, borderType);
     });
 }
 
@@ -31,7 +31,7 @@ CVAPI(ExceptionStatus) core_copyMakeBorder(
     interop::Scalar value)
 {
     return cvTry([&] {
-    cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
+        cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
     });
 }
 
@@ -43,7 +43,7 @@ CVAPI(ExceptionStatus) core_add(
     int dtype)
 {
     return cvTry([&] {
-    cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 
@@ -55,7 +55,7 @@ CVAPI(ExceptionStatus) core_subtract_InputArray2(
     int dtype)
 {
     return cvTry([&] {
-    cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
@@ -66,7 +66,7 @@ CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
     int dtype)
 {
     return cvTry([&] {
-    cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
@@ -77,7 +77,7 @@ CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
     int dtype)
 {
     return cvTry([&] {
-    cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
+        cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 
@@ -89,7 +89,7 @@ CVAPI(ExceptionStatus) core_multiply(
     int dtype)
 {
     return cvTry([&] {
-    cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
+        cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide1(
@@ -99,7 +99,7 @@ CVAPI(ExceptionStatus) core_divide1(
     int dtype)
 {
     return cvTry([&] {
-    cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
+        cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide2(
@@ -110,7 +110,7 @@ CVAPI(ExceptionStatus) core_divide2(
     int dtype)
 {
     return cvTry([&] {
-    cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
+        cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 
@@ -121,7 +121,7 @@ CVAPI(ExceptionStatus) core_scaleAdd(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
+        cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_addWeighted(
@@ -134,7 +134,7 @@ CVAPI(ExceptionStatus) core_addWeighted(
     int dtype)
 {
     return cvTry([&] {
-    cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
+        cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
     });
 }
 
@@ -145,7 +145,7 @@ CVAPI(ExceptionStatus) core_convertScaleAbs(
     double beta)
 {
     return cvTry([&] {
-    cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
+        cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
     });
 }
 
@@ -155,28 +155,28 @@ CVAPI(ExceptionStatus) core_LUT(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
+        cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_sum(interop::InputArrayProxy src, interop::Scalar* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::sum(InProxy(src)));
+        *returnValue = c(cv::sum(InProxy(src)));
     });
 }
 
 CVAPI(ExceptionStatus) core_countNonZero(interop::InputArrayProxy src, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::countNonZero(InProxy(src));
+        *returnValue = cv::countNonZero(InProxy(src));
     });
 }
 
 CVAPI(ExceptionStatus) core_findNonZero(interop::InputArrayProxy src, interop::OutputArrayProxy idx)
 {
     return cvTry([&] {
-    cv::findNonZero(InProxy(src), OutProxy(idx));
+        cv::findNonZero(InProxy(src), OutProxy(idx));
     });
 }
 
@@ -186,7 +186,7 @@ CVAPI(ExceptionStatus) core_mean(
     interop::Scalar* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
+        *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
     });
 }
 
@@ -197,7 +197,7 @@ CVAPI(ExceptionStatus) core_meanStdDev_OutputArray(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::meanStdDev(InProxy(src), OutProxy(mean), OutProxy(stddev), InProxy(mask));
+        cv::meanStdDev(InProxy(src), OutProxy(mean), OutProxy(stddev), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_meanStdDev_Scalar(
@@ -207,10 +207,10 @@ CVAPI(ExceptionStatus) core_meanStdDev_Scalar(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::Scalar mean0, stddev0;
-    cv::meanStdDev(InProxy(src), mean0, stddev0, InProxy(mask));
-    *mean = c(mean0);
-    *stddev = c(stddev0);
+        cv::Scalar mean0, stddev0;
+        cv::meanStdDev(InProxy(src), mean0, stddev0, InProxy(mask));
+        *mean = c(mean0);
+        *stddev = c(stddev0);
     });
 }
 
@@ -221,7 +221,7 @@ CVAPI(ExceptionStatus) core_norm1(
     double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::norm(InProxy(src1), normType, InProxy(mask));
+        *returnValue = cv::norm(InProxy(src1), normType, InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_norm2(
@@ -232,7 +232,7 @@ CVAPI(ExceptionStatus) core_norm2(
     double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::norm(InProxy(src1), InProxy(src2), normType, InProxy(mask));
+        *returnValue = cv::norm(InProxy(src1), InProxy(src2), normType, InProxy(mask));
     });
 }
 
@@ -243,7 +243,7 @@ CVAPI(ExceptionStatus) core_PSNR(
     double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::PSNR(InProxy(src1), InProxy(src2), R);
+        *returnValue = cv::PSNR(InProxy(src1), InProxy(src2), R);
     });
 }
 
@@ -260,8 +260,8 @@ CVAPI(ExceptionStatus) core_batchDistance(
     int crosscheck)
 {
     return cvTry([&] {
-    cv::batchDistance(
-        InProxy(src1), InProxy(src2), OutProxy(dist), dtype, OutProxy(nidx), normType, K, InProxy(mask), update, crosscheck != 0);
+        cv::batchDistance(
+            InProxy(src1), InProxy(src2), OutProxy(dist), dtype, OutProxy(nidx), normType, K, InProxy(mask), update, crosscheck != 0);
     });
 }
 
@@ -275,7 +275,7 @@ CVAPI(ExceptionStatus) core_normalize(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::normalize(InProxy(src), IoProxy(dst), alpha, beta, normType, dtype, InProxy(mask));
+        cv::normalize(InProxy(src), IoProxy(dst), alpha, beta, normType, dtype, InProxy(mask));
     });
 }
 
@@ -286,7 +286,7 @@ CVAPI(ExceptionStatus) core_reduceArgMax(
     bool lastIndex)
 {
     return cvTry([&] {
-    cv::reduceArgMax(InProxy(src), OutProxy(dst), axis, lastIndex);
+        cv::reduceArgMax(InProxy(src), OutProxy(dst), axis, lastIndex);
     });
 }
 
@@ -297,14 +297,14 @@ CVAPI(ExceptionStatus) core_reduceArgMin(
     bool lastIndex)
 {
     return cvTry([&] {
-    cv::reduceArgMin(InProxy(src), OutProxy(dst), axis, lastIndex);
+        cv::reduceArgMin(InProxy(src), OutProxy(dst), axis, lastIndex);
     });
 }
 
 CVAPI(ExceptionStatus) core_minMaxLoc1(interop::InputArrayProxy src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-    cv::minMaxLoc(InProxy(src), minVal, maxVal);
+        cv::minMaxLoc(InProxy(src), minVal, maxVal);
     });
 }
 CVAPI(ExceptionStatus) core_minMaxLoc2(
@@ -316,17 +316,17 @@ CVAPI(ExceptionStatus) core_minMaxLoc2(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::Point minLoc0, maxLoc0;
-    cv::minMaxLoc(InProxy(src), minVal, maxVal, &minLoc0, &maxLoc0, InProxy(mask));
-    *minLoc = c(minLoc0);
-    *maxLoc = c(maxLoc0);
+        cv::Point minLoc0, maxLoc0;
+        cv::minMaxLoc(InProxy(src), minVal, maxVal, &minLoc0, &maxLoc0, InProxy(mask));
+        *minLoc = c(minLoc0);
+        *maxLoc = c(maxLoc0);
     });
 }
 
 CVAPI(ExceptionStatus) core_minMaxIdx1(interop::InputArrayProxy src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-    cv::minMaxIdx(InProxy(src), minVal, maxVal);
+        cv::minMaxIdx(InProxy(src), minVal, maxVal);
     });
 }
 CVAPI(ExceptionStatus) core_minMaxIdx2(
@@ -338,7 +338,7 @@ CVAPI(ExceptionStatus) core_minMaxIdx2(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::minMaxIdx(InProxy(src), minVal, maxVal, minIdx, maxIdx, InProxy(mask));
+        cv::minMaxIdx(InProxy(src), minVal, maxVal, minIdx, maxIdx, InProxy(mask));
     });
 }
 
@@ -350,67 +350,67 @@ CVAPI(ExceptionStatus) core_reduce(
     int dtype)
 {
     return cvTry([&] {
-    cv::reduce(InProxy(src), OutProxy(dst), dim, rtype, dtype);
+        cv::reduce(InProxy(src), OutProxy(dst), dim, rtype, dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_merge(cv::Mat** mv, uint32_t count, cv::Mat* dst)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> vec(static_cast<size_t>(count));
-    for (uint32_t i = 0; i < count; i++)
-        vec[i] = *mv[i];
+        std::vector<cv::Mat> vec(static_cast<size_t>(count));
+        for (uint32_t i = 0; i < count; i++)
+            vec[i] = *mv[i];
 
-    cv::merge(vec, *dst);
+        cv::merge(vec, *dst);
     });
 }
 
 CVAPI(ExceptionStatus) core_split(cv::Mat* src, std::vector<cv::Mat>* mv)
 {
     return cvTry([&] {
-    cv::split(*src, *mv);
+        cv::split(*src, *mv);
     });
 }
 
 CVAPI(ExceptionStatus) core_mixChannels(cv::Mat** src, uint32_t nsrcs, cv::Mat** dst, uint32_t ndsts, int* fromTo, uint32_t npairs)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrcs));
-    std::vector<cv::Mat> dstVec(static_cast<size_t>(ndsts));
-    for (uint32_t i = 0; i < nsrcs; i++)
-        srcVec[i] = *(src[i]);
-    for (uint32_t i = 0; i < ndsts; i++)
-        dstVec[i] = *(dst[i]);
+        std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrcs));
+        std::vector<cv::Mat> dstVec(static_cast<size_t>(ndsts));
+        for (uint32_t i = 0; i < nsrcs; i++)
+            srcVec[i] = *(src[i]);
+        for (uint32_t i = 0; i < ndsts; i++)
+            dstVec[i] = *(dst[i]);
 
-    cv::mixChannels(srcVec, dstVec, fromTo, npairs);
+        cv::mixChannels(srcVec, dstVec, fromTo, npairs);
     });
 }
 
 CVAPI(ExceptionStatus) core_extractChannel(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int coi)
 {
     return cvTry([&] {
-    cv::extractChannel(InProxy(src), OutProxy(dst), coi);
+        cv::extractChannel(InProxy(src), OutProxy(dst), coi);
     });
 }
 
 CVAPI(ExceptionStatus) core_insertChannel(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, int coi)
 {
     return cvTry([&] {
-    cv::insertChannel(InProxy(src), IoProxy(dst), coi);
+        cv::insertChannel(InProxy(src), IoProxy(dst), coi);
     });
 }
 
 CVAPI(ExceptionStatus) core_flip(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flipCode)
 {
     return cvTry([&] {
-    cv::flip(InProxy(src), OutProxy(dst), flipCode);
+        cv::flip(InProxy(src), OutProxy(dst), flipCode);
     });
 }
 
 CVAPI(ExceptionStatus) core_rotate(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int rotateCode)
 {
     return cvTry([&] {
-    cv::rotate(InProxy(src), OutProxy(dst), rotateCode);
+        cv::rotate(InProxy(src), OutProxy(dst), rotateCode);
     });
 }
 
@@ -421,46 +421,46 @@ CVAPI(ExceptionStatus) core_repeat1(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::repeat(InProxy(src), ny, nx, OutProxy(dst));
+        cv::repeat(InProxy(src), ny, nx, OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** returnValue)
 {
     return cvTry([&] {
-    const cv::Mat ret = cv::repeat(*src, ny, nx);
-    *returnValue = new cv::Mat(ret);
+        const cv::Mat ret = cv::repeat(*src, ny, nx);
+        *returnValue = new cv::Mat(ret);
     });
 }
 
 CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
-    for (uint32_t i = 0; i < nsrc; i++)
-        srcVec[i] = *(src[i]);
-    cv::hconcat(&srcVec[0], nsrc, *dst);
+        std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
+        for (uint32_t i = 0; i < nsrc; i++)
+            srcVec[i] = *(src[i]);
+        cv::hconcat(&srcVec[0], nsrc, *dst);
     });
 }
 CVAPI(ExceptionStatus) core_hconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::hconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::hconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
-    for (uint32_t i = 0; i < nsrc; i++)
-        srcVec[i] = *(src[i]);
-    cv::vconcat(&srcVec[0], nsrc, *dst);
+        std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
+        for (uint32_t i = 0; i < nsrc; i++)
+            srcVec[i] = *(src[i]);
+        cv::vconcat(&srcVec[0], nsrc, *dst);
     });
 }
 CVAPI(ExceptionStatus) core_vconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::vconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::vconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
@@ -471,7 +471,7 @@ CVAPI(ExceptionStatus) core_bitwise_and(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
@@ -481,7 +481,7 @@ CVAPI(ExceptionStatus) core_bitwise_or(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
@@ -491,7 +491,7 @@ CVAPI(ExceptionStatus) core_bitwise_xor(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
+        cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
@@ -500,7 +500,7 @@ CVAPI(ExceptionStatus) core_bitwise_not(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
+        cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
     });
 }
 
@@ -510,7 +510,7 @@ CVAPI(ExceptionStatus) core_absdiff(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
+        cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
@@ -520,7 +520,7 @@ CVAPI(ExceptionStatus) core_copyTo(
     interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
+        cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
     });
 }
 
@@ -531,7 +531,7 @@ CVAPI(ExceptionStatus) core_inRange_InputArray(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
+        cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
@@ -541,7 +541,7 @@ CVAPI(ExceptionStatus) core_inRange_Scalar(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
+        cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
     });
 }
 
@@ -552,7 +552,7 @@ CVAPI(ExceptionStatus) core_compare(
     int cmpop)
 {
     return cvTry([&] {
-    cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
+        cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
     });
 }
 
@@ -562,27 +562,27 @@ CVAPI(ExceptionStatus) core_min1(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
-    // overload, and passing InProxy temporaries makes overload resolution pick it (it builds a MatExpr
-    // over dangling temporaries -> heap corruption, plus C4834). Binding to named cv::_InputArray
-    // lvalues forces the void min(InputArray,InputArray,OutputArray) overload.
-    cv::Scalar s1, s2;
-    const cv::_InputArray a = fromInputProxy(src1, s1);
-    const cv::_InputArray b = fromInputProxy(src2, s2);
-    cv::_OutputArray d = fromOutputProxy(dst);
-    cv::min(a, b, d);
+        // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
+        // overload, and passing InProxy temporaries makes overload resolution pick it (it builds a MatExpr
+        // over dangling temporaries -> heap corruption, plus C4834). Binding to named cv::_InputArray
+        // lvalues forces the void min(InputArray,InputArray,OutputArray) overload.
+        cv::Scalar s1, s2;
+        const cv::_InputArray a = fromInputProxy(src1, s1);
+        const cv::_InputArray b = fromInputProxy(src2, s2);
+        cv::_OutputArray d = fromOutputProxy(dst);
+        cv::min(a, b, d);
     });
 }
 CVAPI(ExceptionStatus) core_min_MatMat(cv::Mat* src1, cv::Mat* src2, cv::Mat* dst)
 {
     return cvTry([&] {
-    cv::min(*src1, *src2, *dst);
+        cv::min(*src1, *src2, *dst);
     });
 }
 CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* dst)
 {
     return cvTry([&] {
-    cv::min(*src1, src2, *dst);
+        cv::min(*src1, src2, *dst);
     });
 }
 
@@ -592,53 +592,53 @@ CVAPI(ExceptionStatus) core_max1(
     interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
-    // instead of the [[nodiscard]] MatExpr max(Mat,Mat).
-    cv::Scalar s1, s2;
-    const cv::_InputArray a = fromInputProxy(src1, s1);
-    const cv::_InputArray b = fromInputProxy(src2, s2);
-    cv::_OutputArray d = fromOutputProxy(dst);
-    cv::max(a, b, d);
+        // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
+        // instead of the [[nodiscard]] MatExpr max(Mat,Mat).
+        cv::Scalar s1, s2;
+        const cv::_InputArray a = fromInputProxy(src1, s1);
+        const cv::_InputArray b = fromInputProxy(src2, s2);
+        cv::_OutputArray d = fromOutputProxy(dst);
+        cv::max(a, b, d);
     });
 }
 CVAPI(ExceptionStatus) core_max_MatMat(cv::Mat *src1, const cv::Mat *src2, cv::Mat *dst)
 {
     return cvTry([&] {
-    cv::max(*src1, *src2, *dst);
+        cv::max(*src1, *src2, *dst);
     });
 }
 CVAPI(ExceptionStatus) core_max_MatDouble(cv::Mat *src1, double src2, cv::Mat *dst)
 {
     return cvTry([&] {
-    cv::max(*src1, src2, *dst);
+        cv::max(*src1, src2, *dst);
     });
 }
 
 CVAPI(ExceptionStatus) core_sqrt(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::sqrt(InProxy(src), OutProxy(dst));
+        cv::sqrt(InProxy(src), OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_pow_Mat(interop::InputArrayProxy src, double power, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::pow(InProxy(src), power, OutProxy(dst));
+        cv::pow(InProxy(src), power, OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_exp_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::exp(InProxy(src), OutProxy(dst));
+        cv::exp(InProxy(src), OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_log_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::log(InProxy(src), OutProxy(dst));
+        cv::log(InProxy(src), OutProxy(dst));
     });
 }
 
@@ -650,7 +650,7 @@ CVAPI(ExceptionStatus) core_polarToCart(
     int angleInDegrees)
 {
     return cvTry([&] {
-    cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
+        cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
     });
 }
 
@@ -662,7 +662,7 @@ CVAPI(ExceptionStatus) core_cartToPolar(
     int angleInDegrees)
 {
     return cvTry([&] {
-    cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
+        cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
@@ -673,7 +673,7 @@ CVAPI(ExceptionStatus) core_phase(
     int angleInDegrees)
 {
     return cvTry([&] {
-    cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
+        cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
@@ -683,7 +683,7 @@ CVAPI(ExceptionStatus) core_magnitude_Mat(
     interop::OutputArrayProxy magnitude)
 {
     return cvTry([&] {
-    cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));
+        cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));
     });
 }
 
@@ -696,16 +696,16 @@ CVAPI(ExceptionStatus) core_checkRange(
     int* returnValue)
 {
     return cvTry([&] {
-    cv::Point pos0;
-    *returnValue = cv::checkRange(InProxy(a), quiet != 0, &pos0, minVal, maxVal);
-    *pos = c(pos0);
+        cv::Point pos0;
+        *returnValue = cv::checkRange(InProxy(a), quiet != 0, &pos0, minVal, maxVal);
+        *pos = c(pos0);
     });
 }
 
 CVAPI(ExceptionStatus) core_patchNaNs(interop::InputOutputArrayProxy a, double val)
 {
     return cvTry([&] {
-    cv::patchNaNs(IoProxy(a), val);
+        cv::patchNaNs(IoProxy(a), val);
     });
 }
 
@@ -719,7 +719,7 @@ CVAPI(ExceptionStatus) core_gemm(
     int flags)
 {
     return cvTry([&] {
-    cv::gemm(InProxy(src1), InProxy(src2), alpha, InProxy(src3), gamma, OutProxy(dst), flags);
+        cv::gemm(InProxy(src1), InProxy(src2), alpha, InProxy(src3), gamma, OutProxy(dst), flags);
     });
 }
 
@@ -732,7 +732,7 @@ CVAPI(ExceptionStatus) core_mulTransposed(
     int dtype)
 {
     return cvTry([&] {
-    cv::mulTransposed(InProxy(src), OutProxy(dst), aTa != 0, InProxy(delta), scale, dtype);
+        cv::mulTransposed(InProxy(src), OutProxy(dst), aTa != 0, InProxy(delta), scale, dtype);
     });
 }
 
@@ -744,7 +744,7 @@ CVAPI(ExceptionStatus) core_mulTransposed(
 CVAPI(ExceptionStatus) core_transpose(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::transpose(InProxy(src), OutProxy(dst));
+        cv::transpose(InProxy(src), OutProxy(dst));
     });
 }
 
@@ -754,7 +754,7 @@ CVAPI(ExceptionStatus) core_transform(
     interop::InputArrayProxy m)
 {
     return cvTry([&] {
-    cv::transform(InProxy(src), OutProxy(dst), InProxy(m));
+        cv::transform(InProxy(src), OutProxy(dst), InProxy(m));
     });
 }
 
@@ -764,52 +764,52 @@ CVAPI(ExceptionStatus) core_perspectiveTransform(
     interop::InputArrayProxy m)
 {
     return cvTry([&] {
-    cv::perspectiveTransform(InProxy(src), OutProxy(dst), InProxy(m));
+        cv::perspectiveTransform(InProxy(src), OutProxy(dst), InProxy(m));
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst, cv::Mat *m)
 {
     return cvTry([&] {
-    cv::perspectiveTransform(*src, *dst, *m);
+        cv::perspectiveTransform(*src, *dst, *m);
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, cv::_InputArray *m)
 {
     return cvTry([&] {
-    const std::vector<cv::Point2f> srcVector(src, src + srcLength);
-    std::vector<cv::Point2f> dstVector(dst, dst + dstLength);
-    cv::perspectiveTransform(srcVector, dstVector, *m);
+        const std::vector<cv::Point2f> srcVector(src, src + srcLength);
+        std::vector<cv::Point2f> dstVector(dst, dst + dstLength);
+        cv::perspectiveTransform(srcVector, dstVector, *m);
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, cv::_InputArray *m)
 {
     return cvTry([&] {
-    const std::vector<cv::Point2d> srcVector(src, src + srcLength);
-    std::vector<cv::Point2d> dstVector(dst, dst + dstLength);
-    cv::perspectiveTransform(srcVector, dstVector, *m);
+        const std::vector<cv::Point2d> srcVector(src, src + srcLength);
+        std::vector<cv::Point2d> dstVector(dst, dst + dstLength);
+        cv::perspectiveTransform(srcVector, dstVector, *m);
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, cv::_InputArray *m)
 {
     return cvTry([&] {
-    const std::vector<cv::Point3f> srcVector(src, src + srcLength);
-    std::vector<cv::Point3f> dstVector(dst, dst + dstLength);
-    cv::perspectiveTransform(srcVector, dstVector, *m);
+        const std::vector<cv::Point3f> srcVector(src, src + srcLength);
+        std::vector<cv::Point3f> dstVector(dst, dst + dstLength);
+        cv::perspectiveTransform(srcVector, dstVector, *m);
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, cv::_InputArray *m)
 {
     return cvTry([&] {
-    const std::vector<cv::Point3d> srcVector(src, src + srcLength);
-    std::vector<cv::Point3d> dstVector(dst, dst + dstLength);
-    cv::perspectiveTransform(srcVector, dstVector, *m);
+        const std::vector<cv::Point3d> srcVector(src, src + srcLength);
+        std::vector<cv::Point3d> dstVector(dst, dst + dstLength);
+        cv::perspectiveTransform(srcVector, dstVector, *m);
     });
 }
 
 CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerToUpper)
 {
     return cvTry([&] {
-    cv::completeSymm(*mtx, lowerToUpper != 0);
+        cv::completeSymm(*mtx, lowerToUpper != 0);
     });
 }
 
@@ -817,28 +817,28 @@ CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerTo
 CVAPI(ExceptionStatus) core_completeSymm_io(interop::InputOutputArrayProxy mtx, int lowerToUpper)
 {
     return cvTry([&] {
-    cv::completeSymm(fromInputOutputProxy(mtx), lowerToUpper != 0);
+        cv::completeSymm(fromInputOutputProxy(mtx), lowerToUpper != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_setIdentity(interop::InputOutputArrayProxy mtx, interop::Scalar s)
 {
     return cvTry([&] {
-    cv::setIdentity(IoProxy(mtx), cpp(s));
+        cv::setIdentity(IoProxy(mtx), cpp(s));
     });
 }
 
 CVAPI(ExceptionStatus) core_determinant(interop::InputArrayProxy mtx, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::determinant(InProxy(mtx));
+        *returnValue = cv::determinant(InProxy(mtx));
     });
 }
 
 CVAPI(ExceptionStatus) core_trace(interop::InputArrayProxy mtx, interop::Scalar *returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::trace(InProxy(mtx)));
+        *returnValue = c(cv::trace(InProxy(mtx)));
     });
 }
 
@@ -849,7 +849,7 @@ CVAPI(ExceptionStatus) core_invert(
     double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::invert(InProxy(src), OutProxy(dst), flags);
+        *returnValue = cv::invert(InProxy(src), OutProxy(dst), flags);
     });
 }
 
@@ -861,7 +861,7 @@ CVAPI(ExceptionStatus) core_solve(
     int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::solve(InProxy(src1), InProxy(src2), OutProxy(dst), flags);
+        *returnValue = cv::solve(InProxy(src1), InProxy(src2), OutProxy(dst), flags);
     });
 }
 
@@ -872,28 +872,28 @@ CVAPI(ExceptionStatus) core_solveLP(
     int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::solveLP(InProxy(Func), InProxy(Constr), OutProxy(z));
+        *returnValue = cv::solveLP(InProxy(Func), InProxy(Constr), OutProxy(z));
     });
 }
 
 CVAPI(ExceptionStatus) core_sort(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
 {
     return cvTry([&] {
-    cv::sort(InProxy(src), OutProxy(dst), flags);
+        cv::sort(InProxy(src), OutProxy(dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_sortIdx(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
 {
     return cvTry([&] {
-    cv::sortIdx(InProxy(src), OutProxy(dst), flags);
+        cv::sortIdx(InProxy(src), OutProxy(dst), flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_solveCubic(interop::InputArrayProxy coeffs, interop::OutputArrayProxy roots, int *returnValue)
 {
     return cvTry([&] {
-    *returnValue =  cv::solveCubic(InProxy(coeffs), OutProxy(roots));
+        *returnValue =  cv::solveCubic(InProxy(coeffs), OutProxy(roots));
     });
 }
 
@@ -904,14 +904,14 @@ CVAPI(ExceptionStatus) core_solvePoly(
     double *returnValue)
 {
     return cvTry([&] {
-    *returnValue =  cv::solvePoly(InProxy(coeffs), OutProxy(roots), maxIters);
+        *returnValue =  cv::solvePoly(InProxy(coeffs), OutProxy(roots), maxIters);
     });
 }
 
 CVAPI(ExceptionStatus) core_eigen(cv::_InputArray *src, cv::_OutputArray *eigenvalues,    cv::_OutputArray *eigenvectors, int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::eigen(*src, *eigenvalues, *eigenvectors) ? 1 : 0;
+        *returnValue = cv::eigen(*src, *eigenvalues, *eigenvectors) ? 1 : 0;
     });
 }
 
@@ -919,7 +919,7 @@ CVAPI(ExceptionStatus) core_eigenNonSymmetric(
     cv::_InputArray *src,  cv::_OutputArray *eigenvalues, cv::_OutputArray *eigenvectors)
 {
     return cvTry([&] {
-    cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
+        cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
     });
 }
 
@@ -927,18 +927,18 @@ CVAPI(ExceptionStatus) core_calcCovarMatrix_Mat(cv::Mat **samples, int nsamples,
                                      cv::Mat *mean, int flags, int ctype)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> samplesVec(nsamples);
-    for (int i = 0; i < nsamples; i++)    
-        samplesVec[i] = *samples[i];
+        std::vector<cv::Mat> samplesVec(nsamples);
+        for (int i = 0; i < nsamples; i++)    
+            samplesVec[i] = *samples[i];
     
-    cv::calcCovarMatrix(&samplesVec[0], nsamples, *covar, *mean, flags, ctype);
+        cv::calcCovarMatrix(&samplesVec[0], nsamples, *covar, *mean, flags, ctype);
     });
 }
 CVAPI(ExceptionStatus) core_calcCovarMatrix_InputArray(cv::_InputArray *samples, cv::_OutputArray *covar, 
                                             cv::_InputOutputArray *mean, int flags, int ctype)
 {
     return cvTry([&] {
-    cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
+        cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
     });
 }
 
@@ -946,14 +946,14 @@ CVAPI(ExceptionStatus) core_PCACompute(cv::_InputArray *data, cv::_InputOutputAr
                             cv::_OutputArray *eigenvectors, int maxComponents)
 {
     return cvTry([&] {
-    cv::PCACompute(*data, *mean, *eigenvectors, maxComponents);
+        cv::PCACompute(*data, *mean, *eigenvectors, maxComponents);
     });
 }
 CVAPI(ExceptionStatus) core_PCACompute2(cv::_InputArray *data, cv::_InputOutputArray *mean,
                             cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, int maxComponents)
 {
     return cvTry([&] {
-    cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, maxComponents);
+        cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, maxComponents);
     });
 }
 
@@ -961,14 +961,14 @@ CVAPI(ExceptionStatus) core_PCAComputeVar(cv::_InputArray *data, cv::_InputOutpu
                                cv::_OutputArray *eigenvectors, double retainedVariance)
 {
     return cvTry([&] {
-    cv::PCACompute(*data, *mean, *eigenvectors, retainedVariance);
+        cv::PCACompute(*data, *mean, *eigenvectors, retainedVariance);
     });
 }
 CVAPI(ExceptionStatus) core_PCAComputeVar2(cv::_InputArray *data, cv::_InputOutputArray *mean,
                                cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, double retainedVariance)
 {
     return cvTry([&] {
-    cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, retainedVariance);
+        cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, retainedVariance);
     });
 }
 
@@ -976,14 +976,14 @@ CVAPI(ExceptionStatus) core_PCAProject(cv::_InputArray *data, cv::_InputArray *m
                             cv::_InputArray *eigenvectors, cv::_OutputArray *result)
 {
     return cvTry([&] {
-    cv::PCAProject(*data, *mean, *eigenvectors, *result);
+        cv::PCAProject(*data, *mean, *eigenvectors, *result);
     });
 }
 CVAPI(ExceptionStatus) core_PCABackProject(cv::_InputArray *data, cv::_InputArray *mean,
                                 cv::_InputArray *eigenvectors, cv::_OutputArray *result)
 {
     return cvTry([&] {
-    cv::PCABackProject(*data, *mean, *eigenvectors, *result);
+        cv::PCABackProject(*data, *mean, *eigenvectors, *result);
     });
 }
 
@@ -991,7 +991,7 @@ CVAPI(ExceptionStatus) core_SVDecomp(cv::_InputArray *src, cv::_OutputArray *w,
                           cv::_OutputArray *u, cv::_OutputArray *vt, int flags)
 {
     return cvTry([&] {
-    cv::SVDecomp(*src, *w, *u, *vt, flags);
+        cv::SVDecomp(*src, *w, *u, *vt, flags);
     });
 }
 
@@ -999,106 +999,106 @@ CVAPI(ExceptionStatus) core_SVBackSubst(cv::_InputArray *w, cv::_InputArray *u, 
                              cv::_InputArray *rhs, cv::_OutputArray *dst)
 {
     return cvTry([&] {
-    cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
+        cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
     });
 }
 
 CVAPI(ExceptionStatus) core_Mahalanobis(cv::_InputArray *v1, cv::_InputArray *v2, cv::_InputArray *icovar, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::Mahalanobis(*v1, *v2, *icovar);
+        *returnValue = cv::Mahalanobis(*v1, *v2, *icovar);
     });
 }
 
 CVAPI(ExceptionStatus) core_dft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-    cv::dft(*src, *dst, flags, nonzeroRows);
+        cv::dft(*src, *dst, flags, nonzeroRows);
     });
 }
 
 CVAPI(ExceptionStatus) core_idft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-    cv::idft(*src, *dst, flags, nonzeroRows);
+        cv::idft(*src, *dst, flags, nonzeroRows);
     });
 }
 
 CVAPI(ExceptionStatus) core_dct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
     return cvTry([&] {
-    cv::dct(*src, *dst, flags); 
+        cv::dct(*src, *dst, flags); 
     });
 }
 
 CVAPI(ExceptionStatus) core_idct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
 {
     return cvTry([&] {
-    cv::idct(*src, *dst, flags);
+        cv::idct(*src, *dst, flags);
     });
 }
 
 CVAPI(ExceptionStatus) core_mulSpectrums(cv::_InputArray *a, cv::_InputArray *b, cv::_OutputArray *c, int flags, int conjB)
 {
     return cvTry([&] {
-    cv::mulSpectrums(*a, *b, *c, flags, conjB != 0);
+        cv::mulSpectrums(*a, *b, *c, flags, conjB != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_getOptimalDFTSize(int vecsize, int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getOptimalDFTSize(vecsize);
+        *returnValue = cv::getOptimalDFTSize(vecsize);
     });
 }
 
 CVAPI(ExceptionStatus) core_theRNG_get(uint64 *returnValue)
 {
     return cvTry([&] {
-    cv::RNG &rng = cv::theRNG();
-    *returnValue = rng.state;
+        cv::RNG &rng = cv::theRNG();
+        *returnValue = rng.state;
     });
 }
 
 CVAPI(ExceptionStatus) core_theRNG_set(uint64 value)
 {
     return cvTry([&] {
-    cv::theRNG().state = value;
+        cv::theRNG().state = value;
     });
 }
 
 CVAPI(ExceptionStatus) core_randu_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *low, cv::_InputArray *high)
 {
     return cvTry([&] {
-    cv::randu(*dst, *low, *high);
+        cv::randu(*dst, *low, *high);
     });
 }
 CVAPI(ExceptionStatus) core_randu_Scalar(cv::_InputOutputArray *dst, interop::Scalar low, interop::Scalar high)
 {
     return cvTry([&] {
-    cv::randu(*dst, cpp(low), cpp(high));
+        cv::randu(*dst, cpp(low), cpp(high));
     });
 }
 
 CVAPI(ExceptionStatus) core_randn_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *mean, cv::_InputArray *stddev)
 {
     return cvTry([&] {
-    cv::randn(*dst, *mean, *stddev);
+        cv::randn(*dst, *mean, *stddev);
     });
 }
 CVAPI(ExceptionStatus) core_randn_Scalar(cv::_InputOutputArray *dst, interop::Scalar mean, interop::Scalar stddev)
 {
     return cvTry([&] {
-    cv::randn(*dst, cpp(mean), cpp(stddev));
+        cv::randn(*dst, cpp(mean), cpp(stddev));
     });
 }
 
 CVAPI(ExceptionStatus) core_randShuffle(cv::_InputOutputArray *dst, double iterFactor, uint64 *rng)
 {
     return cvTry([&] {
-    cv::RNG rng0;
-    cv::randShuffle(*dst, iterFactor, &rng0);
-    *rng = rng0.state;
+        cv::RNG rng0;
+        cv::randShuffle(*dst, iterFactor, &rng0);
+        *rng = rng0.state;
     });
 }
 
@@ -1108,7 +1108,7 @@ CVAPI(ExceptionStatus) core_kmeans(
     double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::kmeans(*data, k, *bestLabels, cpp(criteria), attempts, flags, entity(centers));
+        *returnValue = cv::kmeans(*data, k, *bestLabels, cpp(criteria), attempts, flags, entity(centers));
     });
 }
 
@@ -1119,13 +1119,13 @@ CVAPI(ExceptionStatus) core_kmeans(
 CVAPI(ExceptionStatus) core_cubeRoot(float val, float* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::cubeRoot(val);
+        *returnValue = cv::cubeRoot(val);
     });
 }
 CVAPI(ExceptionStatus) core_fastAtan2(float y, float x, float* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::fastAtan2(y, x);
+        *returnValue = cv::fastAtan2(y, x);
     });
 }
 
@@ -1157,7 +1157,7 @@ static int opencvsharp_silentErrorHandler(int /*status*/, const char* /*funcName
 CVAPI(ExceptionStatus) core_setSilentErrorHandler()
 {
     return cvTry([&] {
-        cv::redirectError(opencvsharp_silentErrorHandler);
+            cv::redirectError(opencvsharp_silentErrorHandler);
     });
 }
 
@@ -1168,144 +1168,144 @@ CVAPI(ExceptionStatus) core_getLastException(
     int* code, int* line, std::string* func, std::string* file, std::string* message)
 {
     return cvTry([&] {
-    const auto& last = lastNativeException();
-    *code = last.code;
-    *line = last.line;
-    func->assign(last.func);
-    file->assign(last.file);
-    message->assign(last.message);
+        const auto& last = lastNativeException();
+        *code = last.code;
+        *line = last.line;
+        func->assign(last.func);
+        file->assign(last.file);
+        message->assign(last.message);
     });
 }
 
 CVAPI(ExceptionStatus) core_setNumThreads(int nthreads)
 {
     return cvTry([&] {
-    cv::setNumThreads(nthreads);
+        cv::setNumThreads(nthreads);
     });
 }
 
 CVAPI(ExceptionStatus) core_getNumThreads(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getNumThreads();
+        *returnValue = cv::getNumThreads();
     });
 }
 CVAPI(ExceptionStatus) core_getThreadNum(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getThreadNum();
+        *returnValue = cv::getThreadNum();
     });
 }
 
 CVAPI(ExceptionStatus) core_getBuildInformation(std::string *buf)
 {
     return cvTry([&] {
-    const auto& str = cv::getBuildInformation();
-    buf->assign(str);
+        const auto& str = cv::getBuildInformation();
+        buf->assign(str);
     });
 }
 
 CVAPI(ExceptionStatus) core_getVersionString(char *buf, int bufLength)
 {
     return cvTry([&] {
-    const auto& str = cv::getVersionString();
-    copyString(str, buf, bufLength);
+        const auto& str = cv::getVersionString();
+        copyString(str, buf, bufLength);
     });
 }
 
 CVAPI(ExceptionStatus) core_getVersionMajor(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getVersionMajor();
+        *returnValue = cv::getVersionMajor();
     });
 }
 
 CVAPI(ExceptionStatus) core_getVersionMinor(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getVersionMinor();
+        *returnValue = cv::getVersionMinor();
     });
 }
 
 CVAPI(ExceptionStatus) core_getVersionRevision(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getVersionRevision();
+        *returnValue = cv::getVersionRevision();
     });
 }
 
 CVAPI(ExceptionStatus) core_getTickCount(int64* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getTickCount();
+        *returnValue = cv::getTickCount();
     });
 }
 
 CVAPI(ExceptionStatus) core_getTickFrequency(double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getTickFrequency();
+        *returnValue = cv::getTickFrequency();
     });
 }
 
 CVAPI(ExceptionStatus) core_getCPUTickCount(int64* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getCPUTickCount();
+        *returnValue = cv::getCPUTickCount();
     });
 }
 
 CVAPI(ExceptionStatus) core_checkHardwareSupport(int feature, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::checkHardwareSupport(feature) ? 1 : 0;
+        *returnValue = cv::checkHardwareSupport(feature) ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) core_getHardwareFeatureName(int feature, std::string *buf)
 {
     return cvTry([&] {
-    const auto& str = cv::getHardwareFeatureName(feature);
-    buf->assign(str);
+        const auto& str = cv::getHardwareFeatureName(feature);
+        buf->assign(str);
     });
 }
 
 CVAPI(ExceptionStatus) core_getCPUFeaturesLine(std::string *buf)
 {
     return cvTry([&] {
-    const auto& str = cv::getCPUFeaturesLine();
-    buf->assign(str);
+        const auto& str = cv::getCPUFeaturesLine();
+        buf->assign(str);
     });
 }
 
 CVAPI(ExceptionStatus) core_getNumberOfCPUs(int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::getNumberOfCPUs();
+        *returnValue = cv::getNumberOfCPUs();
     });
 }
 
 CVAPI(ExceptionStatus) core_setUseOptimized(int onoff)
 {
     return cvTry([&] {
-    cv::setUseOptimized(onoff != 0);
+        cv::setUseOptimized(onoff != 0);
     });
 }
 CVAPI(ExceptionStatus) core_useOptimized(int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::useOptimized() ? 1 : 0;
+        *returnValue = cv::useOptimized() ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) core_format(cv::_InputArray *mtx, int fmt, std::string *buf)
 {
     return cvTry([&] {
-    const auto formatted = cv::format(*mtx, static_cast<cv::Formatter::FormatType>(fmt));
+        const auto formatted = cv::format(*mtx, static_cast<cv::Formatter::FormatType>(fmt));
 
-    std::stringstream s;
-    s << formatted;
-    buf->assign(s.str());
+        std::stringstream s;
+        s << formatted;
+        buf->assign(s.str());
     });
 }
 
@@ -1316,14 +1316,14 @@ CVAPI(ExceptionStatus) core_format(cv::_InputArray *mtx, int fmt, std::string *b
 CVAPI(ExceptionStatus) core_logger_setLogLevel(cv::utils::logging::LogLevel logLevel, cv::utils::logging::LogLevel* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::utils::logging::setLogLevel(logLevel);
+        *returnValue = cv::utils::logging::setLogLevel(logLevel);
     });
 }
 
 CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::utils::logging::getLogLevel();
+        *returnValue = cv::utils::logging::getLogLevel();
     });
 }
 
@@ -1334,18 +1334,18 @@ CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *ret
 CVAPI(ExceptionStatus) core_RNG_fill(uint64 *state, cv::_InputOutputArray *mat, int distType, cv::_InputArray *a, cv::_InputArray *b, int saturateRange)
 {
     return cvTry([&] {
-    cv::RNG rng(*state);
-    rng.fill(*mat, distType, *a, *b, saturateRange != 0);
-    *state = rng.state;
+        cv::RNG rng(*state);
+        rng.fill(*mat, distType, *a, *b, saturateRange != 0);
+        *state = rng.state;
     });
 }
 
 CVAPI(ExceptionStatus) core_RNG_gaussian(uint64 *state, double sigma, double *returnValue)
 {
     return cvTry([&] {
-    cv::RNG rng(*state);
-    *returnValue = rng.gaussian(sigma);
-    *state = rng.state;
+        cv::RNG rng(*state);
+        *returnValue = rng.gaussian(sigma);
+        *state = rng.state;
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -432,13 +432,13 @@ CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** retu
     });
 }
 
-CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
         std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
         for (uint32_t i = 0; i < nsrc; i++)
             srcVec[i] = *(src[i]);
-        cv::hconcat(&srcVec[0], nsrc, *dst);
+        cv::hconcat(&srcVec[0], nsrc, OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_hconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
@@ -448,13 +448,13 @@ CVAPI(ExceptionStatus) core_hconcat2(interop::InputArrayProxy src1, interop::Inp
     });
 }
 
-CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
         std::vector<cv::Mat> srcVec(static_cast<size_t>(nsrc));
         for (uint32_t i = 0; i < nsrc; i++)
             srcVec[i] = *(src[i]);
-        cv::vconcat(&srcVec[0], nsrc, *dst);
+        cv::vconcat(&srcVec[0], nsrc, OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_vconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
@@ -773,51 +773,43 @@ CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst,
         cv::perspectiveTransform(*src, *dst, *m);
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point2f(cv::Point2f *src, int srcLength, cv::Point2f *dst, int dstLength, interop::InputArrayProxy m)
 {
     return cvTry([&] {
         const std::vector<cv::Point2f> srcVector(src, src + srcLength);
         std::vector<cv::Point2f> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, *m);
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point2d(cv::Point2d *src, int srcLength, cv::Point2d *dst, int dstLength, interop::InputArrayProxy m)
 {
     return cvTry([&] {
         const std::vector<cv::Point2d> srcVector(src, src + srcLength);
         std::vector<cv::Point2d> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, *m);
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point3f(cv::Point3f *src, int srcLength, cv::Point3f *dst, int dstLength, interop::InputArrayProxy m)
 {
     return cvTry([&] {
         const std::vector<cv::Point3f> srcVector(src, src + srcLength);
         std::vector<cv::Point3f> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, *m);
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
     });
 }
-CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_perspectiveTransform_Point3d(cv::Point3d *src, int srcLength, cv::Point3d *dst, int dstLength, interop::InputArrayProxy m)
 {
     return cvTry([&] {
         const std::vector<cv::Point3d> srcVector(src, src + srcLength);
         std::vector<cv::Point3d> dstVector(dst, dst + dstLength);
-        cv::perspectiveTransform(srcVector, dstVector, *m);
+        cv::perspectiveTransform(srcVector, dstVector, InProxy(m));
     });
 }
 
-CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerToUpper)
+CVAPI(ExceptionStatus) core_completeSymm(interop::InputOutputArrayProxy mtx, int lowerToUpper)
 {
     return cvTry([&] {
-        cv::completeSymm(*mtx, lowerToUpper != 0);
-    });
-}
-
-// FOUNDATION: ref-struct proxy path for an _InputOutputArray argument (see core_transpose_io).
-CVAPI(ExceptionStatus) core_completeSymm_io(interop::InputOutputArrayProxy mtx, int lowerToUpper)
-{
-    return cvTry([&] {
-        cv::completeSymm(fromInputOutputProxy(mtx), lowerToUpper != 0);
+        cv::completeSymm(IoProxy(mtx), lowerToUpper != 0);
     });
 }
 
@@ -1350,10 +1342,10 @@ CVAPI(ExceptionStatus) core_useOptimized(int *returnValue)
     });
 }
 
-CVAPI(ExceptionStatus) core_format(cv::_InputArray *mtx, int fmt, std::string *buf)
+CVAPI(ExceptionStatus) core_format(interop::InputArrayProxy mtx, int fmt, std::string *buf)
 {
     return cvTry([&] {
-        const auto formatted = cv::format(*mtx, static_cast<cv::Formatter::FormatType>(fmt));
+        const auto formatted = cv::format(InProxy(mtx), static_cast<cv::Formatter::FormatType>(fmt));
 
         std::stringstream s;
         s << formatted;

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -191,118 +191,166 @@ CVAPI(ExceptionStatus) core_mean(
 }
 
 CVAPI(ExceptionStatus) core_meanStdDev_OutputArray(
-    cv::_InputArray* src, cv::_OutputArray* mean, cv::_OutputArray* stddev, cv::_InputArray* mask)
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy mean,
+    interop::OutputArrayProxy stddev,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::meanStdDev(*src, *mean, *stddev, entity(mask));
+    cv::meanStdDev(InProxy(src), OutProxy(mean), OutProxy(stddev), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_meanStdDev_Scalar(
-    cv::_InputArray* src, interop::Scalar* mean, interop::Scalar* stddev, cv::_InputArray* mask)
+    interop::InputArrayProxy src,
+    interop::Scalar* mean,
+    interop::Scalar* stddev,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::Scalar mean0, stddev0;
-    cv::meanStdDev(*src, mean0, stddev0, entity(mask));
+    cv::meanStdDev(InProxy(src), mean0, stddev0, InProxy(mask));
     *mean = c(mean0);
     *stddev = c(stddev0);
     });
 }
 
 CVAPI(ExceptionStatus) core_norm1(
-    cv::_InputArray* src1, int normType, cv::_InputArray* mask, double *returnValue)
+    interop::InputArrayProxy src1,
+    int normType,
+    interop::InputArrayProxy mask,
+    double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::norm(*src1, normType, entity(mask));
+    *returnValue = cv::norm(InProxy(src1), normType, InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_norm2(
-    cv::_InputArray* src1, cv::_InputArray* src2,
-    int normType, cv::_InputArray* mask, double* returnValue)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    int normType,
+    interop::InputArrayProxy mask,
+    double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::norm(*src1, *src2, normType, entity(mask));
+    *returnValue = cv::norm(InProxy(src1), InProxy(src2), normType, InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) core_PSNR(cv::_InputArray* src1, cv::_InputArray* src2, double R, double* returnValue)
+CVAPI(ExceptionStatus) core_PSNR(
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    double R,
+    double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::PSNR(*src1, *src2, R);
+    *returnValue = cv::PSNR(InProxy(src1), InProxy(src2), R);
     });
 }
 
 CVAPI(ExceptionStatus) core_batchDistance(
-    cv::_InputArray* src1, cv::_InputArray* src2,
-    cv::_OutputArray* dist, int dtype, cv::_OutputArray* nidx,
-    int normType, int K, cv::_InputArray* mask,
-    int update, int crosscheck)
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dist,
+    int dtype,
+    interop::OutputArrayProxy nidx,
+    int normType,
+    int K,
+    interop::InputArrayProxy mask,
+    int update,
+    int crosscheck)
 {
     return cvTry([&] {
     cv::batchDistance(
-        *src1, *src2, *dist, dtype, *nidx, normType, K, entity(mask), update, crosscheck != 0);
+        InProxy(src1), InProxy(src2), OutProxy(dist), dtype, OutProxy(nidx), normType, K, InProxy(mask), update, crosscheck != 0);
     });
 }
 
 CVAPI(ExceptionStatus) core_normalize(
-    cv::_InputArray* src, cv::_InputOutputArray* dst, double alpha, double beta, int normType, int dtype, cv::_InputArray* mask)
+    interop::InputArrayProxy src,
+    interop::InputOutputArrayProxy dst,
+    double alpha,
+    double beta,
+    int normType,
+    int dtype,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::InputArray maskVal = entity(mask);
-    cv::normalize(*src, *dst, alpha, beta, normType, dtype, maskVal);
+    cv::normalize(InProxy(src), IoProxy(dst), alpha, beta, normType, dtype, InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) core_reduceArgMax(cv::_InputArray* src, cv::_OutputArray* dst, int axis, bool lastIndex)
+CVAPI(ExceptionStatus) core_reduceArgMax(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int axis,
+    bool lastIndex)
 {
     return cvTry([&] {
-    cv::reduceArgMax(*src, *dst, axis, lastIndex);
+    cv::reduceArgMax(InProxy(src), OutProxy(dst), axis, lastIndex);
     });
 }
 
-CVAPI(ExceptionStatus) core_reduceArgMin(cv::_InputArray* src, cv::_OutputArray* dst, int axis, bool lastIndex)
+CVAPI(ExceptionStatus) core_reduceArgMin(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int axis,
+    bool lastIndex)
 {
     return cvTry([&] {
-    cv::reduceArgMin(*src, *dst, axis, lastIndex);
+    cv::reduceArgMin(InProxy(src), OutProxy(dst), axis, lastIndex);
     });
 }
 
-CVAPI(ExceptionStatus) core_minMaxLoc1(cv::_InputArray* src, double* minVal, double* maxVal)
+CVAPI(ExceptionStatus) core_minMaxLoc1(interop::InputArrayProxy src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-    cv::minMaxLoc(*src, minVal, maxVal);
+    cv::minMaxLoc(InProxy(src), minVal, maxVal);
     });
 }
-CVAPI(ExceptionStatus) core_minMaxLoc2(cv::_InputArray* src, double* minVal, double* maxVal,
-    interop::Point* minLoc, interop::Point* maxLoc, cv::_InputArray* mask)
+CVAPI(ExceptionStatus) core_minMaxLoc2(
+    interop::InputArrayProxy src,
+    double* minVal,
+    double* maxVal,
+    interop::Point* minLoc,
+    interop::Point* maxLoc,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::InputArray maskVal = entity(mask);
     cv::Point minLoc0, maxLoc0;
-    cv::minMaxLoc(*src, minVal, maxVal, &minLoc0, &maxLoc0, maskVal);
+    cv::minMaxLoc(InProxy(src), minVal, maxVal, &minLoc0, &maxLoc0, InProxy(mask));
     *minLoc = c(minLoc0);
     *maxLoc = c(maxLoc0);
     });
 }
 
-CVAPI(ExceptionStatus) core_minMaxIdx1(cv::_InputArray* src, double* minVal, double* maxVal)
+CVAPI(ExceptionStatus) core_minMaxIdx1(interop::InputArrayProxy src, double* minVal, double* maxVal)
 {
     return cvTry([&] {
-    cv::minMaxIdx(*src, minVal, maxVal);
+    cv::minMaxIdx(InProxy(src), minVal, maxVal);
     });
 }
-CVAPI(ExceptionStatus) core_minMaxIdx2(cv::_InputArray* src, double* minVal, double* maxVal,
-    int* minIdx, int* maxIdx, cv::_InputArray* mask)
+CVAPI(ExceptionStatus) core_minMaxIdx2(
+    interop::InputArrayProxy src,
+    double* minVal,
+    double* maxVal,
+    int* minIdx,
+    int* maxIdx,
+    interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::InputArray maskVal = entity(mask);
-    cv::minMaxIdx(*src, minVal, maxVal, minIdx, maxIdx, maskVal);
+    cv::minMaxIdx(InProxy(src), minVal, maxVal, minIdx, maxIdx, InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) core_reduce(cv::_InputArray* src, cv::_OutputArray* dst, int dim, int rtype, int dtype)
+CVAPI(ExceptionStatus) core_reduce(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int dim,
+    int rtype,
+    int dtype)
 {
     return cvTry([&] {
-    cv::reduce(*src, *dst, dim, rtype, dtype);
+    cv::reduce(InProxy(src), OutProxy(dst), dim, rtype, dtype);
     });
 }
 
@@ -338,17 +386,17 @@ CVAPI(ExceptionStatus) core_mixChannels(cv::Mat** src, uint32_t nsrcs, cv::Mat**
     });
 }
 
-CVAPI(ExceptionStatus) core_extractChannel(cv::_InputArray* src, cv::_OutputArray* dst, int coi)
+CVAPI(ExceptionStatus) core_extractChannel(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int coi)
 {
     return cvTry([&] {
-    cv::extractChannel(*src, *dst, coi);
+    cv::extractChannel(InProxy(src), OutProxy(dst), coi);
     });
 }
 
-CVAPI(ExceptionStatus) core_insertChannel(cv::_InputArray* src, cv::_InputOutputArray* dst, int coi)
+CVAPI(ExceptionStatus) core_insertChannel(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, int coi)
 {
     return cvTry([&] {
-    cv::insertChannel(*src, *dst, coi);
+    cv::insertChannel(InProxy(src), IoProxy(dst), coi);
     });
 }
 
@@ -359,17 +407,21 @@ CVAPI(ExceptionStatus) core_flip(interop::InputArrayProxy src, interop::OutputAr
     });
 }
 
-CVAPI(ExceptionStatus) core_rotate(cv::_InputArray *src, cv::_OutputArray *dst, int rotateCode)
+CVAPI(ExceptionStatus) core_rotate(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int rotateCode)
 {
     return cvTry([&] {
-    cv::rotate(*src, *dst, rotateCode);
+    cv::rotate(InProxy(src), OutProxy(dst), rotateCode);
     });
 }
 
-CVAPI(ExceptionStatus) core_repeat1(cv::_InputArray* src, int ny, int nx, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_repeat1(
+    interop::InputArrayProxy src,
+    int ny,
+    int nx,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::repeat(*src, ny, nx, *dst);
+    cv::repeat(InProxy(src), ny, nx, OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_repeat2(cv::Mat* src, int ny, int nx, cv::Mat** returnValue)
@@ -389,10 +441,10 @@ CVAPI(ExceptionStatus) core_hconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputAr
     cv::hconcat(&srcVec[0], nsrc, *dst);
     });
 }
-CVAPI(ExceptionStatus) core_hconcat2(cv::_InputArray* src1, cv::_InputArray* src2, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_hconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::hconcat(*src1, *src2, *dst);
+    cv::hconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
@@ -405,10 +457,10 @@ CVAPI(ExceptionStatus) core_vconcat1(cv::Mat** src, uint32_t nsrc, cv::_OutputAr
     cv::vconcat(&srcVec[0], nsrc, *dst);
     });
 }
-CVAPI(ExceptionStatus) core_vconcat2(cv::_InputArray* src1, cv::_InputArray* src2, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_vconcat2(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::vconcat(*src1, *src2, *dst);
+    cv::vconcat(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -24,10 +24,10 @@ CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, in
 }
 
 CVAPI(ExceptionStatus) core_copyMakeBorder(
-    cv::_InputArray* src, cv::_OutputArray* dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
+    interop::ArrayProxy src, interop::ArrayProxy dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
 {
     return cvTry([&] {
-    cv::copyMakeBorder(*src, *dst, top, bottom, left, right, borderType, cpp(value));
+    cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
     });
 }
 
@@ -301,10 +301,10 @@ CVAPI(ExceptionStatus) core_insertChannel(cv::_InputArray* src, cv::_InputOutput
     });
 }
 
-CVAPI(ExceptionStatus) core_flip(cv::_InputArray* src, cv::_OutputArray* dst, int flipCode)
+CVAPI(ExceptionStatus) core_flip(interop::ArrayProxy src, interop::ArrayProxy dst, int flipCode)
 {
     return cvTry([&] {
-    cv::flip(*src, *dst, flipCode);
+    cv::flip(InProxy(src), OutProxy(dst), flipCode);
     });
 }
 
@@ -398,33 +398,33 @@ CVAPI(ExceptionStatus) core_absdiff(
     });
 }
 
-CVAPI(ExceptionStatus) core_copyTo(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) core_copyTo(interop::ArrayProxy src, interop::ArrayProxy dst, interop::ArrayProxy mask)
 {
     return cvTry([&] {
-    cv::copyTo(*src, *dst, entity(mask));
+    cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
     });
 }
 
 CVAPI(ExceptionStatus) core_inRange_InputArray(
-    cv::_InputArray *src, cv::_InputArray *lowerb, cv::_InputArray *upperb, cv::_OutputArray *dst)
+    interop::ArrayProxy src, interop::ArrayProxy lowerb, interop::ArrayProxy upperb, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::inRange(*src, *lowerb, *upperb, *dst);
+    cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
-    cv::_InputArray *src, interop::Scalar lowerb, interop::Scalar upperb, cv::_OutputArray *dst)
+    interop::ArrayProxy src, interop::Scalar lowerb, interop::Scalar upperb, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::inRange(*src, cpp(lowerb), cpp(upperb), *dst);
+    cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
     });
 }
 
 CVAPI(ExceptionStatus) core_compare(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int cmpop)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, int cmpop)
 {
     return cvTry([&] {
-    cv::compare(*src1, *src2, *dst, cmpop);
+    cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
     });
 }
 
@@ -480,61 +480,61 @@ CVAPI(ExceptionStatus) core_max_MatDouble(cv::Mat *src1, double src2, cv::Mat *d
     });
 }
 
-CVAPI(ExceptionStatus) core_sqrt(cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_sqrt(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::sqrt(*src, *dst);
+    cv::sqrt(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_pow_Mat(cv::_InputArray *src, double power, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_pow_Mat(interop::ArrayProxy src, double power, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::pow(*src, power, *dst);
+    cv::pow(InProxy(src), power, OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_exp_Mat(cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_exp_Mat(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::exp(*src, *dst);
+    cv::exp(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_log_Mat(cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_log_Mat(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::log(*src, *dst);
+    cv::log(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_polarToCart(cv::_InputArray* magnitude, cv::_InputArray* angle,
-    cv::_OutputArray* x, cv::_OutputArray* y, int angleInDegrees)
+CVAPI(ExceptionStatus) core_polarToCart(interop::ArrayProxy magnitude, interop::ArrayProxy angle,
+    interop::ArrayProxy x, interop::ArrayProxy y, int angleInDegrees)
 {
     return cvTry([&] {
-    cv::polarToCart(*magnitude, *angle, *x, *y, angleInDegrees != 0);
+    cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_cartToPolar(cv::_InputArray* x, cv::_InputArray* y,
-    cv::_OutputArray* magnitude, cv::_OutputArray* angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_cartToPolar(interop::ArrayProxy x, interop::ArrayProxy y,
+    interop::ArrayProxy magnitude, interop::ArrayProxy angle, int angleInDegrees)
 {
     return cvTry([&] {
-    cv::cartToPolar(*x, *y, *magnitude, *angle, angleInDegrees != 0);
+    cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_phase(cv::_InputArray* x, cv::_InputArray* y, cv::_OutputArray* angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_phase(interop::ArrayProxy x, interop::ArrayProxy y, interop::ArrayProxy angle, int angleInDegrees)
 {
     return cvTry([&] {
-    cv::phase(*x, *y, *angle, angleInDegrees != 0);
+    cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_magnitude_Mat(cv::_InputArray* x, cv::_InputArray* y, cv::_OutputArray* magnitude)
+CVAPI(ExceptionStatus) core_magnitude_Mat(interop::ArrayProxy x, interop::ArrayProxy y, interop::ArrayProxy magnitude)
 {
     return cvTry([&] {
-    cv::magnitude(*x, *y, *magnitude);
+    cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -24,7 +24,7 @@ CVAPI(ExceptionStatus) core_borderInterpolate(int p, int len, int borderType, in
 }
 
 CVAPI(ExceptionStatus) core_copyMakeBorder(
-    interop::ArrayProxy src, interop::ArrayProxy dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
+    interop::InputArrayProxy src, interop::OutputArrayProxy dst, int top, int bottom, int left, int right, int borderType, interop::Scalar value)
 {
     return cvTry([&] {
     cv::copyMakeBorder(InProxy(src), OutProxy(dst), top, bottom, left, right, borderType, cpp(value));
@@ -32,7 +32,7 @@ CVAPI(ExceptionStatus) core_copyMakeBorder(
 }
 
 CVAPI(ExceptionStatus) core_add(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
 {
     return cvTry([&] {
     cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
@@ -40,21 +40,21 @@ CVAPI(ExceptionStatus) core_add(
 }
 
 CVAPI(ExceptionStatus) core_subtract_InputArray2(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
 {
     return cvTry([&] {
     cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
-    interop::ArrayProxy src1, interop::Scalar src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
+    interop::InputArrayProxy src1, interop::Scalar src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
 {
     return cvTry([&] {
     cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
-    interop::Scalar src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
+    interop::Scalar src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask, int dtype)
 {
     return cvTry([&] {
     cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
@@ -62,77 +62,77 @@ CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
 }
 
 CVAPI(ExceptionStatus) core_multiply(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, double scale, int dtype)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, double scale, int dtype)
 {
     return cvTry([&] {
     cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide1(
-    double scale, interop::ArrayProxy src2, interop::ArrayProxy dst, int dtype)
+    double scale, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int dtype)
 {
     return cvTry([&] {
     cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide2(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, double scale, int dtype)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, double scale, int dtype)
 {
     return cvTry([&] {
     cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 
-CVAPI(ExceptionStatus) core_scaleAdd(interop::ArrayProxy src1, double alpha, interop::ArrayProxy src2, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_scaleAdd(interop::InputArrayProxy src1, double alpha, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
     });
 }
-CVAPI(ExceptionStatus) core_addWeighted(interop::ArrayProxy src1, double alpha, interop::ArrayProxy src2,
-                             double beta, double gamma, interop::ArrayProxy dst, int dtype)
+CVAPI(ExceptionStatus) core_addWeighted(interop::InputArrayProxy src1, double alpha, interop::InputArrayProxy src2,
+                             double beta, double gamma, interop::OutputArrayProxy dst, int dtype)
 {
     return cvTry([&] {
     cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
     });
 }
 
-CVAPI(ExceptionStatus) core_convertScaleAbs(interop::ArrayProxy src, interop::ArrayProxy dst, double alpha, double beta)
+CVAPI(ExceptionStatus) core_convertScaleAbs(interop::InputArrayProxy src, interop::OutputArrayProxy dst, double alpha, double beta)
 {
     return cvTry([&] {
     cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
     });
 }
 
-CVAPI(ExceptionStatus) core_LUT(interop::ArrayProxy src, interop::ArrayProxy lut, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_LUT(interop::InputArrayProxy src, interop::InputArrayProxy lut, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_sum(interop::ArrayProxy src, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_sum(interop::InputArrayProxy src, interop::Scalar* returnValue)
 {
     return cvTry([&] {
     *returnValue = c(cv::sum(InProxy(src)));
     });
 }
 
-CVAPI(ExceptionStatus) core_countNonZero(interop::ArrayProxy src, int* returnValue)
+CVAPI(ExceptionStatus) core_countNonZero(interop::InputArrayProxy src, int* returnValue)
 {
     return cvTry([&] {
     *returnValue = cv::countNonZero(InProxy(src));
     });
 }
 
-CVAPI(ExceptionStatus) core_findNonZero(interop::ArrayProxy src, interop::ArrayProxy idx)
+CVAPI(ExceptionStatus) core_findNonZero(interop::InputArrayProxy src, interop::OutputArrayProxy idx)
 {
     return cvTry([&] {
     cv::findNonZero(InProxy(src), OutProxy(idx));
     });
 }
 
-CVAPI(ExceptionStatus) core_mean(interop::ArrayProxy src, interop::ArrayProxy mask, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_mean(interop::InputArrayProxy src, interop::InputArrayProxy mask, interop::Scalar* returnValue)
 {
     return cvTry([&] {
     *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
@@ -301,7 +301,7 @@ CVAPI(ExceptionStatus) core_insertChannel(cv::_InputArray* src, cv::_InputOutput
     });
 }
 
-CVAPI(ExceptionStatus) core_flip(interop::ArrayProxy src, interop::ArrayProxy dst, int flipCode)
+CVAPI(ExceptionStatus) core_flip(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flipCode)
 {
     return cvTry([&] {
     cv::flip(InProxy(src), OutProxy(dst), flipCode);
@@ -362,28 +362,28 @@ CVAPI(ExceptionStatus) core_vconcat2(cv::_InputArray* src1, cv::_InputArray* src
 }
 
 CVAPI(ExceptionStatus) core_bitwise_and(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
-    interop::ArrayProxy src, interop::ArrayProxy dst, interop::ArrayProxy mask)
+    interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
@@ -391,14 +391,14 @@ CVAPI(ExceptionStatus) core_bitwise_not(
 }
 
 CVAPI(ExceptionStatus) core_absdiff(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_copyTo(interop::ArrayProxy src, interop::ArrayProxy dst, interop::ArrayProxy mask)
+CVAPI(ExceptionStatus) core_copyTo(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
     cv::copyTo(InProxy(src), OutProxy(dst), InProxy(mask));
@@ -406,14 +406,14 @@ CVAPI(ExceptionStatus) core_copyTo(interop::ArrayProxy src, interop::ArrayProxy 
 }
 
 CVAPI(ExceptionStatus) core_inRange_InputArray(
-    interop::ArrayProxy src, interop::ArrayProxy lowerb, interop::ArrayProxy upperb, interop::ArrayProxy dst)
+    interop::InputArrayProxy src, interop::InputArrayProxy lowerb, interop::InputArrayProxy upperb, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::inRange(InProxy(src), InProxy(lowerb), InProxy(upperb), OutProxy(dst));
     });
 }
 CVAPI(ExceptionStatus) core_inRange_Scalar(
-    interop::ArrayProxy src, interop::Scalar lowerb, interop::Scalar upperb, interop::ArrayProxy dst)
+    interop::InputArrayProxy src, interop::Scalar lowerb, interop::Scalar upperb, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::inRange(InProxy(src), cpp(lowerb), cpp(upperb), OutProxy(dst));
@@ -421,14 +421,14 @@ CVAPI(ExceptionStatus) core_inRange_Scalar(
 }
 
 CVAPI(ExceptionStatus) core_compare(
-    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, int cmpop)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int cmpop)
 {
     return cvTry([&] {
     cv::compare(InProxy(src1), InProxy(src2), OutProxy(dst), cmpop);
     });
 }
 
-CVAPI(ExceptionStatus) core_min1(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_min1(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
@@ -455,7 +455,7 @@ CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* d
     });
 }
 
-CVAPI(ExceptionStatus) core_max1(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_max1(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
@@ -480,58 +480,58 @@ CVAPI(ExceptionStatus) core_max_MatDouble(cv::Mat *src1, double src2, cv::Mat *d
     });
 }
 
-CVAPI(ExceptionStatus) core_sqrt(interop::ArrayProxy src, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_sqrt(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::sqrt(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_pow_Mat(interop::ArrayProxy src, double power, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_pow_Mat(interop::InputArrayProxy src, double power, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::pow(InProxy(src), power, OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_exp_Mat(interop::ArrayProxy src, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_exp_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::exp(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_log_Mat(interop::ArrayProxy src, interop::ArrayProxy dst)
+CVAPI(ExceptionStatus) core_log_Mat(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::log(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_polarToCart(interop::ArrayProxy magnitude, interop::ArrayProxy angle,
-    interop::ArrayProxy x, interop::ArrayProxy y, int angleInDegrees)
+CVAPI(ExceptionStatus) core_polarToCart(interop::InputArrayProxy magnitude, interop::InputArrayProxy angle,
+    interop::OutputArrayProxy x, interop::OutputArrayProxy y, int angleInDegrees)
 {
     return cvTry([&] {
     cv::polarToCart(InProxy(magnitude), InProxy(angle), OutProxy(x), OutProxy(y), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_cartToPolar(interop::ArrayProxy x, interop::ArrayProxy y,
-    interop::ArrayProxy magnitude, interop::ArrayProxy angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_cartToPolar(interop::InputArrayProxy x, interop::InputArrayProxy y,
+    interop::OutputArrayProxy magnitude, interop::OutputArrayProxy angle, int angleInDegrees)
 {
     return cvTry([&] {
     cv::cartToPolar(InProxy(x), InProxy(y), OutProxy(magnitude), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_phase(interop::ArrayProxy x, interop::ArrayProxy y, interop::ArrayProxy angle, int angleInDegrees)
+CVAPI(ExceptionStatus) core_phase(interop::InputArrayProxy x, interop::InputArrayProxy y, interop::OutputArrayProxy angle, int angleInDegrees)
 {
     return cvTry([&] {
     cv::phase(InProxy(x), InProxy(y), OutProxy(angle), angleInDegrees != 0);
     });
 }
 
-CVAPI(ExceptionStatus) core_magnitude_Mat(interop::ArrayProxy x, interop::ArrayProxy y, interop::ArrayProxy magnitude)
+CVAPI(ExceptionStatus) core_magnitude_Mat(interop::InputArrayProxy x, interop::InputArrayProxy y, interop::OutputArrayProxy magnitude)
 {
     return cvTry([&] {
     cv::magnitude(InProxy(x), InProxy(y), OutProxy(magnitude));
@@ -570,12 +570,12 @@ CVAPI(ExceptionStatus) core_mulTransposed(cv::_InputArray *src, cv::_OutputArray
     });
 }
 
-// MIGRATION (issue #1976, strategy 3): array arguments arrive as interop::ArrayProxy passed BY VALUE;
-// fromInputProxy()/fromOutputProxy() (my_types.h) rebuild cv::_InputArray/_OutputArray on this stack
+// MIGRATION (issue #1976, strategy 3): array arguments arrive as interop::{Input,Output,InputOutput}
+// ArrayProxy passed BY VALUE (the type names keep the signature self-documenting about in/out).
+// The InProxy/OutProxy/IoProxy views (my_types.h) rebuild cv::_InputArray/_OutputArray on this stack
 // frame. The same signature serves both the ref-struct path (optimized kinds, zero managed alloc) and
-// the still-class path (Raw kinds that wrap an existing cv::_InputArray*). Scalar-kind inputs
-// reference a stack-local cv::Scalar scratch that must outlive the OpenCV call.
-CVAPI(ExceptionStatus) core_transpose(interop::ArrayProxy src, interop::ArrayProxy dst)
+// the still-class path (Raw kinds that wrap an existing cv::_InputArray*).
+CVAPI(ExceptionStatus) core_transpose(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
     cv::transpose(InProxy(src), OutProxy(dst));
@@ -642,7 +642,7 @@ CVAPI(ExceptionStatus) core_completeSymm(cv::_InputOutputArray *mtx, int lowerTo
 }
 
 // FOUNDATION: ref-struct proxy path for an _InputOutputArray argument (see core_transpose_io).
-CVAPI(ExceptionStatus) core_completeSymm_io(interop::ArrayProxy mtx, int lowerToUpper)
+CVAPI(ExceptionStatus) core_completeSymm_io(interop::InputOutputArrayProxy mtx, int lowerToUpper)
 {
     return cvTry([&] {
     cv::completeSymm(fromInputOutputProxy(mtx), lowerToUpper != 0);

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -32,10 +32,10 @@ CVAPI(ExceptionStatus) core_copyMakeBorder(
 }
 
 CVAPI(ExceptionStatus) core_add(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
 {
     return cvTry([&] {
-    cv::add(*src1, *src2, *dst, entity(mask), dtype);
+    cv::add(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 
@@ -564,16 +564,7 @@ CVAPI(ExceptionStatus) core_mulTransposed(cv::_InputArray *src, cv::_OutputArray
 CVAPI(ExceptionStatus) core_transpose(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::Scalar s;
-    cv::transpose(fromInputProxy(src, s), fromOutputProxy(dst));
-    });
-}
-
-CVAPI(ExceptionStatus) core_add_io(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
-{
-    return cvTry([&] {
-    cv::Scalar s1, s2;
-    cv::add(fromInputProxy(src1, s1), fromInputProxy(src2, s2), fromOutputProxy(dst));
+    cv::transpose(InProxy(src), OutProxy(dst));
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -556,18 +556,12 @@ CVAPI(ExceptionStatus) core_mulTransposed(cv::_InputArray *src, cv::_OutputArray
     });
 }
 
-CVAPI(ExceptionStatus) core_transpose(cv::_InputArray *src, cv::_OutputArray *dst)
-{
-    return cvTry([&] {
-    cv::transpose(*src, *dst);
-    });
-}
-
-// FOUNDATION: ref-struct proxy path. Each array argument arrives as an interop::ArrayProxy passed
-// BY VALUE; fromInputProxy()/fromOutputProxy() (in my_types.h) rebuild a cv::_InputArray /
-// _OutputArray on this stack frame, so the managed side never allocates a heap _InputArray per call.
-// Scalar-kind inputs reference a stack-local cv::Scalar scratch that must outlive the OpenCV call.
-CVAPI(ExceptionStatus) core_transpose_io(interop::ArrayProxy src, interop::ArrayProxy dst)
+// MIGRATION (issue #1976, strategy 3): array arguments arrive as interop::ArrayProxy passed BY VALUE;
+// fromInputProxy()/fromOutputProxy() (my_types.h) rebuild cv::_InputArray/_OutputArray on this stack
+// frame. The same signature serves both the ref-struct path (optimized kinds, zero managed alloc) and
+// the still-class path (Raw kinds that wrap an existing cv::_InputArray*). Scalar-kind inputs
+// reference a stack-local cv::Scalar scratch that must outlive the OpenCV call.
+CVAPI(ExceptionStatus) core_transpose(interop::ArrayProxy src, interop::ArrayProxy dst)
 {
     return cvTry([&] {
     cv::Scalar s;

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -362,31 +362,31 @@ CVAPI(ExceptionStatus) core_vconcat2(cv::_InputArray* src1, cv::_InputArray* src
 }
 
 CVAPI(ExceptionStatus) core_bitwise_and(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_and(*src1, *src2, *dst, entity(mask));
+    cv::bitwise_and(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_or(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_or(*src1, *src2, *dst, entity(mask));
+    cv::bitwise_or(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_xor(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_xor(*src1, *src2, *dst, entity(mask));
+    cv::bitwise_xor(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask));
     });
 }
 CVAPI(ExceptionStatus) core_bitwise_not(
-    cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *mask)
+    interop::ArrayProxy src, interop::ArrayProxy dst, interop::ArrayProxy mask)
 {
     return cvTry([&] {
-    cv::bitwise_not(*src, *dst, entity(mask));
+    cv::bitwise_not(InProxy(src), OutProxy(dst), InProxy(mask));
     });
 }
 
@@ -428,10 +428,18 @@ CVAPI(ExceptionStatus) core_compare(
     });
 }
 
-CVAPI(ExceptionStatus) core_min1(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_min1(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::min(*src1, *src2, *dst);
+    // Named lvalues (not InProxy temporaries): cv::min/max also have a [[nodiscard]] MatExpr(Mat,Mat)
+    // overload, and passing InProxy temporaries makes overload resolution pick it (it builds a MatExpr
+    // over dangling temporaries -> heap corruption, plus C4834). Binding to named cv::_InputArray
+    // lvalues forces the void min(InputArray,InputArray,OutputArray) overload.
+    cv::Scalar s1, s2;
+    const cv::_InputArray a = fromInputProxy(src1, s1);
+    const cv::_InputArray b = fromInputProxy(src2, s2);
+    cv::_OutputArray d = fromOutputProxy(dst);
+    cv::min(a, b, d);
     });
 }
 CVAPI(ExceptionStatus) core_min_MatMat(cv::Mat* src1, cv::Mat* src2, cv::Mat* dst)
@@ -447,10 +455,16 @@ CVAPI(ExceptionStatus) core_min_MatDouble(cv::Mat* src1, double src2, cv::Mat* d
     });
 }
 
-CVAPI(ExceptionStatus) core_max1(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_max1(interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::max(*src1, *src2, *dst);
+    // See core_min1: named lvalues force the void max(InputArray,InputArray,OutputArray) overload
+    // instead of the [[nodiscard]] MatExpr max(Mat,Mat).
+    cv::Scalar s1, s2;
+    const cv::_InputArray a = fromInputProxy(src1, s1);
+    const cv::_InputArray b = fromInputProxy(src2, s2);
+    cv::_OutputArray d = fromOutputProxy(dst);
+    cv::max(a, b, d);
     });
 }
 CVAPI(ExceptionStatus) core_max_MatMat(cv::Mat *src1, const cv::Mat *src2, cv::Mat *dst)

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -40,46 +40,46 @@ CVAPI(ExceptionStatus) core_add(
 }
 
 CVAPI(ExceptionStatus) core_subtract_InputArray2(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
 {
     return cvTry([&] {
-    cv::subtract(*src1, *src2, *dst, entity(mask), dtype);
+    cv::subtract(InProxy(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_InputArrayScalar(
-    cv::_InputArray *src1, interop::Scalar src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
+    interop::ArrayProxy src1, interop::Scalar src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
 {
     return cvTry([&] {
-    cv::subtract(*src1, cpp(src2), *dst, entity(mask), dtype);
+    cv::subtract(InProxy(src1), cpp(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_subtract_ScalarInputArray(
-    interop::Scalar src1, cv::_InputArray *src2, cv::_OutputArray *dst, cv::_InputArray *mask, int dtype)
+    interop::Scalar src1, interop::ArrayProxy src2, interop::ArrayProxy dst, interop::ArrayProxy mask, int dtype)
 {
     return cvTry([&] {
-    cv::subtract(cpp(src1), *src2, *dst, entity(mask), dtype);
+    cv::subtract(cpp(src1), InProxy(src2), OutProxy(dst), InProxy(mask), dtype);
     });
 }
 
 CVAPI(ExceptionStatus) core_multiply(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, double scale, int dtype)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, double scale, int dtype)
 {
     return cvTry([&] {
-    cv::multiply(*src1, *src2, *dst, scale, dtype);
+    cv::multiply(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide1(
-    double scale, cv::_InputArray *src2, cv::_OutputArray *dst, int dtype)
+    double scale, interop::ArrayProxy src2, interop::ArrayProxy dst, int dtype)
 {
     return cvTry([&] {
-    cv::divide(scale, *src2, *dst, dtype);
+    cv::divide(scale, InProxy(src2), OutProxy(dst), dtype);
     });
 }
 CVAPI(ExceptionStatus) core_divide2(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, double scale, int dtype)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst, double scale, int dtype)
 {
     return cvTry([&] {
-    cv::divide(*src1, *src2, *dst, scale, dtype);
+    cv::divide(InProxy(src1), InProxy(src2), OutProxy(dst), scale, dtype);
     });
 }
 
@@ -391,10 +391,10 @@ CVAPI(ExceptionStatus) core_bitwise_not(
 }
 
 CVAPI(ExceptionStatus) core_absdiff(
-    cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
+    interop::ArrayProxy src1, interop::ArrayProxy src2, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::absdiff(*src1, *src2, *dst);
+    cv::absdiff(InProxy(src1), InProxy(src2), OutProxy(dst));
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -1136,8 +1136,11 @@ CVAPI(ExceptionStatus) core_randShuffle(interop::InputOutputArrayProxy dst, doub
 {
     return cvTry([&] {
         cv::RNG rng0;
+        if (rng != nullptr)
+            rng0.state = *rng;
         cv::randShuffle(IoProxy(dst), iterFactor, &rng0);
-        *rng = rng0.state;
+        if (rng != nullptr)
+            *rng = rng0.state;
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -687,35 +687,52 @@ CVAPI(ExceptionStatus) core_magnitude_Mat(
     });
 }
 
-CVAPI(ExceptionStatus) core_checkRange(cv::_InputArray* a, int quiet, interop::Point* pos, double minVal, double maxVal, int* returnValue)
+CVAPI(ExceptionStatus) core_checkRange(
+    interop::InputArrayProxy a,
+    int quiet,
+    interop::Point* pos,
+    double minVal,
+    double maxVal,
+    int* returnValue)
 {
     return cvTry([&] {
     cv::Point pos0;
-    *returnValue = cv::checkRange(*a, quiet != 0, &pos0, minVal, maxVal);
+    *returnValue = cv::checkRange(InProxy(a), quiet != 0, &pos0, minVal, maxVal);
     *pos = c(pos0);
     });
 }
 
-CVAPI(ExceptionStatus) core_patchNaNs(cv::_InputOutputArray *a, double val)
+CVAPI(ExceptionStatus) core_patchNaNs(interop::InputOutputArrayProxy a, double val)
 {
     return cvTry([&] {
-    cv::patchNaNs(*a, val);
+    cv::patchNaNs(IoProxy(a), val);
     });
 }
 
-CVAPI(ExceptionStatus) core_gemm(cv::_InputArray *src1, cv::_InputArray *src2, double alpha,
-                      cv::_InputArray *src3, double gamma, cv::_OutputArray *dst, int flags)
+CVAPI(ExceptionStatus) core_gemm(
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    double alpha,
+    interop::InputArrayProxy src3,
+    double gamma,
+    interop::OutputArrayProxy dst,
+    int flags)
 {
     return cvTry([&] {
-    cv::gemm(*src1, *src2, alpha, *src3, gamma, *dst, flags);
+    cv::gemm(InProxy(src1), InProxy(src2), alpha, InProxy(src3), gamma, OutProxy(dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_mulTransposed(cv::_InputArray *src, cv::_OutputArray *dst, int aTa,
-                               cv::_InputArray *delta, double scale, int dtype)
+CVAPI(ExceptionStatus) core_mulTransposed(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int aTa,
+    interop::InputArrayProxy delta,
+    double scale,
+    int dtype)
 {
     return cvTry([&] {
-    cv::mulTransposed(*src, *dst, aTa != 0, entity(delta), scale, dtype);
+    cv::mulTransposed(InProxy(src), OutProxy(dst), aTa != 0, InProxy(delta), scale, dtype);
     });
 }
 
@@ -731,17 +748,23 @@ CVAPI(ExceptionStatus) core_transpose(interop::InputArrayProxy src, interop::Out
     });
 }
 
-CVAPI(ExceptionStatus) core_transform(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_transform(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy m)
 {
     return cvTry([&] {
-    cv::transform(*src, *dst, *m);
+    cv::transform(InProxy(src), OutProxy(dst), InProxy(m));
     });
 }
 
-CVAPI(ExceptionStatus) core_perspectiveTransform(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *m)
+CVAPI(ExceptionStatus) core_perspectiveTransform(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    interop::InputArrayProxy m)
 {
     return cvTry([&] {
-    cv::perspectiveTransform(*src, *dst, *m);
+    cv::perspectiveTransform(InProxy(src), OutProxy(dst), InProxy(m));
     });
 }
 CVAPI(ExceptionStatus) core_perspectiveTransform_Mat(cv::Mat *src, cv::Mat *dst, cv::Mat *m)
@@ -798,73 +821,90 @@ CVAPI(ExceptionStatus) core_completeSymm_io(interop::InputOutputArrayProxy mtx, 
     });
 }
 
-CVAPI(ExceptionStatus) core_setIdentity(cv::_InputOutputArray *mtx, interop::Scalar s)
+CVAPI(ExceptionStatus) core_setIdentity(interop::InputOutputArrayProxy mtx, interop::Scalar s)
 {
     return cvTry([&] {
-    cv::setIdentity(*mtx, cpp(s));
+    cv::setIdentity(IoProxy(mtx), cpp(s));
     });
 }
 
-CVAPI(ExceptionStatus) core_determinant(cv::_InputArray *mtx, double *returnValue)
+CVAPI(ExceptionStatus) core_determinant(interop::InputArrayProxy mtx, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::determinant(*mtx);
+    *returnValue = cv::determinant(InProxy(mtx));
     });
 }
 
-CVAPI(ExceptionStatus) core_trace(cv::_InputArray *mtx, interop::Scalar *returnValue)
+CVAPI(ExceptionStatus) core_trace(interop::InputArrayProxy mtx, interop::Scalar *returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::trace(*mtx));
+    *returnValue = c(cv::trace(InProxy(mtx)));
     });
 }
 
-CVAPI(ExceptionStatus) core_invert(cv::_InputArray *src, cv::_OutputArray *dst, int flags, double *returnValue)
+CVAPI(ExceptionStatus) core_invert(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy dst,
+    int flags,
+    double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::invert(*src, *dst, flags);
+    *returnValue = cv::invert(InProxy(src), OutProxy(dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_solve(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int flags, int *returnValue)
+CVAPI(ExceptionStatus) core_solve(
+    interop::InputArrayProxy src1,
+    interop::InputArrayProxy src2,
+    interop::OutputArrayProxy dst,
+    int flags,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::solve(*src1, *src2, *dst, flags);
+    *returnValue = cv::solve(InProxy(src1), InProxy(src2), OutProxy(dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_solveLP(cv::_InputArray *Func, cv::_InputArray *Constr, cv::_OutputArray *z, int *returnValue)
+CVAPI(ExceptionStatus) core_solveLP(
+    interop::InputArrayProxy Func,
+    interop::InputArrayProxy Constr,
+    interop::OutputArrayProxy z,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::solveLP(*Func, *Constr, *z);
+    *returnValue = cv::solveLP(InProxy(Func), InProxy(Constr), OutProxy(z));
     });
 }
 
-CVAPI(ExceptionStatus) core_sort(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
+CVAPI(ExceptionStatus) core_sort(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
 {
     return cvTry([&] {
-    cv::sort(*src, *dst, flags);
+    cv::sort(InProxy(src), OutProxy(dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_sortIdx(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
+CVAPI(ExceptionStatus) core_sortIdx(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
 {
     return cvTry([&] {
-    cv::sortIdx(*src, *dst, flags);
+    cv::sortIdx(InProxy(src), OutProxy(dst), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_solveCubic(cv::_InputArray *coeffs, cv::_OutputArray *roots, int *returnValue)
+CVAPI(ExceptionStatus) core_solveCubic(interop::InputArrayProxy coeffs, interop::OutputArrayProxy roots, int *returnValue)
 {
     return cvTry([&] {
-    *returnValue =  cv::solveCubic(*coeffs, *roots);
+    *returnValue =  cv::solveCubic(InProxy(coeffs), OutProxy(roots));
     });
 }
 
-CVAPI(ExceptionStatus) core_solvePoly(cv::_InputArray *coeffs, cv::_OutputArray *roots, int maxIters, double *returnValue)
+CVAPI(ExceptionStatus) core_solvePoly(
+    interop::InputArrayProxy coeffs,
+    interop::OutputArrayProxy roots,
+    int maxIters,
+    double *returnValue)
 {
     return cvTry([&] {
-    *returnValue =  cv::solvePoly(*coeffs, *roots, maxIters);
+    *returnValue =  cv::solvePoly(InProxy(coeffs), OutProxy(roots), maxIters);
     });
 }
 

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -908,18 +908,24 @@ CVAPI(ExceptionStatus) core_solvePoly(
     });
 }
 
-CVAPI(ExceptionStatus) core_eigen(cv::_InputArray *src, cv::_OutputArray *eigenvalues,    cv::_OutputArray *eigenvectors, int *returnValue)
+CVAPI(ExceptionStatus) core_eigen(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy eigenvalues,
+    interop::OutputArrayProxy eigenvectors,
+    int *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::eigen(*src, *eigenvalues, *eigenvectors) ? 1 : 0;
+        *returnValue = cv::eigen(InProxy(src), OutProxy(eigenvalues), OutProxy(eigenvectors)) ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) core_eigenNonSymmetric(
-    cv::_InputArray *src,  cv::_OutputArray *eigenvalues, cv::_OutputArray *eigenvectors)
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy eigenvalues,
+    interop::OutputArrayProxy eigenvectors)
 {
     return cvTry([&] {
-        cv::eigenNonSymmetric(*src, *eigenvalues, *eigenvectors);
+        cv::eigenNonSymmetric(InProxy(src), OutProxy(eigenvalues), OutProxy(eigenvectors));
     });
 }
 
@@ -934,114 +940,155 @@ CVAPI(ExceptionStatus) core_calcCovarMatrix_Mat(cv::Mat **samples, int nsamples,
         cv::calcCovarMatrix(&samplesVec[0], nsamples, *covar, *mean, flags, ctype);
     });
 }
-CVAPI(ExceptionStatus) core_calcCovarMatrix_InputArray(cv::_InputArray *samples, cv::_OutputArray *covar, 
-                                            cv::_InputOutputArray *mean, int flags, int ctype)
+CVAPI(ExceptionStatus) core_calcCovarMatrix_InputArray(
+    interop::InputArrayProxy samples,
+    interop::OutputArrayProxy covar,
+    interop::InputOutputArrayProxy mean,
+    int flags,
+    int ctype)
 {
     return cvTry([&] {
-        cv::calcCovarMatrix(*samples, *covar, *mean, flags, ctype);
+        cv::calcCovarMatrix(InProxy(samples), OutProxy(covar), IoProxy(mean), flags, ctype);
     });
 }
 
-CVAPI(ExceptionStatus) core_PCACompute(cv::_InputArray *data, cv::_InputOutputArray *mean,
-                            cv::_OutputArray *eigenvectors, int maxComponents)
+CVAPI(ExceptionStatus) core_PCACompute(
+    interop::InputArrayProxy data,
+    interop::InputOutputArrayProxy mean,
+    interop::OutputArrayProxy eigenvectors,
+    int maxComponents)
 {
     return cvTry([&] {
-        cv::PCACompute(*data, *mean, *eigenvectors, maxComponents);
+        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), maxComponents);
     });
 }
-CVAPI(ExceptionStatus) core_PCACompute2(cv::_InputArray *data, cv::_InputOutputArray *mean,
-                            cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, int maxComponents)
+CVAPI(ExceptionStatus) core_PCACompute2(
+    interop::InputArrayProxy data,
+    interop::InputOutputArrayProxy mean,
+    interop::OutputArrayProxy eigenvectors,
+    interop::OutputArrayProxy eigenvalues,
+    int maxComponents)
 {
     return cvTry([&] {
-        cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, maxComponents);
-    });
-}
-
-CVAPI(ExceptionStatus) core_PCAComputeVar(cv::_InputArray *data, cv::_InputOutputArray *mean,
-                               cv::_OutputArray *eigenvectors, double retainedVariance)
-{
-    return cvTry([&] {
-        cv::PCACompute(*data, *mean, *eigenvectors, retainedVariance);
-    });
-}
-CVAPI(ExceptionStatus) core_PCAComputeVar2(cv::_InputArray *data, cv::_InputOutputArray *mean,
-                               cv::_OutputArray *eigenvectors, cv::_OutputArray *eigenvalues, double retainedVariance)
-{
-    return cvTry([&] {
-        cv::PCACompute(*data, *mean, *eigenvectors, *eigenvalues, retainedVariance);
+        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), OutProxy(eigenvalues), maxComponents);
     });
 }
 
-CVAPI(ExceptionStatus) core_PCAProject(cv::_InputArray *data, cv::_InputArray *mean,
-                            cv::_InputArray *eigenvectors, cv::_OutputArray *result)
+CVAPI(ExceptionStatus) core_PCAComputeVar(
+    interop::InputArrayProxy data,
+    interop::InputOutputArrayProxy mean,
+    interop::OutputArrayProxy eigenvectors,
+    double retainedVariance)
 {
     return cvTry([&] {
-        cv::PCAProject(*data, *mean, *eigenvectors, *result);
+        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), retainedVariance);
     });
 }
-CVAPI(ExceptionStatus) core_PCABackProject(cv::_InputArray *data, cv::_InputArray *mean,
-                                cv::_InputArray *eigenvectors, cv::_OutputArray *result)
+CVAPI(ExceptionStatus) core_PCAComputeVar2(
+    interop::InputArrayProxy data,
+    interop::InputOutputArrayProxy mean,
+    interop::OutputArrayProxy eigenvectors,
+    interop::OutputArrayProxy eigenvalues,
+    double retainedVariance)
 {
     return cvTry([&] {
-        cv::PCABackProject(*data, *mean, *eigenvectors, *result);
-    });
-}
-
-CVAPI(ExceptionStatus) core_SVDecomp(cv::_InputArray *src, cv::_OutputArray *w,
-                          cv::_OutputArray *u, cv::_OutputArray *vt, int flags)
-{
-    return cvTry([&] {
-        cv::SVDecomp(*src, *w, *u, *vt, flags);
-    });
-}
-
-CVAPI(ExceptionStatus) core_SVBackSubst(cv::_InputArray *w, cv::_InputArray *u, cv::_InputArray *vt,
-                             cv::_InputArray *rhs, cv::_OutputArray *dst)
-{
-    return cvTry([&] {
-        cv::SVBackSubst(*w, *u, *vt, *rhs, *dst);
+        cv::PCACompute(InProxy(data), IoProxy(mean), OutProxy(eigenvectors), OutProxy(eigenvalues), retainedVariance);
     });
 }
 
-CVAPI(ExceptionStatus) core_Mahalanobis(cv::_InputArray *v1, cv::_InputArray *v2, cv::_InputArray *icovar, double *returnValue)
+CVAPI(ExceptionStatus) core_PCAProject(
+    interop::InputArrayProxy data,
+    interop::InputArrayProxy mean,
+    interop::InputArrayProxy eigenvectors,
+    interop::OutputArrayProxy result)
 {
     return cvTry([&] {
-        *returnValue = cv::Mahalanobis(*v1, *v2, *icovar);
+        cv::PCAProject(InProxy(data), InProxy(mean), InProxy(eigenvectors), OutProxy(result));
+    });
+}
+CVAPI(ExceptionStatus) core_PCABackProject(
+    interop::InputArrayProxy data,
+    interop::InputArrayProxy mean,
+    interop::InputArrayProxy eigenvectors,
+    interop::OutputArrayProxy result)
+{
+    return cvTry([&] {
+        cv::PCABackProject(InProxy(data), InProxy(mean), InProxy(eigenvectors), OutProxy(result));
     });
 }
 
-CVAPI(ExceptionStatus) core_dft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
+CVAPI(ExceptionStatus) core_SVDecomp(
+    interop::InputArrayProxy src,
+    interop::OutputArrayProxy w,
+    interop::OutputArrayProxy u,
+    interop::OutputArrayProxy vt,
+    int flags)
 {
     return cvTry([&] {
-        cv::dft(*src, *dst, flags, nonzeroRows);
+        cv::SVDecomp(InProxy(src), OutProxy(w), OutProxy(u), OutProxy(vt), flags);
     });
 }
 
-CVAPI(ExceptionStatus) core_idft(cv::_InputArray *src, cv::_OutputArray *dst, int flags, int nonzeroRows)
+CVAPI(ExceptionStatus) core_SVBackSubst(
+    interop::InputArrayProxy w,
+    interop::InputArrayProxy u,
+    interop::InputArrayProxy vt,
+    interop::InputArrayProxy rhs,
+    interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-        cv::idft(*src, *dst, flags, nonzeroRows);
+        cv::SVBackSubst(InProxy(w), InProxy(u), InProxy(vt), InProxy(rhs), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_dct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
+CVAPI(ExceptionStatus) core_Mahalanobis(
+    interop::InputArrayProxy v1,
+    interop::InputArrayProxy v2,
+    interop::InputArrayProxy icovar,
+    double *returnValue)
 {
     return cvTry([&] {
-        cv::dct(*src, *dst, flags); 
+        *returnValue = cv::Mahalanobis(InProxy(v1), InProxy(v2), InProxy(icovar));
     });
 }
 
-CVAPI(ExceptionStatus) core_idct(cv::_InputArray *src, cv::_OutputArray *dst, int flags)
+CVAPI(ExceptionStatus) core_dft(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-        cv::idct(*src, *dst, flags);
+        cv::dft(InProxy(src), OutProxy(dst), flags, nonzeroRows);
     });
 }
 
-CVAPI(ExceptionStatus) core_mulSpectrums(cv::_InputArray *a, cv::_InputArray *b, cv::_OutputArray *c, int flags, int conjB)
+CVAPI(ExceptionStatus) core_idft(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags, int nonzeroRows)
 {
     return cvTry([&] {
-        cv::mulSpectrums(*a, *b, *c, flags, conjB != 0);
+        cv::idft(InProxy(src), OutProxy(dst), flags, nonzeroRows);
+    });
+}
+
+CVAPI(ExceptionStatus) core_dct(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+{
+    return cvTry([&] {
+        cv::dct(InProxy(src), OutProxy(dst), flags);
+    });
+}
+
+CVAPI(ExceptionStatus) core_idct(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int flags)
+{
+    return cvTry([&] {
+        cv::idct(InProxy(src), OutProxy(dst), flags);
+    });
+}
+
+CVAPI(ExceptionStatus) core_mulSpectrums(
+    interop::InputArrayProxy a,
+    interop::InputArrayProxy b,
+    interop::OutputArrayProxy c,
+    int flags,
+    int conjB)
+{
+    return cvTry([&] {
+        cv::mulSpectrums(InProxy(a), InProxy(b), OutProxy(c), flags, conjB != 0);
     });
 }
 
@@ -1067,48 +1114,53 @@ CVAPI(ExceptionStatus) core_theRNG_set(uint64 value)
     });
 }
 
-CVAPI(ExceptionStatus) core_randu_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *low, cv::_InputArray *high)
+CVAPI(ExceptionStatus) core_randu_InputArray(interop::InputOutputArrayProxy dst, interop::InputArrayProxy low, interop::InputArrayProxy high)
 {
     return cvTry([&] {
-        cv::randu(*dst, *low, *high);
+        cv::randu(IoProxy(dst), InProxy(low), InProxy(high));
     });
 }
-CVAPI(ExceptionStatus) core_randu_Scalar(cv::_InputOutputArray *dst, interop::Scalar low, interop::Scalar high)
+CVAPI(ExceptionStatus) core_randu_Scalar(interop::InputOutputArrayProxy dst, interop::Scalar low, interop::Scalar high)
 {
     return cvTry([&] {
-        cv::randu(*dst, cpp(low), cpp(high));
-    });
-}
-
-CVAPI(ExceptionStatus) core_randn_InputArray(cv::_InputOutputArray *dst, cv::_InputArray *mean, cv::_InputArray *stddev)
-{
-    return cvTry([&] {
-        cv::randn(*dst, *mean, *stddev);
-    });
-}
-CVAPI(ExceptionStatus) core_randn_Scalar(cv::_InputOutputArray *dst, interop::Scalar mean, interop::Scalar stddev)
-{
-    return cvTry([&] {
-        cv::randn(*dst, cpp(mean), cpp(stddev));
+        cv::randu(IoProxy(dst), cpp(low), cpp(high));
     });
 }
 
-CVAPI(ExceptionStatus) core_randShuffle(cv::_InputOutputArray *dst, double iterFactor, uint64 *rng)
+CVAPI(ExceptionStatus) core_randn_InputArray(interop::InputOutputArrayProxy dst, interop::InputArrayProxy mean, interop::InputArrayProxy stddev)
+{
+    return cvTry([&] {
+        cv::randn(IoProxy(dst), InProxy(mean), InProxy(stddev));
+    });
+}
+CVAPI(ExceptionStatus) core_randn_Scalar(interop::InputOutputArrayProxy dst, interop::Scalar mean, interop::Scalar stddev)
+{
+    return cvTry([&] {
+        cv::randn(IoProxy(dst), cpp(mean), cpp(stddev));
+    });
+}
+
+CVAPI(ExceptionStatus) core_randShuffle(interop::InputOutputArrayProxy dst, double iterFactor, uint64 *rng)
 {
     return cvTry([&] {
         cv::RNG rng0;
-        cv::randShuffle(*dst, iterFactor, &rng0);
+        cv::randShuffle(IoProxy(dst), iterFactor, &rng0);
         *rng = rng0.state;
     });
 }
 
 CVAPI(ExceptionStatus) core_kmeans(
-    cv::_InputArray *data, int k, cv::_InputOutputArray *bestLabels,
-    interop::TermCriteria criteria, int attempts, int flags, cv::_OutputArray *centers, 
+    interop::InputArrayProxy data,
+    int k,
+    interop::InputOutputArrayProxy bestLabels,
+    interop::TermCriteria criteria,
+    int attempts,
+    int flags,
+    interop::OutputArrayProxy centers,
     double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::kmeans(*data, k, *bestLabels, cpp(criteria), attempts, flags, entity(centers));
+        *returnValue = cv::kmeans(InProxy(data), k, IoProxy(bestLabels), cpp(criteria), attempts, flags, OutProxy(centers));
     });
 }
 
@@ -1331,11 +1383,17 @@ CVAPI(ExceptionStatus) core_logger_getLogLevel(cv::utils::logging::LogLevel *ret
 
 #pragma region RNG
 
-CVAPI(ExceptionStatus) core_RNG_fill(uint64 *state, cv::_InputOutputArray *mat, int distType, cv::_InputArray *a, cv::_InputArray *b, int saturateRange)
+CVAPI(ExceptionStatus) core_RNG_fill(
+    uint64 *state,
+    interop::InputOutputArrayProxy mat,
+    int distType,
+    interop::InputArrayProxy a,
+    interop::InputArrayProxy b,
+    int saturateRange)
 {
     return cvTry([&] {
         cv::RNG rng(*state);
-        rng.fill(*mat, distType, *a, *b, saturateRange != 0);
+        rng.fill(IoProxy(mat), distType, InProxy(a), InProxy(b), saturateRange != 0);
         *state = rng.state;
     });
 }

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -83,59 +83,59 @@ CVAPI(ExceptionStatus) core_divide2(
     });
 }
 
-CVAPI(ExceptionStatus) core_scaleAdd(cv::_InputArray *src1, double alpha, cv::_InputArray *src2, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) core_scaleAdd(interop::ArrayProxy src1, double alpha, interop::ArrayProxy src2, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    cv::scaleAdd(*src1, alpha, *src2, *dst);
+    cv::scaleAdd(InProxy(src1), alpha, InProxy(src2), OutProxy(dst));
     });
 }
-CVAPI(ExceptionStatus) core_addWeighted(cv::_InputArray *src1, double alpha, cv::_InputArray *src2,
-                             double beta, double gamma, cv::_OutputArray *dst, int dtype)
+CVAPI(ExceptionStatus) core_addWeighted(interop::ArrayProxy src1, double alpha, interop::ArrayProxy src2,
+                             double beta, double gamma, interop::ArrayProxy dst, int dtype)
 {
     return cvTry([&] {
-    cv::addWeighted(*src1, alpha, *src2, beta, gamma, *dst, dtype);
-    });
-}
-
-CVAPI(ExceptionStatus) core_convertScaleAbs(cv::_InputArray* src, cv::_OutputArray* dst, double alpha, double beta)
-{
-    return cvTry([&] {
-    cv::convertScaleAbs(*src, *dst, alpha, beta);
+    cv::addWeighted(InProxy(src1), alpha, InProxy(src2), beta, gamma, OutProxy(dst), dtype);
     });
 }
 
-CVAPI(ExceptionStatus) core_LUT(cv::_InputArray* src, cv::_InputArray* lut, cv::_OutputArray* dst)
+CVAPI(ExceptionStatus) core_convertScaleAbs(interop::ArrayProxy src, interop::ArrayProxy dst, double alpha, double beta)
 {
     return cvTry([&] {
-    cv::LUT(*src, *lut, *dst);
+    cv::convertScaleAbs(InProxy(src), OutProxy(dst), alpha, beta);
     });
 }
 
-CVAPI(ExceptionStatus) core_sum(cv::_InputArray* src, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_LUT(interop::ArrayProxy src, interop::ArrayProxy lut, interop::ArrayProxy dst)
 {
     return cvTry([&] {
-    *returnValue = c(cv::sum(*src));
+    cv::LUT(InProxy(src), InProxy(lut), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) core_countNonZero(cv::_InputArray* src, int* returnValue)
+CVAPI(ExceptionStatus) core_sum(interop::ArrayProxy src, interop::Scalar* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::countNonZero(*src);
+    *returnValue = c(cv::sum(InProxy(src)));
     });
 }
 
-CVAPI(ExceptionStatus) core_findNonZero(cv::_InputArray* src, cv::_OutputArray* idx)
+CVAPI(ExceptionStatus) core_countNonZero(interop::ArrayProxy src, int* returnValue)
 {
     return cvTry([&] {
-    cv::findNonZero(*src, *idx);
+    *returnValue = cv::countNonZero(InProxy(src));
     });
 }
 
-CVAPI(ExceptionStatus) core_mean(cv::_InputArray* src, cv::_InputArray* mask, interop::Scalar* returnValue)
+CVAPI(ExceptionStatus) core_findNonZero(interop::ArrayProxy src, interop::ArrayProxy idx)
 {
     return cvTry([&] {
-    *returnValue = c(cv::mean(*src, entity(mask)));
+    cv::findNonZero(InProxy(src), OutProxy(idx));
+    });
+}
+
+CVAPI(ExceptionStatus) core_mean(interop::ArrayProxy src, interop::ArrayProxy mask, interop::Scalar* returnValue)
+{
+    return cvTry([&] {
+    *returnValue = c(cv::mean(InProxy(src), InProxy(mask)));
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -15,11 +15,11 @@ CVAPI(ExceptionStatus) imgproc_getGaussianKernel(int ksize, double sigma, int kt
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getDerivKernels(cv::_OutputArray *kx, cv::_OutputArray *ky,
+CVAPI(ExceptionStatus) imgproc_getDerivKernels(interop::OutputArrayProxy kx, interop::OutputArrayProxy ky,
     int dx, int dy, int ksize, int normalize, int ktype)
 {
     return cvTry([&] {
-    cv::getDerivKernels(*kx, *ky, dx, dy, ksize, normalize != 0, ktype);
+        cv::getDerivKernels(OutProxy(kx), OutProxy(ky), dx, dy, ksize, normalize != 0, ktype);
     });
 }
 
@@ -40,291 +40,291 @@ CVAPI(ExceptionStatus) imgproc_getStructuringElement(int shape, interop::Size ks
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_medianBlur(cv::_InputArray *src, cv::_OutputArray *dst, int ksize)
+CVAPI(ExceptionStatus) imgproc_medianBlur(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ksize)
 {
     return cvTry([&] {
-    cv::medianBlur(*src, *dst, ksize);
+        cv::medianBlur(InProxy(src), OutProxy(dst), ksize);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_GaussianBlur(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_GaussianBlur(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                             interop::Size ksize, double sigmaX, double sigmaY, int borderType, int hint)
 {
     return cvTry([&] {
-    cv::GaussianBlur(*src, *dst, cpp(ksize), sigmaX, sigmaY, borderType, static_cast<cv::AlgorithmHint>(hint));
+        cv::GaussianBlur(InProxy(src), OutProxy(dst), cpp(ksize), sigmaX, sigmaY, borderType, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_bilateralFilter(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_bilateralFilter(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                     int d, double sigmaColor, double sigmaSpace, int borderType)
 {
     return cvTry([&] {
-    cv::bilateralFilter(*src, *dst, d, sigmaColor, sigmaSpace, borderType);
+        cv::bilateralFilter(InProxy(src), OutProxy(dst), d, sigmaColor, sigmaSpace, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boxFilter(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
+CVAPI(ExceptionStatus) imgproc_boxFilter(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
                               interop::Size ksize, interop::Point anchor, int normalize, int borderType)
 {
     return cvTry([&] {
-    cv::boxFilter(*src, *dst, ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
+        cv::boxFilter(InProxy(src), OutProxy(dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_sqrBoxFilter(
-    cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
+    interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
     interop::Size ksize, interop::Point anchor, int normalize, int borderType)
 {
     return cvTry([&] {
-    cv::sqrBoxFilter(*src, *dst, ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
+        cv::sqrBoxFilter(InProxy(src), OutProxy(dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_blur(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size ksize, interop::Point anchor, int borderType)
+CVAPI(ExceptionStatus) imgproc_blur(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size ksize, interop::Point anchor, int borderType)
 {
     return cvTry([&] {
-    cv::blur(*src, *dst, cpp(ksize), cpp(anchor), borderType);
+        cv::blur(InProxy(src), OutProxy(dst), cpp(ksize), cpp(anchor), borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_filter2D(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
-                             cv::_InputArray *kernel, interop::Point anchor, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_filter2D(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
+                             interop::InputArrayProxy kernel, interop::Point anchor, double delta, int borderType)
 {
     return cvTry([&] {
-    cv::filter2D(*src, *dst, ddepth, *kernel, cpp(anchor), delta, borderType);
+        cv::filter2D(InProxy(src), OutProxy(dst), ddepth, InProxy(kernel), cpp(anchor), delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_filter2Dp(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
+CVAPI(ExceptionStatus) imgproc_filter2Dp(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
                              int anchorX, int anchorY, int borderType, interop::Scalar borderValue, int ddepth, double scale, double shift)
 {
     return cvTry([&] {
-    cv::Filter2DParams params;
-    params.anchorX = anchorX;
-    params.anchorY = anchorY;
-    params.borderType = borderType;
-    params.borderValue = cpp(borderValue);
-    params.ddepth = ddepth;
-    params.scale = scale;
-    params.shift = shift;
-    cv::filter2D(*src, *dst, *kernel, params);
+        cv::Filter2DParams params;
+        params.anchorX = anchorX;
+        params.anchorY = anchorY;
+        params.borderType = borderType;
+        params.borderValue = cpp(borderValue);
+        params.ddepth = ddepth;
+        params.scale = scale;
+        params.shift = shift;
+        cv::filter2D(InProxy(src), OutProxy(dst), InProxy(kernel), params);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_sepFilter2D(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
-                                cv::_InputArray *kernelX, cv::_InputArray *kernelY,
+CVAPI(ExceptionStatus) imgproc_sepFilter2D(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
+                                interop::InputArrayProxy kernelX, interop::InputArrayProxy kernelY,
                                 interop::Point anchor, double delta, int borderType)
 {
     return cvTry([&] {
-    cv::sepFilter2D(*src, *dst, ddepth, *kernelX, *kernelY, cpp(anchor), delta, borderType);
+        cv::sepFilter2D(InProxy(src), OutProxy(dst), ddepth, InProxy(kernelX), InProxy(kernelY), cpp(anchor), delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Sobel(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
+CVAPI(ExceptionStatus) imgproc_Sobel(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
                           int dx, int dy, int ksize, double scale, double delta, int borderType)
 {
     return cvTry([&] {
-    cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
+        cv::Sobel(InProxy(src), OutProxy(dst), ddepth, dx, dy, ksize, scale, delta, borderType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_spatialGradient(
-    cv::_InputArray *src, cv::_OutputArray *dx, cv::_OutputArray *dy, int ksize, int borderType)
+    interop::InputArrayProxy src, interop::OutputArrayProxy dx, interop::OutputArrayProxy dy, int ksize, int borderType)
 {
     return cvTry([&] {
-    cv::spatialGradient(*src, *dx, *dy, ksize, borderType);
+        cv::spatialGradient(InProxy(src), OutProxy(dx), OutProxy(dy), ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Scharr(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
+CVAPI(ExceptionStatus) imgproc_Scharr(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
                            int dx, int dy, double scale, double delta, int borderType)
 {
     return cvTry([&] {
-    cv::Scharr(*src, *dst, ddepth, dx, dy, scale, delta, borderType);
+        cv::Scharr(InProxy(src), OutProxy(dst), ddepth, dx, dy, scale, delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Laplacian(cv::_InputArray *src, cv::_OutputArray *dst, int ddepth,
+CVAPI(ExceptionStatus) imgproc_Laplacian(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
                               int ksize, double scale, double delta, int borderType)
 {
     return cvTry([&] {
-    cv::Laplacian(*src, *dst, ddepth, ksize, scale, delta, borderType);
+        cv::Laplacian(InProxy(src), OutProxy(dst), ddepth, ksize, scale, delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Canny1(cv::_InputArray *src, cv::_OutputArray *edges,
+CVAPI(ExceptionStatus) imgproc_Canny1(interop::InputArrayProxy src, interop::OutputArrayProxy edges,
                           double threshold1, double threshold2, int apertureSize, int L2gradient)
 {
     return cvTry([&] {
-    cv::Canny(*src, *edges, threshold1, threshold2, apertureSize, L2gradient != 0);
+        cv::Canny(InProxy(src), OutProxy(edges), threshold1, threshold2, apertureSize, L2gradient != 0);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_Canny2(
-    cv::_InputArray *dx, cv::_InputArray *dy, cv::_OutputArray *edges,
+    interop::InputArrayProxy dx, interop::InputArrayProxy dy, interop::OutputArrayProxy edges,
     double threshold1, double threshold2, int L2gradient = false)
 {
     return cvTry([&] {
-    cv::Canny(*dx, *dy, *edges, threshold1, threshold2, L2gradient != 0);
+        cv::Canny(InProxy(dx), InProxy(dy), OutProxy(edges), threshold1, threshold2, L2gradient != 0);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerMinEigenVal(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_cornerMinEigenVal(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                       int blockSize, int ksize, int borderType)
 {
     return cvTry([&] {
-    cv::cornerMinEigenVal(*src, *dst, blockSize, ksize, borderType);
+        cv::cornerMinEigenVal(InProxy(src), OutProxy(dst), blockSize, ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerHarris(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_cornerHarris(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                  int blockSize, int ksize, double k, int borderType)
 {
     return cvTry([&] {
-    cv::cornerHarris(*src, *dst, blockSize, ksize, k, borderType);
+        cv::cornerHarris(InProxy(src), OutProxy(dst), blockSize, ksize, k, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerEigenValsAndVecs(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_cornerEigenValsAndVecs(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                            int blockSize, int ksize, int borderType)
 {
     return cvTry([&] {
-    cv::cornerEigenValsAndVecs(*src, *dst, blockSize, ksize, borderType);
+        cv::cornerEigenValsAndVecs(InProxy(src), OutProxy(dst), blockSize, ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_preCornerDetect(cv::_InputArray *src, cv::_OutputArray *dst, int ksize, int borderType)
+CVAPI(ExceptionStatus) imgproc_preCornerDetect(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ksize, int borderType)
 {
     return cvTry([&] {
-    cv::preCornerDetect(*src, *dst, ksize, borderType);
+        cv::preCornerDetect(InProxy(src), OutProxy(dst), ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerSubPix(cv::_InputArray *image, std::vector<cv::Point2f> *corners,
+CVAPI(ExceptionStatus) imgproc_cornerSubPix(interop::InputArrayProxy image, std::vector<cv::Point2f> *corners,
                                  interop::Size winSize, interop::Size zeroZone, interop::TermCriteria criteria)
 {
     return cvTry([&] {
-    cv::cornerSubPix(*image, *corners, cpp(winSize), cpp(zeroZone), cpp(criteria));
+        cv::cornerSubPix(InProxy(image), *corners, cpp(winSize), cpp(zeroZone), cpp(criteria));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(cv::_InputArray *src, std::vector<cv::Point2f> *corners,
+CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(interop::InputArrayProxy src, std::vector<cv::Point2f> *corners,
                                         int maxCorners, double qualityLevel, double minDistance,
-                                        cv::_InputArray *mask, int blockSize, int useHarrisDetector, double k)
+                                        interop::InputArrayProxy mask, int blockSize, int useHarrisDetector, double k)
 {
     return cvTry([&] {
-    cv::goodFeaturesToTrack(*src, *corners, maxCorners, qualityLevel, minDistance, 
-        entity(mask), blockSize, useHarrisDetector != 0, k);
+        cv::goodFeaturesToTrack(InProxy(src), *corners, maxCorners, qualityLevel, minDistance, 
+            InProxy(mask), blockSize, useHarrisDetector != 0, k);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughLines(cv::_InputArray *src, std::vector<cv::Vec2f> *lines,
+CVAPI(ExceptionStatus) imgproc_HoughLines(interop::InputArrayProxy src, std::vector<cv::Vec2f> *lines,
                                double rho, double theta, int threshold,
                                double srn, double stn)
 {
     return cvTry([&] {
-    cv::HoughLines(*src, *lines, rho, theta, threshold, srn, stn);
+        cv::HoughLines(InProxy(src), *lines, rho, theta, threshold, srn, stn);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughLinesP(cv::_InputArray *src, std::vector<cv::Vec4i> *lines,
+CVAPI(ExceptionStatus) imgproc_HoughLinesP(interop::InputArrayProxy src, std::vector<cv::Vec4i> *lines,
                                 double rho, double theta, int threshold,
                                 double minLineLength, double maxLineGap)
 {
     return cvTry([&] {
-    cv::HoughLinesP(*src, *lines, rho, theta, threshold, minLineLength, maxLineGap);
+        cv::HoughLinesP(InProxy(src), *lines, rho, theta, threshold, minLineLength, maxLineGap);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughLinesPointSet(
-    cv::_InputArray *_point, cv::_OutputArray *_lines, int lines_max, int threshold,
+    interop::InputArrayProxy _point, interop::OutputArrayProxy _lines, int lines_max, int threshold,
     double min_rho, double max_rho, double rho_step,
     double min_theta, double max_theta, double theta_step)
 {
     return cvTry([&] {
-    cv::HoughLinesPointSet(*_point, *_lines, lines_max, threshold, min_rho, max_rho, rho_step, min_theta, max_theta, theta_step);
+        cv::HoughLinesPointSet(InProxy(_point), OutProxy(_lines), lines_max, threshold, min_rho, max_rho, rho_step, min_theta, max_theta, theta_step);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughCircles(cv::_InputArray *src, std::vector<cv::Vec3f> *circles,
+CVAPI(ExceptionStatus) imgproc_HoughCircles(interop::InputArrayProxy src, std::vector<cv::Vec3f> *circles,
                                  int method, double dp, double minDist,
                                  double param1, double param2, int minRadius, int maxRadius)
 {
     return cvTry([&] {
-    cv::HoughCircles(*src, *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
+        cv::HoughCircles(InProxy(src), *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
     });
 }
 
 
-CVAPI(ExceptionStatus) imgproc_erode(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
+CVAPI(ExceptionStatus) imgproc_erode(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
                           interop::Point anchor, int iterations,    int borderType, interop::Scalar borderValue)
 {
     return cvTry([&] {
-    cv::erode(*src, *dst, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::erode(InProxy(src), OutProxy(dst), InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_dilate(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *kernel,
+CVAPI(ExceptionStatus) imgproc_dilate(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
                            interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
 {
     return cvTry([&] {
-    cv::dilate(*src, *dst, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::dilate(InProxy(src), OutProxy(dst), InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_morphologyEx(cv::_InputArray *src, cv::_OutputArray *dst, int op, cv::_InputArray *kernel,
+CVAPI(ExceptionStatus) imgproc_morphologyEx(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int op, interop::InputArrayProxy kernel,
                                  interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
 {
     return cvTry([&] {
-    cv::morphologyEx(*src, *dst, op, entity(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::morphologyEx(InProxy(src), OutProxy(dst), op, InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_resize(cv::_InputArray* src, cv::_OutputArray* dst, interop::Size dsize, double fx, double fy, int interpolation)
+CVAPI(ExceptionStatus) imgproc_resize(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dsize, double fx, double fy, int interpolation)
 {
     return cvTry([&] {
-    cv::resize(*src, *dst, cpp(dsize), fx, fy, interpolation);
+        cv::resize(InProxy(src), OutProxy(dst), cpp(dsize), fx, fy, interpolation);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpAffine(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* M, interop::Size dsize,
+CVAPI(ExceptionStatus) imgproc_warpAffine(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy M, interop::Size dsize,
                                           int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
     return cvTry([&] {
-    cv::warpAffine(*src, *dst, *M, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::warpAffine(InProxy(src), OutProxy(dst), InProxy(M), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpPerspective_MisInputArray(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* m, interop::Size dsize,
+CVAPI(ExceptionStatus) imgproc_warpPerspective_MisInputArray(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy m, interop::Size dsize,
                                                              int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
     return cvTry([&] {
-    cv::warpPerspective(*src, *dst, *m, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::warpPerspective(InProxy(src), OutProxy(dst), InProxy(m), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpPerspective_MisArray(cv::_InputArray* src, cv::_OutputArray* dst, float* m, int mRow, int mCol, interop::Size dsize,
+CVAPI(ExceptionStatus) imgproc_warpPerspective_MisArray(interop::InputArrayProxy src, interop::OutputArrayProxy dst, float* m, int mRow, int mCol, interop::Size dsize,
                                                         int flags, int borderMode, interop::Scalar borderValue, int hint)
 {
     return cvTry([&] {
-    const cv::Mat mmat(mRow, mCol, CV_32FC1, m);
-    cv::warpPerspective(*src, *dst, mmat, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        const cv::Mat mmat(mRow, mCol, CV_32FC1, m);
+        cv::warpPerspective(InProxy(src), OutProxy(dst), mmat, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_remap(cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray* map1, cv::_InputArray* map2,
+CVAPI(ExceptionStatus) imgproc_remap(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy map1, interop::InputArrayProxy map2,
                                      int interpolation, int borderMode, interop::Scalar borderValue, int hint)
 {
     return cvTry([&] {
-    cv::remap(*src, *dst, *map1, *map2, interpolation, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::remap(InProxy(src), OutProxy(dst), InProxy(map1), InProxy(map2), interpolation, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convertMaps(cv::_InputArray* map1, cv::_InputArray* map2, cv::_OutputArray* dstmap1, cv::_OutputArray* dstmap2,
+CVAPI(ExceptionStatus) imgproc_convertMaps(interop::InputArrayProxy map1, interop::InputArrayProxy map2, interop::OutputArrayProxy dstmap1, interop::OutputArrayProxy dstmap2,
                                            int dstmap1type, int nnInterpolation)
 {
     return cvTry([&] {
-    cv::convertMaps(*map1, *map2, *dstmap1, *dstmap2, dstmap1type, nnInterpolation != 0);
+        cv::convertMaps(InProxy(map1), InProxy(map2), OutProxy(dstmap1), OutProxy(dstmap2), dstmap1type, nnInterpolation != 0);
     });
 }
 
@@ -336,10 +336,10 @@ CVAPI(ExceptionStatus) imgproc_getRotationMatrix2D(interop::Point2f center, doub
     });
 
 }
-CVAPI(ExceptionStatus) imgproc_invertAffineTransform(cv::_InputArray* M, cv::_OutputArray *iM)
+CVAPI(ExceptionStatus) imgproc_invertAffineTransform(interop::InputArrayProxy M, interop::OutputArrayProxy iM)
 {
     return cvTry([&] {
-    cv::invertAffineTransform(*M, *iM);
+        cv::invertAffineTransform(InProxy(M), OutProxy(iM));
     });
 }
 
@@ -350,11 +350,11 @@ CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform1(cv::Point2f *src, cv::Po
     *returnValue = new cv::Mat(ret);
     });
 }
-CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform2(cv::_InputArray *src, cv::_InputArray *dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform2(interop::InputArrayProxy src, interop::InputArrayProxy dst, cv::Mat** returnValue)
 {
     return cvTry([&] {
-    const auto ret = cv::getPerspectiveTransform(*src, *dst);
-    *returnValue = new cv::Mat(ret);
+        const auto ret = cv::getPerspectiveTransform(InProxy(src), InProxy(dst));
+        *returnValue = new cv::Mat(ret);
     });
 }
 
@@ -365,274 +365,274 @@ CVAPI(ExceptionStatus) imgproc_getAffineTransform1(cv::Point2f *src, cv::Point2f
     *returnValue = new cv::Mat(ret);
     });
 }
-CVAPI(ExceptionStatus) imgproc_getAffineTransform2(cv::_InputArray *src, cv::_InputArray *dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getAffineTransform2(interop::InputArrayProxy src, interop::InputArrayProxy dst, cv::Mat** returnValue)
 {
     return cvTry([&] {
-    const auto ret = cv::getAffineTransform(*src, *dst);
-    *returnValue = new cv::Mat(ret);
+        const auto ret = cv::getAffineTransform(InProxy(src), InProxy(dst));
+        *returnValue = new cv::Mat(ret);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getRectSubPix(cv::_InputArray *image, interop::Size patchSize, interop::Point2f center, cv::_OutputArray *patch, int patchType)
+CVAPI(ExceptionStatus) imgproc_getRectSubPix(interop::InputArrayProxy image, interop::Size patchSize, interop::Point2f center, interop::OutputArrayProxy patch, int patchType)
 {
     return cvTry([&] {
-    cv::getRectSubPix(*image, cpp(patchSize), cpp(center), *patch, patchType);
+        cv::getRectSubPix(InProxy(image), cpp(patchSize), cpp(center), OutProxy(patch), patchType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpPolar(
-    cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dsize,
+    interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dsize,
     interop::Point2f center, double maxRadius, int flags)
 {
     return cvTry([&] {
-    cv::warpPolar(*src, *dst, cpp(dsize), cpp(center), maxRadius, flags);
+        cv::warpPolar(InProxy(src), OutProxy(dst), cpp(dsize), cpp(center), maxRadius, flags);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral1(cv::_InputArray *src, cv::_OutputArray *sum, int sdepth)
+CVAPI(ExceptionStatus) imgproc_integral1(interop::InputArrayProxy src, interop::OutputArrayProxy sum, int sdepth)
 {
     return cvTry([&] {
-    cv::integral(*src, *sum, sdepth);
+        cv::integral(InProxy(src), OutProxy(sum), sdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral2(cv::_InputArray *src, cv::_OutputArray *sum, cv::_OutputArray *sqsum, int sdepth)
+CVAPI(ExceptionStatus) imgproc_integral2(interop::InputArrayProxy src, interop::OutputArrayProxy sum, interop::OutputArrayProxy sqsum, int sdepth)
 {
     return cvTry([&] {
-    cv::integral(*src, *sum, *sqsum, sdepth);
+        cv::integral(InProxy(src), OutProxy(sum), OutProxy(sqsum), sdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral3(cv::_InputArray *src, cv::_OutputArray *sum, cv::_OutputArray *sqsum, cv::_OutputArray *tilted, int sdepth, int sqdepth)
+CVAPI(ExceptionStatus) imgproc_integral3(interop::InputArrayProxy src, interop::OutputArrayProxy sum, interop::OutputArrayProxy sqsum, interop::OutputArrayProxy tilted, int sdepth, int sqdepth)
 {
     return cvTry([&] {
-    cv::integral(*src, *sum, *sqsum, *tilted, sdepth, sqdepth);
+        cv::integral(InProxy(src), OutProxy(sum), OutProxy(sqsum), OutProxy(tilted), sdepth, sqdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulate(cv::_InputArray *src, cv::_InputOutputArray *dst, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) imgproc_accumulate(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::accumulate(*src, *dst, entity(mask));
+        cv::accumulate(InProxy(src), IoProxy(dst), InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateSquare(cv::_InputArray* src, cv::_InputOutputArray *dst, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) imgproc_accumulateSquare(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::accumulateSquare(*src, *dst, entity(mask));
+        cv::accumulateSquare(InProxy(src), IoProxy(dst), InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateProduct(cv::_InputArray *src1, cv::_InputArray *src2, cv::_InputOutputArray *dst, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) imgproc_accumulateProduct(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::accumulateProduct(*src1, *src2, *dst, entity(mask));
+        cv::accumulateProduct(InProxy(src1), InProxy(src2), IoProxy(dst), InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateWeighted(cv::_InputArray *src, cv::_InputOutputArray *dst, double alpha, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) imgproc_accumulateWeighted(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, double alpha, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::accumulateWeighted(*src, *dst, alpha, entity(mask));
+        cv::accumulateWeighted(InProxy(src), IoProxy(dst), alpha, InProxy(mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_phaseCorrelate(cv::_InputArray *src1, cv::_InputArray *src2,
-                                              cv::_InputArray *window, double* response, interop::Point2d* returnValue)
+CVAPI(ExceptionStatus) imgproc_phaseCorrelate(interop::InputArrayProxy src1, interop::InputArrayProxy src2,
+                                              interop::InputArrayProxy window, double* response, interop::Point2d* returnValue)
 {
     return cvTry([&] {
-    const auto p = cv::phaseCorrelate(*src1, *src2, *window, response);
-    *returnValue = { p.x, p.y };
+        const auto p = cv::phaseCorrelate(InProxy(src1), InProxy(src2), InProxy(window), response);
+        *returnValue = { p.x, p.y };
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_createHanningWindow(cv::_OutputArray *dst, interop::Size winSize, int type)
+CVAPI(ExceptionStatus) imgproc_createHanningWindow(interop::OutputArrayProxy dst, interop::Size winSize, int type)
 {
     return cvTry([&] {
-    cv::createHanningWindow(*dst, cpp(winSize), type);
+        cv::createHanningWindow(OutProxy(dst), cpp(winSize), type);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_threshold(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_threshold(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                 double thresh, double maxVal, int type, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::threshold(*src, *dst, thresh, maxVal, type);
+        *returnValue = cv::threshold(InProxy(src), OutProxy(dst), thresh, maxVal, type);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_adaptiveThreshold(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_adaptiveThreshold(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                       double maxValue, int adaptiveMethod,
                                       int thresholdType, int blockSize, double C)
 {
     return cvTry([&] {
-    cv::adaptiveThreshold(*src, *dst, maxValue, adaptiveMethod, thresholdType, blockSize, C);
+        cv::adaptiveThreshold(InProxy(src), OutProxy(dst), maxValue, adaptiveMethod, thresholdType, blockSize, C);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_pyrDown(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dstSize, int borderType)
+CVAPI(ExceptionStatus) imgproc_pyrDown(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dstSize, int borderType)
 {
     return cvTry([&] {
-    cv::pyrDown(*src, *dst, cpp(dstSize), borderType);
+        cv::pyrDown(InProxy(src), OutProxy(dst), cpp(dstSize), borderType);
     });
 }
-CVAPI(ExceptionStatus) imgproc_pyrUp(cv::_InputArray *src, cv::_OutputArray *dst, interop::Size dstSize, int borderType)
+CVAPI(ExceptionStatus) imgproc_pyrUp(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dstSize, int borderType)
 {
     return cvTry([&] {
-    cv::pyrUp(*src, *dst, cpp(dstSize), borderType);
+        cv::pyrUp(InProxy(src), OutProxy(dst), cpp(dstSize), borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_buildPyramid(cv::_InputArray *src, std::vector<cv::Mat> *dst,int maxlevel, int borderType)
+CVAPI(ExceptionStatus) imgproc_buildPyramid(interop::InputArrayProxy src, std::vector<cv::Mat> *dst,int maxlevel, int borderType)
 {
     return cvTry([&] {
-        cv::buildPyramid(*src, *dst, maxlevel, borderType);
+        cv::buildPyramid(InProxy(src), *dst, maxlevel, borderType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_calcHist(cv::Mat **images, int nimages,
-                              const int* channels, cv::_InputArray *mask,
-                              cv::_OutputArray *hist, int dims, const int* histSize,
+                              const int* channels, interop::InputArrayProxy mask,
+                              interop::OutputArrayProxy hist, int dims, const int* histSize,
                               const float** ranges, int uniform, int accumulate)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> imagesVec(nimages);
-    for (auto i = 0; i < nimages; i++)
-        imagesVec[i] = *(images[i]);
-    cv::calcHist(&imagesVec[0], nimages, channels, entity(mask), *hist, dims, histSize, ranges, uniform != 0, accumulate != 0);
+        std::vector<cv::Mat> imagesVec(nimages);
+        for (auto i = 0; i < nimages; i++)
+            imagesVec[i] = *(images[i]);
+        cv::calcHist(&imagesVec[0], nimages, channels, InProxy(mask), OutProxy(hist), dims, histSize, ranges, uniform != 0, accumulate != 0);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_calcBackProject(cv::Mat **images, int nimages,
-                                    const int* channels, cv::_InputArray *hist, cv::_OutputArray *backProject, 
+                                    const int* channels, interop::InputArrayProxy hist, interop::OutputArrayProxy backProject, 
                                     const float** ranges, int uniform)
 {
     return cvTry([&] {
-    std::vector<cv::Mat> imagesVec(nimages);
-    for (auto i = 0; i < nimages; i++)
-        imagesVec[i] = *(images[i]);
-    cv::calcBackProject(&imagesVec[0], nimages, channels, *hist, *backProject, ranges, uniform != 0);
+        std::vector<cv::Mat> imagesVec(nimages);
+        for (auto i = 0; i < nimages; i++)
+            imagesVec[i] = *(images[i]);
+        cv::calcBackProject(&imagesVec[0], nimages, channels, InProxy(hist), OutProxy(backProject), ranges, uniform != 0);
     });
 }
 
 
-CVAPI(ExceptionStatus) imgproc_compareHist(cv::_InputArray *h1, cv::_InputArray *h2, int method, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_compareHist(interop::InputArrayProxy h1, interop::InputArrayProxy h2, int method, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::compareHist(*h1, *h2, method);
+        *returnValue = cv::compareHist(InProxy(h1), InProxy(h2), method);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_equalizeHist(cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) imgproc_equalizeHist(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-    cv::equalizeHist(*src, *dst);
+        cv::equalizeHist(InProxy(src), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_EMD(cv::_InputArray *signature1, cv::_InputArray *signature2,
-                         int distType, cv::_InputArray *cost, float* lowerBound, cv::_OutputArray *flow, float* returnValue)
+CVAPI(ExceptionStatus) imgproc_EMD(interop::InputArrayProxy signature1, interop::InputArrayProxy signature2,
+                         int distType, interop::InputArrayProxy cost, float* lowerBound, interop::OutputArrayProxy flow, float* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::EMD(*signature1, *signature2, distType, entity(cost), lowerBound, entity(flow));
+        *returnValue = cv::EMD(InProxy(signature1), InProxy(signature2), distType, InProxy(cost), lowerBound, OutProxy(flow));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_watershed(cv::_InputArray *image, cv::_InputOutputArray *markers)
+CVAPI(ExceptionStatus) imgproc_watershed(interop::InputArrayProxy image, interop::InputOutputArrayProxy markers)
 {
     return cvTry([&] {
-    cv::watershed(*image, *markers);
+        cv::watershed(InProxy(image), IoProxy(markers));
     });
 }
-CVAPI(ExceptionStatus) imgproc_pyrMeanShiftFiltering(cv::_InputArray *src, cv::_InputOutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_pyrMeanShiftFiltering(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                           double sp, double sr, int maxLevel, interop::TermCriteria termCrit)
 {
     return cvTry([&] {
-    cv::pyrMeanShiftFiltering(*src, *dst, sp, sr, maxLevel, cpp(termCrit));
+        cv::pyrMeanShiftFiltering(InProxy(src), OutProxy(dst), sp, sr, maxLevel, cpp(termCrit));
     });
 }
-CVAPI(ExceptionStatus) imgproc_grabCut(cv::_InputArray *img, cv::_InputOutputArray *mask, interop::Rect rect,
-                            cv::_InputOutputArray *bgdModel, cv::_InputOutputArray *fgdModel,
+CVAPI(ExceptionStatus) imgproc_grabCut(interop::InputArrayProxy img, interop::InputOutputArrayProxy mask, interop::Rect rect,
+                            interop::InputOutputArrayProxy bgdModel, interop::InputOutputArrayProxy fgdModel,
                             int iterCount, int mode)
 {
     return cvTry([&] {
-    cv::grabCut(*img, *mask, cpp(rect), *bgdModel, *fgdModel, iterCount, mode);
+        cv::grabCut(InProxy(img), IoProxy(mask), cpp(rect), IoProxy(bgdModel), IoProxy(fgdModel), iterCount, mode);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_distanceTransformWithLabels(cv::_InputArray *src, cv::_OutputArray *dst,
-                                                cv::_OutputArray *labels, int distanceType, int maskSize,
+CVAPI(ExceptionStatus) imgproc_distanceTransformWithLabels(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
+                                                interop::OutputArrayProxy labels, int distanceType, int maskSize,
                                                 int labelType)
 {
     return cvTry([&] {
-    cv::distanceTransform(*src, *dst, *labels, distanceType, maskSize, labelType);
+        cv::distanceTransform(InProxy(src), OutProxy(dst), OutProxy(labels), distanceType, maskSize, labelType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_distanceTransform(cv::_InputArray *src, cv::_OutputArray *dst,
+CVAPI(ExceptionStatus) imgproc_distanceTransform(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
                                       int distanceType, int maskSize, int dstType)
 {
     return cvTry([&] {
-    cv::distanceTransform(*src, *dst, distanceType, maskSize, dstType);
+        cv::distanceTransform(InProxy(src), OutProxy(dst), distanceType, maskSize, dstType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_floodFill1(cv::_InputOutputArray *image,
+CVAPI(ExceptionStatus) imgproc_floodFill1(interop::InputOutputArrayProxy image,
                               interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
                               interop::Scalar loDiff, interop::Scalar upDiff, int flags, int *returnValue)
 {
     return cvTry([&] {
-    cv::Rect rect0;
-    *returnValue = cv::floodFill(*image, cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
-    *rect = c(rect0);
+        cv::Rect rect0;
+        *returnValue = cv::floodFill(IoProxy(image), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
+        *rect = c(rect0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_floodFill2(cv::_InputOutputArray *image, cv::_InputOutputArray *mask,
+CVAPI(ExceptionStatus) imgproc_floodFill2(interop::InputOutputArrayProxy image, interop::InputOutputArrayProxy mask,
                               interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
                               interop::Scalar loDiff, interop::Scalar upDiff, int flags, int* returnValue)
 {
     return cvTry([&] {
-    cv::Rect rect0;
-    *returnValue = cv::floodFill(*image, *mask, cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
-    *rect = c(rect0);
+        cv::Rect rect0;
+        *returnValue = cv::floodFill(IoProxy(image), IoProxy(mask), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
+        *rect = c(rect0);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_blendLinear(
-    cv::_InputArray* src1, cv::_InputArray* src2, cv::_InputArray* weights1, cv::_InputArray* weights2, cv::_OutputArray* dst)
+    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::InputArrayProxy weights1, interop::InputArrayProxy weights2, interop::OutputArrayProxy dst)
 {
     return cvTry([&] {
-        cv::blendLinear(*src1, *src2, *weights1, *weights2, *dst);
+        cv::blendLinear(InProxy(src1), InProxy(src2), InProxy(weights1), InProxy(weights2), OutProxy(dst));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cvtColor(cv::_InputArray *src, cv::_OutputArray *dst, int code, int dstCn, int hint)
+CVAPI(ExceptionStatus) imgproc_cvtColor(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int code, int dstCn, int hint)
 {
     return cvTry([&] {
-    cv::cvtColor(*src, *dst, code, dstCn, static_cast<cv::AlgorithmHint>(hint));
+        cv::cvtColor(InProxy(src), OutProxy(dst), code, dstCn, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cvtColorTwoPlane(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst, int code, int hint)
+CVAPI(ExceptionStatus) imgproc_cvtColorTwoPlane(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int code, int hint)
 {
     return cvTry([&] {
-    cv::cvtColorTwoPlane(*src1, *src2, *dst, code, static_cast<cv::AlgorithmHint>(hint));
+        cv::cvtColorTwoPlane(InProxy(src1), InProxy(src2), OutProxy(dst), code, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_demosaicing(cv::_InputArray *src, cv::_OutputArray *dst, int code, int dstCn)
+CVAPI(ExceptionStatus) imgproc_demosaicing(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int code, int dstCn)
 {
     return cvTry([&] {
-    cv::demosaicing(*src, *dst, code, dstCn);
+        cv::demosaicing(InProxy(src), OutProxy(dst), code, dstCn);
     });    
 }
 
-CVAPI(ExceptionStatus) imgproc_moments(cv::_InputArray *arr, int binaryImage, interop::Moments *returnValue)
+CVAPI(ExceptionStatus) imgproc_moments(interop::InputArrayProxy arr, int binaryImage, interop::Moments *returnValue)
 {
     return cvTry([&] {
-    const auto m = cv::moments(*arr, binaryImage != 0);
-    *returnValue = c(m);
+        const auto m = cv::moments(InProxy(arr), binaryImage != 0);
+        *returnValue = c(m);
     });
 }
 /*
@@ -643,98 +643,98 @@ CVAPI(ExceptionStatus) imgproc_HuMoments(interop::Moments *moments, double hu[7]
     });
 }
 */
-CVAPI(ExceptionStatus) imgproc_matchTemplate(cv::_InputArray *image, cv::_InputArray *templ,
-                                  cv::_OutputArray *result, int method, cv::_InputArray *mask)
+CVAPI(ExceptionStatus) imgproc_matchTemplate(interop::InputArrayProxy image, interop::InputArrayProxy templ,
+                                  interop::OutputArrayProxy result, int method, interop::InputArrayProxy mask)
 {
     return cvTry([&] {
-    cv::matchTemplate(*image, *templ, *result, method, entity(mask));
+        cv::matchTemplate(InProxy(image), InProxy(templ), OutProxy(result), method, InProxy(mask));
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithAlgorithm(
-    cv::_InputArray *image, cv::_OutputArray *labels, int connectivity, int ltype, int ccltype, int* returnValue)
+    interop::InputArrayProxy image, interop::OutputArrayProxy labels, int connectivity, int ltype, int ccltype, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::connectedComponents(entity(image), entity(labels), connectivity, ltype, ccltype);
+        *returnValue = cv::connectedComponents(InProxy(image), OutProxy(labels), connectivity, ltype, ccltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_connectedComponents(cv::_InputArray *image, cv::_OutputArray *labels,
+CVAPI(ExceptionStatus) imgproc_connectedComponents(interop::InputArrayProxy image, interop::OutputArrayProxy labels,
                                        int connectivity, int ltype, int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::connectedComponents(entity(image), entity(labels), connectivity, ltype);
+        *returnValue = cv::connectedComponents(InProxy(image), OutProxy(labels), connectivity, ltype);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStatsWithAlgorithm(
-    cv::_InputArray *image, cv::_OutputArray *labels,
-    cv::_OutputArray *stats, cv::_OutputArray *centroids,
+    interop::InputArrayProxy image, interop::OutputArrayProxy labels,
+    interop::OutputArrayProxy stats, interop::OutputArrayProxy centroids,
     int connectivity, int ltype, int ccltype, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::connectedComponentsWithStats(
-            entity(image), entity(labels), entity(stats), entity(centroids), connectivity, ltype, ccltype);
+        *returnValue = cv::connectedComponentsWithStats(
+                InProxy(image), OutProxy(labels), OutProxy(stats), OutProxy(centroids), connectivity, ltype, ccltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStats(cv::_InputArray *image, cv::_OutputArray *labels,
-                                                cv::_OutputArray *stats, cv::_OutputArray *centroids, int connectivity, int ltype, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStats(interop::InputArrayProxy image, interop::OutputArrayProxy labels,
+                                                interop::OutputArrayProxy stats, interop::OutputArrayProxy centroids, int connectivity, int ltype, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::connectedComponentsWithStats(
-        entity(image), entity(labels), entity(stats), entity(centroids), connectivity, ltype);
+        *returnValue = cv::connectedComponentsWithStats(
+            InProxy(image), OutProxy(labels), OutProxy(stats), OutProxy(centroids), connectivity, ltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_findContours1_vector(cv::_InputArray *image, std::vector<std::vector<cv::Point> > *contours,
+CVAPI(ExceptionStatus) imgproc_findContours1_vector(interop::InputArrayProxy image, std::vector<std::vector<cv::Point> > *contours,
                                          std::vector<cv::Vec4i> *hierarchy, int mode, int method, interop::Point offset)
 {
     return cvTry([&] {
-    cv::findContours(*image, *contours, *hierarchy, mode, method, cpp(offset));
+        cv::findContours(InProxy(image), *contours, *hierarchy, mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours1_OutputArray(cv::_InputArray *image, std::vector<cv::Mat> *contours,
-                                              cv::_OutputArray *hierarchy, int mode, int method, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_findContours1_OutputArray(interop::InputArrayProxy image, std::vector<cv::Mat> *contours,
+                                              interop::OutputArrayProxy hierarchy, int mode, int method, interop::Point offset)
 {
     return cvTry([&] {
-    cv::findContours(*image, *contours, *hierarchy, mode, method, cpp(offset));
+        cv::findContours(InProxy(image), *contours, OutProxy(hierarchy), mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours2_vector(cv::_InputArray *image, std::vector<std::vector<cv::Point> > *contours,
+CVAPI(ExceptionStatus) imgproc_findContours2_vector(interop::InputArrayProxy image, std::vector<std::vector<cv::Point> > *contours,
                                          int mode, int method, interop::Point offset)
 {
     return cvTry([&] {
-    cv::findContours(*image, *contours, mode, method, cpp(offset));
+        cv::findContours(InProxy(image), *contours, mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(cv::_InputArray *image, std::vector<cv::Mat> *contours,
+CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(interop::InputArrayProxy image, std::vector<cv::Mat> *contours,
                                               int mode, int method, interop::Point offset)
 {
     return cvTry([&] {
-    cv::findContours(*image, *contours, mode, method, cpp(offset));
+        cv::findContours(InProxy(image), *contours, mode, method, cpp(offset));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(cv::_InputArray *image,
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(interop::InputArrayProxy image,
                                           std::vector<std::vector<cv::Point> > *contours, std::vector<cv::Vec4i> *hierarchy)
 {
     return cvTry([&] {
-    cv::findContoursLinkRuns(*image, *contours, *hierarchy);
+        cv::findContoursLinkRuns(InProxy(image), *contours, *hierarchy);
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(cv::_InputArray *image,
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(interop::InputArrayProxy image,
                                           std::vector<std::vector<cv::Point> > *contours)
 {
     return cvTry([&] {
-    cv::findContoursLinkRuns(*image, *contours);
+        cv::findContoursLinkRuns(InProxy(image), *contours);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_approxPolyDP_InputArray(cv::_InputArray *curve, cv::_OutputArray *approxCurve, double epsilon, int closed)
+CVAPI(ExceptionStatus) imgproc_approxPolyDP_InputArray(interop::InputArrayProxy curve, interop::OutputArrayProxy approxCurve, double epsilon, int closed)
 {
     return cvTry([&] {
-    cv::approxPolyDP(*curve, *approxCurve, epsilon, closed != 0);
+        cv::approxPolyDP(InProxy(curve), OutProxy(approxCurve), epsilon, closed != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point(cv::Point *curve, int curveLength, std::vector<cv::Point> *approxCurve, double epsilon, int closed)
@@ -752,10 +752,10 @@ CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point2f(cv::Point2f *curve, int curv
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_arcLength_InputArray(cv::_InputArray *curve, int closed, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_arcLength_InputArray(interop::InputArrayProxy curve, int closed, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::arcLength(*curve, closed != 0);
+        *returnValue = cv::arcLength(InProxy(curve), closed != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_arcLength_Point(cv::Point *curve, int curveLength, int closed, double* returnValue)
@@ -773,10 +773,10 @@ CVAPI(ExceptionStatus) imgproc_arcLength_Point2f(cv::Point2f *curve, int curveLe
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boundingRect_InputArray(cv::_InputArray *curve, interop::Rect* returnValue)
+CVAPI(ExceptionStatus) imgproc_boundingRect_InputArray(interop::InputArrayProxy curve, interop::Rect* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::boundingRect(*curve));
+        *returnValue = c(cv::boundingRect(InProxy(curve)));
     });
 }
 CVAPI(ExceptionStatus) imgproc_boundingRect_Point(cv::Point *curve, int curveLength, interop::Rect* returnValue)
@@ -794,10 +794,10 @@ CVAPI(ExceptionStatus) imgproc_boundingRect_Point2f(cv::Point2f *curve, int curv
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_contourArea_InputArray(cv::_InputArray *contour, int oriented, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_contourArea_InputArray(interop::InputArrayProxy contour, int oriented, double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::contourArea(*contour, oriented != 0);
+        *returnValue = cv::contourArea(InProxy(contour), oriented != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_contourArea_Point(cv::Point *contour, int contourLength, int oriented, double* returnValue)
@@ -815,10 +815,10 @@ CVAPI(ExceptionStatus) imgproc_contourArea_Point2f(cv::Point2f *contour, int con
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minAreaRect_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_minAreaRect_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::minAreaRect(*points));
+        *returnValue = c(cv::minAreaRect(InProxy(points)));
     });
 }
 CVAPI(ExceptionStatus) imgproc_minAreaRect_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
@@ -836,10 +836,10 @@ CVAPI(ExceptionStatus) imgproc_minAreaRect_Point2f(cv::Point2f *points, int poin
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boxPoints_OutputArray(interop::RotatedRect box, cv::_OutputArray* points)
+CVAPI(ExceptionStatus) imgproc_boxPoints_OutputArray(interop::RotatedRect box, interop::OutputArrayProxy points)
 {
     return cvTry([&] {
-    cv::boxPoints(cpp(box), *points);
+        cv::boxPoints(cpp(box), OutProxy(points));
     });
 }
 CVAPI(ExceptionStatus) imgproc_boxPoints_Point2f(interop::RotatedRect box, cv::Point2f points[4])
@@ -849,14 +849,14 @@ CVAPI(ExceptionStatus) imgproc_boxPoints_Point2f(interop::RotatedRect box, cv::P
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_InputArray(cv::_InputArray *points, interop::Point2f *center, float *radius)
+CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_InputArray(interop::InputArrayProxy points, interop::Point2f *center, float *radius)
 {
     return cvTry([&] {
-    cv::Point2f center0;
-    float radius0;
-    cv::minEnclosingCircle(*points, center0, radius0);
-    *center = c(center0);
-    *radius = radius0;
+        cv::Point2f center0;
+        float radius0;
+        cv::minEnclosingCircle(InProxy(points), center0, radius0);
+        *center = c(center0);
+        *radius = radius0;
     });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point(cv::Point *points, int pointsLength, interop::Point2f*center, float *radius)
@@ -882,10 +882,10 @@ CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point2f(cv::Point2f *points, i
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_InputOutputArray(cv::_InputArray *points, cv::_OutputArray *triangle, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_InputOutputArray(interop::InputArrayProxy points, interop::OutputArrayProxy triangle, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::minEnclosingTriangle(*points, *triangle);
+        *returnValue = cv::minEnclosingTriangle(InProxy(points), OutProxy(triangle));
     });
 }
 CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point(cv::Point* points, int pointsLength, std::vector<cv::Point2f>* triangle, double* returnValue)
@@ -904,10 +904,10 @@ CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point2f(cv::Point2f* points,
 }
 
 CVAPI(ExceptionStatus) imgproc_matchShapes_InputArray(
-    cv::_InputArray *contour1, cv::_InputArray *contour2, int method, double parameter, double* returnValue)
+    interop::InputArrayProxy contour1, interop::InputArrayProxy contour2, int method, double parameter, double* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::matchShapes(*contour1, *contour2, method, parameter);
+        *returnValue = cv::matchShapes(InProxy(contour1), InProxy(contour2), method, parameter);
     });
 }
 CVAPI(ExceptionStatus) imgproc_matchShapes_Point(
@@ -920,10 +920,10 @@ CVAPI(ExceptionStatus) imgproc_matchShapes_Point(
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convexHull_InputArray(cv::_InputArray *points, cv::_OutputArray *hull, int clockwise, int returnPoints)
+CVAPI(ExceptionStatus) imgproc_convexHull_InputArray(interop::InputArrayProxy points, interop::OutputArrayProxy hull, int clockwise, int returnPoints)
 {
     return cvTry([&] {
-    cv::convexHull(*points, *hull, clockwise != 0, returnPoints != 0);
+        cv::convexHull(InProxy(points), OutProxy(hull), clockwise != 0, returnPoints != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsPoints(cv::Point *points, int pointsLength, std::vector<cv::Point> *hull, int clockwise)
@@ -955,11 +955,11 @@ CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsIndices(cv::Point2f *po
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convexityDefects_InputArray(cv::_InputArray *contour, cv::_InputArray *convexHull,
-                                                cv::_OutputArray *convexityDefects)
+CVAPI(ExceptionStatus) imgproc_convexityDefects_InputArray(interop::InputArrayProxy contour, interop::InputArrayProxy convexHull,
+                                                interop::OutputArrayProxy convexityDefects)
 {
     return cvTry([&] {
-    cv::convexityDefects(*contour, *convexHull, *convexityDefects);
+        cv::convexityDefects(InProxy(contour), InProxy(convexHull), OutProxy(convexityDefects));
     });
 }
 CVAPI(ExceptionStatus) imgproc_convexityDefects_Point(cv::Point *contour, int contourLength, int *convexHull, int convexHullLength,
@@ -981,10 +981,10 @@ CVAPI(ExceptionStatus) imgproc_convexityDefects_Point2f(cv::Point2f *contour, in
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_isContourConvex_InputArray(cv::_InputArray *contour, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_isContourConvex_InputArray(interop::InputArrayProxy contour, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::isContourConvex(*contour) ? 1 : 0;
+        *returnValue = cv::isContourConvex(InProxy(contour)) ? 1 : 0;
     });
 }
 CVAPI(ExceptionStatus) imgproc_isContourConvex_Point(cv::Point *contour, int contourLength, int* returnValue)
@@ -1002,11 +1002,11 @@ CVAPI(ExceptionStatus) imgproc_isContourConvex_Point2f(cv::Point2f *contour, int
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_InputArray(cv::_InputArray *p1, cv::_InputArray *p2,
-                                                      cv::_OutputArray *p12, int handleNested, float* returnValue)
+CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_InputArray(interop::InputArrayProxy p1, interop::InputArrayProxy p2,
+                                                      interop::OutputArrayProxy p12, int handleNested, float* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::intersectConvexConvex(*p1, *p2, *p12, handleNested != 0);
+        *returnValue = cv::intersectConvexConvex(InProxy(p1), InProxy(p2), OutProxy(p12), handleNested != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point(cv::Point *p1, int p1Length, cv::Point *p2, int p2Length,
@@ -1028,10 +1028,10 @@ CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point2f(cv::Point2f *p1, in
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipse_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipse_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::fitEllipse(*points));
+        *returnValue = c(cv::fitEllipse(InProxy(points)));
     });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipse_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
@@ -1049,10 +1049,10 @@ CVAPI(ExceptionStatus) imgproc_fitEllipse_Point2f(cv::Point2f *points, int point
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_InputArray(cv::_InputArray *points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::fitEllipseAMS(*points));
+        *returnValue = c(cv::fitEllipseAMS(InProxy(points)));
     });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
@@ -1070,10 +1070,10 @@ CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point2f(cv::Point2f* points, int po
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_InputArray(cv::_InputArray* points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::fitEllipseDirect(*points));
+        *returnValue = c(cv::fitEllipseDirect(InProxy(points)));
     });
 }
 CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
@@ -1091,11 +1091,11 @@ CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point2f(cv::Point2f* points, int
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitLine_InputArray(cv::_InputArray *points, cv::_OutputArray *line,
+CVAPI(ExceptionStatus) imgproc_fitLine_InputArray(interop::InputArrayProxy points, interop::OutputArrayProxy line,
                                        int distType, double param, double reps, double aeps)
 {
     return cvTry([&] {
-    cv::fitLine(*points, *line, distType, param, reps, aeps);
+        cv::fitLine(InProxy(points), OutProxy(line), distType, param, reps, aeps);
     });
 }
 CVAPI(ExceptionStatus) imgproc_fitLine_Point(cv::Point *points, int pointsLength, float *line, int distType,
@@ -1136,10 +1136,10 @@ CVAPI(ExceptionStatus) imgproc_fitLine_Point3f(cv::Point3f *points, int pointsLe
 }
 
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_InputArray(
-    cv::_InputArray* contour, interop::Point2f pt, int measureDist, double *returnValue)
+    interop::InputArrayProxy contour, interop::Point2f pt, int measureDist, double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::pointPolygonTest(*contour, cpp(pt), measureDist != 0);
+        *returnValue = cv::pointPolygonTest(InProxy(contour), cpp(pt), measureDist != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point(
@@ -1160,10 +1160,10 @@ CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point2f(
 }
 
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_OutputArray(
-    interop::RotatedRect rect1, interop::RotatedRect rect2, cv::_OutputArray *intersectingRegion, int* returnValue)
+    interop::RotatedRect rect1, interop::RotatedRect rect2, interop::OutputArrayProxy intersectingRegion, int* returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), *intersectingRegion);
+        *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), OutProxy(intersectingRegion));
     });
 }
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_vector(
@@ -1174,55 +1174,55 @@ CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_vector(
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_applyColorMap1(cv::_InputArray *src, cv::_OutputArray *dst, int colorMap)
+CVAPI(ExceptionStatus) imgproc_applyColorMap1(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int colorMap)
 {
     return cvTry([&] {
-    cv::applyColorMap(*src, *dst, colorMap);
+        cv::applyColorMap(InProxy(src), OutProxy(dst), colorMap);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_applyColorMap2(cv::_InputArray *src, cv::_OutputArray *dst, cv::_InputArray *userColor)
+CVAPI(ExceptionStatus) imgproc_applyColorMap2(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy userColor)
 {
     return cvTry([&] {
-    cv::applyColorMap(*src, *dst, *userColor);
+        cv::applyColorMap(InProxy(src), OutProxy(dst), InProxy(userColor));
     });    
 }
 
 #pragma region Drawing
 
 CVAPI(ExceptionStatus) imgproc_line(
-    cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
+    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
     int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::line(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
+        cv::line(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_arrowedLine(
-    cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
+    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
     int thickness, int line_type, int shift, double tipLength)
 {
     return cvTry([&] {
-    cv::arrowedLine(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, line_type, shift, tipLength);
+        cv::arrowedLine(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, line_type, shift, tipLength);
     });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Point(
-    cv::_InputOutputArray *img, interop::Point pt1, interop::Point pt2,
+    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::rectangle(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
+        cv::rectangle(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Rect(
-    cv::_InputOutputArray* img, interop::Rect rect,
+    interop::InputOutputArrayProxy img, interop::Rect rect,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::rectangle(*img, cpp(rect), cpp(color), thickness, lineType, shift);
+        cv::rectangle(IoProxy(img), cpp(rect), cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Point(
@@ -1244,37 +1244,37 @@ CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Rect(
 
 
 CVAPI(ExceptionStatus) imgproc_circle(
-    cv::_InputOutputArray *img, interop::Point center, int radius,
+    interop::InputOutputArrayProxy img, interop::Point center, int radius,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::circle(*img, cpp(center), radius, cpp(color), thickness, lineType, shift);
+        cv::circle(IoProxy(img), cpp(center), radius, cpp(color), thickness, lineType, shift);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse1(
-    cv::_InputOutputArray *img, interop::Point center, interop::Size axes,
+    interop::InputOutputArrayProxy img, interop::Point center, interop::Size axes,
     double angle, double startAngle, double endAngle,
     interop::Scalar color, int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::ellipse(*img, cpp(center), cpp(axes), angle, startAngle, endAngle, cpp(color), thickness, lineType, shift);
+        cv::ellipse(IoProxy(img), cpp(center), cpp(axes), angle, startAngle, endAngle, cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_ellipse2(
-    cv::_InputOutputArray *img, interop::RotatedRect box, interop::Scalar color, int thickness, int lineType)
+    interop::InputOutputArrayProxy img, interop::RotatedRect box, interop::Scalar color, int thickness, int lineType)
 {
     return cvTry([&] {
-    cv::ellipse(*img, cpp(box), cpp(color), thickness, lineType);
+        cv::ellipse(IoProxy(img), cpp(box), cpp(color), thickness, lineType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_drawMarker(
-    cv::_InputOutputArray *img, interop::Point position, interop::Scalar color,
+    interop::InputOutputArrayProxy img, interop::Point position, interop::Scalar color,
     int markerType, int markerSize, int thickness, int lineType)
 {
     return cvTry([&] {
-    cv::drawMarker(*img, cpp(position), cpp(color), markerType, markerSize, thickness, lineType);
+        cv::drawMarker(IoProxy(img), cpp(position), cpp(color), markerType, markerSize, thickness, lineType);
     });
 }
 
@@ -1286,10 +1286,10 @@ CVAPI(ExceptionStatus) imgproc_fillConvexPoly_Mat(
     });
 }
 CVAPI(ExceptionStatus) imgproc_fillConvexPoly_InputOutputArray(
-    cv::_InputOutputArray *img, cv::_InputArray *points, interop::Scalar color, int lineType, int shift)
+    interop::InputOutputArrayProxy img, interop::InputArrayProxy points, interop::Scalar color, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::fillConvexPoly(*img, *points, cpp(color), lineType, shift);
+        cv::fillConvexPoly(IoProxy(img), InProxy(points), cpp(color), lineType, shift);
     });
 }
 
@@ -1300,11 +1300,11 @@ CVAPI(ExceptionStatus) imgproc_fillPoly_Mat(cv::Mat *img, const cv::Point **pts,
     cv::fillPoly(*img, pts, npts, ncontours, cpp(color), lineType, shift, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fillPoly_InputOutputArray(cv::_InputOutputArray *img, cv::_InputArray *pts,
+CVAPI(ExceptionStatus) imgproc_fillPoly_InputOutputArray(interop::InputOutputArrayProxy img, interop::InputArrayProxy pts,
                                               interop::Scalar color, int lineType, int shift, interop::Point offset)
 {
     return cvTry([&] {
-    cv::fillPoly(*img, *pts, cpp(color), lineType, shift, cpp(offset));
+        cv::fillPoly(IoProxy(img), InProxy(pts), cpp(color), lineType, shift, cpp(offset));
     });
 }
 
@@ -1319,47 +1319,47 @@ CVAPI(ExceptionStatus) imgproc_polylines_Mat(
     });
 }
 CVAPI(ExceptionStatus) imgproc_polylines_InputOutputArray(
-    cv::_InputOutputArray *img, cv::_InputArray *pts, int isClosed, interop::Scalar color,
+    interop::InputOutputArrayProxy img, interop::InputArrayProxy pts, int isClosed, interop::Scalar color,
     int thickness, int lineType, int shift)
 {
     return cvTry([&] {
-    cv::polylines(*img, *pts, isClosed != 0, cpp(color), thickness, lineType, shift);
+        cv::polylines(IoProxy(img), InProxy(pts), isClosed != 0, cpp(color), thickness, lineType, shift);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_drawContours_vector(cv::_InputOutputArray *image,
+CVAPI(ExceptionStatus) imgproc_drawContours_vector(interop::InputOutputArrayProxy image,
                                         cv::Point **contours, int contoursSize1, int *contoursSize2,
                                         int contourIdx, interop::Scalar color, int thickness, int lineType,
                                         cv::Vec4i *hierarchy, int hiearchyLength, int maxLevel, interop::Point offset)
 {
     return cvTry([&] {
-    std::vector<std::vector<cv::Point> > contoursVec;
-    for (auto i = 0; i < contoursSize1; i++)
-    {
-        std::vector<cv::Point> c1(contours[i], contours[i] + contoursSize2[i]);
-        contoursVec.push_back(c1);
-    }
-    std::vector<cv::Vec4i> hierarchyVec;
-    if (hierarchy != nullptr)
-    {
-        hierarchyVec = std::vector<cv::Vec4i>(hierarchy, hierarchy + hiearchyLength);
-    }
+        std::vector<std::vector<cv::Point> > contoursVec;
+        for (auto i = 0; i < contoursSize1; i++)
+        {
+            std::vector<cv::Point> c1(contours[i], contours[i] + contoursSize2[i]);
+            contoursVec.push_back(c1);
+        }
+        std::vector<cv::Vec4i> hierarchyVec;
+        if (hierarchy != nullptr)
+        {
+            hierarchyVec = std::vector<cv::Vec4i>(hierarchy, hierarchy + hiearchyLength);
+        }
 
-    cv::drawContours(
-        *image, contoursVec, contourIdx, cpp(color), thickness, lineType, hierarchyVec, maxLevel, cpp(offset));
+        cv::drawContours(
+            IoProxy(image), contoursVec, contourIdx, cpp(color), thickness, lineType, hierarchyVec, maxLevel, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_drawContours_InputArray(cv::_InputOutputArray *image,
+CVAPI(ExceptionStatus) imgproc_drawContours_InputArray(interop::InputOutputArrayProxy image,
                                             cv::Mat **contours, int contoursLength,
                                             int contourIdx, interop::Scalar color, int thickness, int lineType,
-                                            cv::_InputArray *hierarchy, int maxLevel, interop::Point offset)
+                                            interop::InputArrayProxy hierarchy, int maxLevel, interop::Point offset)
 {
     return cvTry([&] {
-    std::vector<std::vector<cv::Point> > contoursVec(contoursLength);
-    for (auto i = 0; i < contoursLength; i++)
-        contoursVec[i] = *contours[i];
-    cv::drawContours(
-        *image, contoursVec, contourIdx, cpp(color), thickness, lineType, entity(hierarchy), maxLevel, cpp(offset));
+        std::vector<std::vector<cv::Point> > contoursVec(contoursLength);
+        for (auto i = 0; i < contoursLength; i++)
+            contoursVec[i] = *contours[i];
+        cv::drawContours(
+            IoProxy(image), contoursVec, contourIdx, cpp(color), thickness, lineType, InProxy(hierarchy), maxLevel, cpp(offset));
     });
 }
 
@@ -1402,12 +1402,12 @@ CVAPI(ExceptionStatus) imgproc_ellipse2Poly_double(
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_putText(cv::_InputOutputArray *img, const char *text, interop::Point org,
+CVAPI(ExceptionStatus) imgproc_putText(interop::InputOutputArrayProxy img, const char *text, interop::Point org,
                          int fontFace, double fontScale, interop::Scalar color,
                          int thickness, int lineType, int bottomLeftOrigin)
 {
     return cvTry([&] {
-    cv::putText(*img, text, cpp(org), fontFace, fontScale, cpp(color), thickness, lineType, bottomLeftOrigin != 0);
+        cv::putText(IoProxy(img), text, cpp(org), fontFace, fontScale, cpp(color), thickness, lineType, bottomLeftOrigin != 0);
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -7,7 +7,11 @@
 #include "include_opencv.h"
 
 
-CVAPI(ExceptionStatus) imgproc_getGaussianKernel(int ksize, double sigma, int ktype, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) imgproc_getGaussianKernel(
+    int ksize,
+    double sigma,
+    int ktype,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getGaussianKernel(ksize, sigma, ktype);
@@ -15,16 +19,29 @@ CVAPI(ExceptionStatus) imgproc_getGaussianKernel(int ksize, double sigma, int kt
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getDerivKernels(interop::OutputArrayProxy kx, interop::OutputArrayProxy ky,
-    int dx, int dy, int ksize, int normalize, int ktype)
+CVAPI(ExceptionStatus) imgproc_getDerivKernels(
+    const interop::OutputArrayProxy* kx,
+    const interop::OutputArrayProxy* ky,
+    int dx,
+    int dy,
+    int ksize,
+    int normalize,
+    int ktype)
 {
     return cvTry([&] {
-        cv::getDerivKernels(OutProxy(kx), OutProxy(ky), dx, dy, ksize, normalize != 0, ktype);
+        cv::getDerivKernels(OutProxy(*kx), OutProxy(*ky), dx, dy, ksize, normalize != 0, ktype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getGaborKernel(interop::Size ksize, double sigma, double theta,
-    double lambd, double gamma, double psi, int ktype, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) imgproc_getGaborKernel(
+    interop::Size ksize,
+    double sigma,
+    double theta,
+    double lambd,
+    double gamma,
+    double psi,
+    int ktype,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getGaborKernel(cpp(ksize), sigma, theta, lambd, gamma, psi, ktype);
@@ -32,7 +49,11 @@ CVAPI(ExceptionStatus) imgproc_getGaborKernel(interop::Size ksize, double sigma,
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getStructuringElement(int shape, interop::Size ksize, interop::Point anchor, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) imgproc_getStructuringElement(
+    int shape,
+    interop::Size ksize,
+    interop::Point anchor,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getStructuringElement(shape, cpp(ksize), cpp(anchor));
@@ -40,63 +61,108 @@ CVAPI(ExceptionStatus) imgproc_getStructuringElement(int shape, interop::Size ks
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_medianBlur(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ksize)
+CVAPI(ExceptionStatus) imgproc_medianBlur(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ksize)
 {
     return cvTry([&] {
-        cv::medianBlur(InProxy(src), OutProxy(dst), ksize);
+        cv::medianBlur(InProxy(*src), OutProxy(*dst), ksize);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_GaussianBlur(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                            interop::Size ksize, double sigmaX, double sigmaY, int borderType, int hint)
+CVAPI(ExceptionStatus) imgproc_GaussianBlur(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size ksize,
+    double sigmaX,
+    double sigmaY,
+    int borderType,
+    int hint)
 {
     return cvTry([&] {
-        cv::GaussianBlur(InProxy(src), OutProxy(dst), cpp(ksize), sigmaX, sigmaY, borderType, static_cast<cv::AlgorithmHint>(hint));
+        cv::GaussianBlur(InProxy(*src), OutProxy(*dst), cpp(ksize), sigmaX, sigmaY, borderType, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_bilateralFilter(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                    int d, double sigmaColor, double sigmaSpace, int borderType)
+CVAPI(ExceptionStatus) imgproc_bilateralFilter(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int d,
+    double sigmaColor,
+    double sigmaSpace,
+    int borderType)
 {
     return cvTry([&] {
-        cv::bilateralFilter(InProxy(src), OutProxy(dst), d, sigmaColor, sigmaSpace, borderType);
+        cv::bilateralFilter(InProxy(*src), OutProxy(*dst), d, sigmaColor, sigmaSpace, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boxFilter(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                              interop::Size ksize, interop::Point anchor, int normalize, int borderType)
+CVAPI(ExceptionStatus) imgproc_boxFilter(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    interop::Size ksize,
+    interop::Point anchor,
+    int normalize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::boxFilter(InProxy(src), OutProxy(dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
+        cv::boxFilter(InProxy(*src), OutProxy(*dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_sqrBoxFilter(
-    interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-    interop::Size ksize, interop::Point anchor, int normalize, int borderType)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    interop::Size ksize,
+    interop::Point anchor,
+    int normalize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::sqrBoxFilter(InProxy(src), OutProxy(dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
+        cv::sqrBoxFilter(InProxy(*src), OutProxy(*dst), ddepth, cpp(ksize), cpp(anchor), normalize != 0, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_blur(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size ksize, interop::Point anchor, int borderType)
+CVAPI(ExceptionStatus) imgproc_blur(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size ksize,
+    interop::Point anchor,
+    int borderType)
 {
     return cvTry([&] {
-        cv::blur(InProxy(src), OutProxy(dst), cpp(ksize), cpp(anchor), borderType);
+        cv::blur(InProxy(*src), OutProxy(*dst), cpp(ksize), cpp(anchor), borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_filter2D(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                             interop::InputArrayProxy kernel, interop::Point anchor, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_filter2D(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    const interop::InputArrayProxy* kernel,
+    interop::Point anchor,
+    double delta,
+    int borderType)
 {
     return cvTry([&] {
-        cv::filter2D(InProxy(src), OutProxy(dst), ddepth, InProxy(kernel), cpp(anchor), delta, borderType);
+        cv::filter2D(InProxy(*src), OutProxy(*dst), ddepth, InProxy(*kernel), cpp(anchor), delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_filter2Dp(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
-                             int anchorX, int anchorY, int borderType, interop::Scalar borderValue, int ddepth, double scale, double shift)
+CVAPI(ExceptionStatus) imgproc_filter2Dp(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* kernel,
+    int anchorX,
+    int anchorY,
+    int borderType,
+    interop::Scalar borderValue,
+    int ddepth,
+    double scale,
+    double shift)
 {
     return cvTry([&] {
         cv::Filter2DParams params;
@@ -107,228 +173,384 @@ CVAPI(ExceptionStatus) imgproc_filter2Dp(interop::InputArrayProxy src, interop::
         params.ddepth = ddepth;
         params.scale = scale;
         params.shift = shift;
-        cv::filter2D(InProxy(src), OutProxy(dst), InProxy(kernel), params);
+        cv::filter2D(InProxy(*src), OutProxy(*dst), InProxy(*kernel), params);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_sepFilter2D(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                                interop::InputArrayProxy kernelX, interop::InputArrayProxy kernelY,
-                                interop::Point anchor, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_sepFilter2D(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    const interop::InputArrayProxy* kernelX,
+    const interop::InputArrayProxy* kernelY,
+    interop::Point anchor,
+    double delta,
+    int borderType)
 {
     return cvTry([&] {
-        cv::sepFilter2D(InProxy(src), OutProxy(dst), ddepth, InProxy(kernelX), InProxy(kernelY), cpp(anchor), delta, borderType);
+        cv::sepFilter2D(InProxy(*src), OutProxy(*dst), ddepth, InProxy(*kernelX), InProxy(*kernelY), cpp(anchor), delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Sobel(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                          int dx, int dy, int ksize, double scale, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_Sobel(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    int dx,
+    int dy,
+    int ksize,
+    double scale,
+    double delta,
+    int borderType)
 {
     return cvTry([&] {
-        cv::Sobel(InProxy(src), OutProxy(dst), ddepth, dx, dy, ksize, scale, delta, borderType);
+        cv::Sobel(InProxy(*src), OutProxy(*dst), ddepth, dx, dy, ksize, scale, delta, borderType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_spatialGradient(
-    interop::InputArrayProxy src, interop::OutputArrayProxy dx, interop::OutputArrayProxy dy, int ksize, int borderType)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dx,
+    const interop::OutputArrayProxy* dy,
+    int ksize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::spatialGradient(InProxy(src), OutProxy(dx), OutProxy(dy), ksize, borderType);
+        cv::spatialGradient(InProxy(*src), OutProxy(*dx), OutProxy(*dy), ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Scharr(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                           int dx, int dy, double scale, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_Scharr(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    int dx,
+    int dy,
+    double scale,
+    double delta,
+    int borderType)
 {
     return cvTry([&] {
-        cv::Scharr(InProxy(src), OutProxy(dst), ddepth, dx, dy, scale, delta, borderType);
+        cv::Scharr(InProxy(*src), OutProxy(*dst), ddepth, dx, dy, scale, delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Laplacian(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ddepth,
-                              int ksize, double scale, double delta, int borderType)
+CVAPI(ExceptionStatus) imgproc_Laplacian(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ddepth,
+    int ksize,
+    double scale,
+    double delta,
+    int borderType)
 {
     return cvTry([&] {
-        cv::Laplacian(InProxy(src), OutProxy(dst), ddepth, ksize, scale, delta, borderType);
+        cv::Laplacian(InProxy(*src), OutProxy(*dst), ddepth, ksize, scale, delta, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_Canny1(interop::InputArrayProxy src, interop::OutputArrayProxy edges,
-                          double threshold1, double threshold2, int apertureSize, int L2gradient)
+CVAPI(ExceptionStatus) imgproc_Canny1(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* edges,
+    double threshold1,
+    double threshold2,
+    int apertureSize,
+    int L2gradient)
 {
     return cvTry([&] {
-        cv::Canny(InProxy(src), OutProxy(edges), threshold1, threshold2, apertureSize, L2gradient != 0);
+        cv::Canny(InProxy(*src), OutProxy(*edges), threshold1, threshold2, apertureSize, L2gradient != 0);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_Canny2(
-    interop::InputArrayProxy dx, interop::InputArrayProxy dy, interop::OutputArrayProxy edges,
-    double threshold1, double threshold2, int L2gradient = false)
+    const interop::InputArrayProxy* dx,
+    const interop::InputArrayProxy* dy,
+    const interop::OutputArrayProxy* edges,
+    double threshold1,
+    double threshold2,
+    int L2gradient = false)
 {
     return cvTry([&] {
-        cv::Canny(InProxy(dx), InProxy(dy), OutProxy(edges), threshold1, threshold2, L2gradient != 0);
+        cv::Canny(InProxy(*dx), InProxy(*dy), OutProxy(*edges), threshold1, threshold2, L2gradient != 0);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerMinEigenVal(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                      int blockSize, int ksize, int borderType)
+CVAPI(ExceptionStatus) imgproc_cornerMinEigenVal(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int blockSize,
+    int ksize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::cornerMinEigenVal(InProxy(src), OutProxy(dst), blockSize, ksize, borderType);
+        cv::cornerMinEigenVal(InProxy(*src), OutProxy(*dst), blockSize, ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerHarris(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                 int blockSize, int ksize, double k, int borderType)
+CVAPI(ExceptionStatus) imgproc_cornerHarris(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int blockSize,
+    int ksize,
+    double k,
+    int borderType)
 {
     return cvTry([&] {
-        cv::cornerHarris(InProxy(src), OutProxy(dst), blockSize, ksize, k, borderType);
+        cv::cornerHarris(InProxy(*src), OutProxy(*dst), blockSize, ksize, k, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerEigenValsAndVecs(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                           int blockSize, int ksize, int borderType)
+CVAPI(ExceptionStatus) imgproc_cornerEigenValsAndVecs(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int blockSize,
+    int ksize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::cornerEigenValsAndVecs(InProxy(src), OutProxy(dst), blockSize, ksize, borderType);
+        cv::cornerEigenValsAndVecs(InProxy(*src), OutProxy(*dst), blockSize, ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_preCornerDetect(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int ksize, int borderType)
+CVAPI(ExceptionStatus) imgproc_preCornerDetect(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int ksize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::preCornerDetect(InProxy(src), OutProxy(dst), ksize, borderType);
+        cv::preCornerDetect(InProxy(*src), OutProxy(*dst), ksize, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cornerSubPix(interop::InputArrayProxy image, std::vector<cv::Point2f> *corners,
-                                 interop::Size winSize, interop::Size zeroZone, interop::TermCriteria criteria)
+CVAPI(ExceptionStatus) imgproc_cornerSubPix(
+    const interop::InputArrayProxy* image,
+    std::vector<cv::Point2f> *corners,
+    interop::Size winSize,
+    interop::Size zeroZone,
+    interop::TermCriteria criteria)
 {
     return cvTry([&] {
-        cv::cornerSubPix(InProxy(image), *corners, cpp(winSize), cpp(zeroZone), cpp(criteria));
+        cv::cornerSubPix(InProxy(*image), *corners, cpp(winSize), cpp(zeroZone), cpp(criteria));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(interop::InputArrayProxy src, std::vector<cv::Point2f> *corners,
-                                        int maxCorners, double qualityLevel, double minDistance,
-                                        interop::InputArrayProxy mask, int blockSize, int useHarrisDetector, double k)
+CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Point2f> *corners,
+    int maxCorners,
+    double qualityLevel,
+    double minDistance,
+    const interop::InputArrayProxy* mask,
+    int blockSize,
+    int useHarrisDetector,
+    double k)
 {
     return cvTry([&] {
-        cv::goodFeaturesToTrack(InProxy(src), *corners, maxCorners, qualityLevel, minDistance, 
-            InProxy(mask), blockSize, useHarrisDetector != 0, k);
+        cv::goodFeaturesToTrack(InProxy(*src), *corners, maxCorners, qualityLevel, minDistance, 
+            InProxy(*mask), blockSize, useHarrisDetector != 0, k);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughLines(interop::InputArrayProxy src, std::vector<cv::Vec2f> *lines,
-                               double rho, double theta, int threshold,
-                               double srn, double stn)
+CVAPI(ExceptionStatus) imgproc_HoughLines(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Vec2f> *lines,
+    double rho,
+    double theta,
+    int threshold,
+    double srn,
+    double stn)
 {
     return cvTry([&] {
-        cv::HoughLines(InProxy(src), *lines, rho, theta, threshold, srn, stn);
+        cv::HoughLines(InProxy(*src), *lines, rho, theta, threshold, srn, stn);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughLinesP(interop::InputArrayProxy src, std::vector<cv::Vec4i> *lines,
-                                double rho, double theta, int threshold,
-                                double minLineLength, double maxLineGap)
+CVAPI(ExceptionStatus) imgproc_HoughLinesP(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Vec4i> *lines,
+    double rho,
+    double theta,
+    int threshold,
+    double minLineLength,
+    double maxLineGap)
 {
     return cvTry([&] {
-        cv::HoughLinesP(InProxy(src), *lines, rho, theta, threshold, minLineLength, maxLineGap);
+        cv::HoughLinesP(InProxy(*src), *lines, rho, theta, threshold, minLineLength, maxLineGap);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_HoughLinesPointSet(
-    interop::InputArrayProxy _point, interop::OutputArrayProxy _lines, int lines_max, int threshold,
-    double min_rho, double max_rho, double rho_step,
-    double min_theta, double max_theta, double theta_step)
+    const interop::InputArrayProxy* _point,
+    const interop::OutputArrayProxy* _lines,
+    int lines_max,
+    int threshold,
+    double min_rho,
+    double max_rho,
+    double rho_step,
+    double min_theta,
+    double max_theta,
+    double theta_step)
 {
     return cvTry([&] {
-        cv::HoughLinesPointSet(InProxy(_point), OutProxy(_lines), lines_max, threshold, min_rho, max_rho, rho_step, min_theta, max_theta, theta_step);
+        cv::HoughLinesPointSet(InProxy(*_point), OutProxy(*_lines), lines_max, threshold, min_rho, max_rho, rho_step, min_theta, max_theta, theta_step);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_HoughCircles(interop::InputArrayProxy src, std::vector<cv::Vec3f> *circles,
-                                 int method, double dp, double minDist,
-                                 double param1, double param2, int minRadius, int maxRadius)
+CVAPI(ExceptionStatus) imgproc_HoughCircles(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Vec3f> *circles,
+    int method,
+    double dp,
+    double minDist,
+    double param1,
+    double param2,
+    int minRadius,
+    int maxRadius)
 {
     return cvTry([&] {
-        cv::HoughCircles(InProxy(src), *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
+        cv::HoughCircles(InProxy(*src), *circles, method, dp, minDist, param1, param2, minRadius, maxRadius);
     });
 }
 
 
-CVAPI(ExceptionStatus) imgproc_erode(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
-                          interop::Point anchor, int iterations,    int borderType, interop::Scalar borderValue)
+CVAPI(ExceptionStatus) imgproc_erode(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* kernel,
+    interop::Point anchor,
+    int iterations,
+    int borderType,
+    interop::Scalar borderValue)
 {
     return cvTry([&] {
-        cv::erode(InProxy(src), OutProxy(dst), InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::erode(InProxy(*src), OutProxy(*dst), InProxy(*kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_dilate(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy kernel,
-                           interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
+CVAPI(ExceptionStatus) imgproc_dilate(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* kernel,
+    interop::Point anchor,
+    int iterations,
+    int borderType,
+    interop::Scalar borderValue)
 {
     return cvTry([&] {
-        cv::dilate(InProxy(src), OutProxy(dst), InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::dilate(InProxy(*src), OutProxy(*dst), InProxy(*kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_morphologyEx(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int op, interop::InputArrayProxy kernel,
-                                 interop::Point anchor, int iterations, int borderType, interop::Scalar borderValue)
+CVAPI(ExceptionStatus) imgproc_morphologyEx(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int op,
+    const interop::InputArrayProxy* kernel,
+    interop::Point anchor,
+    int iterations,
+    int borderType,
+    interop::Scalar borderValue)
 {
     return cvTry([&] {
-        cv::morphologyEx(InProxy(src), OutProxy(dst), op, InProxy(kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
+        cv::morphologyEx(InProxy(*src), OutProxy(*dst), op, InProxy(*kernel), cpp(anchor), iterations, borderType, cpp(borderValue));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_resize(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dsize, double fx, double fy, int interpolation)
+CVAPI(ExceptionStatus) imgproc_resize(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size dsize,
+    double fx,
+    double fy,
+    int interpolation)
 {
     return cvTry([&] {
-        cv::resize(InProxy(src), OutProxy(dst), cpp(dsize), fx, fy, interpolation);
+        cv::resize(InProxy(*src), OutProxy(*dst), cpp(dsize), fx, fy, interpolation);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpAffine(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy M, interop::Size dsize,
-                                          int flags, int borderMode, interop::Scalar borderValue, int hint)
+CVAPI(ExceptionStatus) imgproc_warpAffine(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* M,
+    interop::Size dsize,
+    int flags,
+    int borderMode,
+    interop::Scalar borderValue,
+    int hint)
 {
     return cvTry([&] {
-        cv::warpAffine(InProxy(src), OutProxy(dst), InProxy(M), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::warpAffine(InProxy(*src), OutProxy(*dst), InProxy(*M), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpPerspective_MisInputArray(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy m, interop::Size dsize,
-                                                             int flags, int borderMode, interop::Scalar borderValue, int hint)
+CVAPI(ExceptionStatus) imgproc_warpPerspective_MisInputArray(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* m,
+    interop::Size dsize,
+    int flags,
+    int borderMode,
+    interop::Scalar borderValue,
+    int hint)
 {
     return cvTry([&] {
-        cv::warpPerspective(InProxy(src), OutProxy(dst), InProxy(m), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::warpPerspective(InProxy(*src), OutProxy(*dst), InProxy(*m), cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_warpPerspective_MisArray(interop::InputArrayProxy src, interop::OutputArrayProxy dst, float* m, int mRow, int mCol, interop::Size dsize,
-                                                        int flags, int borderMode, interop::Scalar borderValue, int hint)
+CVAPI(ExceptionStatus) imgproc_warpPerspective_MisArray(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float* m,
+    int mRow,
+    int mCol,
+    interop::Size dsize,
+    int flags,
+    int borderMode,
+    interop::Scalar borderValue,
+    int hint)
 {
     return cvTry([&] {
         const cv::Mat mmat(mRow, mCol, CV_32FC1, m);
-        cv::warpPerspective(InProxy(src), OutProxy(dst), mmat, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::warpPerspective(InProxy(*src), OutProxy(*dst), mmat, cpp(dsize), flags, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_remap(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy map1, interop::InputArrayProxy map2,
-                                     int interpolation, int borderMode, interop::Scalar borderValue, int hint)
+CVAPI(ExceptionStatus) imgproc_remap(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* map1,
+    const interop::InputArrayProxy* map2,
+    int interpolation,
+    int borderMode,
+    interop::Scalar borderValue,
+    int hint)
 {
     return cvTry([&] {
-        cv::remap(InProxy(src), OutProxy(dst), InProxy(map1), InProxy(map2), interpolation, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
+        cv::remap(InProxy(*src), OutProxy(*dst), InProxy(*map1), InProxy(*map2), interpolation, borderMode, cpp(borderValue), static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convertMaps(interop::InputArrayProxy map1, interop::InputArrayProxy map2, interop::OutputArrayProxy dstmap1, interop::OutputArrayProxy dstmap2,
-                                           int dstmap1type, int nnInterpolation)
+CVAPI(ExceptionStatus) imgproc_convertMaps(
+    const interop::InputArrayProxy* map1,
+    const interop::InputArrayProxy* map2,
+    const interop::OutputArrayProxy* dstmap1,
+    const interop::OutputArrayProxy* dstmap2,
+    int dstmap1type,
+    int nnInterpolation)
 {
     return cvTry([&] {
-        cv::convertMaps(InProxy(map1), InProxy(map2), OutProxy(dstmap1), OutProxy(dstmap2), dstmap1type, nnInterpolation != 0);
+        cv::convertMaps(InProxy(*map1), InProxy(*map2), OutProxy(*dstmap1), OutProxy(*dstmap2), dstmap1type, nnInterpolation != 0);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getRotationMatrix2D(interop::Point2f center, double angle, double scale, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getRotationMatrix2D(
+    interop::Point2f center,
+    double angle,
+    double scale,
+    cv::Mat** returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getRotationMatrix2D(cpp(center), angle, scale);
@@ -336,302 +558,453 @@ CVAPI(ExceptionStatus) imgproc_getRotationMatrix2D(interop::Point2f center, doub
     });
 
 }
-CVAPI(ExceptionStatus) imgproc_invertAffineTransform(interop::InputArrayProxy M, interop::OutputArrayProxy iM)
+CVAPI(ExceptionStatus) imgproc_invertAffineTransform(const interop::InputArrayProxy* M, const interop::OutputArrayProxy* iM)
 {
     return cvTry([&] {
-        cv::invertAffineTransform(InProxy(M), OutProxy(iM));
+        cv::invertAffineTransform(InProxy(*M), OutProxy(*iM));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform1(cv::Point2f *src, cv::Point2f *dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform1(
+    cv::Point2f *src,
+    cv::Point2f *dst,
+    cv::Mat** returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getPerspectiveTransform(src, dst);
     *returnValue = new cv::Mat(ret);
     });
 }
-CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform2(interop::InputArrayProxy src, interop::InputArrayProxy dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getPerspectiveTransform2(
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* dst,
+    cv::Mat** returnValue)
 {
     return cvTry([&] {
-        const auto ret = cv::getPerspectiveTransform(InProxy(src), InProxy(dst));
+        const auto ret = cv::getPerspectiveTransform(InProxy(*src), InProxy(*dst));
         *returnValue = new cv::Mat(ret);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getAffineTransform1(cv::Point2f *src, cv::Point2f *dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getAffineTransform1(
+    cv::Point2f *src,
+    cv::Point2f *dst,
+    cv::Mat** returnValue)
 {
     return cvTry([&] {
     const auto ret = cv::getAffineTransform(src, dst);
     *returnValue = new cv::Mat(ret);
     });
 }
-CVAPI(ExceptionStatus) imgproc_getAffineTransform2(interop::InputArrayProxy src, interop::InputArrayProxy dst, cv::Mat** returnValue)
+CVAPI(ExceptionStatus) imgproc_getAffineTransform2(
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* dst,
+    cv::Mat** returnValue)
 {
     return cvTry([&] {
-        const auto ret = cv::getAffineTransform(InProxy(src), InProxy(dst));
+        const auto ret = cv::getAffineTransform(InProxy(*src), InProxy(*dst));
         *returnValue = new cv::Mat(ret);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getRectSubPix(interop::InputArrayProxy image, interop::Size patchSize, interop::Point2f center, interop::OutputArrayProxy patch, int patchType)
+CVAPI(ExceptionStatus) imgproc_getRectSubPix(
+    const interop::InputArrayProxy* image,
+    interop::Size patchSize,
+    interop::Point2f center,
+    const interop::OutputArrayProxy* patch,
+    int patchType)
 {
     return cvTry([&] {
-        cv::getRectSubPix(InProxy(image), cpp(patchSize), cpp(center), OutProxy(patch), patchType);
+        cv::getRectSubPix(InProxy(*image), cpp(patchSize), cpp(center), OutProxy(*patch), patchType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_warpPolar(
-    interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dsize,
-    interop::Point2f center, double maxRadius, int flags)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size dsize,
+    interop::Point2f center,
+    double maxRadius,
+    int flags)
 {
     return cvTry([&] {
-        cv::warpPolar(InProxy(src), OutProxy(dst), cpp(dsize), cpp(center), maxRadius, flags);
+        cv::warpPolar(InProxy(*src), OutProxy(*dst), cpp(dsize), cpp(center), maxRadius, flags);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral1(interop::InputArrayProxy src, interop::OutputArrayProxy sum, int sdepth)
+CVAPI(ExceptionStatus) imgproc_integral1(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* sum,
+    int sdepth)
 {
     return cvTry([&] {
-        cv::integral(InProxy(src), OutProxy(sum), sdepth);
+        cv::integral(InProxy(*src), OutProxy(*sum), sdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral2(interop::InputArrayProxy src, interop::OutputArrayProxy sum, interop::OutputArrayProxy sqsum, int sdepth)
+CVAPI(ExceptionStatus) imgproc_integral2(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* sum,
+    const interop::OutputArrayProxy* sqsum,
+    int sdepth)
 {
     return cvTry([&] {
-        cv::integral(InProxy(src), OutProxy(sum), OutProxy(sqsum), sdepth);
+        cv::integral(InProxy(*src), OutProxy(*sum), OutProxy(*sqsum), sdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_integral3(interop::InputArrayProxy src, interop::OutputArrayProxy sum, interop::OutputArrayProxy sqsum, interop::OutputArrayProxy tilted, int sdepth, int sqdepth)
+CVAPI(ExceptionStatus) imgproc_integral3(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* sum,
+    const interop::OutputArrayProxy* sqsum,
+    const interop::OutputArrayProxy* tilted,
+    int sdepth,
+    int sqdepth)
 {
     return cvTry([&] {
-        cv::integral(InProxy(src), OutProxy(sum), OutProxy(sqsum), OutProxy(tilted), sdepth, sqdepth);
+        cv::integral(InProxy(*src), OutProxy(*sum), OutProxy(*sqsum), OutProxy(*tilted), sdepth, sqdepth);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulate(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) imgproc_accumulate(
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::accumulate(InProxy(src), IoProxy(dst), InProxy(mask));
+        cv::accumulate(InProxy(*src), IoProxy(*dst), InProxy(*mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateSquare(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) imgproc_accumulateSquare(
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::accumulateSquare(InProxy(src), IoProxy(dst), InProxy(mask));
+        cv::accumulateSquare(InProxy(*src), IoProxy(*dst), InProxy(*mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateProduct(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::InputOutputArrayProxy dst, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) imgproc_accumulateProduct(
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::InputOutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::accumulateProduct(InProxy(src1), InProxy(src2), IoProxy(dst), InProxy(mask));
+        cv::accumulateProduct(InProxy(*src1), InProxy(*src2), IoProxy(*dst), InProxy(*mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_accumulateWeighted(interop::InputArrayProxy src, interop::InputOutputArrayProxy dst, double alpha, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) imgproc_accumulateWeighted(
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dst,
+    double alpha,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::accumulateWeighted(InProxy(src), IoProxy(dst), alpha, InProxy(mask));
+        cv::accumulateWeighted(InProxy(*src), IoProxy(*dst), alpha, InProxy(*mask));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_phaseCorrelate(interop::InputArrayProxy src1, interop::InputArrayProxy src2,
-                                              interop::InputArrayProxy window, double* response, interop::Point2d* returnValue)
+CVAPI(ExceptionStatus) imgproc_phaseCorrelate(
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::InputArrayProxy* window,
+    double* response,
+    interop::Point2d* returnValue)
 {
     return cvTry([&] {
-        const auto p = cv::phaseCorrelate(InProxy(src1), InProxy(src2), InProxy(window), response);
+        const auto p = cv::phaseCorrelate(InProxy(*src1), InProxy(*src2), InProxy(*window), response);
         *returnValue = { p.x, p.y };
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_createHanningWindow(interop::OutputArrayProxy dst, interop::Size winSize, int type)
+CVAPI(ExceptionStatus) imgproc_createHanningWindow(
+    const interop::OutputArrayProxy* dst,
+    interop::Size winSize,
+    int type)
 {
     return cvTry([&] {
-        cv::createHanningWindow(OutProxy(dst), cpp(winSize), type);
+        cv::createHanningWindow(OutProxy(*dst), cpp(winSize), type);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_threshold(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                double thresh, double maxVal, int type, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_threshold(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double thresh,
+    double maxVal,
+    int type,
+    double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::threshold(InProxy(src), OutProxy(dst), thresh, maxVal, type);
+        *returnValue = cv::threshold(InProxy(*src), OutProxy(*dst), thresh, maxVal, type);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_adaptiveThreshold(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                      double maxValue, int adaptiveMethod,
-                                      int thresholdType, int blockSize, double C)
+CVAPI(ExceptionStatus) imgproc_adaptiveThreshold(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double maxValue,
+    int adaptiveMethod,
+    int thresholdType,
+    int blockSize,
+    double C)
 {
     return cvTry([&] {
-        cv::adaptiveThreshold(InProxy(src), OutProxy(dst), maxValue, adaptiveMethod, thresholdType, blockSize, C);
+        cv::adaptiveThreshold(InProxy(*src), OutProxy(*dst), maxValue, adaptiveMethod, thresholdType, blockSize, C);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_pyrDown(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dstSize, int borderType)
+CVAPI(ExceptionStatus) imgproc_pyrDown(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size dstSize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::pyrDown(InProxy(src), OutProxy(dst), cpp(dstSize), borderType);
+        cv::pyrDown(InProxy(*src), OutProxy(*dst), cpp(dstSize), borderType);
     });
 }
-CVAPI(ExceptionStatus) imgproc_pyrUp(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::Size dstSize, int borderType)
+CVAPI(ExceptionStatus) imgproc_pyrUp(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size dstSize,
+    int borderType)
 {
     return cvTry([&] {
-        cv::pyrUp(InProxy(src), OutProxy(dst), cpp(dstSize), borderType);
+        cv::pyrUp(InProxy(*src), OutProxy(*dst), cpp(dstSize), borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_buildPyramid(interop::InputArrayProxy src, std::vector<cv::Mat> *dst,int maxlevel, int borderType)
+CVAPI(ExceptionStatus) imgproc_buildPyramid(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Mat> *dst,
+    int maxlevel,
+    int borderType)
 {
     return cvTry([&] {
-        cv::buildPyramid(InProxy(src), *dst, maxlevel, borderType);
+        cv::buildPyramid(InProxy(*src), *dst, maxlevel, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_calcHist(cv::Mat **images, int nimages,
-                              const int* channels, interop::InputArrayProxy mask,
-                              interop::OutputArrayProxy hist, int dims, const int* histSize,
-                              const float** ranges, int uniform, int accumulate)
+CVAPI(ExceptionStatus) imgproc_calcHist(
+    cv::Mat **images,
+    int nimages,
+    const int* channels,
+    const interop::InputArrayProxy* mask,
+    const interop::OutputArrayProxy* hist,
+    int dims,
+    const int* histSize,
+    const float** ranges,
+    int uniform,
+    int accumulate)
 {
     return cvTry([&] {
         std::vector<cv::Mat> imagesVec(nimages);
         for (auto i = 0; i < nimages; i++)
             imagesVec[i] = *(images[i]);
-        cv::calcHist(&imagesVec[0], nimages, channels, InProxy(mask), OutProxy(hist), dims, histSize, ranges, uniform != 0, accumulate != 0);
+        cv::calcHist(&imagesVec[0], nimages, channels, InProxy(*mask), OutProxy(*hist), dims, histSize, ranges, uniform != 0, accumulate != 0);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_calcBackProject(cv::Mat **images, int nimages,
-                                    const int* channels, interop::InputArrayProxy hist, interop::OutputArrayProxy backProject, 
-                                    const float** ranges, int uniform)
+CVAPI(ExceptionStatus) imgproc_calcBackProject(
+    cv::Mat **images,
+    int nimages,
+    const int* channels,
+    const interop::InputArrayProxy* hist,
+    const interop::OutputArrayProxy* backProject,
+    const float** ranges,
+    int uniform)
 {
     return cvTry([&] {
         std::vector<cv::Mat> imagesVec(nimages);
         for (auto i = 0; i < nimages; i++)
             imagesVec[i] = *(images[i]);
-        cv::calcBackProject(&imagesVec[0], nimages, channels, InProxy(hist), OutProxy(backProject), ranges, uniform != 0);
+        cv::calcBackProject(&imagesVec[0], nimages, channels, InProxy(*hist), OutProxy(*backProject), ranges, uniform != 0);
     });
 }
 
 
-CVAPI(ExceptionStatus) imgproc_compareHist(interop::InputArrayProxy h1, interop::InputArrayProxy h2, int method, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_compareHist(
+    const interop::InputArrayProxy* h1,
+    const interop::InputArrayProxy* h2,
+    int method,
+    double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::compareHist(InProxy(h1), InProxy(h2), method);
+        *returnValue = cv::compareHist(InProxy(*h1), InProxy(*h2), method);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_equalizeHist(interop::InputArrayProxy src, interop::OutputArrayProxy dst)
+CVAPI(ExceptionStatus) imgproc_equalizeHist(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::equalizeHist(InProxy(src), OutProxy(dst));
+        cv::equalizeHist(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_EMD(interop::InputArrayProxy signature1, interop::InputArrayProxy signature2,
-                         int distType, interop::InputArrayProxy cost, float* lowerBound, interop::OutputArrayProxy flow, float* returnValue)
+CVAPI(ExceptionStatus) imgproc_EMD(
+    const interop::InputArrayProxy* signature1,
+    const interop::InputArrayProxy* signature2,
+    int distType,
+    const interop::InputArrayProxy* cost,
+    float* lowerBound,
+    const interop::OutputArrayProxy* flow,
+    float* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::EMD(InProxy(signature1), InProxy(signature2), distType, InProxy(cost), lowerBound, OutProxy(flow));
+        *returnValue = cv::EMD(InProxy(*signature1), InProxy(*signature2), distType, InProxy(*cost), lowerBound, OutProxy(*flow));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_watershed(interop::InputArrayProxy image, interop::InputOutputArrayProxy markers)
+CVAPI(ExceptionStatus) imgproc_watershed(const interop::InputArrayProxy* image, const interop::InputOutputArrayProxy* markers)
 {
     return cvTry([&] {
-        cv::watershed(InProxy(image), IoProxy(markers));
+        cv::watershed(InProxy(*image), IoProxy(*markers));
     });
 }
-CVAPI(ExceptionStatus) imgproc_pyrMeanShiftFiltering(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                          double sp, double sr, int maxLevel, interop::TermCriteria termCrit)
+CVAPI(ExceptionStatus) imgproc_pyrMeanShiftFiltering(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double sp,
+    double sr,
+    int maxLevel,
+    interop::TermCriteria termCrit)
 {
     return cvTry([&] {
-        cv::pyrMeanShiftFiltering(InProxy(src), OutProxy(dst), sp, sr, maxLevel, cpp(termCrit));
+        cv::pyrMeanShiftFiltering(InProxy(*src), OutProxy(*dst), sp, sr, maxLevel, cpp(termCrit));
     });
 }
-CVAPI(ExceptionStatus) imgproc_grabCut(interop::InputArrayProxy img, interop::InputOutputArrayProxy mask, interop::Rect rect,
-                            interop::InputOutputArrayProxy bgdModel, interop::InputOutputArrayProxy fgdModel,
-                            int iterCount, int mode)
+CVAPI(ExceptionStatus) imgproc_grabCut(
+    const interop::InputArrayProxy* img,
+    const interop::InputOutputArrayProxy* mask,
+    interop::Rect rect,
+    const interop::InputOutputArrayProxy* bgdModel,
+    const interop::InputOutputArrayProxy* fgdModel,
+    int iterCount,
+    int mode)
 {
     return cvTry([&] {
-        cv::grabCut(InProxy(img), IoProxy(mask), cpp(rect), IoProxy(bgdModel), IoProxy(fgdModel), iterCount, mode);
-    });
-}
-
-CVAPI(ExceptionStatus) imgproc_distanceTransformWithLabels(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                                interop::OutputArrayProxy labels, int distanceType, int maskSize,
-                                                int labelType)
-{
-    return cvTry([&] {
-        cv::distanceTransform(InProxy(src), OutProxy(dst), OutProxy(labels), distanceType, maskSize, labelType);
-    });
-}
-
-CVAPI(ExceptionStatus) imgproc_distanceTransform(interop::InputArrayProxy src, interop::OutputArrayProxy dst,
-                                      int distanceType, int maskSize, int dstType)
-{
-    return cvTry([&] {
-        cv::distanceTransform(InProxy(src), OutProxy(dst), distanceType, maskSize, dstType);
+        cv::grabCut(InProxy(*img), IoProxy(*mask), cpp(rect), IoProxy(*bgdModel), IoProxy(*fgdModel), iterCount, mode);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_floodFill1(interop::InputOutputArrayProxy image,
-                              interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
-                              interop::Scalar loDiff, interop::Scalar upDiff, int flags, int *returnValue)
+CVAPI(ExceptionStatus) imgproc_distanceTransformWithLabels(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::OutputArrayProxy* labels,
+    int distanceType,
+    int maskSize,
+    int labelType)
+{
+    return cvTry([&] {
+        cv::distanceTransform(InProxy(*src), OutProxy(*dst), OutProxy(*labels), distanceType, maskSize, labelType);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_distanceTransform(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int distanceType,
+    int maskSize,
+    int dstType)
+{
+    return cvTry([&] {
+        cv::distanceTransform(InProxy(*src), OutProxy(*dst), distanceType, maskSize, dstType);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_floodFill1(
+    const interop::InputOutputArrayProxy* image,
+    interop::Point seedPoint,
+    interop::Scalar newVal,
+    interop::Rect *rect,
+    interop::Scalar loDiff,
+    interop::Scalar upDiff,
+    int flags,
+    int *returnValue)
 {
     return cvTry([&] {
         cv::Rect rect0;
-        *returnValue = cv::floodFill(IoProxy(image), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
+        *returnValue = cv::floodFill(IoProxy(*image), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
         *rect = c(rect0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_floodFill2(interop::InputOutputArrayProxy image, interop::InputOutputArrayProxy mask,
-                              interop::Point seedPoint, interop::Scalar newVal, interop::Rect *rect,
-                              interop::Scalar loDiff, interop::Scalar upDiff, int flags, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_floodFill2(
+    const interop::InputOutputArrayProxy* image,
+    const interop::InputOutputArrayProxy* mask,
+    interop::Point seedPoint,
+    interop::Scalar newVal,
+    interop::Rect *rect,
+    interop::Scalar loDiff,
+    interop::Scalar upDiff,
+    int flags,
+    int* returnValue)
 {
     return cvTry([&] {
         cv::Rect rect0;
-        *returnValue = cv::floodFill(IoProxy(image), IoProxy(mask), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
+        *returnValue = cv::floodFill(IoProxy(*image), IoProxy(*mask), cpp(seedPoint), cpp(newVal), &rect0, cpp(loDiff), cpp(upDiff), flags);
         *rect = c(rect0);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_blendLinear(
-    interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::InputArrayProxy weights1, interop::InputArrayProxy weights2, interop::OutputArrayProxy dst)
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::InputArrayProxy* weights1,
+    const interop::InputArrayProxy* weights2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-        cv::blendLinear(InProxy(src1), InProxy(src2), InProxy(weights1), InProxy(weights2), OutProxy(dst));
+        cv::blendLinear(InProxy(*src1), InProxy(*src2), InProxy(*weights1), InProxy(*weights2), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cvtColor(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int code, int dstCn, int hint)
+CVAPI(ExceptionStatus) imgproc_cvtColor(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int code,
+    int dstCn,
+    int hint)
 {
     return cvTry([&] {
-        cv::cvtColor(InProxy(src), OutProxy(dst), code, dstCn, static_cast<cv::AlgorithmHint>(hint));
+        cv::cvtColor(InProxy(*src), OutProxy(*dst), code, dstCn, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_cvtColorTwoPlane(interop::InputArrayProxy src1, interop::InputArrayProxy src2, interop::OutputArrayProxy dst, int code, int hint)
+CVAPI(ExceptionStatus) imgproc_cvtColorTwoPlane(
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst,
+    int code,
+    int hint)
 {
     return cvTry([&] {
-        cv::cvtColorTwoPlane(InProxy(src1), InProxy(src2), OutProxy(dst), code, static_cast<cv::AlgorithmHint>(hint));
+        cv::cvtColorTwoPlane(InProxy(*src1), InProxy(*src2), OutProxy(*dst), code, static_cast<cv::AlgorithmHint>(hint));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_demosaicing(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int code, int dstCn)
+CVAPI(ExceptionStatus) imgproc_demosaicing(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int code,
+    int dstCn)
 {
     return cvTry([&] {
-        cv::demosaicing(InProxy(src), OutProxy(dst), code, dstCn);
+        cv::demosaicing(InProxy(*src), OutProxy(*dst), code, dstCn);
     });    
 }
 
-CVAPI(ExceptionStatus) imgproc_moments(interop::InputArrayProxy arr, int binaryImage, interop::Moments *returnValue)
+CVAPI(ExceptionStatus) imgproc_moments(
+    const interop::InputArrayProxy* arr,
+    int binaryImage,
+    interop::Moments *returnValue)
 {
     return cvTry([&] {
-        const auto m = cv::moments(InProxy(arr), binaryImage != 0);
+        const auto m = cv::moments(InProxy(*arr), binaryImage != 0);
         *returnValue = c(m);
     });
 }
@@ -643,108 +1016,166 @@ CVAPI(ExceptionStatus) imgproc_HuMoments(interop::Moments *moments, double hu[7]
     });
 }
 */
-CVAPI(ExceptionStatus) imgproc_matchTemplate(interop::InputArrayProxy image, interop::InputArrayProxy templ,
-                                  interop::OutputArrayProxy result, int method, interop::InputArrayProxy mask)
+CVAPI(ExceptionStatus) imgproc_matchTemplate(
+    const interop::InputArrayProxy* image,
+    const interop::InputArrayProxy* templ,
+    const interop::OutputArrayProxy* result,
+    int method,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-        cv::matchTemplate(InProxy(image), InProxy(templ), OutProxy(result), method, InProxy(mask));
+        cv::matchTemplate(InProxy(*image), InProxy(*templ), OutProxy(*result), method, InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithAlgorithm(
-    interop::InputArrayProxy image, interop::OutputArrayProxy labels, int connectivity, int ltype, int ccltype, int* returnValue)
+    const interop::InputArrayProxy* image,
+    const interop::OutputArrayProxy* labels,
+    int connectivity,
+    int ltype,
+    int ccltype,
+    int* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::connectedComponents(InProxy(image), OutProxy(labels), connectivity, ltype, ccltype);
+        *returnValue = cv::connectedComponents(InProxy(*image), OutProxy(*labels), connectivity, ltype, ccltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_connectedComponents(interop::InputArrayProxy image, interop::OutputArrayProxy labels,
-                                       int connectivity, int ltype, int *returnValue)
+CVAPI(ExceptionStatus) imgproc_connectedComponents(
+    const interop::InputArrayProxy* image,
+    const interop::OutputArrayProxy* labels,
+    int connectivity,
+    int ltype,
+    int *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::connectedComponents(InProxy(image), OutProxy(labels), connectivity, ltype);
+        *returnValue = cv::connectedComponents(InProxy(*image), OutProxy(*labels), connectivity, ltype);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStatsWithAlgorithm(
-    interop::InputArrayProxy image, interop::OutputArrayProxy labels,
-    interop::OutputArrayProxy stats, interop::OutputArrayProxy centroids,
-    int connectivity, int ltype, int ccltype, int* returnValue)
+    const interop::InputArrayProxy* image,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* stats,
+    const interop::OutputArrayProxy* centroids,
+    int connectivity,
+    int ltype,
+    int ccltype,
+    int* returnValue)
 {
     return cvTry([&] {
         *returnValue = cv::connectedComponentsWithStats(
-                InProxy(image), OutProxy(labels), OutProxy(stats), OutProxy(centroids), connectivity, ltype, ccltype);
+                InProxy(*image), OutProxy(*labels), OutProxy(*stats), OutProxy(*centroids), connectivity, ltype, ccltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStats(interop::InputArrayProxy image, interop::OutputArrayProxy labels,
-                                                interop::OutputArrayProxy stats, interop::OutputArrayProxy centroids, int connectivity, int ltype, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_connectedComponentsWithStats(
+    const interop::InputArrayProxy* image,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* stats,
+    const interop::OutputArrayProxy* centroids,
+    int connectivity,
+    int ltype,
+    int* returnValue)
 {
     return cvTry([&] {
         *returnValue = cv::connectedComponentsWithStats(
-            InProxy(image), OutProxy(labels), OutProxy(stats), OutProxy(centroids), connectivity, ltype);
+            InProxy(*image), OutProxy(*labels), OutProxy(*stats), OutProxy(*centroids), connectivity, ltype);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_findContours1_vector(interop::InputArrayProxy image, std::vector<std::vector<cv::Point> > *contours,
-                                         std::vector<cv::Vec4i> *hierarchy, int mode, int method, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_findContours1_vector(
+    const interop::InputArrayProxy* image,
+    std::vector<std::vector<cv::Point> > *contours,
+    std::vector<cv::Vec4i> *hierarchy,
+    int mode,
+    int method,
+    interop::Point offset)
 {
     return cvTry([&] {
-        cv::findContours(InProxy(image), *contours, *hierarchy, mode, method, cpp(offset));
+        cv::findContours(InProxy(*image), *contours, *hierarchy, mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours1_OutputArray(interop::InputArrayProxy image, std::vector<cv::Mat> *contours,
-                                              interop::OutputArrayProxy hierarchy, int mode, int method, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_findContours1_OutputArray(
+    const interop::InputArrayProxy* image,
+    std::vector<cv::Mat> *contours,
+    const interop::OutputArrayProxy* hierarchy,
+    int mode,
+    int method,
+    interop::Point offset)
 {
     return cvTry([&] {
-        cv::findContours(InProxy(image), *contours, OutProxy(hierarchy), mode, method, cpp(offset));
+        cv::findContours(InProxy(*image), *contours, OutProxy(*hierarchy), mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours2_vector(interop::InputArrayProxy image, std::vector<std::vector<cv::Point> > *contours,
-                                         int mode, int method, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_findContours2_vector(
+    const interop::InputArrayProxy* image,
+    std::vector<std::vector<cv::Point> > *contours,
+    int mode,
+    int method,
+    interop::Point offset)
 {
     return cvTry([&] {
-        cv::findContours(InProxy(image), *contours, mode, method, cpp(offset));
+        cv::findContours(InProxy(*image), *contours, mode, method, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(interop::InputArrayProxy image, std::vector<cv::Mat> *contours,
-                                              int mode, int method, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_findContours2_OutputArray(
+    const interop::InputArrayProxy* image,
+    std::vector<cv::Mat> *contours,
+    int mode,
+    int method,
+    interop::Point offset)
 {
     return cvTry([&] {
-        cv::findContours(InProxy(image), *contours, mode, method, cpp(offset));
+        cv::findContours(InProxy(*image), *contours, mode, method, cpp(offset));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(interop::InputArrayProxy image,
-                                          std::vector<std::vector<cv::Point> > *contours, std::vector<cv::Vec4i> *hierarchy)
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns1(
+    const interop::InputArrayProxy* image,
+    std::vector<std::vector<cv::Point> > *contours,
+    std::vector<cv::Vec4i> *hierarchy)
 {
     return cvTry([&] {
-        cv::findContoursLinkRuns(InProxy(image), *contours, *hierarchy);
+        cv::findContoursLinkRuns(InProxy(*image), *contours, *hierarchy);
     });
 }
-CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(interop::InputArrayProxy image,
+CVAPI(ExceptionStatus) imgproc_findContoursLinkRuns2(const interop::InputArrayProxy* image,
                                           std::vector<std::vector<cv::Point> > *contours)
 {
     return cvTry([&] {
-        cv::findContoursLinkRuns(InProxy(image), *contours);
+        cv::findContoursLinkRuns(InProxy(*image), *contours);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_approxPolyDP_InputArray(interop::InputArrayProxy curve, interop::OutputArrayProxy approxCurve, double epsilon, int closed)
+CVAPI(ExceptionStatus) imgproc_approxPolyDP_InputArray(
+    const interop::InputArrayProxy* curve,
+    const interop::OutputArrayProxy* approxCurve,
+    double epsilon,
+    int closed)
 {
     return cvTry([&] {
-        cv::approxPolyDP(InProxy(curve), OutProxy(approxCurve), epsilon, closed != 0);
+        cv::approxPolyDP(InProxy(*curve), OutProxy(*approxCurve), epsilon, closed != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point(cv::Point *curve, int curveLength, std::vector<cv::Point> *approxCurve, double epsilon, int closed)
+CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point(
+    cv::Point *curve,
+    int curveLength,
+    std::vector<cv::Point> *approxCurve,
+    double epsilon,
+    int closed)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     cv::approxPolyDP(curveMat, *approxCurve, epsilon, closed != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point2f(cv::Point2f *curve, int curveLength, std::vector<cv::Point2f> *approxCurve, double epsilon, int closed)
+CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point2f(
+    cv::Point2f *curve,
+    int curveLength,
+    std::vector<cv::Point2f> *approxCurve,
+    double epsilon,
+    int closed)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
@@ -752,20 +1183,31 @@ CVAPI(ExceptionStatus) imgproc_approxPolyDP_Point2f(cv::Point2f *curve, int curv
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_arcLength_InputArray(interop::InputArrayProxy curve, int closed, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_arcLength_InputArray(
+    const interop::InputArrayProxy* curve,
+    int closed,
+    double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::arcLength(InProxy(curve), closed != 0);
+        *returnValue = cv::arcLength(InProxy(*curve), closed != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_arcLength_Point(cv::Point *curve, int curveLength, int closed, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_arcLength_Point(
+    cv::Point *curve,
+    int curveLength,
+    int closed,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     *returnValue = cv::arcLength(curveMat, closed != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_arcLength_Point2f(cv::Point2f *curve, int curveLength, int closed, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_arcLength_Point2f(
+    cv::Point2f *curve,
+    int curveLength,
+    int closed,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
@@ -773,20 +1215,26 @@ CVAPI(ExceptionStatus) imgproc_arcLength_Point2f(cv::Point2f *curve, int curveLe
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boundingRect_InputArray(interop::InputArrayProxy curve, interop::Rect* returnValue)
+CVAPI(ExceptionStatus) imgproc_boundingRect_InputArray(const interop::InputArrayProxy* curve, interop::Rect* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::boundingRect(InProxy(curve)));
+        *returnValue = c(cv::boundingRect(InProxy(*curve)));
     });
 }
-CVAPI(ExceptionStatus) imgproc_boundingRect_Point(cv::Point *curve, int curveLength, interop::Rect* returnValue)
+CVAPI(ExceptionStatus) imgproc_boundingRect_Point(
+    cv::Point *curve,
+    int curveLength,
+    interop::Rect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> curveMat(curveLength, 1, curve);
     *returnValue = c(cv::boundingRect(curveMat));
     });
 }
-CVAPI(ExceptionStatus) imgproc_boundingRect_Point2f(cv::Point2f *curve, int curveLength, interop::Rect* returnValue)
+CVAPI(ExceptionStatus) imgproc_boundingRect_Point2f(
+    cv::Point2f *curve,
+    int curveLength,
+    interop::Rect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> curveMat(curveLength, 1, curve);
@@ -794,20 +1242,31 @@ CVAPI(ExceptionStatus) imgproc_boundingRect_Point2f(cv::Point2f *curve, int curv
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_contourArea_InputArray(interop::InputArrayProxy contour, int oriented, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_contourArea_InputArray(
+    const interop::InputArrayProxy* contour,
+    int oriented,
+    double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::contourArea(InProxy(contour), oriented != 0);
+        *returnValue = cv::contourArea(InProxy(*contour), oriented != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_contourArea_Point(cv::Point *contour, int contourLength, int oriented, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_contourArea_Point(
+    cv::Point *contour,
+    int contourLength,
+    int oriented,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
     *returnValue = cv::contourArea(contourMat, oriented != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_contourArea_Point2f(cv::Point2f *contour, int contourLength, int oriented, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_contourArea_Point2f(
+    cv::Point2f *contour,
+    int contourLength,
+    int oriented,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
@@ -815,20 +1274,26 @@ CVAPI(ExceptionStatus) imgproc_contourArea_Point2f(cv::Point2f *contour, int con
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minAreaRect_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_minAreaRect_InputArray(const interop::InputArrayProxy* points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::minAreaRect(InProxy(points)));
+        *returnValue = c(cv::minAreaRect(InProxy(*points)));
     });
 }
-CVAPI(ExceptionStatus) imgproc_minAreaRect_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_minAreaRect_Point(
+    cv::Point *points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     *returnValue = c(cv::minAreaRect(pointsMat));
     });
 }
-CVAPI(ExceptionStatus) imgproc_minAreaRect_Point2f(cv::Point2f *points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_minAreaRect_Point2f(
+    cv::Point2f *points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
@@ -836,10 +1301,10 @@ CVAPI(ExceptionStatus) imgproc_minAreaRect_Point2f(cv::Point2f *points, int poin
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_boxPoints_OutputArray(interop::RotatedRect box, interop::OutputArrayProxy points)
+CVAPI(ExceptionStatus) imgproc_boxPoints_OutputArray(interop::RotatedRect box, const interop::OutputArrayProxy* points)
 {
     return cvTry([&] {
-        cv::boxPoints(cpp(box), OutProxy(points));
+        cv::boxPoints(cpp(box), OutProxy(*points));
     });
 }
 CVAPI(ExceptionStatus) imgproc_boxPoints_Point2f(interop::RotatedRect box, cv::Point2f points[4])
@@ -849,17 +1314,24 @@ CVAPI(ExceptionStatus) imgproc_boxPoints_Point2f(interop::RotatedRect box, cv::P
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_InputArray(interop::InputArrayProxy points, interop::Point2f *center, float *radius)
+CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_InputArray(
+    const interop::InputArrayProxy* points,
+    interop::Point2f *center,
+    float *radius)
 {
     return cvTry([&] {
         cv::Point2f center0;
         float radius0;
-        cv::minEnclosingCircle(InProxy(points), center0, radius0);
+        cv::minEnclosingCircle(InProxy(*points), center0, radius0);
         *center = c(center0);
         *radius = radius0;
     });
 }
-CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point(cv::Point *points, int pointsLength, interop::Point2f*center, float *radius)
+CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point(
+    cv::Point *points,
+    int pointsLength,
+    interop::Point2f*center,
+    float *radius)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
@@ -870,7 +1342,11 @@ CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point(cv::Point *points, int p
     *radius = radius0;
     });
 }
-CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point2f(cv::Point2f *points, int pointsLength, interop::Point2f*center, float *radius)
+CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point2f(
+    cv::Point2f *points,
+    int pointsLength,
+    interop::Point2f*center,
+    float *radius)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
@@ -882,20 +1358,31 @@ CVAPI(ExceptionStatus) imgproc_minEnclosingCircle_Point2f(cv::Point2f *points, i
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_InputOutputArray(interop::InputArrayProxy points, interop::OutputArrayProxy triangle, double *returnValue)
+CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_InputOutputArray(
+    const interop::InputArrayProxy* points,
+    const interop::OutputArrayProxy* triangle,
+    double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::minEnclosingTriangle(InProxy(points), OutProxy(triangle));
+        *returnValue = cv::minEnclosingTriangle(InProxy(*points), OutProxy(*triangle));
     });
 }
-CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point(cv::Point* points, int pointsLength, std::vector<cv::Point2f>* triangle, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point(
+    cv::Point* points,
+    int pointsLength,
+    std::vector<cv::Point2f>* triangle,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     *returnValue = cv::minEnclosingTriangle(pointsMat, *triangle);
     });
 }
-CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point2f(cv::Point2f* points, int pointsLength, std::vector<cv::Point2f>* triangle, double* returnValue)
+CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point2f(
+    cv::Point2f* points,
+    int pointsLength,
+    std::vector<cv::Point2f>* triangle,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
@@ -904,14 +1391,24 @@ CVAPI(ExceptionStatus) imgproc_minEnclosingTriangle_Point2f(cv::Point2f* points,
 }
 
 CVAPI(ExceptionStatus) imgproc_matchShapes_InputArray(
-    interop::InputArrayProxy contour1, interop::InputArrayProxy contour2, int method, double parameter, double* returnValue)
+    const interop::InputArrayProxy* contour1,
+    const interop::InputArrayProxy* contour2,
+    int method,
+    double parameter,
+    double* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::matchShapes(InProxy(contour1), InProxy(contour2), method, parameter);
+        *returnValue = cv::matchShapes(InProxy(*contour1), InProxy(*contour2), method, parameter);
     });
 }
 CVAPI(ExceptionStatus) imgproc_matchShapes_Point(
-    cv::Point *contour1, int contour1Length, cv::Point *contour2, int contour2Length, int method, double parameter, double* returnValue)
+    cv::Point *contour1,
+    int contour1Length,
+    cv::Point *contour2,
+    int contour2Length,
+    int method,
+    double parameter,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> contour1Mat(contour1Length, 1, contour1);
@@ -920,34 +1417,54 @@ CVAPI(ExceptionStatus) imgproc_matchShapes_Point(
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convexHull_InputArray(interop::InputArrayProxy points, interop::OutputArrayProxy hull, int clockwise, int returnPoints)
+CVAPI(ExceptionStatus) imgproc_convexHull_InputArray(
+    const interop::InputArrayProxy* points,
+    const interop::OutputArrayProxy* hull,
+    int clockwise,
+    int returnPoints)
 {
     return cvTry([&] {
-        cv::convexHull(InProxy(points), OutProxy(hull), clockwise != 0, returnPoints != 0);
+        cv::convexHull(InProxy(*points), OutProxy(*hull), clockwise != 0, returnPoints != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsPoints(cv::Point *points, int pointsLength, std::vector<cv::Point> *hull, int clockwise)
+CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsPoints(
+    cv::Point *points,
+    int pointsLength,
+    std::vector<cv::Point> *hull,
+    int clockwise)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, true);
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsPoints(cv::Point2f *points, int pointsLength, std::vector<cv::Point2f> *hull, int clockwise)
+CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsPoints(
+    cv::Point2f *points,
+    int pointsLength,
+    std::vector<cv::Point2f> *hull,
+    int clockwise)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, true);
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsIndices(cv::Point *points, int pointsLength, std::vector<int> *hull, int clockwise)
+CVAPI(ExceptionStatus) imgproc_convexHull_Point_ReturnsIndices(
+    cv::Point *points,
+    int pointsLength,
+    std::vector<int> *hull,
+    int clockwise)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsMat(pointsLength, 1, points);
     cv::convexHull(pointsMat, *hull, clockwise != 0, false);
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsIndices(cv::Point2f *points, int pointsLength, std::vector<int> *hull, int clockwise)
+CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsIndices(
+    cv::Point2f *points,
+    int pointsLength,
+    std::vector<int> *hull,
+    int clockwise)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsMat(pointsLength, 1, points);
@@ -955,15 +1472,21 @@ CVAPI(ExceptionStatus) imgproc_convexHull_Point2f_ReturnsIndices(cv::Point2f *po
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_convexityDefects_InputArray(interop::InputArrayProxy contour, interop::InputArrayProxy convexHull,
-                                                interop::OutputArrayProxy convexityDefects)
+CVAPI(ExceptionStatus) imgproc_convexityDefects_InputArray(
+    const interop::InputArrayProxy* contour,
+    const interop::InputArrayProxy* convexHull,
+    const interop::OutputArrayProxy* convexityDefects)
 {
     return cvTry([&] {
-        cv::convexityDefects(InProxy(contour), InProxy(convexHull), OutProxy(convexityDefects));
+        cv::convexityDefects(InProxy(*contour), InProxy(*convexHull), OutProxy(*convexityDefects));
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexityDefects_Point(cv::Point *contour, int contourLength, int *convexHull, int convexHullLength,
-                                           std::vector<cv::Vec4i> *convexityDefects)
+CVAPI(ExceptionStatus) imgproc_convexityDefects_Point(
+    cv::Point *contour,
+    int contourLength,
+    int *convexHull,
+    int convexHullLength,
+    std::vector<cv::Vec4i> *convexityDefects)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
@@ -971,8 +1494,12 @@ CVAPI(ExceptionStatus) imgproc_convexityDefects_Point(cv::Point *contour, int co
     cv::convexityDefects(contourMat, convexHullMat, *convexityDefects);
     });
 }
-CVAPI(ExceptionStatus) imgproc_convexityDefects_Point2f(cv::Point2f *contour, int contourLength, int *convexHull, int convexHullLength,
-                                             std::vector<cv::Vec4i> *convexityDefects)
+CVAPI(ExceptionStatus) imgproc_convexityDefects_Point2f(
+    cv::Point2f *contour,
+    int contourLength,
+    int *convexHull,
+    int convexHullLength,
+    std::vector<cv::Vec4i> *convexityDefects)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
@@ -981,20 +1508,26 @@ CVAPI(ExceptionStatus) imgproc_convexityDefects_Point2f(cv::Point2f *contour, in
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_isContourConvex_InputArray(interop::InputArrayProxy contour, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_isContourConvex_InputArray(const interop::InputArrayProxy* contour, int* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::isContourConvex(InProxy(contour)) ? 1 : 0;
+        *returnValue = cv::isContourConvex(InProxy(*contour)) ? 1 : 0;
     });
 }
-CVAPI(ExceptionStatus) imgproc_isContourConvex_Point(cv::Point *contour, int contourLength, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_isContourConvex_Point(
+    cv::Point *contour,
+    int contourLength,
+    int* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> contourMat(contourLength, 1, contour);
     *returnValue = cv::isContourConvex(contourMat) ? 1 : 0;
     });
 }
-CVAPI(ExceptionStatus) imgproc_isContourConvex_Point2f(cv::Point2f *contour, int contourLength, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_isContourConvex_Point2f(
+    cv::Point2f *contour,
+    int contourLength,
+    int* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourMat(contourLength, 1, contour);
@@ -1002,15 +1535,25 @@ CVAPI(ExceptionStatus) imgproc_isContourConvex_Point2f(cv::Point2f *contour, int
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_InputArray(interop::InputArrayProxy p1, interop::InputArrayProxy p2,
-                                                      interop::OutputArrayProxy p12, int handleNested, float* returnValue)
+CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_InputArray(
+    const interop::InputArrayProxy* p1,
+    const interop::InputArrayProxy* p2,
+    const interop::OutputArrayProxy* p12,
+    int handleNested,
+    float* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::intersectConvexConvex(InProxy(p1), InProxy(p2), OutProxy(p12), handleNested != 0);
+        *returnValue = cv::intersectConvexConvex(InProxy(*p1), InProxy(*p2), OutProxy(*p12), handleNested != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point(cv::Point *p1, int p1Length, cv::Point *p2, int p2Length,
-                                                 std::vector<cv::Point> *p12, int handleNested, float* returnValue)
+CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point(
+    cv::Point *p1,
+    int p1Length,
+    cv::Point *p2,
+    int p2Length,
+    std::vector<cv::Point> *p12,
+    int handleNested,
+    float* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> p1Vec(p1Length, 1, p1);
@@ -1018,8 +1561,14 @@ CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point(cv::Point *p1, int p1
     *returnValue = cv::intersectConvexConvex(p1Vec, p2Vec, *p12, handleNested != 0);
     });
 }
-CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point2f(cv::Point2f *p1, int p1Length, cv::Point2f *p2, int p2Length,
-                                                   std::vector<cv::Point2f> *p12, int handleNested, float *returnValue)
+CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point2f(
+    cv::Point2f *p1,
+    int p1Length,
+    cv::Point2f *p2,
+    int p2Length,
+    std::vector<cv::Point2f> *p12,
+    int handleNested,
+    float *returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> p1Vec(p1Length, 1, p1);
@@ -1028,20 +1577,26 @@ CVAPI(ExceptionStatus) imgproc_intersectConvexConvex_Point2f(cv::Point2f *p1, in
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipse_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipse_InputArray(const interop::InputArrayProxy* points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::fitEllipse(InProxy(points)));
+        *returnValue = c(cv::fitEllipse(InProxy(*points)));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipse_Point(cv::Point *points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipse_Point(
+    cv::Point *points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipse(pointsVec));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipse_Point2f(cv::Point2f *points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipse_Point2f(
+    cv::Point2f *points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
@@ -1049,20 +1604,26 @@ CVAPI(ExceptionStatus) imgproc_fitEllipse_Point2f(cv::Point2f *points, int point
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_InputArray(const interop::InputArrayProxy* points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::fitEllipseAMS(InProxy(points)));
+        *returnValue = c(cv::fitEllipseAMS(InProxy(*points)));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point(
+    cv::Point* points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseAMS(pointsVec));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point2f(cv::Point2f* points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point2f(
+    cv::Point2f* points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
@@ -1070,20 +1631,26 @@ CVAPI(ExceptionStatus) imgproc_fitEllipseAMS_Point2f(cv::Point2f* points, int po
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_InputArray(interop::InputArrayProxy points, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_InputArray(const interop::InputArrayProxy* points, interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
-        *returnValue = c(cv::fitEllipseDirect(InProxy(points)));
+        *returnValue = c(cv::fitEllipseDirect(InProxy(*points)));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point(cv::Point* points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point(
+    cv::Point* points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
     *returnValue = c(cv::fitEllipseDirect(pointsVec));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point2f(cv::Point2f* points, int pointsLength, interop::RotatedRect* returnValue)
+CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point2f(
+    cv::Point2f* points,
+    int pointsLength,
+    interop::RotatedRect* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
@@ -1091,15 +1658,26 @@ CVAPI(ExceptionStatus) imgproc_fitEllipseDirect_Point2f(cv::Point2f* points, int
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fitLine_InputArray(interop::InputArrayProxy points, interop::OutputArrayProxy line,
-                                       int distType, double param, double reps, double aeps)
+CVAPI(ExceptionStatus) imgproc_fitLine_InputArray(
+    const interop::InputArrayProxy* points,
+    const interop::OutputArrayProxy* line,
+    int distType,
+    double param,
+    double reps,
+    double aeps)
 {
     return cvTry([&] {
-        cv::fitLine(InProxy(points), OutProxy(line), distType, param, reps, aeps);
+        cv::fitLine(InProxy(*points), OutProxy(*line), distType, param, reps, aeps);
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitLine_Point(cv::Point *points, int pointsLength, float *line, int distType,
-                                  double param, double reps, double aeps)
+CVAPI(ExceptionStatus) imgproc_fitLine_Point(
+    cv::Point *points,
+    int pointsLength,
+    float *line,
+    int distType,
+    double param,
+    double reps,
+    double aeps)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> pointsVec(pointsLength, 1, points);
@@ -1107,8 +1685,14 @@ CVAPI(ExceptionStatus) imgproc_fitLine_Point(cv::Point *points, int pointsLength
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitLine_Point2f(cv::Point2f *points, int pointsLength, float *line, int distType,
-                                    double param, double reps, double aeps)
+CVAPI(ExceptionStatus) imgproc_fitLine_Point2f(
+    cv::Point2f *points,
+    int pointsLength,
+    float *line,
+    int distType,
+    double param,
+    double reps,
+    double aeps)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> pointsVec(pointsLength, 1, points);
@@ -1116,8 +1700,14 @@ CVAPI(ExceptionStatus) imgproc_fitLine_Point2f(cv::Point2f *points, int pointsLe
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitLine_Point3i(cv::Point3i *points, int pointsLength, float *line, int distType,
-                                    double param, double reps, double aeps)
+CVAPI(ExceptionStatus) imgproc_fitLine_Point3i(
+    cv::Point3i *points,
+    int pointsLength,
+    float *line,
+    int distType,
+    double param,
+    double reps,
+    double aeps)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point3i> pointsVec(pointsLength, 1, points);
@@ -1125,8 +1715,14 @@ CVAPI(ExceptionStatus) imgproc_fitLine_Point3i(cv::Point3i *points, int pointsLe
     cv::fitLine(pointsVec, lineVec, distType, param, reps, aeps);
     });
 }
-CVAPI(ExceptionStatus) imgproc_fitLine_Point3f(cv::Point3f *points, int pointsLength, float *line, int distType,
-                                    double param, double reps, double aeps)
+CVAPI(ExceptionStatus) imgproc_fitLine_Point3f(
+    cv::Point3f *points,
+    int pointsLength,
+    float *line,
+    int distType,
+    double param,
+    double reps,
+    double aeps)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point3f> pointsVec(pointsLength, 1, points);
@@ -1136,14 +1732,21 @@ CVAPI(ExceptionStatus) imgproc_fitLine_Point3f(cv::Point3f *points, int pointsLe
 }
 
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_InputArray(
-    interop::InputArrayProxy contour, interop::Point2f pt, int measureDist, double *returnValue)
+    const interop::InputArrayProxy* contour,
+    interop::Point2f pt,
+    int measureDist,
+    double *returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::pointPolygonTest(InProxy(contour), cpp(pt), measureDist != 0);
+        *returnValue = cv::pointPolygonTest(InProxy(*contour), cpp(pt), measureDist != 0);
     });
 }
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point(
-    cv::Point *contour, int contourLength, interop::Point2f pt, int measureDist, double* returnValue)
+    cv::Point *contour,
+    int contourLength,
+    interop::Point2f pt,
+    int measureDist,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point> contourVec(contourLength, 1, contour);
@@ -1151,7 +1754,11 @@ CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point(
     });
 }
 CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point2f(
-    cv::Point2f *contour, int contourLength, interop::Point2f pt, int measureDist, double* returnValue)
+    cv::Point2f *contour,
+    int contourLength,
+    interop::Point2f pt,
+    int measureDist,
+    double* returnValue)
 {
     return cvTry([&] {
     const cv::Mat_<cv::Point2f> contourVec(contourLength, 1, contour);
@@ -1160,82 +1767,123 @@ CVAPI(ExceptionStatus) imgproc_pointPolygonTest_Point2f(
 }
 
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_OutputArray(
-    interop::RotatedRect rect1, interop::RotatedRect rect2, interop::OutputArrayProxy intersectingRegion, int* returnValue)
+    interop::RotatedRect rect1,
+    interop::RotatedRect rect2,
+    const interop::OutputArrayProxy* intersectingRegion,
+    int* returnValue)
 {
     return cvTry([&] {
-        *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), OutProxy(intersectingRegion));
+        *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), OutProxy(*intersectingRegion));
     });
 }
 CVAPI(ExceptionStatus) imgproc_rotatedRectangleIntersection_vector(
-    interop::RotatedRect rect1, interop::RotatedRect rect2, std::vector<cv::Point2f> *intersectingRegion, int* returnValue)
+    interop::RotatedRect rect1,
+    interop::RotatedRect rect2,
+    std::vector<cv::Point2f> *intersectingRegion,
+    int* returnValue)
 {
     return cvTry([&] {
     *returnValue = cv::rotatedRectangleIntersection(cpp(rect1), cpp(rect2), *intersectingRegion);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_applyColorMap1(interop::InputArrayProxy src, interop::OutputArrayProxy dst, int colorMap)
+CVAPI(ExceptionStatus) imgproc_applyColorMap1(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int colorMap)
 {
     return cvTry([&] {
-        cv::applyColorMap(InProxy(src), OutProxy(dst), colorMap);
+        cv::applyColorMap(InProxy(*src), OutProxy(*dst), colorMap);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_applyColorMap2(interop::InputArrayProxy src, interop::OutputArrayProxy dst, interop::InputArrayProxy userColor)
+CVAPI(ExceptionStatus) imgproc_applyColorMap2(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* userColor)
 {
     return cvTry([&] {
-        cv::applyColorMap(InProxy(src), OutProxy(dst), InProxy(userColor));
+        cv::applyColorMap(InProxy(*src), OutProxy(*dst), InProxy(*userColor));
     });    
 }
 
 #pragma region Drawing
 
 CVAPI(ExceptionStatus) imgproc_line(
-    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
-    int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point pt1,
+    interop::Point pt2,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::line(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
+        cv::line(IoProxy(*img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_arrowedLine(
-    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2, interop::Scalar color,
-    int thickness, int line_type, int shift, double tipLength)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point pt1,
+    interop::Point pt2,
+    interop::Scalar color,
+    int thickness,
+    int line_type,
+    int shift,
+    double tipLength)
 {
     return cvTry([&] {
-        cv::arrowedLine(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, line_type, shift, tipLength);
+        cv::arrowedLine(IoProxy(*img), cpp(pt1), cpp(pt2), cpp(color), thickness, line_type, shift, tipLength);
     });
 }
 
 
 CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Point(
-    interop::InputOutputArrayProxy img, interop::Point pt1, interop::Point pt2,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point pt1,
+    interop::Point pt2,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::rectangle(IoProxy(img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
+        cv::rectangle(IoProxy(*img), cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_InputOutputArray_Rect(
-    interop::InputOutputArrayProxy img, interop::Rect rect,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    interop::Rect rect,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::rectangle(IoProxy(img), cpp(rect), cpp(color), thickness, lineType, shift);
+        cv::rectangle(IoProxy(*img), cpp(rect), cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Point(
-    cv::Mat* img, interop::Point pt1, interop::Point pt2,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    cv::Mat* img,
+    interop::Point pt1,
+    interop::Point pt2,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
     cv::rectangle(*img, cpp(pt1), cpp(pt2), cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Rect(
-    cv::Mat *img, interop::Rect rect,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    cv::Mat *img,
+    interop::Rect rect,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
     cv::rectangle(*img, cpp(rect), cpp(color), thickness, lineType, shift);
@@ -1244,74 +1892,122 @@ CVAPI(ExceptionStatus) imgproc_rectangle_Mat_Rect(
 
 
 CVAPI(ExceptionStatus) imgproc_circle(
-    interop::InputOutputArrayProxy img, interop::Point center, int radius,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point center,
+    int radius,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::circle(IoProxy(img), cpp(center), radius, cpp(color), thickness, lineType, shift);
+        cv::circle(IoProxy(*img), cpp(center), radius, cpp(color), thickness, lineType, shift);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse1(
-    interop::InputOutputArrayProxy img, interop::Point center, interop::Size axes,
-    double angle, double startAngle, double endAngle,
-    interop::Scalar color, int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point center,
+    interop::Size axes,
+    double angle,
+    double startAngle,
+    double endAngle,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::ellipse(IoProxy(img), cpp(center), cpp(axes), angle, startAngle, endAngle, cpp(color), thickness, lineType, shift);
+        cv::ellipse(IoProxy(*img), cpp(center), cpp(axes), angle, startAngle, endAngle, cpp(color), thickness, lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_ellipse2(
-    interop::InputOutputArrayProxy img, interop::RotatedRect box, interop::Scalar color, int thickness, int lineType)
+    const interop::InputOutputArrayProxy* img,
+    interop::RotatedRect box,
+    interop::Scalar color,
+    int thickness,
+    int lineType)
 {
     return cvTry([&] {
-        cv::ellipse(IoProxy(img), cpp(box), cpp(color), thickness, lineType);
+        cv::ellipse(IoProxy(*img), cpp(box), cpp(color), thickness, lineType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_drawMarker(
-    interop::InputOutputArrayProxy img, interop::Point position, interop::Scalar color,
-    int markerType, int markerSize, int thickness, int lineType)
+    const interop::InputOutputArrayProxy* img,
+    interop::Point position,
+    interop::Scalar color,
+    int markerType,
+    int markerSize,
+    int thickness,
+    int lineType)
 {
     return cvTry([&] {
-        cv::drawMarker(IoProxy(img), cpp(position), cpp(color), markerType, markerSize, thickness, lineType);
+        cv::drawMarker(IoProxy(*img), cpp(position), cpp(color), markerType, markerSize, thickness, lineType);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_fillConvexPoly_Mat(
-    cv::Mat *img, cv::Point *pts, int npts, interop::Scalar color, int lineType, int shift)
+    cv::Mat *img,
+    cv::Point *pts,
+    int npts,
+    interop::Scalar color,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
     cv::fillConvexPoly(*img, pts, npts, cpp(color), lineType, shift);
     });
 }
 CVAPI(ExceptionStatus) imgproc_fillConvexPoly_InputOutputArray(
-    interop::InputOutputArrayProxy img, interop::InputArrayProxy points, interop::Scalar color, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    const interop::InputArrayProxy* points,
+    interop::Scalar color,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::fillConvexPoly(IoProxy(img), InProxy(points), cpp(color), lineType, shift);
+        cv::fillConvexPoly(IoProxy(*img), InProxy(*points), cpp(color), lineType, shift);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_fillPoly_Mat(cv::Mat *img, const cv::Point **pts, const int *npts,
-                                 int ncontours, interop::Scalar color, int lineType, int shift, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_fillPoly_Mat(
+    cv::Mat *img,
+    const cv::Point **pts,
+    const int *npts,
+    int ncontours,
+    interop::Scalar color,
+    int lineType,
+    int shift,
+    interop::Point offset)
 {
     return cvTry([&] {
     cv::fillPoly(*img, pts, npts, ncontours, cpp(color), lineType, shift, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_fillPoly_InputOutputArray(interop::InputOutputArrayProxy img, interop::InputArrayProxy pts,
-                                              interop::Scalar color, int lineType, int shift, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_fillPoly_InputOutputArray(
+    const interop::InputOutputArrayProxy* img,
+    const interop::InputArrayProxy* pts,
+    interop::Scalar color,
+    int lineType,
+    int shift,
+    interop::Point offset)
 {
     return cvTry([&] {
-        cv::fillPoly(IoProxy(img), InProxy(pts), cpp(color), lineType, shift, cpp(offset));
+        cv::fillPoly(IoProxy(*img), InProxy(*pts), cpp(color), lineType, shift, cpp(offset));
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_polylines_Mat(
-    cv::Mat *img, const cv::Point **pts, const int *npts,
-    int ncontours, int isClosed, interop::Scalar color,
-    int thickness, int lineType, int shift)
+    cv::Mat *img,
+    const cv::Point **pts,
+    const int *npts,
+    int ncontours,
+    int isClosed,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
     cv::polylines(
@@ -1319,18 +2015,32 @@ CVAPI(ExceptionStatus) imgproc_polylines_Mat(
     });
 }
 CVAPI(ExceptionStatus) imgproc_polylines_InputOutputArray(
-    interop::InputOutputArrayProxy img, interop::InputArrayProxy pts, int isClosed, interop::Scalar color,
-    int thickness, int lineType, int shift)
+    const interop::InputOutputArrayProxy* img,
+    const interop::InputArrayProxy* pts,
+    int isClosed,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int shift)
 {
     return cvTry([&] {
-        cv::polylines(IoProxy(img), InProxy(pts), isClosed != 0, cpp(color), thickness, lineType, shift);
+        cv::polylines(IoProxy(*img), InProxy(*pts), isClosed != 0, cpp(color), thickness, lineType, shift);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_drawContours_vector(interop::InputOutputArrayProxy image,
-                                        cv::Point **contours, int contoursSize1, int *contoursSize2,
-                                        int contourIdx, interop::Scalar color, int thickness, int lineType,
-                                        cv::Vec4i *hierarchy, int hiearchyLength, int maxLevel, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_drawContours_vector(
+    const interop::InputOutputArrayProxy* image,
+    cv::Point **contours,
+    int contoursSize1,
+    int *contoursSize2,
+    int contourIdx,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    cv::Vec4i *hierarchy,
+    int hiearchyLength,
+    int maxLevel,
+    interop::Point offset)
 {
     return cvTry([&] {
         std::vector<std::vector<cv::Point> > contoursVec;
@@ -1346,24 +2056,35 @@ CVAPI(ExceptionStatus) imgproc_drawContours_vector(interop::InputOutputArrayProx
         }
 
         cv::drawContours(
-            IoProxy(image), contoursVec, contourIdx, cpp(color), thickness, lineType, hierarchyVec, maxLevel, cpp(offset));
+            IoProxy(*image), contoursVec, contourIdx, cpp(color), thickness, lineType, hierarchyVec, maxLevel, cpp(offset));
     });
 }
-CVAPI(ExceptionStatus) imgproc_drawContours_InputArray(interop::InputOutputArrayProxy image,
-                                            cv::Mat **contours, int contoursLength,
-                                            int contourIdx, interop::Scalar color, int thickness, int lineType,
-                                            interop::InputArrayProxy hierarchy, int maxLevel, interop::Point offset)
+CVAPI(ExceptionStatus) imgproc_drawContours_InputArray(
+    const interop::InputOutputArrayProxy* image,
+    cv::Mat **contours,
+    int contoursLength,
+    int contourIdx,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    const interop::InputArrayProxy* hierarchy,
+    int maxLevel,
+    interop::Point offset)
 {
     return cvTry([&] {
         std::vector<std::vector<cv::Point> > contoursVec(contoursLength);
         for (auto i = 0; i < contoursLength; i++)
             contoursVec[i] = *contours[i];
         cv::drawContours(
-            IoProxy(image), contoursVec, contourIdx, cpp(color), thickness, lineType, InProxy(hierarchy), maxLevel, cpp(offset));
+            IoProxy(*image), contoursVec, contourIdx, cpp(color), thickness, lineType, InProxy(*hierarchy), maxLevel, cpp(offset));
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_clipLine1(interop::Size imgSize, interop::Point *pt1, interop::Point *pt2, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_clipLine1(
+    interop::Size imgSize,
+    interop::Point *pt1,
+    interop::Point *pt2,
+    int* returnValue)
 {
     return cvTry([&] {
     auto pt1c = cpp(*pt1), pt2c = cpp(*pt2);
@@ -1373,7 +2094,11 @@ CVAPI(ExceptionStatus) imgproc_clipLine1(interop::Size imgSize, interop::Point *
     *returnValue = result ? 1 : 0;
     });
 }
-CVAPI(ExceptionStatus) imgproc_clipLine2(interop::Rect imgRect, interop::Point *pt1, interop::Point *pt2, int* returnValue)
+CVAPI(ExceptionStatus) imgproc_clipLine2(
+    interop::Rect imgRect,
+    interop::Point *pt1,
+    interop::Point *pt2,
+    int* returnValue)
 {
     return cvTry([&] {
     auto pt1c = cpp(*pt1), pt2c = cpp(*pt2);
@@ -1385,8 +2110,13 @@ CVAPI(ExceptionStatus) imgproc_clipLine2(interop::Rect imgRect, interop::Point *
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse2Poly_int(
-    interop::Point center, interop::Size axes, int angle, int arcStart, int arcEnd,
-    int delta, std::vector<cv::Point>* pts)
+    interop::Point center,
+    interop::Size axes,
+    int angle,
+    int arcStart,
+    int arcEnd,
+    int delta,
+    std::vector<cv::Point>* pts)
 {
     return cvTry([&] {
     cv::ellipse2Poly(cpp(center), cpp(axes), angle, arcStart, arcEnd, delta, *pts);
@@ -1394,25 +2124,42 @@ CVAPI(ExceptionStatus) imgproc_ellipse2Poly_int(
 }
 
 CVAPI(ExceptionStatus) imgproc_ellipse2Poly_double(
-    interop::Point2d center, interop::Size2d axes, int angle, int arcStart, int arcEnd,
-    int delta, std::vector<cv::Point2d>* pts)
+    interop::Point2d center,
+    interop::Size2d axes,
+    int angle,
+    int arcStart,
+    int arcEnd,
+    int delta,
+    std::vector<cv::Point2d>* pts)
 {
     return cvTry([&] {
     cv::ellipse2Poly(cpp(center), cpp(axes), angle, arcStart, arcEnd, delta, *pts);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_putText(interop::InputOutputArrayProxy img, const char *text, interop::Point org,
-                         int fontFace, double fontScale, interop::Scalar color,
-                         int thickness, int lineType, int bottomLeftOrigin)
+CVAPI(ExceptionStatus) imgproc_putText(
+    const interop::InputOutputArrayProxy* img,
+    const char *text,
+    interop::Point org,
+    int fontFace,
+    double fontScale,
+    interop::Scalar color,
+    int thickness,
+    int lineType,
+    int bottomLeftOrigin)
 {
     return cvTry([&] {
-        cv::putText(IoProxy(img), text, cpp(org), fontFace, fontScale, cpp(color), thickness, lineType, bottomLeftOrigin != 0);
+        cv::putText(IoProxy(*img), text, cpp(org), fontFace, fontScale, cpp(color), thickness, lineType, bottomLeftOrigin != 0);
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_getTextSize(const char *text, int fontFace,
-                                 double fontScale, int thickness, int *baseLine, interop::Size *returnValue)
+CVAPI(ExceptionStatus) imgproc_getTextSize(
+    const char *text,
+    int fontFace,
+    double fontScale,
+    int thickness,
+    int *baseLine,
+    interop::Size *returnValue)
 {
     return cvTry([&] {
     *returnValue = c(cv::getTextSize(text, fontFace, fontScale, thickness, baseLine));
@@ -1420,7 +2167,10 @@ CVAPI(ExceptionStatus) imgproc_getTextSize(const char *text, int fontFace,
 }
 
 CVAPI(ExceptionStatus) imgproc_getFontScaleFromHeight(
-    int fontFace, int pixelHeight, int thickness, double* returnValue)
+    int fontFace,
+    int pixelHeight,
+    int thickness,
+    double* returnValue)
 {
     return cvTry([&] {
     *returnValue = cv::getFontScaleFromHeight(fontFace, pixelHeight, thickness);

--- a/src/OpenCvSharpExtern/imgproc_FontFace.h
+++ b/src/OpenCvSharpExtern/imgproc_FontFace.h
@@ -63,15 +63,15 @@ CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(cv::FontFace *obj, std::vect
 #pragma region putText / getTextSize with FontFace
 
 CVAPI(ExceptionStatus) imgproc_putText_FontFace(
-    cv::_InputOutputArray *img, const char *text, interop::Point org, interop::Scalar color,
+    interop::InputOutputArrayProxy img, const char *text, interop::Point org, interop::Scalar color,
     cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
     interop::Point *returnValue)
 {
     return cvTry([&] {
-    const auto p = cv::putText(
-        *img, cv::String(text), cpp(org), cpp(color), *fface, size, weight,
-        static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
-    *returnValue = c(p);
+        const auto p = cv::putText(
+            IoProxy(img), cv::String(text), cpp(org), cpp(color), *fface, size, weight,
+            static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
+        *returnValue = c(p);
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc_FontFace.h
+++ b/src/OpenCvSharpExtern/imgproc_FontFace.h
@@ -29,7 +29,10 @@ CVAPI(ExceptionStatus) imgproc_FontFace_delete(cv::FontFace *obj)
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_FontFace_set(cv::FontFace *obj, const char *fontPathOrName, int *returnValue)
+CVAPI(ExceptionStatus) imgproc_FontFace_set(
+    cv::FontFace *obj,
+    const char *fontPathOrName,
+    int *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->set(cv::String(fontPathOrName)) ? 1 : 0;
@@ -43,7 +46,11 @@ CVAPI(ExceptionStatus) imgproc_FontFace_getName(cv::FontFace *obj, std::string *
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_FontFace_setInstance(cv::FontFace *obj, int *params, int paramsLength, int *returnValue)
+CVAPI(ExceptionStatus) imgproc_FontFace_setInstance(
+    cv::FontFace *obj,
+    int *params,
+    int paramsLength,
+    int *returnValue)
 {
     return cvTry([&] {
     const std::vector<int> v(params, params + paramsLength);
@@ -51,7 +58,10 @@ CVAPI(ExceptionStatus) imgproc_FontFace_setInstance(cv::FontFace *obj, int *para
     });
 }
 
-CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(cv::FontFace *obj, std::vector<int> *params, int *returnValue)
+CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(
+    cv::FontFace *obj,
+    std::vector<int> *params,
+    int *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getInstance(*params) ? 1 : 0;
@@ -63,21 +73,36 @@ CVAPI(ExceptionStatus) imgproc_FontFace_getInstance(cv::FontFace *obj, std::vect
 #pragma region putText / getTextSize with FontFace
 
 CVAPI(ExceptionStatus) imgproc_putText_FontFace(
-    interop::InputOutputArrayProxy img, const char *text, interop::Point org, interop::Scalar color,
-    cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
+    const interop::InputOutputArrayProxy* img,
+    const char *text,
+    interop::Point org,
+    interop::Scalar color,
+    cv::FontFace *fface,
+    int size,
+    int weight,
+    int flags,
+    int wrapStart,
+    int wrapEnd,
     interop::Point *returnValue)
 {
     return cvTry([&] {
         const auto p = cv::putText(
-            IoProxy(img), cv::String(text), cpp(org), cpp(color), *fface, size, weight,
+            IoProxy(*img), cv::String(text), cpp(org), cpp(color), *fface, size, weight,
             static_cast<cv::PutTextFlags>(flags), cv::Range(wrapStart, wrapEnd));
         *returnValue = c(p);
     });
 }
 
 CVAPI(ExceptionStatus) imgproc_getTextSize_FontFace(
-    interop::Size imgsize, const char *text, interop::Point org,
-    cv::FontFace *fface, int size, int weight, int flags, int wrapStart, int wrapEnd,
+    interop::Size imgsize,
+    const char *text,
+    interop::Point org,
+    cv::FontFace *fface,
+    int size,
+    int weight,
+    int flags,
+    int wrapStart,
+    int wrapEnd,
     interop::Rect *returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -197,29 +197,47 @@ namespace interop
     typedef struct Vec4d { double val[4]; } Vec4d;
     typedef struct Vec6d { double val[6]; } Vec6d;
 
-    // Stack-only array proxy for the ref-struct InputArray/OutputArray redesign. It mirrors
-    // cv::_InputArray/_OutputArray (a kind tag + a pointer/inline payload) and is passed BY VALUE
+    // Stack-only array proxies for the ref-struct InputArray/OutputArray redesign. They mirror
+    // cv::_InputArray/_OutputArray (a kind tag + a pointer/inline payload) and are passed BY VALUE
     // across the P/Invoke boundary, so the managed side never allocates a heap cv::_InputArray per
-    // call. The native side rebuilds a cv::_InputArray/_OutputArray on its own stack from these
-    // fields via fromInputProxy()/fromOutputProxy().
+    // call. The native side rebuilds the cv:: array on its own stack via from{Input,Output,
+    // InputOutput}Proxy().
     //
-    // For Scalar kinds the inline payload feeds a stack-local cv::Scalar (see fromInputProxy). For
-    // Vec kinds the cv::_InputArray references this struct's own `payload` storage; because the
-    // proxy is taken by value, the parameter copy stays valid for the duration of the OpenCV call.
-    struct ArrayProxy
+    // There are three distinct types so a CVAPI signature is self-documenting (which argument is in
+    // vs out, like the old cv::_InputArray*/_OutputArray*) and so the in/out role is type-checked.
+    // Only inputs can be a Scalar/Vec value, so only InputArrayProxy carries the inline payload; the
+    // output proxies are just a handle + kind.
+
+    struct InputArrayProxy
     {
         void  *handle;     // cv::Mat*/cv::UMat*/cv::MatExpr* for handle kinds; null otherwise
-        int    kind;       // ArrayProxyKind: 0 None, 1 Mat, 2 UMat, 3 MatExpr, 4 Scalar, 5 Double, 6 Vec
+        int    kind;       // ArrayProxyKind: 0 None, 1 Mat, 2 UMat, 3 MatExpr, 4 Scalar, 5 Double, 6 Vec, 7 Raw
         int    vecDepth;   // Vec only: CV_8U..CV_64F element depth; otherwise 0
         int    vecLength;  // Vec only: element count (2/3/4/6); otherwise 0
         double payload[6]; // inline storage: Scalar (4 doubles) | double (1) | Vec (raw bytes, <= 48)
     };
 
-    // ArrayProxy is passed BY VALUE through extern "C" (CVAPI), so it must stay a C-ABI-compatible
-    // POD: standard-layout and trivially copyable (no user copy/move/dtor, no virtuals). This guard
-    // fails the build the moment a non-trivial member sneaks in.
-    static_assert(std::is_standard_layout_v<ArrayProxy> && std::is_trivially_copyable_v<ArrayProxy>,
-        "interop::ArrayProxy must stay a C-ABI-compatible POD");
+    struct OutputArrayProxy
+    {
+        void *handle;      // cv::Mat*/cv::UMat* (or a cv::_OutputArray* for the Raw kind)
+        int   kind;        // ArrayProxyKind: 0 None, 1 Mat, 2 UMat, 8 RawOutputArray
+    };
+
+    struct InputOutputArrayProxy
+    {
+        void *handle;      // cv::Mat*/cv::UMat* (or a cv::_InputOutputArray* for the Raw kind)
+        int   kind;        // ArrayProxyKind: 0 None, 1 Mat, 2 UMat, 9 RawInputOutputArray
+    };
+
+    // These are passed BY VALUE through extern "C" (CVAPI), so each must stay a C-ABI-compatible POD:
+    // standard-layout and trivially copyable (no user copy/move/dtor, no virtuals). The guards fail
+    // the build the moment a non-trivial member sneaks in.
+    static_assert(std::is_standard_layout_v<InputArrayProxy> && std::is_trivially_copyable_v<InputArrayProxy>,
+        "interop::InputArrayProxy must stay a C-ABI-compatible POD");
+    static_assert(std::is_standard_layout_v<OutputArrayProxy> && std::is_trivially_copyable_v<OutputArrayProxy>,
+        "interop::OutputArrayProxy must stay a C-ABI-compatible POD");
+    static_assert(std::is_standard_layout_v<InputOutputArrayProxy> && std::is_trivially_copyable_v<InputOutputArrayProxy>,
+        "interop::InputOutputArrayProxy must stay a C-ABI-compatible POD");
 
 } // namespace interop
 
@@ -356,26 +374,20 @@ static cv::Moments cpp(const interop::Moments &m)
 }
 
 // -------------------------------------------------------------------------
-// interop::ArrayProxy -> cv::_InputArray / _OutputArray / _InputOutputArray
+// interop::{Input,Output,InputOutput}ArrayProxy -> cv::_InputArray / _OutputArray /
+// _InputOutputArray
 //
-// These build the cv:: array proxy on the caller's stack from a by-value
-// interop::ArrayProxy, so no heap cv::_InputArray is allocated per call. Use
-// them at the head of a CVAPI body, e.g.:
+// These build the cv:: array proxy on the caller's stack from a by-value proxy, so
+// no heap cv::_InputArray is allocated per call. Use the InProxy/OutProxy/IoProxy
+// views below at the head of a CVAPI body.
 //
-//     CVAPI(...) foo(interop::ArrayProxy src, interop::ArrayProxy dst) {
-//         return cvTry([&] {
-//         cv::Scalar s; // scratch storage for scalar-kind inputs (see below)
-//         cv::bar(fromInputProxy(src, s), fromOutputProxy(dst));
-//         });
-//     }
-//
-// Scalar/Double inputs: cv::_InputArray references a cv::Scalar, so the caller
-// must keep `scalarScratch` alive for the whole OpenCV call (one scratch per
-// input that may be a scalar).
-// Vec inputs: cv::_InputArray references proxy.payload; the by-value parameter
-// copy stays valid for the call.
+// Scalar/Double inputs: cv::_InputArray references a cv::Scalar, so the caller must
+// keep `scalarScratch` alive for the whole OpenCV call (one scratch per input that
+// may be a scalar).
+// Vec inputs: cv::_InputArray references proxy.payload; the by-value parameter copy
+// stays valid for the call.
 // -------------------------------------------------------------------------
-static cv::_InputArray fromInputProxy(const interop::ArrayProxy &p, cv::Scalar &scalarScratch)
+static cv::_InputArray fromInputProxy(const interop::InputArrayProxy &p, cv::Scalar &scalarScratch)
 {
     switch (p.kind)
     {
@@ -403,7 +415,7 @@ static cv::_InputArray fromInputProxy(const interop::ArrayProxy &p, cv::Scalar &
     }
 }
 
-static cv::_OutputArray fromOutputProxy(const interop::ArrayProxy &p)
+static cv::_OutputArray fromOutputProxy(const interop::OutputArrayProxy &p)
 {
     switch (p.kind)
     {
@@ -414,7 +426,7 @@ static cv::_OutputArray fromOutputProxy(const interop::ArrayProxy &p)
     }
 }
 
-static cv::_InputOutputArray fromInputOutputProxy(const interop::ArrayProxy &p)
+static cv::_InputOutputArray fromInputOutputProxy(const interop::InputOutputArrayProxy &p)
 {
     switch (p.kind)
     {
@@ -426,13 +438,13 @@ static cv::_InputOutputArray fromInputOutputProxy(const interop::ArrayProxy &p)
 }
 
 // -------------------------------------------------------------------------
-// RAII views that turn a by-value interop::ArrayProxy into a cv::_InputArray /
-// _OutputArray / _InputOutputArray for use directly inside an OpenCV call. Each
-// view owns the scratch storage its proxy may reference (the scalar for scalar
-// kinds), so as long as the view lives to the end of the call expression the
-// cv:: array stays valid. This keeps migrated CVAPI bodies a one-liner, e.g.
+// RAII views that turn a by-value proxy into a cv::_InputArray / _OutputArray /
+// _InputOutputArray for use directly inside an OpenCV call. Each view owns the
+// scratch storage its proxy may reference (the scalar for scalar kinds), so as long
+// as the view lives to the end of the call expression the cv:: array stays valid.
+// This keeps migrated CVAPI bodies a one-liner, e.g.
 //
-//     CVAPI(...) core_foo(interop::ArrayProxy src, interop::ArrayProxy dst) {
+//     CVAPI(...) core_foo(interop::InputArrayProxy src, interop::OutputArrayProxy dst) {
 //         return cvTry([&] { cv::foo(InProxy(src), OutProxy(dst)); });
 //     }
 // -------------------------------------------------------------------------
@@ -441,7 +453,7 @@ class InProxy
     cv::Scalar scratch_;
     cv::_InputArray ia_;
 public:
-    explicit InProxy(const interop::ArrayProxy &p) : ia_(fromInputProxy(p, scratch_)) {}
+    explicit InProxy(const interop::InputArrayProxy &p) : ia_(fromInputProxy(p, scratch_)) {}
     InProxy(const InProxy &) = delete;
     InProxy &operator=(const InProxy &) = delete;
     operator const cv::_InputArray &() const { return ia_; }
@@ -451,7 +463,7 @@ class OutProxy
 {
     cv::_OutputArray oa_;
 public:
-    explicit OutProxy(const interop::ArrayProxy &p) : oa_(fromOutputProxy(p)) {}
+    explicit OutProxy(const interop::OutputArrayProxy &p) : oa_(fromOutputProxy(p)) {}
     OutProxy(const OutProxy &) = delete;
     OutProxy &operator=(const OutProxy &) = delete;
     operator const cv::_OutputArray &() const { return oa_; }
@@ -461,7 +473,7 @@ class IoProxy
 {
     cv::_InputOutputArray ioa_;
 public:
-    explicit IoProxy(const interop::ArrayProxy &p) : ioa_(fromInputOutputProxy(p)) {}
+    explicit IoProxy(const interop::InputOutputArrayProxy &p) : ioa_(fromInputOutputProxy(p)) {}
     IoProxy(const IoProxy &) = delete;
     IoProxy &operator=(const IoProxy &) = delete;
     operator const cv::_InputOutputArray &() const { return ioa_; }

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -418,3 +418,45 @@ static cv::_InputOutputArray fromInputOutputProxy(const interop::ArrayProxy &p)
     default: return cv::noArray();
     }
 }
+
+// -------------------------------------------------------------------------
+// RAII views that turn a by-value interop::ArrayProxy into a cv::_InputArray /
+// _OutputArray / _InputOutputArray for use directly inside an OpenCV call. Each
+// view owns the scratch storage its proxy may reference (the scalar for scalar
+// kinds), so as long as the view lives to the end of the call expression the
+// cv:: array stays valid. This keeps migrated CVAPI bodies a one-liner, e.g.
+//
+//     CVAPI(...) core_foo(interop::ArrayProxy src, interop::ArrayProxy dst) {
+//         return cvTry([&] { cv::foo(InProxy(src), OutProxy(dst)); });
+//     }
+// -------------------------------------------------------------------------
+class InProxy
+{
+    cv::Scalar scratch_;
+    cv::_InputArray ia_;
+public:
+    explicit InProxy(const interop::ArrayProxy &p) : ia_(fromInputProxy(p, scratch_)) {}
+    InProxy(const InProxy &) = delete;
+    InProxy &operator=(const InProxy &) = delete;
+    operator const cv::_InputArray &() const { return ia_; }
+};
+
+class OutProxy
+{
+    cv::_OutputArray oa_;
+public:
+    explicit OutProxy(const interop::ArrayProxy &p) : oa_(fromOutputProxy(p)) {}
+    OutProxy(const OutProxy &) = delete;
+    OutProxy &operator=(const OutProxy &) = delete;
+    operator const cv::_OutputArray &() const { return oa_; }
+};
+
+class IoProxy
+{
+    cv::_InputOutputArray ioa_;
+public:
+    explicit IoProxy(const interop::ArrayProxy &p) : ioa_(fromInputOutputProxy(p)) {}
+    IoProxy(const IoProxy &) = delete;
+    IoProxy &operator=(const IoProxy &) = delete;
+    operator const cv::_InputOutputArray &() const { return ioa_; }
+};

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -215,6 +215,12 @@ namespace interop
         double payload[6]; // inline storage: Scalar (4 doubles) | double (1) | Vec (raw bytes, <= 48)
     };
 
+    // ArrayProxy is passed BY VALUE through extern "C" (CVAPI), so it must stay a C-ABI-compatible
+    // POD: standard-layout and trivially copyable (no user copy/move/dtor, no virtuals). This guard
+    // fails the build the moment a non-trivial member sneaks in.
+    static_assert(std::is_standard_layout_v<ArrayProxy> && std::is_trivially_copyable_v<ArrayProxy>,
+        "interop::ArrayProxy must stay a C-ABI-compatible POD");
+
 } // namespace interop
 
 extern "C"

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -392,6 +392,7 @@ static cv::_InputArray fromInputProxy(const interop::ArrayProxy &p, cv::Scalar &
         case CV_64F: return cv::_InputArray(reinterpret_cast<const double *>(p.payload), p.vecLength);
         default:     return cv::noArray();
         }
+    case 7: return *static_cast<cv::_InputArray *>(p.handle); // RawInputArray (class InputArray)
     default: return cv::noArray();
     }
 }
@@ -402,6 +403,7 @@ static cv::_OutputArray fromOutputProxy(const interop::ArrayProxy &p)
     {
     case 1: return cv::_OutputArray(*static_cast<cv::Mat *>(p.handle));
     case 2: return cv::_OutputArray(*static_cast<cv::UMat *>(p.handle));
+    case 8: return *static_cast<cv::_OutputArray *>(p.handle); // RawOutputArray (class OutputArray)
     default: return cv::noArray();
     }
 }
@@ -412,6 +414,7 @@ static cv::_InputOutputArray fromInputOutputProxy(const interop::ArrayProxy &p)
     {
     case 1: return cv::_InputOutputArray(*static_cast<cv::Mat *>(p.handle));
     case 2: return cv::_InputOutputArray(*static_cast<cv::UMat *>(p.handle));
+    case 9: return *static_cast<cv::_InputOutputArray *>(p.handle); // RawInputOutputArray (class)
     default: return cv::noArray();
     }
 }

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -207,6 +207,17 @@ namespace interop
     // vs out, like the old cv::_InputArray*/_OutputArray*) and so the in/out role is type-checked.
     // Only inputs can be a Scalar/Vec value, so only InputArrayProxy carries the inline payload; the
     // output proxies are just a handle + kind.
+    //
+    // On the cost of passing these BY VALUE: InputArrayProxy is 72 bytes on x64 (8 + 3*4 + 4 pad +
+    // 48-byte payload), OutputArray/InputOutputArrayProxy are 16. That is much larger than the old
+    // 8-byte cv::_InputArray* argument, but it is NOT a regression: the old path had to heap-allocate
+    // a cv::_InputArray per call (core_InputArray_new_byMat) and free it (SafeHandle/finalizer + GC
+    // pressure), whereas this path allocates nothing — passing the proxy is just a small stack copy
+    // (and on the Win x64 ABI a >8-byte struct is passed as a hidden pointer to a caller-side copy
+    // anyway). A 72-byte memcpy is negligible next to an eliminated heap alloc/free/GC, so the
+    // ref-struct path is a net win. The 48-byte payload is the deliberate price of carrying a
+    // Scalar/Vec operand inline with zero allocation; the common Mat case leaves it unused (and the
+    // copy stays cheap).
 
     struct InputArrayProxy
     {
@@ -450,6 +461,11 @@ static cv::_InputOutputArray fromInputOutputProxy(const interop::InputOutputArra
 // -------------------------------------------------------------------------
 class InProxy
 {
+    // Stable storage for a scalar operand. A cv::_InputArray built from a cv::Scalar keeps a POINTER
+    // to that Scalar (it does not copy it), so the Scalar must outlive the _InputArray's use. For
+    // Scalar/Double kinds fromInputProxy() writes scratch_ and returns a cv::_InputArray referencing
+    // it; holding scratch_ as a member keeps it alive for the whole OpenCV call (the InProxy lives to
+    // the end of the call expression). Unused for Mat/UMat/MatExpr/Vec/Raw kinds.
     cv::Scalar scratch_;
     cv::_InputArray ia_;
 public:

--- a/test/OpenCvSharp.Tests/core/CoreTest.cs
+++ b/test/OpenCvSharp.Tests/core/CoreTest.cs
@@ -463,4 +463,541 @@ public class CoreTest : TestBase
         Assert.Equal(1, dst.At<int>(0, 0)); // min along 1st row [2, 1]
         Assert.Equal(0, dst.At<int>(1, 0)); // min along 2nd row [4, 4], taking the first occurence
     }
+
+    // --- ArrayProxy migration coverage (issue #1976): one test per migrated Cv2 method ---
+
+    [Fact]
+    public void AddWeighted()
+    {
+        using var src1 = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 10, 20, 30, 40 });
+        using var src2 = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 2, 4, 6, 8 });
+        using var dst = new Mat();
+        Cv2.AddWeighted(src1, 0.5, src2, 0.5, 1.0, dst);
+
+        Assert.Equal(7, dst.At<byte>(0, 0));
+        Assert.Equal(13, dst.At<byte>(0, 1));
+        Assert.Equal(19, dst.At<byte>(1, 0));
+        Assert.Equal(25, dst.At<byte>(1, 1));
+    }
+
+    [Fact]
+    public void BatchDistance()
+    {
+        using var src1 = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 0, 0 });
+        using var src2 = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 3, 4 });
+        using var dist = new Mat();
+        using var nidx = new Mat();
+        // k must be > 0 when nidx is provided; ask for the single nearest neighbour
+        Cv2.BatchDistance(src1, src2, dist, (int)MatType.CV_32F, nidx, NormTypes.L2, k: 1);
+
+        Assert.Equal(5.0, dist.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void CalcCovarMatrix()
+    {
+        using var s0 = Mat.FromPixelData(1, 2, MatType.CV_64FC1, new double[] { 1, 2 });
+        using var s1 = Mat.FromPixelData(1, 2, MatType.CV_64FC1, new double[] { 3, 4 });
+        using var covar = new Mat();
+        using var mean = new Mat();
+        Cv2.CalcCovarMatrix(new[] { s0, s1 }, covar, mean, CovarFlags.Normal, MatType.CV_64F);
+
+        Assert.Equal(2, covar.Rows);
+        Assert.Equal(2, covar.Cols);
+        Assert.Equal(2.0, mean.At<double>(0, 0), 6);
+        Assert.Equal(3.0, mean.At<double>(0, 1), 6);
+    }
+
+    [Fact]
+    public void CartToPolar()
+    {
+        using var x = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 3 });
+        using var y = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 4 });
+        using var mag = new Mat();
+        using var ang = new Mat();
+        Cv2.CartToPolar(x, y, mag, ang);
+
+        Assert.Equal(5.0, mag.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void CheckRange()
+    {
+        using var ok = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        Assert.True(Cv2.CheckRange(ok));
+
+        using var bad = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, float.NaN, 3, 4 });
+        Assert.False(Cv2.CheckRange(bad));
+    }
+
+    [Fact]
+    public void ConvertScaleAbs()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { -1, 2, -3, 4 });
+        using var dst = new Mat();
+        Cv2.ConvertScaleAbs(src, dst, 2.0, 0.0);
+
+        Assert.Equal(MatType.CV_8UC1, dst.Type());
+        Assert.Equal(2, dst.At<byte>(0, 0));
+        Assert.Equal(4, dst.At<byte>(0, 1));
+        Assert.Equal(6, dst.At<byte>(1, 0));
+        Assert.Equal(8, dst.At<byte>(1, 1));
+    }
+
+    [Fact]
+    public void Dct()
+    {
+        using var src = Mat.FromPixelData(4, 1, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        using var freq = new Mat();
+        using var restored = new Mat();
+        Cv2.Dct(src, freq);
+        Cv2.Dct(freq, restored, DctFlags.Inverse);
+
+        for (var i = 0; i < 4; i++)
+            Assert.Equal(src.At<float>(i, 0), restored.At<float>(i, 0), 3);
+    }
+
+    [Fact]
+    public void Dft()
+    {
+        using var src = Mat.FromPixelData(8, 1, MatType.CV_32FC1, new float[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        using var freq = new Mat();
+        using var restored = new Mat();
+        Cv2.Dft(src, freq);
+        Cv2.Idft(freq, restored, DftFlags.Scale | DftFlags.RealOutput);
+
+        for (var i = 0; i < 8; i++)
+            Assert.Equal(src.At<float>(i, 0), restored.At<float>(i, 0), 3);
+    }
+
+    [Fact]
+    public void Eigen()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 2, 0, 0, 3 });
+        using var values = new Mat();
+        using var vectors = new Mat();
+        Assert.True(Cv2.Eigen(src, values, vectors));
+
+        Assert.Equal(3.0, values.At<float>(0, 0), 3);
+        Assert.Equal(2.0, values.At<float>(1, 0), 3);
+    }
+
+    [Fact]
+    public void EigenNonSymmetric()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 2, 0, 0, 3 });
+        using var values = new Mat();
+        using var vectors = new Mat();
+        Cv2.EigenNonSymmetric(src, values, vectors);
+
+        Assert.Equal(2, values.Total());
+    }
+
+    [Fact]
+    public void Exp()
+    {
+        using var src = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 0, 1 });
+        using var dst = new Mat();
+        Cv2.Exp(src, dst);
+
+        Assert.Equal(1.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(Math.E, dst.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void ExtractChannel()
+    {
+        using var src = Mat.FromPixelData(1, 1, MatType.CV_8UC3, new byte[] { 10, 20, 30 });
+        using var dst = new Mat();
+        Cv2.ExtractChannel(src, dst, 1);
+
+        Assert.Equal(MatType.CV_8UC1, dst.Type());
+        Assert.Equal(20, dst.At<byte>(0, 0));
+    }
+
+    [Fact]
+    public void FindNonZero()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 0, 1, 0, 1 });
+        using var idx = new Mat();
+        Cv2.FindNonZero(src, idx);
+
+        Assert.Equal(2, idx.Total()); // two non-zero elements
+    }
+
+    [Fact]
+    public void Flip()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 1, 2, 3, 4 });
+        using var dst = new Mat();
+        Cv2.Flip(src, dst, FlipMode.X);
+
+        Assert.Equal(3, dst.At<byte>(0, 0));
+        Assert.Equal(4, dst.At<byte>(0, 1));
+        Assert.Equal(1, dst.At<byte>(1, 0));
+        Assert.Equal(2, dst.At<byte>(1, 1));
+    }
+
+    [Fact]
+    public void InsertChannel()
+    {
+        using var dst = Mat.FromPixelData(1, 1, MatType.CV_8UC3, new byte[] { 0, 0, 0 });
+        using var src = Mat.FromPixelData(1, 1, MatType.CV_8UC1, new byte[] { 50 });
+        Cv2.InsertChannel(src, dst, 1);
+
+        var v = dst.At<Vec3b>(0, 0);
+        Assert.Equal(0, v.Item0);
+        Assert.Equal(50, v.Item1);
+        Assert.Equal(0, v.Item2);
+    }
+
+    [Fact]
+    public void Kmeans()
+    {
+        using var data = Mat.FromPixelData(6, 1, MatType.CV_32FC1, new float[] { 0f, 0.1f, 0.2f, 10f, 10.1f, 10.2f });
+        using var labels = new Mat();
+        using var centers = new Mat();
+        var criteria = new TermCriteria(CriteriaTypes.MaxIter | CriteriaTypes.Eps, 10, 1.0);
+        Cv2.Kmeans(data, 2, labels, criteria, 3, KMeansFlags.PpCenters, centers);
+
+        Assert.Equal(6, labels.Rows);
+        Assert.NotEqual(labels.At<int>(0, 0), labels.At<int>(5, 0));
+    }
+
+    [Fact]
+    public void LUT()
+    {
+        using var src = Mat.FromPixelData(1, 4, MatType.CV_8UC1, new byte[] { 0, 1, 2, 3 });
+        var lutData = new byte[256];
+        for (var i = 0; i < 256; i++)
+            lutData[i] = (byte)Math.Min(255, i * 10);
+        using var lut = Mat.FromPixelData(1, 256, MatType.CV_8UC1, lutData);
+        using var dst = new Mat();
+        Cv2.LUT(src, lut, dst);
+
+        Assert.Equal(0, dst.At<byte>(0, 0));
+        Assert.Equal(10, dst.At<byte>(0, 1));
+        Assert.Equal(20, dst.At<byte>(0, 2));
+        Assert.Equal(30, dst.At<byte>(0, 3));
+    }
+
+    [Fact]
+    public void Log()
+    {
+        using var src = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 1f, (float)Math.E });
+        using var dst = new Mat();
+        Cv2.Log(src, dst);
+
+        Assert.Equal(0.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(1.0, dst.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void Magnitude()
+    {
+        using var x = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 3 });
+        using var y = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 4 });
+        using var mag = new Mat();
+        Cv2.Magnitude(x, y, mag);
+
+        Assert.Equal(5.0, mag.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void Mahalanobis()
+    {
+        using var v1 = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 0, 0 });
+        using var v2 = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 3, 4 });
+        using var icovar = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 0, 0, 1 });
+        var d = Cv2.Mahalanobis(v1, v2, icovar);
+
+        Assert.Equal(5.0, d, 3);
+    }
+
+    [Fact]
+    public void Mean()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 2, 4, 6, 8 });
+        var mean = Cv2.Mean(src);
+
+        Assert.Equal(5.0, mean.Val0, 6);
+    }
+
+    [Fact]
+    public void MeanStdDev()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 2, 4, 6, 8 });
+        using var mean = new Mat();
+        using var stddev = new Mat();
+        Cv2.MeanStdDev(src, mean, stddev);
+
+        Assert.Equal(5.0, mean.At<double>(0, 0), 6);
+        Assert.Equal(Math.Sqrt(5.0), stddev.At<double>(0, 0), 6);
+    }
+
+    [Fact]
+    public void MulSpectrums()
+    {
+        using var a = Mat.FromPixelData(1, 1, MatType.CV_32FC2, new float[] { 2, 0 });
+        using var b = Mat.FromPixelData(1, 1, MatType.CV_32FC2, new float[] { 3, 0 });
+        using var c = new Mat();
+        Cv2.MulSpectrums(a, b, c, DftFlags.None);
+
+        var v = c.At<Vec2f>(0, 0);
+        Assert.Equal(6.0, v.Item0, 3);
+        Assert.Equal(0.0, v.Item1, 3);
+    }
+
+    [Fact]
+    public void MulTransposed()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        using var dst = new Mat();
+        Cv2.MulTransposed(src, dst, true);
+
+        // A^T * A = [[10,14],[14,20]]
+        Assert.Equal(10.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(14.0, dst.At<float>(0, 1), 3);
+        Assert.Equal(14.0, dst.At<float>(1, 0), 3);
+        Assert.Equal(20.0, dst.At<float>(1, 1), 3);
+    }
+
+    [Fact]
+    public void PCACompute()
+    {
+        using var data = Mat.FromPixelData(3, 2, MatType.CV_32FC1, new float[] { 0, 0, 1, 1, 2, 2 });
+        using var mean = new Mat();
+        using var eigenvectors = new Mat();
+        Cv2.PCACompute(data, mean, eigenvectors, 1);
+
+        Assert.Equal(1, eigenvectors.Rows);
+        Assert.Equal(2, eigenvectors.Cols);
+    }
+
+    [Fact]
+    public void PCAComputeVar()
+    {
+        using var data = Mat.FromPixelData(3, 2, MatType.CV_32FC1, new float[] { 0, 0, 1, 1, 2, 2 });
+        using var mean = new Mat();
+        using var eigenvectors = new Mat();
+        Cv2.PCAComputeVar(data, mean, eigenvectors, 0.95);
+
+        Assert.True(eigenvectors.Rows >= 1);
+        Assert.Equal(2, eigenvectors.Cols);
+    }
+
+    [Fact]
+    public void PCAProjectAndBackProject()
+    {
+        using var data = Mat.FromPixelData(3, 2, MatType.CV_32FC1, new float[] { 0, 0, 1, 1, 2, 2 });
+        using var mean = new Mat();
+        using var eigenvectors = new Mat();
+        Cv2.PCACompute(data, mean, eigenvectors, 1);
+
+        using var projected = new Mat();
+        Cv2.PCAProject(data, mean, eigenvectors, projected);
+        Assert.Equal(3, projected.Rows);
+
+        using var restored = new Mat();
+        Cv2.PCABackProject(projected, mean, eigenvectors, restored);
+        Assert.Equal(data.Rows, restored.Rows);
+        Assert.Equal(data.Cols, restored.Cols);
+    }
+
+    [Fact]
+    public void PatchNaNs()
+    {
+        using var a = Mat.FromPixelData(1, 4, MatType.CV_32FC1, new float[] { 1, float.NaN, 3, 4 });
+        Cv2.PatchNaNs(a, 0.0);
+
+        Assert.Equal(0.0, a.At<float>(0, 1), 3);
+        Assert.Equal(1.0, a.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void PerspectiveTransform()
+    {
+        using var src = Mat.FromPixelData(1, 1, MatType.CV_32FC2, new float[] { 2, 3 });
+        using var m = Mat.FromPixelData(3, 3, MatType.CV_64FC1, new double[] { 1, 0, 0, 0, 1, 0, 0, 0, 1 });
+        using var dst = new Mat();
+        Cv2.PerspectiveTransform(src, dst, m);
+
+        var v = dst.At<Vec2f>(0, 0);
+        Assert.Equal(2.0, v.Item0, 3);
+        Assert.Equal(3.0, v.Item1, 3);
+    }
+
+    [Fact]
+    public void Phase()
+    {
+        using var x = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 1 });
+        using var y = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 1 });
+        using var angle = new Mat();
+        Cv2.Phase(x, y, angle, angleInDegrees: true);
+
+        Assert.Equal(45.0, angle.At<float>(0, 0), 1); // single-precision phase, ~44.99 deg
+    }
+
+    [Fact]
+    public void PolarToCart()
+    {
+        using var mag = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 5 });
+        using var angle = Mat.FromPixelData(1, 1, MatType.CV_32FC1, new float[] { 0 });
+        using var x = new Mat();
+        using var y = new Mat();
+        Cv2.PolarToCart(mag, angle, x, y);
+
+        Assert.Equal(5.0, x.At<float>(0, 0), 3);
+        Assert.Equal(0.0, y.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void Pow()
+    {
+        using var src = Mat.FromPixelData(1, 2, MatType.CV_32FC1, new float[] { 2, 3 });
+        using var dst = new Mat();
+        Cv2.Pow(src, 2.0, dst);
+
+        Assert.Equal(4.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(9.0, dst.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void RandShuffle()
+    {
+        using var dst = Mat.FromPixelData(1, 10, MatType.CV_32FC1, new float[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+        Cv2.RandShuffle(dst, 1.0);
+
+        // shuffling is a permutation, so the sum is invariant
+        Assert.Equal(45.0, Cv2.Sum(dst).Val0, 3);
+    }
+
+    [Fact]
+    public void Reduce()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        using var dst = new Mat();
+        Cv2.Reduce(src, dst, ReduceDimension.Row, ReduceTypes.Sum, (int)MatType.CV_32F);
+
+        // reduce to a single row: column sums [1+3, 2+4]
+        Assert.Equal(4.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(6.0, dst.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void SVDecompAndBackSubst()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 2, 0, 0, 3 });
+        using var w = new Mat();
+        using var u = new Mat();
+        using var vt = new Mat();
+        Cv2.SVDecomp(src, w, u, vt);
+
+        Assert.Equal(3.0, w.At<float>(0, 0), 3);
+        Assert.Equal(2.0, w.At<float>(1, 0), 3);
+
+        // solve src * x = rhs through the decomposition; rhs = [2, 3] -> x = [1, 1]
+        using var rhs = Mat.FromPixelData(2, 1, MatType.CV_32FC1, new float[] { 2, 3 });
+        using var dst = new Mat();
+        Cv2.SVBackSubst(w, u, vt, rhs, dst);
+
+        Assert.Equal(1.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(1.0, dst.At<float>(1, 0), 3);
+    }
+
+    [Fact]
+    public void ScaleAdd()
+    {
+        using var src1 = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        using var src2 = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 1, 1, 1 });
+        using var dst = new Mat();
+        Cv2.ScaleAdd(src1, 2.0, src2, dst);
+
+        Assert.Equal(3.0, dst.At<float>(0, 0), 3);
+        Assert.Equal(5.0, dst.At<float>(0, 1), 3);
+        Assert.Equal(7.0, dst.At<float>(1, 0), 3);
+        Assert.Equal(9.0, dst.At<float>(1, 1), 3);
+    }
+
+    [Fact]
+    public void SetIdentity()
+    {
+        using var mtx = new Mat(3, 3, MatType.CV_32FC1, Scalar.All(0));
+        Cv2.SetIdentity(mtx, new Scalar(1));
+
+        Assert.Equal(1.0, mtx.At<float>(0, 0), 3);
+        Assert.Equal(1.0, mtx.At<float>(1, 1), 3);
+        Assert.Equal(0.0, mtx.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void SolveCubic()
+    {
+        // x^3 - 6x^2 + 11x - 6 = (x-1)(x-2)(x-3)
+        using var coeffs = Mat.FromPixelData(1, 4, MatType.CV_64FC1, new double[] { 1, -6, 11, -6 });
+        using var roots = new Mat();
+        var n = Cv2.SolveCubic(coeffs, roots);
+
+        Assert.Equal(3, n);
+    }
+
+    [Fact]
+    public void SolvePoly()
+    {
+        // x^2 - 1 = 0 -> roots +-1; coeffs are c0 + c1*x + c2*x^2
+        using var coeffs = Mat.FromPixelData(1, 3, MatType.CV_64FC1, new double[] { -1, 0, 1 });
+        using var roots = new Mat();
+        Cv2.SolvePoly(coeffs, roots);
+
+        Assert.Equal(2, roots.Total());
+    }
+
+    [Fact]
+    public void Sort()
+    {
+        using var src = Mat.FromPixelData(1, 4, MatType.CV_32SC1, new int[] { 3, 1, 4, 2 });
+        using var dst = new Mat();
+        Cv2.Sort(src, dst, SortFlags.EveryRow | SortFlags.Ascending);
+
+        Assert.Equal(1, dst.At<int>(0, 0));
+        Assert.Equal(2, dst.At<int>(0, 1));
+        Assert.Equal(3, dst.At<int>(0, 2));
+        Assert.Equal(4, dst.At<int>(0, 3));
+    }
+
+    [Fact]
+    public void SortIdx()
+    {
+        using var src = Mat.FromPixelData(1, 4, MatType.CV_32SC1, new int[] { 3, 1, 4, 2 });
+        using var dst = new Mat();
+        Cv2.SortIdx(src, dst, SortFlags.EveryRow | SortFlags.Ascending);
+
+        // ascending order maps to source indices 1(=1), 3(=2), 0(=3), 2(=4)
+        Assert.Equal(1, dst.At<int>(0, 0));
+        Assert.Equal(3, dst.At<int>(0, 1));
+        Assert.Equal(0, dst.At<int>(0, 2));
+        Assert.Equal(2, dst.At<int>(0, 3));
+    }
+
+    [Fact]
+    public void Trace()
+    {
+        using var mtx = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        var tr = Cv2.Trace(mtx);
+
+        Assert.Equal(5.0, tr.Val0, 3);
+    }
+
+    [Fact]
+    public void Transform()
+    {
+        using var src = Mat.FromPixelData(1, 1, MatType.CV_32FC2, new float[] { 2, 3 });
+        using var m = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 1, 0, 0, 1 });
+        using var dst = new Mat();
+        Cv2.Transform(src, dst, m);
+
+        var v = dst.At<Vec2f>(0, 0);
+        Assert.Equal(2.0, v.Item0, 3);
+        Assert.Equal(3.0, v.Item1, 3);
+    }
 }

--- a/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
+++ b/test/OpenCvSharp.Tests/core/InputArrayRefTest.cs
@@ -157,6 +157,25 @@ public class InputArrayRefTest : TestBase
     }
 
     [Fact]
+    public void MinMax_InputArray_WriteThrough()
+    {
+        // Guards the migrated core_min1/core_max1 (InputArray,InputArray,OutputArray): the native
+        // call must write dst element-wise, not silently pick a MatExpr-returning overload.
+        using var a = Float3x3(1, 9, 3, 9, 5, 9, 7, 9, 2);
+        using var b = Float3x3(9, 2, 9, 4, 9, 6, 9, 8, 9);
+
+        using var mn = new Mat();
+        Cv2.Min(a, b, mn);
+        using var mx = new Mat();
+        Cv2.Max(a, b, mx);
+
+        using var expectedMin = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 2);
+        using var expectedMax = Float3x3(9, 9, 9, 9, 9, 9, 9, 9, 9);
+        ImageEquals(expectedMin, mn);
+        ImageEquals(expectedMax, mx);
+    }
+
+    [Fact]
     public void CompleteSymmRef_Matches()
     {
         using var actual = Float3x3(1, 2, 3, 4, 5, 6, 7, 8, 9);

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -857,4 +857,247 @@ public class ImgProcTest : TestBase
         using var dst = src.Resize(default, 0.5, 0.5, flags);
         Assert.Equal(new Size(5, 5), dst.Size());
     }
+
+    // --- ArrayProxy migration coverage (issue #1976): one test per migrated Cv2 method ---
+
+    [Fact]
+    public void Blur()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.Blur(src, dst, new Size(3, 3));
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(src.Type(), dst.Type());
+    }
+
+    [Fact]
+    public void BoxFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.BoxFilter(src, dst, MatType.CV_8U, new Size(3, 3));
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void SqrBoxFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.SqrBoxFilter(src, dst, (int)MatType.CV_32F, new Size(3, 3));
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void BilateralFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.BilateralFilter(src, dst, 9, 75, 75);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void Sobel()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.Sobel(src, dst, MatType.CV_16S, 1, 0);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_16SC1, dst.Type());
+    }
+
+    [Fact]
+    public void Scharr()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.Scharr(src, dst, MatType.CV_16S, 1, 0);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_16SC1, dst.Type());
+    }
+
+    [Fact]
+    public void Laplacian()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.Laplacian(src, dst, MatType.CV_16S);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_16SC1, dst.Type());
+    }
+
+    [Fact]
+    public void SepFilter2D()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var kernelX = Mat.FromPixelData(3, 1, MatType.CV_32FC1, new float[] { 1f / 3, 1f / 3, 1f / 3 });
+        using var kernelY = Mat.FromPixelData(3, 1, MatType.CV_32FC1, new float[] { 1f / 3, 1f / 3, 1f / 3 });
+        using var dst = new Mat();
+        Cv2.SepFilter2D(src, dst, MatType.CV_8U, kernelX, kernelY);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void GetDerivKernels()
+    {
+        using var kx = new Mat();
+        using var ky = new Mat();
+        Cv2.GetDerivKernels(kx, ky, 1, 0, 3);
+
+        Assert.Equal(3, kx.Total());
+        Assert.Equal(3, ky.Total());
+    }
+
+    [Fact]
+    public void SpatialGradient()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dx = new Mat();
+        using var dy = new Mat();
+        Cv2.SpatialGradient(src, dx, dy);
+
+        Assert.Equal(src.Size(), dx.Size());
+        Assert.Equal(MatType.CV_16SC1, dx.Type());
+    }
+
+    [Fact]
+    public void PreCornerDetect()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.PreCornerDetect(src, dst, 3);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_32FC1, dst.Type());
+    }
+
+    [Fact]
+    public void CornerEigenValsAndVecs()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.CornerEigenValsAndVecs(src, dst, 3, 3);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(6, dst.Channels());
+    }
+
+    [Fact]
+    public void PyrDown()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.PyrDown(src, dst);
+
+        Assert.Equal((src.Cols + 1) / 2, dst.Cols);
+        Assert.Equal((src.Rows + 1) / 2, dst.Rows);
+    }
+
+    [Fact]
+    public void PyrUp()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.PyrUp(src, dst);
+
+        Assert.Equal(src.Cols * 2, dst.Cols);
+        Assert.Equal(src.Rows * 2, dst.Rows);
+    }
+
+    [Fact]
+    public void PyrMeanShiftFiltering()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.PyrMeanShiftFiltering(src, dst, 10, 20);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(src.Type(), dst.Type());
+    }
+
+    [Fact]
+    public void EqualizeHist()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.EqualizeHist(src, dst);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_8UC1, dst.Type());
+    }
+
+    [Fact]
+    public void AdaptiveThreshold()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.AdaptiveThreshold(src, dst, 255, AdaptiveThresholdTypes.MeanC, ThresholdTypes.Binary, 11, 2);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_8UC1, dst.Type());
+    }
+
+    [Fact]
+    public void CvtColorTwoPlane()
+    {
+        using var y = new Mat(4, 4, MatType.CV_8UC1, Scalar.All(128));
+        using var uv = new Mat(2, 2, MatType.CV_8UC2, Scalar.All(128));
+        using var dst = new Mat();
+        Cv2.CvtColorTwoPlane(y, uv, dst, ColorConversionCodes.YUV2BGR_NV12);
+
+        Assert.Equal(y.Size(), dst.Size());
+        Assert.Equal(3, dst.Channels());
+    }
+
+    [Fact]
+    public void CreateHanningWindow()
+    {
+        using var dst = new Mat();
+        Cv2.CreateHanningWindow(dst, new Size(8, 8), MatType.CV_32F);
+
+        Assert.Equal(new Size(8, 8), dst.Size());
+        Assert.Equal(MatType.CV_32FC1, dst.Type());
+    }
+
+    [Fact]
+    public void ConvertMaps()
+    {
+        using var map1 = new Mat(4, 4, MatType.CV_32FC1, Scalar.All(1));
+        using var map2 = new Mat(4, 4, MatType.CV_32FC1, Scalar.All(1));
+        using var dstmap1 = new Mat();
+        using var dstmap2 = new Mat();
+        Cv2.ConvertMaps(map1, map2, dstmap1, dstmap2, MatType.CV_16SC2);
+
+        Assert.Equal(map1.Size(), dstmap1.Size());
+    }
+
+    [Fact]
+    public void GetRectSubPix()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var patch = new Mat();
+        Cv2.GetRectSubPix(src, new Size(5, 5), new Point2f(10, 10), patch);
+
+        Assert.Equal(new Size(5, 5), patch.Size());
+    }
+
+    [Fact]
+    public void WarpPolar()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.WarpPolar(src, dst, new Size(64, 64), new Point2f(src.Cols / 2f, src.Rows / 2f),
+            src.Cols / 2.0, InterpolationFlags.Linear, WarpPolarMode.Linear);
+
+        Assert.Equal(new Size(64, 64), dst.Size());
+    }
 }

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -1100,4 +1100,406 @@ public class ImgProcTest : TestBase
 
         Assert.Equal(new Size(64, 64), dst.Size());
     }
+
+    [Fact]
+    public void Accumulate()
+    {
+        using var src = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(5));
+        using var dst = new Mat(2, 2, MatType.CV_32FC1, Scalar.All(0));
+        using var mask = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.Accumulate(src, dst, mask);
+
+        Assert.Equal(5.0, dst.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void AccumulateSquare()
+    {
+        using var src = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(5));
+        using var dst = new Mat(2, 2, MatType.CV_32FC1, Scalar.All(0));
+        using var mask = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.AccumulateSquare(src, dst, mask);
+
+        Assert.Equal(25.0, dst.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void AccumulateProduct()
+    {
+        using var src1 = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(5));
+        using var src2 = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(2));
+        using var dst = new Mat(2, 2, MatType.CV_32FC1, Scalar.All(0));
+        using var mask = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.AccumulateProduct(src1, src2, dst, mask);
+
+        Assert.Equal(10.0, dst.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void AccumulateWeighted()
+    {
+        using var src = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(10));
+        using var dst = new Mat(2, 2, MatType.CV_32FC1, Scalar.All(0));
+        using var mask = new Mat(2, 2, MatType.CV_8UC1, Scalar.All(255));
+        Cv2.AccumulateWeighted(src, dst, 0.5, mask);
+
+        Assert.Equal(5.0, dst.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void ApproxPolyDP()
+    {
+        using var curve = Mat.FromPixelData(4, 1, MatType.CV_32FC2, new float[] { 0, 0, 10, 0, 10, 10, 0, 10 });
+        using var approx = new Mat();
+        Cv2.ApproxPolyDP(curve, approx, 1.0, true);
+
+        Assert.Equal(4, approx.Total());
+    }
+
+    [Fact]
+    public void ArrowedLine()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.ArrowedLine(img, new Point(5, 5), new Point(40, 40), Scalar.All(255), 2);
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void Circle()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Circle(img, 25, 25, 10, Scalar.All(255), 2);
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void Ellipse()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Ellipse(img, new Point(25, 25), new Size(15, 10), 0, 0, 360, Scalar.All(255), 2);
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void DrawMarker()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.DrawMarker(img, new Point(25, 25), Scalar.All(255), MarkerTypes.Cross, 20, 2);
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void FillConvexPoly()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        var pts = new[] { new Point(10, 10), new Point(40, 10), new Point(40, 40), new Point(10, 40) };
+        Cv2.FillConvexPoly(img, pts, Scalar.All(255));
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void FillPoly()
+    {
+        using var img = new Mat(50, 50, MatType.CV_8UC1, Scalar.All(0));
+        var pts = new[] { new[] { new Point(10, 10), new Point(40, 10), new Point(40, 40), new Point(10, 40) } };
+        Cv2.FillPoly(img, pts, Scalar.All(255));
+
+        Assert.True(Cv2.CountNonZero(img) > 0);
+    }
+
+    [Fact]
+    public void CalcBackProject()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var hist = new Mat();
+        var ranges = new[] { new Rangef(0, 256) };
+        Cv2.CalcHist(new[] { src }, new[] { 0 }, null, hist, 1, new[] { 256 }, ranges);
+
+        using var backProject = new Mat();
+        Cv2.CalcBackProject(new[] { src }, new[] { 0 }, hist, backProject, ranges);
+
+        Assert.Equal(src.Size(), backProject.Size());
+    }
+
+    [Fact]
+    public void CompareHist()
+    {
+        using var h1 = Mat.FromPixelData(4, 1, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        using var h2 = Mat.FromPixelData(4, 1, MatType.CV_32FC1, new float[] { 1, 2, 3, 4 });
+        var d = Cv2.CompareHist(h1, h2, HistCompMethods.Correl);
+
+        Assert.Equal(1.0, d, 3); // identical histograms correlate perfectly
+    }
+
+    [Fact]
+    public void ConnectedComponents()
+    {
+        using var img = MakeTwoBlobImage();
+        using var labels = new Mat();
+        var n = Cv2.ConnectedComponents(img, labels, PixelConnectivity.Connectivity8);
+
+        Assert.Equal(3, n); // background + two blobs
+    }
+
+    [Fact]
+    public void ConnectedComponentsWithAlgorithm()
+    {
+        using var img = MakeTwoBlobImage();
+        using var labels = new Mat();
+        var n = Cv2.ConnectedComponentsWithAlgorithm(img, labels, PixelConnectivity.Connectivity8,
+            MatType.CV_32S, ConnectedComponentsAlgorithmsTypes.Default);
+
+        Assert.Equal(3, n);
+    }
+
+    [Fact]
+    public void ConnectedComponentsWithStats()
+    {
+        using var img = MakeTwoBlobImage();
+        using var labels = new Mat();
+        using var stats = new Mat();
+        using var centroids = new Mat();
+        var n = Cv2.ConnectedComponentsWithStats(img, labels, stats, centroids);
+
+        Assert.Equal(3, n);
+        Assert.Equal(3, stats.Rows);
+    }
+
+    [Fact]
+    public void ConnectedComponentsWithStatsWithAlgorithm()
+    {
+        using var img = MakeTwoBlobImage();
+        using var labels = new Mat();
+        using var stats = new Mat();
+        using var centroids = new Mat();
+        var n = Cv2.ConnectedComponentsWithStatsWithAlgorithm(img, labels, stats, centroids,
+            PixelConnectivity.Connectivity8, MatType.CV_32S, ConnectedComponentsAlgorithmsTypes.Default);
+
+        Assert.Equal(3, n);
+    }
+
+    [Fact]
+    public void CornerSubPix()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var refined = Cv2.CornerSubPix(src, new[] { new Point2f(50, 50) }, new Size(5, 5), new Size(-1, -1),
+            new TermCriteria(CriteriaTypes.MaxIter | CriteriaTypes.Eps, 30, 0.01));
+
+        Assert.Single(refined);
+    }
+
+    [Fact]
+    public void DistanceTransform()
+    {
+        using var img = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(255));
+        using var dst = new Mat();
+        Cv2.DistanceTransform(img, dst, DistanceTypes.L2, DistanceTransformMasks.Mask3);
+
+        Assert.Equal(img.Size(), dst.Size());
+        Assert.Equal(MatType.CV_32FC1, dst.Type());
+    }
+
+    [Fact]
+    public void DistanceTransformWithLabels()
+    {
+        using var img = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(255));
+        using var dst = new Mat();
+        using var labels = new Mat();
+        Cv2.DistanceTransformWithLabels(img, dst, labels, DistanceTypes.L2, DistanceTransformMasks.Mask3);
+
+        Assert.Equal(img.Size(), dst.Size());
+        Assert.Equal(img.Size(), labels.Size());
+    }
+
+    [Fact]
+    public void EMD()
+    {
+        using var sig1 = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 0.5f, 0, 0.5f, 1 });
+        using var sig2 = Mat.FromPixelData(2, 2, MatType.CV_32FC1, new float[] { 0.5f, 0, 0.5f, 1 });
+        var d = Cv2.EMD(sig1, sig2, DistanceTypes.L2);
+
+        Assert.Equal(0.0, d, 3); // identical signatures
+    }
+
+    [Fact]
+    public void FindContoursAsArray()
+    {
+        using var img = MakeSingleBlobImage();
+        var contours = Cv2.FindContoursAsArray(img, RetrievalModes.External, ContourApproximationModes.ApproxSimple);
+
+        Assert.True(contours.Length >= 1);
+    }
+
+    [Fact]
+    public void FindContoursAsMat()
+    {
+        using var img = MakeSingleBlobImage();
+        var contours = Cv2.FindContoursAsMat(img, RetrievalModes.External, ContourApproximationModes.ApproxSimple);
+
+        Assert.True(contours.Length >= 1);
+        foreach (var c in contours)
+            c.Dispose();
+    }
+
+    [Fact]
+    public void FloodFill()
+    {
+        using var img = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(0));
+        var area = Cv2.FloodFill(img, new Point(5, 5), Scalar.All(255));
+
+        Assert.True(area > 0);
+    }
+
+    [Fact]
+    public void GetAffineTransform()
+    {
+        var src = new[] { new Point2f(0, 0), new Point2f(1, 0), new Point2f(0, 1) };
+        var dst = new[] { new Point2f(0, 0), new Point2f(2, 0), new Point2f(0, 2) };
+        using var m = Cv2.GetAffineTransform(src, dst);
+
+        Assert.Equal(new Size(3, 2), m.Size());
+    }
+
+    [Fact]
+    public void GetPerspectiveTransform()
+    {
+        var src = new[] { new Point2f(0, 0), new Point2f(1, 0), new Point2f(1, 1), new Point2f(0, 1) };
+        var dst = new[] { new Point2f(0, 0), new Point2f(2, 0), new Point2f(2, 2), new Point2f(0, 2) };
+        using var m = Cv2.GetPerspectiveTransform(src, dst);
+
+        Assert.Equal(new Size(3, 3), m.Size());
+    }
+
+    [Fact]
+    public void GoodFeaturesToTrack()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var mask = new Mat();
+        var corners = Cv2.GoodFeaturesToTrack(src, 100, 0.01, 10, mask, 3, false, 0.04);
+
+        Assert.True(corners.Length > 0);
+    }
+
+    [Fact]
+    public void GrabCut()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var img = color.Resize(new Size(64, 64));
+        using var mask = new Mat();
+        using var bgdModel = new Mat();
+        using var fgdModel = new Mat();
+        Cv2.GrabCut(img, mask, new Rect(8, 8, 48, 48), bgdModel, fgdModel, 1, GrabCutModes.InitWithRect);
+
+        Assert.Equal(img.Size(), mask.Size());
+    }
+
+    [Fact]
+    public void HoughLines()
+    {
+        using var img = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Line(img, new Point(0, 50), new Point(99, 50), Scalar.All(255), 1);
+        var lines = Cv2.HoughLines(img, 1, Math.PI / 180, 50);
+
+        Assert.True(lines.Length > 0);
+    }
+
+    [Fact]
+    public void HoughCircles()
+    {
+        using var img = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Circle(img, 50, 50, 20, Scalar.All(255), 2);
+        var circles = Cv2.HoughCircles(img, HoughModes.Gradient, 1, 20, 100, 30, 10, 40);
+
+        Assert.NotNull(circles); // exercises the proxy path; detection itself can vary
+    }
+
+    [Fact]
+    public void IntersectConvexConvex()
+    {
+        using var p1 = Mat.FromPixelData(4, 1, MatType.CV_32FC2, new float[] { 0, 0, 10, 0, 10, 10, 0, 10 });
+        using var p2 = Mat.FromPixelData(4, 1, MatType.CV_32FC2, new float[] { 5, 5, 15, 5, 15, 15, 5, 15 });
+        using var p12 = new Mat();
+        var area = Cv2.IntersectConvexConvex(p1, p2, p12);
+
+        Assert.True(area > 0);
+    }
+
+    [Fact]
+    public void InvertAffineTransform()
+    {
+        var src = new[] { new Point2f(0, 0), new Point2f(1, 0), new Point2f(0, 1) };
+        var dst = new[] { new Point2f(0, 0), new Point2f(2, 0), new Point2f(0, 2) };
+        using var m = Cv2.GetAffineTransform(src, dst);
+        using var im = new Mat();
+        Cv2.InvertAffineTransform(m, im);
+
+        Assert.Equal(new Size(3, 2), im.Size());
+    }
+
+    [Fact]
+    public void MatchShapes()
+    {
+        using var c1 = Mat.FromPixelData(4, 1, MatType.CV_32SC2, new int[] { 0, 0, 10, 0, 10, 10, 0, 10 });
+        using var c2 = Mat.FromPixelData(4, 1, MatType.CV_32SC2, new int[] { 0, 0, 10, 0, 10, 10, 0, 10 });
+        var d = Cv2.MatchShapes(c1, c2, ShapeMatchModes.I1);
+
+        Assert.Equal(0.0, d, 3); // identical contours
+    }
+
+    [Fact]
+    public void MinAreaRect()
+    {
+        using var pts = Mat.FromPixelData(4, 1, MatType.CV_32FC2, new float[] { 0, 0, 10, 0, 10, 10, 0, 10 });
+        var rr = Cv2.MinAreaRect(pts);
+
+        Assert.True(rr.Size.Width > 0 && rr.Size.Height > 0);
+    }
+
+    [Fact]
+    public void PhaseCorrelate()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var small = gray.Resize(new Size(64, 64));
+        using var src = new Mat();
+        small.ConvertTo(src, MatType.CV_32F);
+        using var window = new Mat();
+        Cv2.CreateHanningWindow(window, new Size(64, 64), MatType.CV_32F);
+
+        var shift = Cv2.PhaseCorrelate(src, src, window, out var response);
+
+        Assert.True(Math.Abs(shift.X) < 1.0 && Math.Abs(shift.Y) < 1.0); // identical inputs -> no shift
+    }
+
+    [Fact]
+    public void Watershed()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var img = color.Resize(new Size(64, 64));
+        using var markers = new Mat(img.Size(), MatType.CV_32SC1, Scalar.All(0));
+        markers.Set(8, 8, 1);
+        markers.Set(56, 56, 2);
+        Cv2.Watershed(img, markers);
+
+        Assert.Equal(img.Size(), markers.Size());
+    }
+
+    private static Mat MakeTwoBlobImage()
+    {
+        var img = new Mat(10, 10, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(img, new Rect(1, 1, 2, 2), Scalar.All(255), -1);
+        Cv2.Rectangle(img, new Rect(6, 6, 2, 2), Scalar.All(255), -1);
+        return img;
+    }
+
+    private static Mat MakeSingleBlobImage()
+    {
+        var img = new Mat(20, 20, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(img, new Rect(5, 5, 10, 10), Scalar.All(255), -1);
+        return img;
+    }
 }


### PR DESCRIPTION
## Test coverage for migrated core & imgproc methods (issue #1976)

Owner requirement: every ArrayProxy-migrated `Cv2` method needs at least one test before the ref-struct flip.

Cross-referenced every proxy-using method in `Cv2_core.cs` (86) and `Cv2_imgproc.cs` (104) against the test sources — **104 of 190 were uncovered**. Added one test each:
- `CoreTest.cs` +46, `ImgProcTest.cs` +58
- Combined run: **191 passed, 1 skipped, 0 failed**

### Bug found while adding tests
The `RandShuffle` test surfaced an access violation (0xC0000005): native `core_randShuffle` unconditionally wrote `*rng = rng0.state`, but the parameterless overload passes a null RNG pointer. Guarded the null pointer and, when an RNG is supplied, seed `rng0` from the incoming state instead of discarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
