### PR TITLE
Migration: photo/video/features/xphoto/stitching/aruco/ximgproc/ml/ptcloud to the ArrayProxy ABI (by-pointer)

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_features.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_features.cs
@@ -27,7 +27,7 @@ static partial class Cv2
 
         using var kp = new StdVector<KeyPoint>();
         NativeMethods.HandleException(
-            NativeMethods.features_FAST1(image.CvPtr, kp.CvPtr, threshold, nonmaxSupression ? 1 : 0));
+            NativeMethods.features_FAST1(image.ToInputProxy(), kp.CvPtr, threshold, nonmaxSupression ? 1 : 0));
         GC.KeepAlive(image);
         return kp.ToArray();
     }
@@ -50,7 +50,7 @@ static partial class Cv2
 
         using var kp = new StdVector<KeyPoint>();
         NativeMethods.HandleException(
-            NativeMethods.features_FAST2(image.CvPtr, kp.CvPtr, threshold, nonmaxSupression ? 1 : 0, (int)type));
+            NativeMethods.features_FAST2(image.ToInputProxy(), kp.CvPtr, threshold, nonmaxSupression ? 1 : 0, (int)type));
         GC.KeepAlive(image);
         return kp.ToArray();
     }
@@ -105,7 +105,7 @@ static partial class Cv2
         var keypointsArray = keypoints.CastOrToArray();
         var color0 = color.GetValueOrDefault(Scalar.All(-1));
         NativeMethods.HandleException(
-            NativeMethods.features_drawKeypoints(image.CvPtr, keypointsArray, keypointsArray.Length, outImage.CvPtr, color0, (int)flags));
+            NativeMethods.features_drawKeypoints(image.ToInputProxy(), keypointsArray, keypointsArray.Length, outImage.ToInputOutputProxy(), color0, (int)flags));
 
         GC.KeepAlive(image);
         GC.KeepAlive(outImage);

--- a/src/OpenCvSharp/Cv2/Cv2_photo.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_photo.cs
@@ -26,7 +26,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.photo_inpaint(src.CvPtr, inpaintMask.CvPtr, dst.CvPtr, inpaintRadius, (int)flags));
+            NativeMethods.photo_inpaint(src.ToInputProxy(), inpaintMask.ToInputProxy(), dst.ToOutputProxy(), inpaintRadius, (int)flags));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -58,7 +58,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.photo_fastNlMeansDenoising(src.CvPtr, dst.CvPtr, h, templateWindowSize, searchWindowSize));
+            NativeMethods.photo_fastNlMeansDenoising(src.ToInputProxy(), dst.ToOutputProxy(), h, templateWindowSize, searchWindowSize));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -90,7 +90,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.photo_fastNlMeansDenoisingColored(src.CvPtr, dst.CvPtr, h, hColor, templateWindowSize, searchWindowSize));
+            NativeMethods.photo_fastNlMeansDenoisingColored(src.ToInputProxy(), dst.ToOutputProxy(), h, hColor, templateWindowSize, searchWindowSize));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -126,7 +126,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_fastNlMeansDenoisingMulti(
-                srcImgPtrs, srcImgPtrs.Length, dst.CvPtr,
+                srcImgPtrs, srcImgPtrs.Length, dst.ToOutputProxy(),
                 imgToDenoiseIndex,
                 temporalWindowSize, h, templateWindowSize, searchWindowSize));
 
@@ -163,7 +163,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_fastNlMeansDenoisingColoredMulti(
-                srcImgPtrs, srcImgPtrs.Length, dst.CvPtr, imgToDenoiseIndex,
+                srcImgPtrs, srcImgPtrs.Length, dst.ToOutputProxy(), imgToDenoiseIndex,
                 temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize));
 
         dst.Fix();
@@ -225,7 +225,7 @@ static partial class Cv2
         colorBoost.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.photo_decolor(src.CvPtr, grayscale.CvPtr, colorBoost.CvPtr));
+            NativeMethods.photo_decolor(src.ToInputProxy(), grayscale.ToOutputProxy(), colorBoost.ToOutputProxy()));
 
         GC.KeepAlive(src);
         grayscale.Fix();
@@ -263,7 +263,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_seamlessClone(
-                src.CvPtr, dst.CvPtr, ToPtr(mask), p, blend.CvPtr, (int) flags));
+                src.ToInputProxy(), dst.ToInputProxy(), mask?.ToInputProxy() ?? default, p, blend.ToOutputProxy(), (int) flags));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -295,7 +295,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_colorChange(
-                src.CvPtr, ToPtr(mask), dst.CvPtr, redMul, greenMul, blueMul));
+                src.ToInputProxy(), mask?.ToInputProxy() ?? default, dst.ToOutputProxy(), redMul, greenMul, blueMul));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -330,7 +330,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_illuminationChange(
-                src.CvPtr, ToPtr(mask), dst.CvPtr, alpha, beta));
+                src.ToInputProxy(), mask?.ToInputProxy() ?? default, dst.ToOutputProxy(), alpha, beta));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -364,7 +364,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_textureFlattening(
-                src.CvPtr, ToPtr(mask), dst.CvPtr, lowThreshold, highThreshold, kernelSize));
+                src.ToInputProxy(), mask?.ToInputProxy() ?? default, dst.ToOutputProxy(), lowThreshold, highThreshold, kernelSize));
 
         GC.KeepAlive(src);
         GC.KeepAlive(mask);
@@ -395,7 +395,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_edgePreservingFilter(
-                src.CvPtr, dst.CvPtr, (int) flags, sigmaS, sigmaR));
+                src.ToInputProxy(), dst.ToOutputProxy(), (int) flags, sigmaS, sigmaR));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -422,7 +422,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_detailEnhance(
-                src.CvPtr, dst.CvPtr, sigmaS, sigmaR));
+                src.ToInputProxy(), dst.ToOutputProxy(), sigmaS, sigmaR));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -454,7 +454,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_pencilSketch(
-                src.CvPtr, dst1.CvPtr, dst2.CvPtr, sigmaS, sigmaR, shadeFactor));
+                src.ToInputProxy(), dst1.ToOutputProxy(), dst2.ToOutputProxy(), sigmaS, sigmaR, shadeFactor));
 
         GC.KeepAlive(src);
         dst1.Fix();
@@ -485,7 +485,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.photo_stylization(
-                src.CvPtr, dst.CvPtr, sigmaS, sigmaR));
+                src.ToInputProxy(), dst.ToOutputProxy(), sigmaS, sigmaR));
 
         GC.KeepAlive(src);
         dst.Fix();

--- a/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
@@ -45,9 +45,9 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_registerDepth(
-                unregisteredCameraMatrix.CvPtr, registeredCameraMatrix.CvPtr, registeredDistCoeffs.CvPtr,
-                Rt.CvPtr, unregisteredDepth.CvPtr, outputImagePlaneSize,
-                registeredDepth.CvPtr, depthDilation ? 1 : 0));
+                unregisteredCameraMatrix.ToInputProxy(), registeredCameraMatrix.ToInputProxy(), registeredDistCoeffs.ToInputProxy(),
+                Rt.ToInputProxy(), unregisteredDepth.ToInputProxy(), outputImagePlaneSize,
+                registeredDepth.ToOutputProxy(), depthDilation ? 1 : 0));
 
         registeredDepth.Fix();
         GC.KeepAlive(unregisteredCameraMatrix);
@@ -80,7 +80,7 @@ static partial class Cv2
         points3d.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_depthTo3dSparse(depth.CvPtr, inK.CvPtr, inPoints.CvPtr, points3d.CvPtr));
+            NativeMethods.ptcloud_depthTo3dSparse(depth.ToInputProxy(), inK.ToInputProxy(), inPoints.ToInputProxy(), points3d.ToOutputProxy()));
 
         points3d.Fix();
         GC.KeepAlive(depth);
@@ -109,7 +109,7 @@ static partial class Cv2
         mask?.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_depthTo3d(depth.CvPtr, K.CvPtr, points3d.CvPtr, ToPtr(mask)));
+            NativeMethods.ptcloud_depthTo3d(depth.ToInputProxy(), K.ToInputProxy(), points3d.ToOutputProxy(), mask?.ToInputProxy() ?? default));
 
         points3d.Fix();
         GC.KeepAlive(depth);
@@ -135,7 +135,7 @@ static partial class Cv2
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_rescaleDepth(src.CvPtr, type, dst.CvPtr, depthFactor));
+            NativeMethods.ptcloud_rescaleDepth(src.ToInputProxy(), type, dst.ToOutputProxy(), depthFactor));
 
         dst.Fix();
         GC.KeepAlive(src);
@@ -174,8 +174,8 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_warpFrame(
-                depth.CvPtr, ToPtr(image), ToPtr(mask), Rt.CvPtr, cameraMatrix.CvPtr,
-                ToPtr(warpedDepth), ToPtr(warpedImage), ToPtr(warpedMask)));
+                depth.ToInputProxy(), image?.ToInputProxy() ?? default, mask?.ToInputProxy() ?? default, Rt.ToInputProxy(), cameraMatrix.ToInputProxy(),
+                warpedDepth?.ToOutputProxy() ?? default, warpedImage?.ToOutputProxy() ?? default, warpedMask?.ToOutputProxy() ?? default));
 
         warpedDepth?.Fix();
         warpedImage?.Fix();
@@ -222,7 +222,7 @@ static partial class Cv2
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_findPlanes(
-                points3d.CvPtr, normals.CvPtr, mask.CvPtr, planeCoefficients.CvPtr,
+                points3d.ToInputProxy(), normals.ToInputProxy(), mask.ToOutputProxy(), planeCoefficients.ToOutputProxy(),
                 blockSize, minSize, threshold,
                 sensorErrorA, sensorErrorB, sensorErrorC, (int)method));
 
@@ -250,7 +250,7 @@ static partial class Cv2
         rgb?.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_loadPointCloud(filename, vertices.CvPtr, ToPtr(normals), ToPtr(rgb)));
+            NativeMethods.ptcloud_loadPointCloud(filename, vertices.ToOutputProxy(), normals?.ToOutputProxy() ?? default, rgb?.ToOutputProxy() ?? default));
 
         vertices.Fix();
         normals?.Fix();
@@ -275,7 +275,7 @@ static partial class Cv2
         rgb?.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_savePointCloud(filename, vertices.CvPtr, ToPtr(normals), ToPtr(rgb)));
+            NativeMethods.ptcloud_savePointCloud(filename, vertices.ToInputProxy(), normals?.ToInputProxy() ?? default, rgb?.ToInputProxy() ?? default));
 
         GC.KeepAlive(vertices);
         GC.KeepAlive(normals);
@@ -307,7 +307,7 @@ static partial class Cv2
         using var indicesVec = new VectorOfMat();
         NativeMethods.HandleException(
             NativeMethods.ptcloud_loadMesh(
-                filename, vertices.CvPtr, indicesVec.CvPtr, ToPtr(normals), ToPtr(colors), ToPtr(texCoords)));
+                filename, vertices.ToOutputProxy(), indicesVec.CvPtr, normals?.ToOutputProxy() ?? default, colors?.ToOutputProxy() ?? default, texCoords?.ToOutputProxy() ?? default));
 
         vertices.Fix();
         normals?.Fix();
@@ -344,7 +344,7 @@ static partial class Cv2
         using var indicesVec = new VectorOfMat(indicesArray);
         NativeMethods.HandleException(
             NativeMethods.ptcloud_saveMesh(
-                filename, vertices.CvPtr, indicesVec.CvPtr, ToPtr(normals), ToPtr(colors), ToPtr(texCoords)));
+                filename, vertices.ToInputProxy(), indicesVec.CvPtr, normals?.ToInputProxy() ?? default, colors?.ToInputProxy() ?? default, texCoords?.ToInputProxy() ?? default));
 
         GC.KeepAlive(vertices);
         GC.KeepAlive(normals);

--- a/src/OpenCvSharp/Cv2/Cv2_video.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_video.cs
@@ -21,8 +21,7 @@ static partial class Cv2
         probImage.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_CamShift(
-                probImage.CvPtr, ref window, criteria, out var ret));
+            NativeMethods.video_CamShift(probImage.ToInputProxy(), ref window, criteria, out var ret));
         GC.KeepAlive(probImage);
         return ret;
     }
@@ -42,8 +41,7 @@ static partial class Cv2
         probImage.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_meanShift(
-                probImage.CvPtr, ref window, criteria, out var ret));
+            NativeMethods.video_meanShift(probImage.ToInputProxy(), ref window, criteria, out var ret));
         GC.KeepAlive(probImage);
         return ret;
     }
@@ -81,9 +79,7 @@ static partial class Cv2
         pyramid.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.video_buildOpticalFlowPyramid1(
-                img.CvPtr, pyramid.CvPtr, winSize, maxLevel, withDerivatives ? 1 : 0,
-                (int) pyrBorder, (int) derivBorder, tryReuseInputImage ? 1 : 0, out var ret));
+            NativeMethods.video_buildOpticalFlowPyramid1(img.ToInputProxy(), pyramid.ToOutputProxy(), winSize, maxLevel, withDerivatives ? 1 : 0, (int) pyrBorder, (int) derivBorder, tryReuseInputImage ? 1 : 0, out var ret));
         pyramid.Fix();
         GC.KeepAlive(img);
         return ret;
@@ -120,9 +116,7 @@ static partial class Cv2
 
         using var pyramidVec = new VectorOfMat();
         NativeMethods.HandleException(
-            NativeMethods.video_buildOpticalFlowPyramid2(
-                img.CvPtr, pyramidVec.CvPtr, winSize, maxLevel, withDerivatives ? 1 : 0,
-                (int) pyrBorder, (int) derivBorder, tryReuseInputImage ? 1 : 0, out var ret));
+            NativeMethods.video_buildOpticalFlowPyramid2(img.ToInputProxy(), pyramidVec.CvPtr, winSize, maxLevel, withDerivatives ? 1 : 0, (int) pyrBorder, (int) derivBorder, tryReuseInputImage ? 1 : 0, out var ret));
         GC.KeepAlive(img);
         pyramid = pyramidVec.ToArray();
         return ret;
@@ -176,10 +170,7 @@ static partial class Cv2
             TermCriteria.Both(30, 0.01));
 
         NativeMethods.HandleException(
-            NativeMethods.video_calcOpticalFlowPyrLK_InputArray(
-                prevImg.CvPtr, nextImg.CvPtr, prevPts.CvPtr, nextPts.CvPtr,
-                status.CvPtr, err.CvPtr, winSize0, maxLevel,
-                criteria0, (int) flags, minEigThreshold));
+            NativeMethods.video_calcOpticalFlowPyrLK_InputArray(prevImg.ToInputProxy(), nextImg.ToInputProxy(), prevPts.ToInputProxy(), nextPts.ToInputOutputProxy(), status.ToOutputProxy(), err.ToOutputProxy(), winSize0, maxLevel, criteria0, (int) flags, minEigThreshold));
         GC.KeepAlive(prevImg);
         GC.KeepAlive(nextImg);
         GC.KeepAlive(prevPts);
@@ -233,10 +224,7 @@ static partial class Cv2
         using var statusVec = new StdVector<byte>();
         using var errVec = new StdVector<float>();
         NativeMethods.HandleException(
-            NativeMethods.video_calcOpticalFlowPyrLK_vector(
-                prevImg.CvPtr, nextImg.CvPtr, prevPts, prevPts.Length,
-                nextPtsVec.CvPtr, statusVec.CvPtr, errVec.CvPtr,
-                winSize0, maxLevel, criteria0, (int) flags, minEigThreshold));
+            NativeMethods.video_calcOpticalFlowPyrLK_vector(prevImg.ToInputProxy(), nextImg.ToInputProxy(), prevPts, prevPts.Length, nextPtsVec.CvPtr, statusVec.CvPtr, errVec.CvPtr, winSize0, maxLevel, criteria0, (int) flags, minEigThreshold));
         GC.KeepAlive(prevImg);
         GC.KeepAlive(nextImg);
         nextPts = nextPtsVec.ToArray();
@@ -279,9 +267,7 @@ static partial class Cv2
         flow.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.video_calcOpticalFlowFarneback(
-                prev.CvPtr, next.CvPtr, flow.CvPtr, pyrScale, levels, winsize, 
-                iterations, polyN, polySigma, (int) flags));
+            NativeMethods.video_calcOpticalFlowFarneback(prev.ToInputProxy(), next.ToInputProxy(), flow.ToInputOutputProxy(), pyrScale, levels, winsize, iterations, polyN, polySigma, (int) flags));
         GC.KeepAlive(prev);
         GC.KeepAlive(next);
         flow.Fix();
@@ -305,8 +291,7 @@ static partial class Cv2
         inputMask?.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_computeECC(
-                templateImage.CvPtr, inputImage.CvPtr, inputMask?.CvPtr ?? IntPtr.Zero, out var ret));
+            NativeMethods.video_computeECC(templateImage.ToInputProxy(), inputImage.ToInputProxy(), inputMask?.ToInputProxy() ?? default, out var ret));
 
         GC.KeepAlive(templateImage);
         GC.KeepAlive(inputImage);
@@ -350,10 +335,7 @@ static partial class Cv2
         inputMask?.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_findTransformECC1(
-                templateImage.CvPtr, inputImage.CvPtr, warpMatrix.CvPtr, (int)motionType,
-                criteria, inputMask?.CvPtr ?? IntPtr.Zero, gaussFiltSize,
-                out var ret));
+            NativeMethods.video_findTransformECC1(templateImage.ToInputProxy(), inputImage.ToInputProxy(), warpMatrix.ToInputOutputProxy(), (int)motionType, criteria, inputMask?.ToInputProxy() ?? default, gaussFiltSize, out var ret));
 
         GC.KeepAlive(templateImage);
         GC.KeepAlive(inputImage);
@@ -398,9 +380,7 @@ static partial class Cv2
         var criteriaValue = criteria.GetValueOrDefault(new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 50, 0.001));
 
         NativeMethods.HandleException(
-            NativeMethods.video_findTransformECC2(
-                templateImage.CvPtr, inputImage.CvPtr, warpMatrix.CvPtr, (int)motionType,
-                criteriaValue, inputMask?.CvPtr ?? IntPtr.Zero, out var ret));
+            NativeMethods.video_findTransformECC2(templateImage.ToInputProxy(), inputImage.ToInputProxy(), warpMatrix.ToInputOutputProxy(), (int)motionType, criteriaValue, inputMask?.ToInputProxy() ?? default, out var ret));
 
         GC.KeepAlive(templateImage);
         GC.KeepAlive(inputImage);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_aruco.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_aruco.cs
@@ -11,14 +11,14 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_drawDetectedMarkers(
-        IntPtr image,
+    internal static partial ExceptionStatus aruco_drawDetectedMarkers(
+        in InputOutputArrayProxy image,
         [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2,
         [MarshalAs(UnmanagedType.LPArray)] int[] ids, int idxLength, Scalar borderColor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_drawDetectedMarkers(
-        IntPtr image, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2, IntPtr ids, int idxLength, Scalar borderColor);
+    internal static partial ExceptionStatus aruco_drawDetectedMarkers(
+        in InputOutputArrayProxy image, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2, IntPtr ids, int idxLength, Scalar borderColor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus aruco_getPredefinedDictionary(int name, out IntPtr returnValue);
@@ -27,14 +27,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus aruco_readDictionary([MarshalAs(UnmanagedType.LPStr)] string dictionaryFile, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_drawDetectedDiamonds(
-        IntPtr image,
+    internal static partial ExceptionStatus aruco_drawDetectedDiamonds(
+        in InputOutputArrayProxy image,
         [MarshalAs(UnmanagedType.LPArray)] IntPtr[] corners, int cornerSize1, int[] contoursSize2,
         IntPtr ids, Scalar borderColor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_drawDetectedCornersCharuco(
-        IntPtr image,
+    internal static partial ExceptionStatus aruco_drawDetectedCornersCharuco(
+        in InputOutputArrayProxy image,
         IntPtr corners, IntPtr ids, Scalar cornerColor);
 
     #region ArucoDetector
@@ -47,14 +47,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus aruco_ArucoDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_ArucoDetector_detectMarkers(
-        OpenCvSafeHandle detector, IntPtr image, IntPtr corners, IntPtr ids, IntPtr rejectedImgPoints);
+    internal static partial ExceptionStatus aruco_ArucoDetector_detectMarkers(
+        OpenCvSafeHandle detector, in InputArrayProxy image, IntPtr corners, IntPtr ids, IntPtr rejectedImgPoints);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_ArucoDetector_refineDetectedMarkers(
-        OpenCvSafeHandle detector, IntPtr image, IntPtr board,
+    internal static partial ExceptionStatus aruco_ArucoDetector_refineDetectedMarkers(
+        OpenCvSafeHandle detector, in InputArrayProxy image, IntPtr board,
         IntPtr detectedCorners, IntPtr detectedIds, IntPtr rejectedCorners,
-        IntPtr cameraMatrix, IntPtr distCoeffs, IntPtr recoveredIdxs);
+        in InputArrayProxy cameraMatrix, in InputArrayProxy distCoeffs, IntPtr recoveredIdxs);
 
     #endregion
 
@@ -83,20 +83,20 @@ static partial class NativeMethods
     public static partial ExceptionStatus aruco_CharucoBoard_getLegacyPattern(OpenCvSafeHandle ptr, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_CharucoBoard_generateImage(
-        OpenCvSafeHandle ptr, Size outSize, IntPtr img, int marginSize, int borderBits);
+    internal static partial ExceptionStatus aruco_CharucoBoard_generateImage(
+        OpenCvSafeHandle ptr, Size outSize, in OutputArrayProxy img, int marginSize, int borderBits);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_CharucoBoard_checkCharucoCornersCollinear(
-        OpenCvSafeHandle ptr, IntPtr charucoIds, out int returnValue);
+    internal static partial ExceptionStatus aruco_CharucoBoard_checkCharucoCornersCollinear(
+        OpenCvSafeHandle ptr, in InputArrayProxy charucoIds, out int returnValue);
 
     #endregion
 
     #region CharucoDetector
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_CharucoDetector_create(
-        IntPtr board, IntPtr cameraMatrix, IntPtr distCoeffs,
+    internal static partial ExceptionStatus aruco_CharucoDetector_create(
+        IntPtr board, in InputArrayProxy cameraMatrix, in InputArrayProxy distCoeffs,
         int minMarkers,
         [MarshalAs(UnmanagedType.U1)] bool tryRefineMarkers,
         [MarshalAs(UnmanagedType.U1)] bool checkMarkers,
@@ -107,14 +107,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus aruco_CharucoDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_CharucoDetector_detectBoard(
-        OpenCvSafeHandle detector, IntPtr image,
+    internal static partial ExceptionStatus aruco_CharucoDetector_detectBoard(
+        OpenCvSafeHandle detector, in InputArrayProxy image,
         IntPtr charucoCorners, IntPtr charucoIds,
         IntPtr markerCorners, IntPtr markerIds);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_CharucoDetector_detectDiamonds(
-        OpenCvSafeHandle detector, IntPtr image,
+    internal static partial ExceptionStatus aruco_CharucoDetector_detectDiamonds(
+        OpenCvSafeHandle detector, in InputArrayProxy image,
         IntPtr diamondCorners, IntPtr diamondIds,
         IntPtr markerCorners, IntPtr markerIds);
 
@@ -150,19 +150,19 @@ static partial class NativeMethods
         out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_Dictionary_getDistanceToId(
+    internal static partial ExceptionStatus aruco_Dictionary_getDistanceToId(
         OpenCvSafeHandle obj,
-        IntPtr bits,
+        in InputArrayProxy bits,
         int id,
         int allRotations,
         out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus aruco_Dictionary_generateImageMarker(
+    internal static partial ExceptionStatus aruco_Dictionary_generateImageMarker(
         OpenCvSafeHandle obj,
         int id,
         int sidePixels,
-        IntPtr img,
+        in OutputArrayProxy img,
         int borderBits);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xphoto.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xphoto.cs
@@ -14,10 +14,10 @@ static partial class NativeMethods
     #region bm3d_image_denoising.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_bm3dDenoising1(
-        IntPtr src,
-        IntPtr dstStep1,
-        IntPtr dstStep2,
+    internal static partial ExceptionStatus xphoto_bm3dDenoising1(
+        in InputArrayProxy src,
+        in InputOutputArrayProxy dstStep1,
+        in OutputArrayProxy dstStep2,
         float h,
         int templateWindowSize,
         int searchWindowSize,
@@ -31,9 +31,9 @@ static partial class NativeMethods
         int transformType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_bm3dDenoising2(
-        IntPtr src,
-        IntPtr dst,
+    internal static partial ExceptionStatus xphoto_bm3dDenoising2(
+        in InputArrayProxy src,
+        in OutputArrayProxy dst,
         float h,
         int templateWindowSize,
         int searchWindowSize,
@@ -65,8 +65,8 @@ static partial class NativeMethods
     #region oilpainting.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_oilPainting(
-        IntPtr src, IntPtr dst, int size, int dynRatio, int code);
+    internal static partial ExceptionStatus xphoto_oilPainting(
+        in InputArrayProxy src, in OutputArrayProxy dst, int size, int dynRatio, int code);
         
     #endregion
 
@@ -111,8 +111,8 @@ static partial class NativeMethods
     #region white_balance.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_applyChannelGains(
-        IntPtr src, IntPtr dst, float gainB, float gainG, float gainR);
+    internal static partial ExceptionStatus xphoto_applyChannelGains(
+        in InputArrayProxy src, in OutputArrayProxy dst, float gainB, float gainG, float gainR);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xphoto_createGrayworldWB(out IntPtr returnValue);
@@ -124,7 +124,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_GrayworldWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_GrayworldWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus xphoto_GrayworldWB_balanceWhite(OpenCvSafeHandle prt, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xphoto_GrayworldWB_SaturationThreshold_get(OpenCvSafeHandle ptr, out float returnValue);
@@ -143,10 +143,10 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_LearningBasedWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus xphoto_LearningBasedWB_balanceWhite(OpenCvSafeHandle prt, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_LearningBasedWB_extractSimpleFeatures(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus xphoto_LearningBasedWB_extractSimpleFeatures(OpenCvSafeHandle prt, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xphoto_LearningBasedWB_HistBinNum_set(OpenCvSafeHandle prt, int value);
@@ -177,7 +177,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus xphoto_Ptr_SimpleWB_get(IntPtr prt, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xphoto_SimpleWB_balanceWhite(OpenCvSafeHandle prt, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus xphoto_SimpleWB_balanceWhite(OpenCvSafeHandle prt, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xphoto_SimpleWB_InputMax_get(OpenCvSafeHandle prt, out float returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
@@ -12,9 +12,9 @@ static partial class NativeMethods
     // ReSharper disable InconsistentNaming
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_drawKeypoints(
-        IntPtr image, KeyPoint[] keypoints, int keypointsLength,
-        IntPtr outImage, Scalar color, int flags);
+    internal static partial ExceptionStatus features_drawKeypoints(
+        in InputArrayProxy image, KeyPoint[] keypoints, int keypointsLength,
+        in InputOutputArrayProxy outImage, Scalar color, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_drawMatches(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_ANNIndex.cs
@@ -22,14 +22,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_ANNIndex_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_addItems(OpenCvSafeHandle obj, IntPtr features);
+    internal static partial ExceptionStatus features_ANNIndex_addItems(OpenCvSafeHandle obj, in InputArrayProxy features);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_build(OpenCvSafeHandle obj, int trees);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_ANNIndex_knnSearch(
-        OpenCvSafeHandle obj, IntPtr query, IntPtr indices, IntPtr dists, int knn, int search_k);
+    internal static partial ExceptionStatus features_ANNIndex_knnSearch(
+        OpenCvSafeHandle obj, in InputArrayProxy query, in OutputArrayProxy indices, in OutputArrayProxy dists, int knn, int search_k);
 
     [LibraryImport(DllExtern, EntryPoint = "features_ANNIndex_save"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_ANNIndex_save_NotWindows(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
@@ -138,8 +138,8 @@ static partial class NativeMethods
         byte[] modelData, IntPtr modelDataLength, float scoreThreshold, int backend, int target, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_LightGlueMatcher_setPairInfo(
-        OpenCvSafeHandle obj, IntPtr queryKpts, IntPtr trainKpts, Size queryImageSize, Size trainImageSize);
+    internal static partial ExceptionStatus features_LightGlueMatcher_setPairInfo(
+        OpenCvSafeHandle obj, in InputArrayProxy queryKpts, in InputArrayProxy trainKpts, Size queryImageSize, Size trainImageSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_LightGlueMatcher_clearPairInfo(OpenCvSafeHandle obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
@@ -22,20 +22,20 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Feature2D_detect_Mat2(
         OpenCvSafeHandle detector, IntPtr[] images, int imageLength, IntPtr keypoints, IntPtr[]? mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_detect_InputArray(
-        OpenCvSafeHandle detector, IntPtr image, IntPtr keypoints, IntPtr mask);
+    internal static partial ExceptionStatus features_Feature2D_detect_InputArray(
+        OpenCvSafeHandle detector, in InputArrayProxy image, IntPtr keypoints, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_compute1(OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, IntPtr descriptors);
+    internal static partial ExceptionStatus features_Feature2D_compute1(OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr keypoints, in OutputArrayProxy descriptors);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_compute2(
         OpenCvSafeHandle detector, IntPtr[] images, int imageLength,
         IntPtr keypoints, IntPtr[] descriptors, int descriptorsLength);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_Feature2D_detectAndCompute(
-        OpenCvSafeHandle detector, IntPtr image, IntPtr mask,
-        IntPtr keypoints, IntPtr descriptors, int useProvidedKeypoints);
+    internal static partial ExceptionStatus features_Feature2D_detectAndCompute(
+        OpenCvSafeHandle detector, in InputArrayProxy image, in InputArrayProxy mask,
+        IntPtr keypoints, in OutputArrayProxy descriptors, int useProvidedKeypoints);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Feature2D_descriptorSize(OpenCvSafeHandle obj, out int returnValue);
@@ -137,8 +137,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus features_Ptr_MSER_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_MSER_detectRegions(
-        OpenCvSafeHandle obj, IntPtr image, IntPtr msers, IntPtr bboxes);
+    internal static partial ExceptionStatus features_MSER_detectRegions(
+        OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr msers, IntPtr bboxes);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_MSER_setDelta(OpenCvSafeHandle obj, int delta);
@@ -165,9 +165,9 @@ static partial class NativeMethods
     #region FastFeatureDetector
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FAST1(IntPtr image, IntPtr keypoints, int threshold, int nonmaxSupression);
+    internal static partial ExceptionStatus features_FAST1(in InputArrayProxy image, IntPtr keypoints, int threshold, int nonmaxSupression);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_FAST2(IntPtr image, IntPtr keypoints, int threshold, int nonmaxSupression, int type);
+    internal static partial ExceptionStatus features_FAST2(in InputArrayProxy image, IntPtr keypoints, int threshold, int nonmaxSupression, int type);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_FastFeatureDetector_create(int threshold, int nonmaxSuppression, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_ANN_MLP.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_ANN_MLP.cs
@@ -20,7 +20,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_ANN_MLP_setActivationFunction(OpenCvSafeHandle obj, int type, double param1, double param2);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_ANN_MLP_setLayerSizes(OpenCvSafeHandle obj, IntPtr layerSizes);
+    internal static partial ExceptionStatus ml_ANN_MLP_setLayerSizes(OpenCvSafeHandle obj, in InputArrayProxy layerSizes);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_ANN_MLP_getLayerSizes(OpenCvSafeHandle obj, out IntPtr returnValue);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_EM.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_EM.cs
@@ -35,21 +35,21 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_EM_getCovs(OpenCvSafeHandle obj, IntPtr covs);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_predict2(OpenCvSafeHandle model, IntPtr sample, IntPtr probs, out Vec2d returnValue);
+    internal static partial ExceptionStatus ml_EM_predict2(OpenCvSafeHandle model, in InputArrayProxy sample, in OutputArrayProxy probs, out Vec2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_trainEM(
-        OpenCvSafeHandle obj, IntPtr samples, IntPtr logLikelihoods, IntPtr labels, IntPtr probs, out int returnValue);
+    internal static partial ExceptionStatus ml_EM_trainEM(
+        OpenCvSafeHandle obj, in InputArrayProxy samples, in OutputArrayProxy logLikelihoods, in OutputArrayProxy labels, in OutputArrayProxy probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_trainE(
-        OpenCvSafeHandle model, IntPtr samples, IntPtr means0, IntPtr covs0, IntPtr weights0,
-        IntPtr logLikelihoods, IntPtr labels, IntPtr probs, out int returnValue);
+    internal static partial ExceptionStatus ml_EM_trainE(
+        OpenCvSafeHandle model, in InputArrayProxy samples, in InputArrayProxy means0, in InputArrayProxy covs0, in InputArrayProxy weights0,
+        in OutputArrayProxy logLikelihoods, in OutputArrayProxy labels, in OutputArrayProxy probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_EM_trainM(
-        OpenCvSafeHandle model, IntPtr samples, IntPtr probs0, IntPtr logLikelihoods, 
-        IntPtr labels, IntPtr probs, out int returnValue);
+    internal static partial ExceptionStatus ml_EM_trainM(
+        OpenCvSafeHandle model, in InputArrayProxy samples, in InputArrayProxy probs0, in OutputArrayProxy logLikelihoods, 
+        in OutputArrayProxy labels, in OutputArrayProxy probs, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_EM_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_KNearest.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_KNearest.cs
@@ -31,8 +31,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_KNearest_setAlgorithmType(OpenCvSafeHandle obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_KNearest_findNearest(OpenCvSafeHandle obj, IntPtr samples, int k,
-        IntPtr results, IntPtr neighborResponses, IntPtr dist, out float returnValue);
+    internal static partial ExceptionStatus ml_KNearest_findNearest(OpenCvSafeHandle obj, in InputArrayProxy samples, int k,
+        in OutputArrayProxy results, in OutputArrayProxy neighborResponses, in OutputArrayProxy dist, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_KNearest_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_LogisticRegression.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_LogisticRegression.cs
@@ -41,8 +41,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_LogisticRegression_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_LogisticRegression_predict(
-        OpenCvSafeHandle obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
+    internal static partial ExceptionStatus ml_LogisticRegression_predict(
+        OpenCvSafeHandle obj, in InputArrayProxy samples, in OutputArrayProxy results, int flags, out float returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_LogisticRegression_get_learnt_thetas(OpenCvSafeHandle obj, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_NormalBayesClassifier.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_NormalBayesClassifier.cs
@@ -11,9 +11,9 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_NormalBayesClassifier_predictProb(
-        OpenCvSafeHandle obj, IntPtr inputs,
-        IntPtr samples, IntPtr outputProbs, int flags, out float returnValue);
+    internal static partial ExceptionStatus ml_NormalBayesClassifier_predictProb(
+        OpenCvSafeHandle obj, in InputArrayProxy inputs,
+        in OutputArrayProxy samples, in OutputArrayProxy outputProbs, int flags, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_NormalBayesClassifier_create(out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
@@ -65,8 +65,8 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_SVM_getSupportVectors(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_SVM_getDecisionFunction(
-        OpenCvSafeHandle obj, int i, IntPtr alpha, IntPtr svidx, out double returnValue);
+    internal static partial ExceptionStatus ml_SVM_getDecisionFunction(
+        OpenCvSafeHandle obj, int i, in OutputArrayProxy alpha, in OutputArrayProxy svidx, out double returnValue);
 
     // static
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
@@ -25,10 +25,10 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_StatModel_isClassifier(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_train2(
-        OpenCvSafeHandle obj, IntPtr samples, int layout, IntPtr responses, out int returnValue);
+    internal static partial ExceptionStatus ml_StatModel_train2(
+        OpenCvSafeHandle obj, in InputArrayProxy samples, int layout, in InputArrayProxy responses, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ml_StatModel_predict(
-        OpenCvSafeHandle obj, IntPtr samples, IntPtr results, int flags, out float returnValue);
+    internal static partial ExceptionStatus ml_StatModel_predict(
+        OpenCvSafeHandle obj, in InputArrayProxy samples, in OutputArrayProxy results, int flags, out float returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/photo/NativeMethods_photo.cs
@@ -11,29 +11,29 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_inpaint(
-        IntPtr src, IntPtr inpaintMask,
-        IntPtr dst, double inpaintRadius, int flags);
+    internal static partial ExceptionStatus photo_inpaint(
+        in InputArrayProxy src, in InputArrayProxy inpaintMask,
+        in OutputArrayProxy dst, double inpaintRadius, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_fastNlMeansDenoising(
-        IntPtr src, IntPtr dst, float h,
+    internal static partial ExceptionStatus photo_fastNlMeansDenoising(
+        in InputArrayProxy src, in OutputArrayProxy dst, float h,
         int templateWindowSize, int searchWindowSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_fastNlMeansDenoisingColored(
-        IntPtr src, IntPtr dst,
+    internal static partial ExceptionStatus photo_fastNlMeansDenoisingColored(
+        in InputArrayProxy src, in OutputArrayProxy dst,
         float h, float hColor, int templateWindowSize, int searchWindowSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_fastNlMeansDenoisingMulti(
+    internal static partial ExceptionStatus photo_fastNlMeansDenoisingMulti(
         IntPtr[] srcImgs, int srcImgsLength,
-        IntPtr dst, int imgToDenoiseIndex, int temporalWindowSize,
+        in OutputArrayProxy dst, int imgToDenoiseIndex, int temporalWindowSize,
         float h, int templateWindowSize, int searchWindowSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_fastNlMeansDenoisingColoredMulti(IntPtr[] srcImgs, int srcImgsLength,
-        IntPtr dst, int imgToDenoiseIndex, int temporalWindowSize,
+    internal static partial ExceptionStatus photo_fastNlMeansDenoisingColoredMulti(IntPtr[] srcImgs, int srcImgsLength,
+        in OutputArrayProxy dst, int imgToDenoiseIndex, int temporalWindowSize,
         float h, float hColor, int templateWindowSize, int searchWindowSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -41,41 +41,41 @@ static partial class NativeMethods
         IntPtr[] observations, int observationsSize, IntPtr result, double lambda, int niters);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_decolor(
-        IntPtr src, IntPtr grayscale, IntPtr color_boost);
+    internal static partial ExceptionStatus photo_decolor(
+        in InputArrayProxy src, in OutputArrayProxy grayscale, in OutputArrayProxy color_boost);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_seamlessClone(
-        IntPtr src, IntPtr dst, IntPtr mask, Point p, IntPtr blend, int flags);
+    internal static partial ExceptionStatus photo_seamlessClone(
+        in InputArrayProxy src, in InputArrayProxy dst, in InputArrayProxy mask, Point p, in OutputArrayProxy blend, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_colorChange(
-        IntPtr src, IntPtr mask, IntPtr dst, float red_mul, float green_mul, float blue_mul);
+    internal static partial ExceptionStatus photo_colorChange(
+        in InputArrayProxy src, in InputArrayProxy mask, in OutputArrayProxy dst, float red_mul, float green_mul, float blue_mul);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_illuminationChange(
-        IntPtr src, IntPtr mask, IntPtr dst, float alpha, float beta);
+    internal static partial ExceptionStatus photo_illuminationChange(
+        in InputArrayProxy src, in InputArrayProxy mask, in OutputArrayProxy dst, float alpha, float beta);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_textureFlattening(
-        IntPtr src, IntPtr mask, IntPtr dst,
+    internal static partial ExceptionStatus photo_textureFlattening(
+        in InputArrayProxy src, in InputArrayProxy mask, in OutputArrayProxy dst,
         float low_threshold, float high_threshold, int kernel_size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_edgePreservingFilter(
-        IntPtr src, IntPtr dst, int flags, float sigma_s, float sigma_r);
+    internal static partial ExceptionStatus photo_edgePreservingFilter(
+        in InputArrayProxy src, in OutputArrayProxy dst, int flags, float sigma_s, float sigma_r);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_detailEnhance(
-        IntPtr src, IntPtr dst, float sigma_s, float sigma_r);
+    internal static partial ExceptionStatus photo_detailEnhance(
+        in InputArrayProxy src, in OutputArrayProxy dst, float sigma_s, float sigma_r);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_pencilSketch(
-        IntPtr src, IntPtr dst1, IntPtr dst2,
+    internal static partial ExceptionStatus photo_pencilSketch(
+        in InputArrayProxy src, in OutputArrayProxy dst1, in OutputArrayProxy dst2,
         float sigma_s, float sigma_r, float shade_factor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus photo_stylization(
-        IntPtr src, IntPtr dst, float sigma_s, float sigma_r);
+    internal static partial ExceptionStatus photo_stylization(
+        in InputArrayProxy src, in OutputArrayProxy dst, float sigma_s, float sigma_r);
 
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_Odometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_Odometry.cs
@@ -25,11 +25,11 @@ static partial class NativeMethods
     public static partial ExceptionStatus ptcloud_Odometry_prepareFrames(OpenCvSafeHandle obj, IntPtr srcFrame, IntPtr dstFrame);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Odometry_compute_Frame(OpenCvSafeHandle obj, IntPtr srcFrame, IntPtr dstFrame, IntPtr rt, out int returnValue);
+    internal static partial ExceptionStatus ptcloud_Odometry_compute_Frame(OpenCvSafeHandle obj, IntPtr srcFrame, IntPtr dstFrame, in OutputArrayProxy rt, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Odometry_compute_Depth(OpenCvSafeHandle obj, IntPtr srcDepth, IntPtr dstDepth, IntPtr rt, out int returnValue);
+    internal static partial ExceptionStatus ptcloud_Odometry_compute_Depth(OpenCvSafeHandle obj, in InputArrayProxy srcDepth, in InputArrayProxy dstDepth, in OutputArrayProxy rt, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Odometry_compute_DepthRGB(OpenCvSafeHandle obj, IntPtr srcDepth, IntPtr srcRGB, IntPtr dstDepth, IntPtr dstRGB, IntPtr rt, out int returnValue);
+    internal static partial ExceptionStatus ptcloud_Odometry_compute_DepthRGB(OpenCvSafeHandle obj, in InputArrayProxy srcDepth, in InputArrayProxy srcRGB, in InputArrayProxy dstDepth, in InputArrayProxy dstRGB, in OutputArrayProxy rt, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Odometry_getNormalsComputer(OpenCvSafeHandle obj, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_OdometryFrame.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_OdometryFrame.cs
@@ -11,26 +11,26 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_new(
-        IntPtr depth, IntPtr image, IntPtr mask, IntPtr normals, out IntPtr returnValue);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_new(
+        in InputArrayProxy depth, in InputArrayProxy image, in InputArrayProxy mask, in InputArrayProxy normals, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_OdometryFrame_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getImage(OpenCvSafeHandle obj, IntPtr image);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getImage(OpenCvSafeHandle obj, in OutputArrayProxy image);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getGrayImage(OpenCvSafeHandle obj, IntPtr image);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getGrayImage(OpenCvSafeHandle obj, in OutputArrayProxy image);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getDepth(OpenCvSafeHandle obj, IntPtr depth);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getDepth(OpenCvSafeHandle obj, in OutputArrayProxy depth);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getProcessedDepth(OpenCvSafeHandle obj, IntPtr depth);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getProcessedDepth(OpenCvSafeHandle obj, in OutputArrayProxy depth);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getMask(OpenCvSafeHandle obj, IntPtr mask);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getMask(OpenCvSafeHandle obj, in OutputArrayProxy mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getNormals(OpenCvSafeHandle obj, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getNormals(OpenCvSafeHandle obj, in OutputArrayProxy normals);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_OdometryFrame_getPyramidLevels(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometryFrame_getPyramidAt(OpenCvSafeHandle obj, IntPtr img, int pyrType, IntPtr level);
+    internal static partial ExceptionStatus ptcloud_OdometryFrame_getPyramidAt(OpenCvSafeHandle obj, in OutputArrayProxy img, int pyrType, IntPtr level);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_OdometrySettings.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_OdometrySettings.cs
@@ -16,14 +16,14 @@ static partial class NativeMethods
     public static partial ExceptionStatus ptcloud_OdometrySettings_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_setCameraMatrix(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_setCameraMatrix(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_getCameraMatrix(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_getCameraMatrix(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_setIterCounts(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_setIterCounts(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_getIterCounts(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_getIterCounts(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_OdometrySettings_setMinDepth(OpenCvSafeHandle obj, float val);
@@ -91,7 +91,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus ptcloud_OdometrySettings_getMinGradientMagnitude(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_setMinGradientMagnitudes(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_setMinGradientMagnitudes(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_OdometrySettings_getMinGradientMagnitudes(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_OdometrySettings_getMinGradientMagnitudes(OpenCvSafeHandle obj, in OutputArrayProxy val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_RgbdNormals.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_RgbdNormals.cs
@@ -11,15 +11,15 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_RgbdNormals_create(
-        int rows, int cols, int depth, IntPtr k, int window_size, float diff_threshold, int method, out IntPtr returnValue);
+    internal static partial ExceptionStatus ptcloud_RgbdNormals_create(
+        int rows, int cols, int depth, in InputArrayProxy k, int window_size, float diff_threshold, int method, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Ptr_RgbdNormals_delete(IntPtr obj);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Ptr_RgbdNormals_get(IntPtr obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_RgbdNormals_apply(OpenCvSafeHandle obj, IntPtr points, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_RgbdNormals_apply(OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_RgbdNormals_cache(OpenCvSafeHandle obj);
 
@@ -38,9 +38,9 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_RgbdNormals_getDepth(OpenCvSafeHandle obj, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_RgbdNormals_getK(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_RgbdNormals_getK(OpenCvSafeHandle obj, in OutputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_RgbdNormals_setK(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_RgbdNormals_setK(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_RgbdNormals_getMethod(OpenCvSafeHandle obj, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_Volume.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_Volume.cs
@@ -16,27 +16,27 @@ static partial class NativeMethods
     public static partial ExceptionStatus ptcloud_Volume_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_integrateFrame(OpenCvSafeHandle obj, IntPtr frame, IntPtr pose);
+    internal static partial ExceptionStatus ptcloud_Volume_integrateFrame(OpenCvSafeHandle obj, IntPtr frame, in InputArrayProxy pose);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_integrate(OpenCvSafeHandle obj, IntPtr depth, IntPtr pose);
+    internal static partial ExceptionStatus ptcloud_Volume_integrate(OpenCvSafeHandle obj, in InputArrayProxy depth, in InputArrayProxy pose);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_integrateColor(OpenCvSafeHandle obj, IntPtr depth, IntPtr image, IntPtr pose);
+    internal static partial ExceptionStatus ptcloud_Volume_integrateColor(OpenCvSafeHandle obj, in InputArrayProxy depth, in InputArrayProxy image, in InputArrayProxy pose);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_raycast(OpenCvSafeHandle obj, IntPtr cameraPose, IntPtr points, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_Volume_raycast(OpenCvSafeHandle obj, in InputArrayProxy cameraPose, in OutputArrayProxy points, in OutputArrayProxy normals);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_raycastColor(OpenCvSafeHandle obj, IntPtr cameraPose, IntPtr points, IntPtr normals, IntPtr colors);
+    internal static partial ExceptionStatus ptcloud_Volume_raycastColor(OpenCvSafeHandle obj, in InputArrayProxy cameraPose, in OutputArrayProxy points, in OutputArrayProxy normals, in OutputArrayProxy colors);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_raycastEx(OpenCvSafeHandle obj, IntPtr cameraPose, int height, int width, IntPtr k, IntPtr points, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_Volume_raycastEx(OpenCvSafeHandle obj, in InputArrayProxy cameraPose, int height, int width, in InputArrayProxy k, in OutputArrayProxy points, in OutputArrayProxy normals);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_raycastExColor(OpenCvSafeHandle obj, IntPtr cameraPose, int height, int width, IntPtr k, IntPtr points, IntPtr normals, IntPtr colors);
+    internal static partial ExceptionStatus ptcloud_Volume_raycastExColor(OpenCvSafeHandle obj, in InputArrayProxy cameraPose, int height, int width, in InputArrayProxy k, in OutputArrayProxy points, in OutputArrayProxy normals, in OutputArrayProxy colors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_fetchNormals(OpenCvSafeHandle obj, IntPtr points, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_Volume_fetchNormals(OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_fetchPointsNormals(OpenCvSafeHandle obj, IntPtr points, IntPtr normals);
+    internal static partial ExceptionStatus ptcloud_Volume_fetchPointsNormals(OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_fetchPointsNormalsColors(OpenCvSafeHandle obj, IntPtr points, IntPtr normals, IntPtr colors);
+    internal static partial ExceptionStatus ptcloud_Volume_fetchPointsNormalsColors(OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals, in OutputArrayProxy colors);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Volume_reset(OpenCvSafeHandle obj);
@@ -45,7 +45,7 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Volume_getTotalVolumeUnits(OpenCvSafeHandle obj, out long returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_Volume_getBoundingBox(OpenCvSafeHandle obj, IntPtr bb, int precision);
+    internal static partial ExceptionStatus ptcloud_Volume_getBoundingBox(OpenCvSafeHandle obj, in OutputArrayProxy bb, int precision);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ptcloud_Volume_setEnableGrowth(OpenCvSafeHandle obj, int v);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_VolumeSettings.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_VolumeSettings.cs
@@ -66,25 +66,25 @@ static partial class NativeMethods
     public static partial ExceptionStatus ptcloud_VolumeSettings_getRaycastStepFactor(OpenCvSafeHandle obj, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_setVolumePose(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_setVolumePose(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_getVolumePose(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_getVolumePose(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_setVolumeResolution(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_setVolumeResolution(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_getVolumeResolution(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_getVolumeResolution(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_getVolumeStrides(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_getVolumeStrides(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(OpenCvSafeHandle obj, in OutputArrayProxy val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_setCameraRaycastIntrinsics(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_setCameraRaycastIntrinsics(OpenCvSafeHandle obj, in InputArrayProxy val);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_VolumeSettings_getCameraRaycastIntrinsics(OpenCvSafeHandle obj, IntPtr val);
+    internal static partial ExceptionStatus ptcloud_VolumeSettings_getCameraRaycastIntrinsics(OpenCvSafeHandle obj, in OutputArrayProxy val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_depth.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_depth.cs
@@ -11,28 +11,28 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_registerDepth(
-        IntPtr unregisteredCameraMatrix, IntPtr registeredCameraMatrix, IntPtr registeredDistCoeffs,
-        IntPtr rt, IntPtr unregisteredDepth, Size outputImagePlaneSize,
-        IntPtr registeredDepth, int depthDilation);
+    internal static partial ExceptionStatus ptcloud_registerDepth(
+        in InputArrayProxy unregisteredCameraMatrix, in InputArrayProxy registeredCameraMatrix, in InputArrayProxy registeredDistCoeffs,
+        in InputArrayProxy rt, in InputArrayProxy unregisteredDepth, Size outputImagePlaneSize,
+        in OutputArrayProxy registeredDepth, int depthDilation);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_depthTo3dSparse(IntPtr depth, IntPtr inK, IntPtr inPoints, IntPtr points3d);
+    internal static partial ExceptionStatus ptcloud_depthTo3dSparse(in InputArrayProxy depth, in InputArrayProxy inK, in InputArrayProxy inPoints, in OutputArrayProxy points3d);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_depthTo3d(IntPtr depth, IntPtr k, IntPtr points3d, IntPtr mask);
+    internal static partial ExceptionStatus ptcloud_depthTo3d(in InputArrayProxy depth, in InputArrayProxy k, in OutputArrayProxy points3d, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_rescaleDepth(IntPtr src, int type, IntPtr dst, double depthFactor);
+    internal static partial ExceptionStatus ptcloud_rescaleDepth(in InputArrayProxy src, int type, in OutputArrayProxy dst, double depthFactor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_warpFrame(
-        IntPtr depth, IntPtr image, IntPtr mask, IntPtr rt, IntPtr cameraMatrix,
-        IntPtr warpedDepth, IntPtr warpedImage, IntPtr warpedMask);
+    internal static partial ExceptionStatus ptcloud_warpFrame(
+        in InputArrayProxy depth, in InputArrayProxy image, in InputArrayProxy mask, in InputArrayProxy rt, in InputArrayProxy cameraMatrix,
+        in OutputArrayProxy warpedDepth, in OutputArrayProxy warpedImage, in OutputArrayProxy warpedMask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_findPlanes(
-        IntPtr points3d, IntPtr normals, IntPtr mask, IntPtr planeCoefficients,
+    internal static partial ExceptionStatus ptcloud_findPlanes(
+        in InputArrayProxy points3d, in InputArrayProxy normals, in OutputArrayProxy mask, in OutputArrayProxy planeCoefficients,
         int blockSize, int minSize, double threshold,
         double sensorErrorA, double sensorErrorB, double sensorErrorC, int method);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_io.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ptcloud/NativeMethods_ptcloud_io.cs
@@ -15,14 +15,14 @@ static partial class NativeMethods
     // loadPointCloud
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_loadPointCloud"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_loadPointCloud_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+    internal static partial ExceptionStatus ptcloud_loadPointCloud_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, in OutputArrayProxy vertices, in OutputArrayProxy normals, in OutputArrayProxy rgb);
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_loadPointCloud"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_loadPointCloud_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+    internal static partial ExceptionStatus ptcloud_loadPointCloud_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, in OutputArrayProxy vertices, in OutputArrayProxy normals, in OutputArrayProxy rgb);
 
-    public static ExceptionStatus ptcloud_loadPointCloud(string filename, IntPtr vertices, IntPtr normals, IntPtr rgb)
+    internal static ExceptionStatus ptcloud_loadPointCloud(string filename, in OutputArrayProxy vertices, in OutputArrayProxy normals, in OutputArrayProxy rgb)
         => IsWindows()
             ? ptcloud_loadPointCloud_Windows(filename, vertices, normals, rgb)
             : ptcloud_loadPointCloud_NotWindows(filename, vertices, normals, rgb);
@@ -30,14 +30,14 @@ static partial class NativeMethods
     // savePointCloud
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_savePointCloud"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_savePointCloud_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+    internal static partial ExceptionStatus ptcloud_savePointCloud_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, in InputArrayProxy vertices, in InputArrayProxy normals, in InputArrayProxy rgb);
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_savePointCloud"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_savePointCloud_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr normals, IntPtr rgb);
+    internal static partial ExceptionStatus ptcloud_savePointCloud_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, in InputArrayProxy vertices, in InputArrayProxy normals, in InputArrayProxy rgb);
 
-    public static ExceptionStatus ptcloud_savePointCloud(string filename, IntPtr vertices, IntPtr normals, IntPtr rgb)
+    internal static ExceptionStatus ptcloud_savePointCloud(string filename, in InputArrayProxy vertices, in InputArrayProxy normals, in InputArrayProxy rgb)
         => IsWindows()
             ? ptcloud_savePointCloud_Windows(filename, vertices, normals, rgb)
             : ptcloud_savePointCloud_NotWindows(filename, vertices, normals, rgb);
@@ -45,14 +45,14 @@ static partial class NativeMethods
     // loadMesh
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_loadMesh"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_loadMesh_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+    internal static partial ExceptionStatus ptcloud_loadMesh_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, in OutputArrayProxy vertices, IntPtr indices, in OutputArrayProxy normals, in OutputArrayProxy colors, in OutputArrayProxy texCoords);
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_loadMesh"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_loadMesh_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+    internal static partial ExceptionStatus ptcloud_loadMesh_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, in OutputArrayProxy vertices, IntPtr indices, in OutputArrayProxy normals, in OutputArrayProxy colors, in OutputArrayProxy texCoords);
 
-    public static ExceptionStatus ptcloud_loadMesh(string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords)
+    internal static ExceptionStatus ptcloud_loadMesh(string filename, in OutputArrayProxy vertices, IntPtr indices, in OutputArrayProxy normals, in OutputArrayProxy colors, in OutputArrayProxy texCoords)
         => IsWindows()
             ? ptcloud_loadMesh_Windows(filename, vertices, indices, normals, colors, texCoords)
             : ptcloud_loadMesh_NotWindows(filename, vertices, indices, normals, colors, texCoords);
@@ -60,14 +60,14 @@ static partial class NativeMethods
     // saveMesh
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_saveMesh"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_saveMesh_NotWindows(
-        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+    internal static partial ExceptionStatus ptcloud_saveMesh_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string filename, in InputArrayProxy vertices, IntPtr indices, in InputArrayProxy normals, in InputArrayProxy colors, in InputArrayProxy texCoords);
 
     [LibraryImport(DllExtern, EntryPoint = "ptcloud_saveMesh"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ptcloud_saveMesh_Windows(
-        [MarshalAs(StringUnmanagedTypeWindows)] string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords);
+    internal static partial ExceptionStatus ptcloud_saveMesh_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string filename, in InputArrayProxy vertices, IntPtr indices, in InputArrayProxy normals, in InputArrayProxy colors, in InputArrayProxy texCoords);
 
-    public static ExceptionStatus ptcloud_saveMesh(string filename, IntPtr vertices, IntPtr indices, IntPtr normals, IntPtr colors, IntPtr texCoords)
+    internal static ExceptionStatus ptcloud_saveMesh(string filename, in InputArrayProxy vertices, IntPtr indices, in InputArrayProxy normals, in InputArrayProxy colors, in InputArrayProxy texCoords)
         => IsWindows()
             ? ptcloud_saveMesh_Windows(filename, vertices, indices, normals, colors, texCoords)
             : ptcloud_saveMesh_NotWindows(filename, vertices, indices, normals, colors, texCoords);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching.cs
@@ -44,11 +44,11 @@ static partial class NativeMethods
     public static partial ExceptionStatus stitching_Stitcher_setWaveCorrectKind(OpenCvSafeHandle obj, int kind);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_estimateTransform_InputArray1(
-        OpenCvSafeHandle obj, IntPtr images, out int returnValue);
+    internal static partial ExceptionStatus stitching_Stitcher_estimateTransform_InputArray1(
+        OpenCvSafeHandle obj, in InputArrayProxy images, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_estimateTransform_InputArray2(
-        OpenCvSafeHandle obj, IntPtr images,
+    internal static partial ExceptionStatus stitching_Stitcher_estimateTransform_InputArray2(
+        OpenCvSafeHandle obj, in InputArrayProxy images,
         IntPtr[] rois, int roisSize1, int[] roisSize2, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -60,34 +60,34 @@ static partial class NativeMethods
         IntPtr[] rois, int roisSize1, int[] roisSize2, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_composePanorama1(
-        OpenCvSafeHandle obj, IntPtr pano, out int returnValue);
+    internal static partial ExceptionStatus stitching_Stitcher_composePanorama1(
+        OpenCvSafeHandle obj, in OutputArrayProxy pano, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_composePanorama2_InputArray(
-        OpenCvSafeHandle obj, IntPtr images, IntPtr pano, out int returnValue);
+    internal static partial ExceptionStatus stitching_Stitcher_composePanorama2_InputArray(
+        OpenCvSafeHandle obj, in InputArrayProxy images, in OutputArrayProxy pano, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_composePanorama2_MatArray(
-        OpenCvSafeHandle obj, IntPtr[] images, int imagesSize, IntPtr pano, out int returnValue);
+    internal static partial ExceptionStatus stitching_Stitcher_composePanorama2_MatArray(
+        OpenCvSafeHandle obj, IntPtr[] images, int imagesSize, in OutputArrayProxy pano, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_stitch1_InputArray(
-        OpenCvSafeHandle obj, IntPtr images, IntPtr pano, out int returnValue);
+    internal static partial ExceptionStatus stitching_Stitcher_stitch1_InputArray(
+        OpenCvSafeHandle obj, in InputArrayProxy images, in OutputArrayProxy pano, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_stitch1_MatArray(
+    internal static partial ExceptionStatus stitching_Stitcher_stitch1_MatArray(
         OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] images, int imagesSize, 
-        IntPtr pano, out int returnValue);
+        in OutputArrayProxy pano, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_stitch2_InputArray(
-        OpenCvSafeHandle obj, IntPtr images,
+    internal static partial ExceptionStatus stitching_Stitcher_stitch2_InputArray(
+        OpenCvSafeHandle obj, in InputArrayProxy images,
         IntPtr[] rois, int roisSize1, int[] roisSize2,
-        IntPtr pano, out int returnValue);
+        in OutputArrayProxy pano, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus stitching_Stitcher_stitch2_MatArray(
+    internal static partial ExceptionStatus stitching_Stitcher_stitch2_MatArray(
         OpenCvSafeHandle obj, IntPtr[] images, int imagesSize,
         IntPtr[] rois, int roisSize1, int[] roisSize2,
-        IntPtr pano, out int returnValue);
+        in OutputArrayProxy pano, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stitching_Stitcher_component(OpenCvSafeHandle obj, IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
@@ -19,11 +19,11 @@ static partial class NativeMethods
         IntPtr[]? masks);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static unsafe partial ExceptionStatus stitching_computeImageFeatures2(
+    internal static unsafe partial ExceptionStatus stitching_computeImageFeatures2(
         IntPtr featuresFinder,
-        IntPtr image,
+        in InputArrayProxy image,
         WImageFeatures* features,
-        IntPtr mask);
+        in InputArrayProxy mask);
 
 
     // FeaturesMatcher

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
@@ -10,60 +10,60 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_CamShift(
-        IntPtr probImage, ref Rect window, TermCriteria criteria, out RotatedRect returnValue);
+    internal static partial ExceptionStatus video_CamShift(
+        in InputArrayProxy probImage, ref Rect window, TermCriteria criteria, out RotatedRect returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_meanShift(
-        IntPtr probImage, ref Rect window, TermCriteria criteria, out int returnValue);
+    internal static partial ExceptionStatus video_meanShift(
+        in InputArrayProxy probImage, ref Rect window, TermCriteria criteria, out int returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_buildOpticalFlowPyramid1(
-        IntPtr img, IntPtr pyramid,
+    internal static partial ExceptionStatus video_buildOpticalFlowPyramid1(
+        in InputArrayProxy img, in OutputArrayProxy pyramid,
         Size winSize, int maxLevel, int withDerivatives,
         int pyrBorder, int derivBorder, int tryReuseInputImage, out int returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_buildOpticalFlowPyramid2(
-        IntPtr img, IntPtr pyramidVec,
+    internal static partial ExceptionStatus video_buildOpticalFlowPyramid2(
+        in InputArrayProxy img, IntPtr pyramidVec,
         Size winSize, int maxLevel, int withDerivatives,
         int pyrBorder, int derivBorder, int tryReuseInputImage, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_calcOpticalFlowPyrLK_InputArray(
-        IntPtr prevImg, IntPtr nextImg,
-        IntPtr prevPts, IntPtr nextPts,
-        IntPtr status, IntPtr err,
+    internal static partial ExceptionStatus video_calcOpticalFlowPyrLK_InputArray(
+        in InputArrayProxy prevImg, in InputArrayProxy nextImg,
+        in InputArrayProxy prevPts, in InputOutputArrayProxy nextPts,
+        in OutputArrayProxy status, in OutputArrayProxy err,
         Size winSize, int maxLevel, TermCriteria criteria,
         int flags, double minEigThreshold);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_calcOpticalFlowPyrLK_vector(
-        IntPtr prevImg, IntPtr nextImg,
+    internal static partial ExceptionStatus video_calcOpticalFlowPyrLK_vector(
+        in InputArrayProxy prevImg, in InputArrayProxy nextImg,
         Point2f[] prevPts, int prevPtsSize,
         IntPtr nextPts, IntPtr status, IntPtr err,
         Size winSize, int maxLevel, TermCriteria criteria,
         int flags, double minEigThreshold);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_calcOpticalFlowFarneback(
-        IntPtr prev, IntPtr next,
-        IntPtr flow, double pyrScale, int levels, int winSize,
+    internal static partial ExceptionStatus video_calcOpticalFlowFarneback(
+        in InputArrayProxy prev, in InputArrayProxy next,
+        in InputOutputArrayProxy flow, double pyrScale, int levels, int winSize,
         int iterations, int polyN, double polySigma, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_computeECC(
-        IntPtr templateImage, IntPtr inputImage, IntPtr inputMask, out double returnValue);
+    internal static partial ExceptionStatus video_computeECC(
+        in InputArrayProxy templateImage, in InputArrayProxy inputImage, in InputArrayProxy inputMask, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_findTransformECC1(
-        IntPtr templateImage, IntPtr inputImage,
-        IntPtr warpMatrix, int motionType, TermCriteria criteria,
-        IntPtr inputMask, int gaussFiltSize, out double returnValue);
+    internal static partial ExceptionStatus video_findTransformECC1(
+        in InputArrayProxy templateImage, in InputArrayProxy inputImage,
+        in InputOutputArrayProxy warpMatrix, int motionType, TermCriteria criteria,
+        in InputArrayProxy inputMask, int gaussFiltSize, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_findTransformECC2(
-        IntPtr templateImage, IntPtr inputImage,
-        IntPtr warpMatrix, int motionType, TermCriteria criteria, 
-        IntPtr inputMask, out double returnValue);
+    internal static partial ExceptionStatus video_findTransformECC2(
+        in InputArrayProxy templateImage, in InputArrayProxy inputImage,
+        in InputOutputArrayProxy warpMatrix, int motionType, TermCriteria criteria, 
+        in InputArrayProxy inputMask, out double returnValue);
 
     #region Kalman filter
 
@@ -137,8 +137,8 @@ static partial class NativeMethods
     // TODO
     /*
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_DenseOpticalFlow_calc(
-        IntPtr obj, IntPtr i0, IntPtr i1, IntPtr flow);
+    internal static partial ExceptionStatus video_DenseOpticalFlow_calc(
+        IntPtr obj, in InputArrayProxy i0, in InputArrayProxy i1, in InputOutputArrayProxy flow);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus video_DenseOpticalFlow_collectGarbage(IntPtr obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc.cs
@@ -13,15 +13,15 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_niBlackThreshold(
-        IntPtr src, IntPtr dst, double maxValue, int type,
+    internal static partial ExceptionStatus ximgproc_niBlackThreshold(
+        in InputArrayProxy src, in OutputArrayProxy dst, double maxValue, int type,
         int blockSize, double k, int binarizationMethod, double r);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_thinning(IntPtr src, IntPtr dst, int thinningType);
+    internal static partial ExceptionStatus ximgproc_thinning(in InputArrayProxy src, in OutputArrayProxy dst, int thinningType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_anisotropicDiffusion(IntPtr src, IntPtr dst, float alpha, float K, int niters);
+    internal static partial ExceptionStatus ximgproc_anisotropicDiffusion(in InputArrayProxy src, in OutputArrayProxy dst, float alpha, float K, int niters);
 
     // brightedges.hpp
 
@@ -32,105 +32,105 @@ static partial class NativeMethods
     // color_match.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createQuaternionImage(IntPtr img, IntPtr qimg);
+    internal static partial ExceptionStatus ximgproc_createQuaternionImage(in InputArrayProxy img, in OutputArrayProxy qimg);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_qconj(IntPtr qimg, IntPtr qcimg);
+    internal static partial ExceptionStatus ximgproc_qconj(in InputArrayProxy qimg, in OutputArrayProxy qcimg);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_qunitary(IntPtr qimg, IntPtr qnimg);
+    internal static partial ExceptionStatus ximgproc_qunitary(in InputArrayProxy qimg, in OutputArrayProxy qnimg);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_qmultiply(IntPtr src1, IntPtr src2, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_qmultiply(in InputArrayProxy src1, in InputArrayProxy src2, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_qdft(IntPtr img, IntPtr qimg, int flags, int sideLeft);
+    internal static partial ExceptionStatus ximgproc_qdft(in InputArrayProxy img, in OutputArrayProxy qimg, int flags, int sideLeft);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_colorMatchTemplate(IntPtr img, IntPtr templ, IntPtr result);
+    internal static partial ExceptionStatus ximgproc_colorMatchTemplate(in InputArrayProxy img, in InputArrayProxy templ, in OutputArrayProxy result);
 
     // deriche_filter.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_GradientDericheY(IntPtr op, IntPtr dst, double alpha, double omega);
+    internal static partial ExceptionStatus ximgproc_GradientDericheY(in InputArrayProxy op, in OutputArrayProxy dst, double alpha, double omega);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_GradientDericheX(IntPtr op, IntPtr dst, double alpha, double omega);
+    internal static partial ExceptionStatus ximgproc_GradientDericheX(in InputArrayProxy op, in OutputArrayProxy dst, double alpha, double omega);
 
     // edgepreserving_filter.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_edgePreservingFilter(IntPtr src, IntPtr dst, int d, double threshold);
+    internal static partial ExceptionStatus ximgproc_edgePreservingFilter(in InputArrayProxy src, in OutputArrayProxy dst, int d, double threshold);
 
     // estimated_covariance
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_covarianceEstimation(
-        IntPtr src, IntPtr dst, int windowRows, int windowCols);
+    internal static partial ExceptionStatus ximgproc_covarianceEstimation(
+        in InputArrayProxy src, in OutputArrayProxy dst, int windowRows, int windowCols);
 
     // fast_hough_transform
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastHoughTransform(
-        IntPtr src, IntPtr dst, MatType dstMatDepth, int angleRange, int op, int makeSkew);
+    internal static partial ExceptionStatus ximgproc_FastHoughTransform(
+        in InputArrayProxy src, in OutputArrayProxy dst, MatType dstMatDepth, int angleRange, int op, int makeSkew);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_HoughPoint2Line(
-        Point houghPoint, IntPtr srcImgInfo, int angleRange, int makeSkew, int rules, out Vec4i returnValue);
+    internal static partial ExceptionStatus ximgproc_HoughPoint2Line(
+        Point houghPoint, in InputArrayProxy srcImgInfo, int angleRange, int makeSkew, int rules, out Vec4i returnValue);
 
     // paillou_filter
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_GradientPaillouY(IntPtr op, IntPtr dst, double alpha, double omega);
+    internal static partial ExceptionStatus ximgproc_GradientPaillouY(in InputArrayProxy op, in OutputArrayProxy dst, double alpha, double omega);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_GradientPaillouX(IntPtr op, IntPtr dst, double alpha, double omega);
+    internal static partial ExceptionStatus ximgproc_GradientPaillouX(in InputArrayProxy op, in OutputArrayProxy dst, double alpha, double omega);
 
     // peilin.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static unsafe partial ExceptionStatus ximgproc_PeiLinNormalization_Mat23d(IntPtr I, double* returnValue);
+    internal static unsafe partial ExceptionStatus ximgproc_PeiLinNormalization_Mat23d(in InputArrayProxy I, double* returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_PeiLinNormalization_OutputArray(IntPtr I, IntPtr T);
+    internal static partial ExceptionStatus ximgproc_PeiLinNormalization_OutputArray(in InputArrayProxy I, in OutputArrayProxy T);
 
     // run_length_morphology.hpp
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_threshold(
-        IntPtr src, IntPtr rlDest, double thresh, int type);
+    internal static partial ExceptionStatus ximgproc_rl_threshold(
+        in InputArrayProxy src, in OutputArrayProxy rlDest, double thresh, int type);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_dilate(
-        IntPtr rlSrc, IntPtr rlDest, IntPtr rlKernel, Point anchor);
+    internal static partial ExceptionStatus ximgproc_rl_dilate(
+        in InputArrayProxy rlSrc, in OutputArrayProxy rlDest, in InputArrayProxy rlKernel, Point anchor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_erode(
-        IntPtr rlSrc, IntPtr rlDest, IntPtr rlKernel, int bBoundaryOn, Point anchor);
+    internal static partial ExceptionStatus ximgproc_rl_erode(
+        in InputArrayProxy rlSrc, in OutputArrayProxy rlDest, in InputArrayProxy rlKernel, int bBoundaryOn, Point anchor);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_rl_getStructuringElement(
         int shape, Size ksize, IntPtr outValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_paint(
-        IntPtr image, IntPtr rlSrc, Scalar value);
+    internal static partial ExceptionStatus ximgproc_rl_paint(
+        in InputOutputArrayProxy image, in InputArrayProxy rlSrc, Scalar value);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_isRLMorphologyPossible(
-        IntPtr rlStructuringElement, out int outValue);
+    internal static partial ExceptionStatus ximgproc_rl_isRLMorphologyPossible(
+        in InputArrayProxy rlStructuringElement, out int outValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_createRLEImage(
-        Point3i[] runs, nint runsLength, IntPtr res, Size size);
+    internal static partial ExceptionStatus ximgproc_rl_createRLEImage(
+        Point3i[] runs, nint runsLength, in OutputArrayProxy res, Size size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rl_morphologyEx(
-        IntPtr rlSrc, IntPtr rlDest, int op, IntPtr rlKernel, int bBoundaryOnForErosion, Point anchor);
+    internal static partial ExceptionStatus ximgproc_rl_morphologyEx(
+        in InputArrayProxy rlSrc, in OutputArrayProxy rlDest, int op, in InputArrayProxy rlKernel, int bBoundaryOnForErosion, Point anchor);
 
     // weighted_median_filter
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_weightedMedianFilter(
-        IntPtr joint, IntPtr src, IntPtr dst, int r, double sigma, int weightType, IntPtr mask);
+    internal static partial ExceptionStatus ximgproc_weightedMedianFilter(
+        in InputArrayProxy joint, in InputArrayProxy src, in OutputArrayProxy dst, int r, double sigma, int weightType, in InputArrayProxy mask);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeBoxes.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeBoxes.cs
@@ -12,8 +12,8 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeBoxes_getBoundingBoxes(
-        OpenCvSafeHandle obj, IntPtr edgeMap, IntPtr orientationMap, IntPtr boxes);
+    internal static partial ExceptionStatus ximgproc_EdgeBoxes_getBoundingBoxes(
+        OpenCvSafeHandle obj, in InputArrayProxy edgeMap, in InputArrayProxy orientationMap, IntPtr boxes);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeBoxes_getAlpha(OpenCvSafeHandle obj, out float returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeDrawing.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeDrawing.cs
@@ -44,13 +44,13 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_createEdgeDrawing(out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEdges(OpenCvSafeHandle obj, IntPtr src);
+    internal static partial ExceptionStatus ximgproc_EdgeDrawing_detectEdges(OpenCvSafeHandle obj, in InputArrayProxy src);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getEdgeImage(OpenCvSafeHandle obj, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_EdgeDrawing_getEdgeImage(OpenCvSafeHandle obj, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_getGradientImage(OpenCvSafeHandle obj, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_EdgeDrawing_getGradientImage(OpenCvSafeHandle obj, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegments(OpenCvSafeHandle obj, IntPtr returnValue);
@@ -59,13 +59,13 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_EdgeDrawing_getSegmentIndicesOfLines(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines(OpenCvSafeHandle obj, IntPtr lines);
+    internal static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines(OpenCvSafeHandle obj, in OutputArrayProxy lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeDrawing_detectLines_vector(OpenCvSafeHandle obj, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses(OpenCvSafeHandle obj, IntPtr ellipses);
+    internal static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses(OpenCvSafeHandle obj, in OutputArrayProxy ellipses);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_EdgeDrawing_detectEllipses_vector(OpenCvSafeHandle obj, IntPtr ellipses);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeFilter.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_EdgeFilter.cs
@@ -22,16 +22,16 @@ static partial class NativeMethods
         IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_DTFilter_filter(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, int dDepth);
+    internal static partial ExceptionStatus ximgproc_DTFilter_filter(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst, int dDepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createDTFilter(
-        IntPtr guide, double sigmaSpatial, double sigmaColor, int mode, int numIters, out IntPtr returnValue);
+    internal static partial ExceptionStatus ximgproc_createDTFilter(
+        in InputArrayProxy guide, double sigmaSpatial, double sigmaColor, int mode, int numIters, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_dtFilter(
-        IntPtr guide, IntPtr src, IntPtr dst, double sigmaSpatial, double sigmaColor, int mode, int numIters);
+    internal static partial ExceptionStatus ximgproc_dtFilter(
+        in InputArrayProxy guide, in InputArrayProxy src, in OutputArrayProxy dst, double sigmaSpatial, double sigmaColor, int mode, int numIters);
         
     //////////////////////////////////////////////////////////////////////////
     // GuidedFilter
@@ -45,16 +45,16 @@ static partial class NativeMethods
         IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_GuidedFilter_filter(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, int dDepth);
+    internal static partial ExceptionStatus ximgproc_GuidedFilter_filter(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst, int dDepth);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createGuidedFilter(
-        IntPtr guide, int radius, double eps, out IntPtr returnValue);
+    internal static partial ExceptionStatus ximgproc_createGuidedFilter(
+        in InputArrayProxy guide, int radius, double eps, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_guidedFilter(
-        IntPtr guide, IntPtr src, IntPtr dst, int radius, double eps, int dDepth);
+    internal static partial ExceptionStatus ximgproc_guidedFilter(
+        in InputArrayProxy guide, in InputArrayProxy src, in OutputArrayProxy dst, int radius, double eps, int dDepth);
 
     //////////////////////////////////////////////////////////////////////////
     // AdaptiveManifoldFilter
@@ -68,8 +68,8 @@ static partial class NativeMethods
         IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_filter(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst, IntPtr joint);
+    internal static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_filter(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst, in InputArrayProxy joint);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_AdaptiveManifoldFilter_collectGarbage(
@@ -116,22 +116,22 @@ static partial class NativeMethods
         double sigma_s, double sigma_r, int adjust_outliers, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_amFilter(
-        IntPtr joint, IntPtr src, IntPtr dst, double sigma_s, double sigma_r, int adjust_outliers);
+    internal static partial ExceptionStatus ximgproc_amFilter(
+        in InputArrayProxy joint, in InputArrayProxy src, in OutputArrayProxy dst, double sigma_s, double sigma_r, int adjust_outliers);
 
     //////////////////////////////////////////////////////////////////////////
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_jointBilateralFilter(
-        IntPtr joint, IntPtr src, IntPtr dst, int d, double sigmaColor, double sigmaSpace, int borderType);
+    internal static partial ExceptionStatus ximgproc_jointBilateralFilter(
+        in InputArrayProxy joint, in InputArrayProxy src, in OutputArrayProxy dst, int d, double sigmaColor, double sigmaSpace, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_bilateralTextureFilter(
-        IntPtr src, IntPtr dst, int fr, int numIter, double sigmaAlpha, double sigmaAvg);
+    internal static partial ExceptionStatus ximgproc_bilateralTextureFilter(
+        in InputArrayProxy src, in OutputArrayProxy dst, int fr, int numIter, double sigmaAlpha, double sigmaAvg);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_rollingGuidanceFilter(
-        IntPtr src, IntPtr dst, int d, double sigmaColor, double sigmaSpace, int numOfIter, int borderType);
+    internal static partial ExceptionStatus ximgproc_rollingGuidanceFilter(
+        in InputArrayProxy src, in OutputArrayProxy dst, int d, double sigmaColor, double sigmaSpace, int numOfIter, int borderType);
         
     //////////////////////////////////////////////////////////////////////////
     // FastBilateralSolverFilter 
@@ -145,17 +145,17 @@ static partial class NativeMethods
         IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastBilateralSolverFilter_filter(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr confidence, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_FastBilateralSolverFilter_filter(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in InputArrayProxy confidence, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createFastBilateralSolverFilter(
-        IntPtr guide, double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, 
+    internal static partial ExceptionStatus ximgproc_createFastBilateralSolverFilter(
+        in InputArrayProxy guide, double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, 
         double max_tol, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_fastBilateralSolverFilter(
-        IntPtr guide, IntPtr src, IntPtr confidence, IntPtr dst,
+    internal static partial ExceptionStatus ximgproc_fastBilateralSolverFilter(
+        in InputArrayProxy guide, in InputArrayProxy src, in InputArrayProxy confidence, in OutputArrayProxy dst,
         double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, double max_tol);
         
     //////////////////////////////////////////////////////////////////////////
@@ -170,19 +170,19 @@ static partial class NativeMethods
         IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastGlobalSmootherFilter_filter(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_FastGlobalSmootherFilter_filter(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createFastGlobalSmootherFilter(
-        IntPtr guide, double lambda, double sigma_color, double lambda_attenuation, int num_iter, out IntPtr returnValue);
+    internal static partial ExceptionStatus ximgproc_createFastGlobalSmootherFilter(
+        in InputArrayProxy guide, double lambda, double sigma_color, double lambda_attenuation, int num_iter, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_fastGlobalSmootherFilter(
-        IntPtr guide, IntPtr src, IntPtr dst, double lambda, double sigma_color, double lambda_attenuation, int num_iter);
+    internal static partial ExceptionStatus ximgproc_fastGlobalSmootherFilter(
+        in InputArrayProxy guide, in InputArrayProxy src, in OutputArrayProxy dst, double lambda, double sigma_color, double lambda_attenuation, int num_iter);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_l0Smooth(IntPtr src, IntPtr dst, double lambda, double kappa);
+    internal static partial ExceptionStatus ximgproc_l0Smooth(in InputArrayProxy src, in OutputArrayProxy dst, double lambda, double kappa);
 
 
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_FastLineDetector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_FastLineDetector.cs
@@ -19,16 +19,16 @@ static partial class NativeMethods
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_OutputArray(OpenCvSafeHandle obj, IntPtr image, IntPtr lines);
+    internal static partial ExceptionStatus ximgproc_FastLineDetector_detect_OutputArray(OpenCvSafeHandle obj, in InputArrayProxy image, in OutputArrayProxy lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_detect_vector(OpenCvSafeHandle obj, IntPtr image, IntPtr lines);
+    internal static partial ExceptionStatus ximgproc_FastLineDetector_detect_vector(OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr lines);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_InputArray(OpenCvSafeHandle obj, IntPtr image, IntPtr lines, int draw_arrow);
+    internal static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_InputArray(OpenCvSafeHandle obj, in InputOutputArrayProxy image, in InputArrayProxy lines, int draw_arrow);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_vector(OpenCvSafeHandle obj, IntPtr image, IntPtr lines, int draw_arrow);
+    internal static partial ExceptionStatus ximgproc_FastLineDetector_drawSegments_vector(OpenCvSafeHandle obj, in InputOutputArrayProxy image, IntPtr lines, int draw_arrow);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createFastLineDetector(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_RidgeDetectionFilter.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_RidgeDetectionFilter.cs
@@ -17,8 +17,8 @@ static partial class NativeMethods
         out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(
-        OpenCvSafeHandle obj, IntPtr _img, IntPtr @out);
+    internal static partial ExceptionStatus ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(
+        OpenCvSafeHandle obj, in InputArrayProxy _img, in OutputArrayProxy @out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_Ptr_RidgeDetectionFilter_delete(IntPtr obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Segmentation.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Segmentation.cs
@@ -23,7 +23,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_segmentation_Ptr_GraphSegmentation_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_processImage(OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_processImage(OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_GraphSegmentation_setSigma(OpenCvSafeHandle obj, double value);
@@ -47,8 +47,8 @@ static partial class NativeMethods
     // SelectiveSearchSegmentationStrategy
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(OpenCvSafeHandle obj,
-        IntPtr img, IntPtr regions, IntPtr sizes, int image_id);
+    internal static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(OpenCvSafeHandle obj,
+        in InputArrayProxy img, in InputArrayProxy regions, in InputArrayProxy sizes, int image_id);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(OpenCvSafeHandle obj, int r1, int r2, out float returnValue);
@@ -131,7 +131,7 @@ static partial class NativeMethods
     // SelectiveSearchSegmentation
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(OpenCvSafeHandle obj, IntPtr img);
+    internal static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(OpenCvSafeHandle obj, in InputArrayProxy img);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(OpenCvSafeHandle obj,
@@ -146,7 +146,7 @@ static partial class NativeMethods
         OpenCvSafeHandle obj, int base_k, int inc_k, float sigma);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addImage(OpenCvSafeHandle obj, IntPtr img);
+    internal static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_addImage(OpenCvSafeHandle obj, in InputArrayProxy img);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_segmentation_SelectiveSearchSegmentation_clearImages(OpenCvSafeHandle obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_StructuredEdgeDetection.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_StructuredEdgeDetection.cs
@@ -42,16 +42,16 @@ static partial class NativeMethods
     public static partial ExceptionStatus ximgproc_Ptr_StructuredEdgeDetection_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_detectEdges(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_StructuredEdgeDetection_detectEdges(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_computeOrientation(
-        OpenCvSafeHandle obj, IntPtr src, IntPtr dst);
+    internal static partial ExceptionStatus ximgproc_StructuredEdgeDetection_computeOrientation(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_StructuredEdgeDetection_edgesNms(
-        OpenCvSafeHandle obj, IntPtr edge_image, IntPtr orientation_image, IntPtr dst,
+    internal static partial ExceptionStatus ximgproc_StructuredEdgeDetection_edgesNms(
+        OpenCvSafeHandle obj, in InputArrayProxy edge_image, in InputArrayProxy orientation_image, in OutputArrayProxy dst,
         int r, int s, float m, int isParallel);
 
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Superpixel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ximgproc/NativeMethods_ximgproc_Superpixel.cs
@@ -30,20 +30,20 @@ static partial class NativeMethods
         OpenCvSafeHandle obj, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabels(
-        OpenCvSafeHandle obj, IntPtr labels_out);
+    internal static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabels(
+        OpenCvSafeHandle obj, in OutputArrayProxy labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabelContourMask(
-        OpenCvSafeHandle obj, IntPtr image, int thick_line);
+    internal static partial ExceptionStatus ximgproc_SuperpixelLSC_getLabelContourMask(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelLSC_enforceLabelConnectivity(
         OpenCvSafeHandle obj, int min_element_size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createSuperpixelLSC(
-        IntPtr image, int region_size, float ratio, out IntPtr returnValue);
+    internal static partial ExceptionStatus ximgproc_createSuperpixelLSC(
+        in InputArrayProxy image, int region_size, float ratio, out IntPtr returnValue);
 
 
     // SuperpixelSEEDS
@@ -61,16 +61,16 @@ static partial class NativeMethods
         OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_iterate(
-        OpenCvSafeHandle obj, IntPtr img, int num_iterations);
+    internal static partial ExceptionStatus ximgproc_SuperpixelSEEDS_iterate(
+        OpenCvSafeHandle obj, in InputArrayProxy img, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabels(
-        OpenCvSafeHandle obj, IntPtr labels_out);
+    internal static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabels(
+        OpenCvSafeHandle obj, in OutputArrayProxy labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabelContourMask(
-        OpenCvSafeHandle obj, IntPtr image, int thick_line);
+    internal static partial ExceptionStatus ximgproc_SuperpixelSEEDS_getLabelContourMask(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_createSuperpixelSEEDS(
@@ -99,20 +99,20 @@ static partial class NativeMethods
         OpenCvSafeHandle obj, int num_iterations);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabels(
-        OpenCvSafeHandle obj, IntPtr labels_out);
+    internal static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabels(
+        OpenCvSafeHandle obj, in OutputArrayProxy labels_out);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabelContourMask(
-        OpenCvSafeHandle obj, IntPtr image, int thick_line);
+    internal static partial ExceptionStatus ximgproc_SuperpixelSLIC_getLabelContourMask(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, int thick_line);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
         OpenCvSafeHandle obj, int min_element_size);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus ximgproc_createSuperpixelSLIC(
-        IntPtr image, int algorithm, int region_size, float ruler, out IntPtr returnValue);
+    internal static partial ExceptionStatus ximgproc_createSuperpixelSLIC(
+        in InputArrayProxy image, int algorithm, int region_size, float ruler, out IntPtr returnValue);
 
 
 

--- a/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
@@ -51,7 +51,7 @@ public class ArucoDetector : CvObject
 
         NativeMethods.HandleException(
             NativeMethods.aruco_ArucoDetector_detectMarkers(
-                Handle, image.CvPtr, cornersVec.CvPtr, idsVec.CvPtr, rejectedVec.CvPtr));
+                Handle, image.ToInputProxy(), cornersVec.CvPtr, idsVec.CvPtr, rejectedVec.CvPtr));
 
         corners = cornersVec.ToArray();
         ids = idsVec.ToArray();

--- a/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
@@ -107,7 +107,7 @@ public class CharucoBoard : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.aruco_CharucoBoard_generateImage(Handle, outSize, img.CvPtr, marginSize, borderBits));
+            NativeMethods.aruco_CharucoBoard_generateImage(Handle, outSize, img.ToOutputProxy(), marginSize, borderBits));
         img.Fix();
     }
 
@@ -122,7 +122,7 @@ public class CharucoBoard : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.aruco_CharucoBoard_checkCharucoCornersCollinear(Handle, charucoIds.CvPtr, out var ret));
+            NativeMethods.aruco_CharucoBoard_checkCharucoCornersCollinear(Handle, charucoIds.ToInputProxy(), out var ret));
         GC.KeepAlive(charucoIds);
         return ret != 0;
     }

--- a/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
@@ -41,8 +41,8 @@ public class CharucoDetector : CvObject
         NativeMethods.HandleException(
             NativeMethods.aruco_CharucoDetector_create(
                 board.CvPtr,
-                cameraMatrix?.CvPtr ?? IntPtr.Zero,
-                distCoeffs?.CvPtr ?? IntPtr.Zero,
+                cameraMatrix?.ToInputProxy() ?? default,
+                distCoeffs?.ToInputProxy() ?? default,
                 minMarkers, tryRefineMarkers, checkMarkers,
                 ref dp, ref rp,
                 out var ptr));
@@ -76,7 +76,7 @@ public class CharucoDetector : CvObject
 
         NativeMethods.HandleException(
             NativeMethods.aruco_CharucoDetector_detectBoard(
-                Handle, image.CvPtr,
+                Handle, image.ToInputProxy(),
                 charucoCornersVec.CvPtr, charucoIdsVec.CvPtr,
                 markerCornersVec.CvPtr, markerIdsVec.CvPtr));
 
@@ -109,7 +109,7 @@ public class CharucoDetector : CvObject
 
         NativeMethods.HandleException(
             NativeMethods.aruco_CharucoDetector_detectDiamonds(
-                Handle, image.CvPtr,
+                Handle, image.ToInputProxy(),
                 diamondCornersVec.CvPtr, diamondIdsVec.CvPtr,
                 markerCornersVec.CvPtr, markerIdsVec.CvPtr));
 

--- a/src/OpenCvSharp/Modules/aruco/Cv2.Aruco.cs
+++ b/src/OpenCvSharp/Modules/aruco/Cv2.Aruco.cs
@@ -19,7 +19,7 @@ public static partial class Cv2
         /// <param name="corners">positions of marker corners on input image.
         /// For N detected markers, the dimensions of this array should be Nx4.The order of the corners should be clockwise.</param>
         /// <param name="ids">vector of identifiers for markers in markersCorners. Optional, if not provided, ids are not painted.</param>
-        public static void DrawDetectedMarkers(InputArray image, Point2f[][] corners, IEnumerable<int> ids)
+        public static void DrawDetectedMarkers(InputOutputArray image, Point2f[][] corners, IEnumerable<int> ids)
         {
             DrawDetectedMarkers(image, corners, ids, new Scalar(0, 255, 0));
         }
@@ -33,7 +33,7 @@ public static partial class Cv2
         /// <param name="ids">vector of identifiers for markers in markersCorners. Optional, if not provided, ids are not painted.</param>
         /// <param name="borderColor">color of marker borders. Rest of colors (text color and first corner color)
         ///  are calculated based on this one to improve visualization.</param>
-        public static void DrawDetectedMarkers(InputArray image, Point2f[][] corners, IEnumerable<int>? ids, Scalar borderColor)
+        public static void DrawDetectedMarkers(InputOutputArray image, Point2f[][] corners, IEnumerable<int>? ids, Scalar borderColor)
         {
             if (image is null)
                 throw new ArgumentNullException(nameof(image));
@@ -45,7 +45,7 @@ public static partial class Cv2
             {
                 NativeMethods.HandleException(
                     NativeMethods.aruco_drawDetectedMarkers(
-                        image.CvPtr, cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
+                        image.ToInputOutputProxy(), cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
                         IntPtr.Zero, 0, borderColor));
             }
             else
@@ -53,7 +53,7 @@ public static partial class Cv2
                 var idxArray = ids.ToArray();
                 NativeMethods.HandleException(
                     NativeMethods.aruco_drawDetectedMarkers(
-                        image.CvPtr, cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
+                        image.ToInputOutputProxy(), cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
                         idxArray, idxArray.Length, borderColor));
             }
             GC.KeepAlive(image);
@@ -100,7 +100,7 @@ public static partial class Cv2
         /// <param name="image">input/output image. It must have 1 or 3 channels. The number of channels is not altered.</param>
         /// <param name="diamondCorners">positions of diamond corners in the same format returned by detectCharucoDiamond(). (e.g std::vector&lt;std::vector&lt;cv::Point2f&gt;&gt;). For N detected markers, the dimensions of this array should be Nx4. The order of the corners should be clockwise.</param>
         /// <param name="diamondIds">vector of identifiers for diamonds in diamondCorners, in the same format returned by detectCharucoDiamond() (e.g. std::vector&lt;Vec4i&gt;). Optional, if not provided, ids are not painted.</param>
-        public static void DrawDetectedDiamonds(InputArray image, Point2f[][] diamondCorners, IEnumerable<Vec4i>? diamondIds = null)
+        public static void DrawDetectedDiamonds(InputOutputArray image, Point2f[][] diamondCorners, IEnumerable<Vec4i>? diamondIds = null)
         {
             DrawDetectedDiamonds(image, diamondCorners, diamondIds, new Scalar(0, 0, 255));
         }
@@ -112,7 +112,7 @@ public static partial class Cv2
         /// <param name="diamondCorners">positions of diamond corners in the same format returned by detectCharucoDiamond(). (e.g std::vector&lt;std::vector&lt;cv::Point2f&gt;&gt;). For N detected markers, the dimensions of this array should be Nx4. The order of the corners should be clockwise.</param>
         /// <param name="diamondIds">vector of identifiers for diamonds in diamondCorners, in the same format returned by detectCharucoDiamond() (e.g. std::vector&lt;Vec4i&gt;). Optional, if not provided, ids are not painted.</param>
         /// <param name="borderColor">color of marker borders. Rest of colors (text color and first corner color) are calculated based on this one.</param>
-        public static void DrawDetectedDiamonds(InputArray image,
+        public static void DrawDetectedDiamonds(InputOutputArray image,
             Point2f[][] diamondCorners, IEnumerable<Vec4i>? diamondIds, Scalar borderColor)
         {
             if (image is null)
@@ -125,7 +125,7 @@ public static partial class Cv2
             if (diamondIds is null)
             {
                 NativeMethods.HandleException(
-                    NativeMethods.aruco_drawDetectedDiamonds(image.CvPtr,
+                    NativeMethods.aruco_drawDetectedDiamonds(image.ToInputOutputProxy(),
                         cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
                         IntPtr.Zero, borderColor));
             }
@@ -134,7 +134,7 @@ public static partial class Cv2
                 using var ids = new StdVector<Vec4i>(diamondIds);
 
                 NativeMethods.HandleException(
-                    NativeMethods.aruco_drawDetectedDiamonds(image.CvPtr,
+                    NativeMethods.aruco_drawDetectedDiamonds(image.ToInputOutputProxy(),
                         cornersAddress.GetPointer(), cornersAddress.GetDim1Length(), cornersAddress.GetDim2Lengths(),
                         ids.CvPtr, borderColor));
             }
@@ -148,7 +148,7 @@ public static partial class Cv2
         /// <param name="image">input/output image. It must have 1 or 3 channels. The number of channels is not altered.</param>
         /// <param name="charucoCorners">vector of detected charuco corners.</param>
         /// <param name="charucoIds">list of identifiers for each corner in charucoCorners.</param>
-        public static void DrawDetectedCornersCharuco(InputArray image, Point2f[] charucoCorners, IEnumerable<int>? charucoIds = null)
+        public static void DrawDetectedCornersCharuco(InputOutputArray image, Point2f[] charucoCorners, IEnumerable<int>? charucoIds = null)
         {
             DrawDetectedCornersCharuco(image, charucoCorners, charucoIds, new Scalar(0, 0, 255));
         }
@@ -160,7 +160,7 @@ public static partial class Cv2
         /// <param name="charucoCorners">vector of detected charuco corners.</param>
         /// <param name="charucoIds">list of identifiers for each corner in charucoCorners.</param>
         /// <param name="cornerColor">color of the square surrounding each corner.</param>
-        public static void DrawDetectedCornersCharuco(InputArray image,
+        public static void DrawDetectedCornersCharuco(InputOutputArray image,
             Point2f[] charucoCorners, IEnumerable<int>? charucoIds, Scalar cornerColor)
         {
             if (image is null)
@@ -173,7 +173,7 @@ public static partial class Cv2
             if (charucoIds is null)
             {
                 NativeMethods.HandleException(
-                    NativeMethods.aruco_drawDetectedCornersCharuco(image.CvPtr,
+                    NativeMethods.aruco_drawDetectedCornersCharuco(image.ToInputOutputProxy(),
                         charucoCornersVec.CvPtr, IntPtr.Zero, cornerColor));
             }
             else
@@ -181,7 +181,7 @@ public static partial class Cv2
                 using var ids = new StdVector<int>(charucoIds);
 
                 NativeMethods.HandleException(
-                    NativeMethods.aruco_drawDetectedCornersCharuco(image.CvPtr,
+                    NativeMethods.aruco_drawDetectedCornersCharuco(image.ToInputOutputProxy(),
                         charucoCornersVec.CvPtr, ids.CvPtr, cornerColor));
             }
 

--- a/src/OpenCvSharp/Modules/aruco/Dictionary.cs
+++ b/src/OpenCvSharp/Modules/aruco/Dictionary.cs
@@ -125,7 +125,7 @@ public class Dictionary : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.aruco_Dictionary_getDistanceToId(Handle, bits.CvPtr, id, allRotations ? 1 : 0, out var ret));
+            NativeMethods.aruco_Dictionary_getDistanceToId(Handle, bits.ToInputProxy(), id, allRotations ? 1 : 0, out var ret));
         
         return ret;
     }
@@ -145,7 +145,7 @@ public class Dictionary : CvObject
         ThrowIfDisposed();
         
         NativeMethods.HandleException(
-            NativeMethods.aruco_Dictionary_generateImageMarker(Handle, id, sidePixels, img.CvPtr, borderBits));
+            NativeMethods.aruco_Dictionary_generateImageMarker(Handle, id, sidePixels, img.ToOutputProxy(), borderBits));
         
     }
     

--- a/src/OpenCvSharp/Modules/features/ANNIndex.cs
+++ b/src/OpenCvSharp/Modules/features/ANNIndex.cs
@@ -41,7 +41,7 @@ public class ANNIndex : CvPtrObject
             throw new ArgumentNullException(nameof(features));
         features.ThrowIfDisposed();
 
-        NativeMethods.HandleException(NativeMethods.features_ANNIndex_addItems(Handle, features.CvPtr));
+        NativeMethods.HandleException(NativeMethods.features_ANNIndex_addItems(Handle, features.ToInputProxy()));
         GC.KeepAlive(features);
     }
 
@@ -77,7 +77,7 @@ public class ANNIndex : CvPtrObject
         dists.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.features_ANNIndex_knnSearch(Handle, query.CvPtr, indices.CvPtr, dists.CvPtr, knn, searchK));
+            NativeMethods.features_ANNIndex_knnSearch(Handle, query.ToInputProxy(), indices.ToOutputProxy(), dists.ToOutputProxy(), knn, searchK));
         GC.KeepAlive(query);
         indices.Fix();
         dists.Fix();

--- a/src/OpenCvSharp/Modules/features/Feature2D.cs
+++ b/src/OpenCvSharp/Modules/features/Feature2D.cs
@@ -116,7 +116,7 @@ public class Feature2D : Algorithm
     /// <param name="mask">Mask specifying where to look for keypoints (optional). 
     /// Must be a char matrix with non-zero values in the region of interest.</param>
     /// <returns>The detected keypoints.</returns>
-    public KeyPoint[] Detect(InputArray image, Mat? mask = null)
+    public KeyPoint[] Detect(InputArray image, InputArray? mask = null)
     {
         if (image is null)
             throw new ArgumentNullException(nameof(image));
@@ -127,7 +127,7 @@ public class Feature2D : Algorithm
         {
             using var keypoints = new StdVector<KeyPoint>();
             NativeMethods.HandleException(
-                NativeMethods.features_Feature2D_detect_InputArray(Handle, image.CvPtr, keypoints.CvPtr, Cv2.ToPtr(mask)));
+                NativeMethods.features_Feature2D_detect_InputArray(Handle, image.ToInputProxy(), keypoints.CvPtr, mask?.ToInputProxy() ?? default));
             return keypoints.ToArray();
         }
         finally
@@ -188,7 +188,7 @@ public class Feature2D : Algorithm
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
-        NativeMethods.features_Feature2D_compute1(Handle, image.CvPtr, keypointsVec.CvPtr, descriptors.CvPtr));
+        NativeMethods.features_Feature2D_compute1(Handle, image.ToInputProxy(), keypointsVec.CvPtr, descriptors.ToOutputProxy()));
         keypoints = keypointsVec.ToArray();
 
         GC.KeepAlive(image);
@@ -251,9 +251,7 @@ public class Feature2D : Algorithm
         using var keypointsVec = new StdVector<KeyPoint>();
 
         NativeMethods.HandleException(
-            NativeMethods.features_Feature2D_detectAndCompute(
-                Handle, image.CvPtr, Cv2.ToPtr(mask), keypointsVec.CvPtr, descriptors.CvPtr,
-                useProvidedKeypoints ? 1 : 0));
+            NativeMethods.features_Feature2D_detectAndCompute(Handle, image.ToInputProxy(), mask?.ToInputProxy() ?? default, keypointsVec.CvPtr, descriptors.ToOutputProxy(), useProvidedKeypoints ? 1 : 0));
         keypoints = keypointsVec.ToArray();
 
         GC.KeepAlive(image);

--- a/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
@@ -74,7 +74,7 @@ public class LightGlueMatcher : DescriptorMatcher
         trainKpts.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.features_LightGlueMatcher_setPairInfo(Handle, queryKpts.CvPtr, trainKpts.CvPtr, queryImageSize, trainImageSize));
+            NativeMethods.features_LightGlueMatcher_setPairInfo(Handle, queryKpts.ToInputProxy(), trainKpts.ToInputProxy(), queryImageSize, trainImageSize));
         GC.KeepAlive(queryKpts);
         GC.KeepAlive(trainKpts);
     }

--- a/src/OpenCvSharp/Modules/features/MSER.cs
+++ b/src/OpenCvSharp/Modules/features/MSER.cs
@@ -153,8 +153,7 @@ public class MSER : Feature2D
         using (var bboxesVec = new StdVector<Rect>())
         {
             NativeMethods.HandleException(
-                NativeMethods.features_MSER_detectRegions(
-                    Handle, image.CvPtr, msersVec.CvPtr, bboxesVec.CvPtr));
+                NativeMethods.features_MSER_detectRegions(Handle, image.ToInputProxy(), msersVec.CvPtr, bboxesVec.CvPtr));
             msers = msersVec.ToArray();
             bboxes = bboxesVec.ToArray();
         }

--- a/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
+++ b/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
@@ -291,7 +291,7 @@ public class ANN_MLP : StatModel
             throw new ArgumentNullException(nameof(layerSizes));
 
         NativeMethods.HandleException(
-            NativeMethods.ml_ANN_MLP_setLayerSizes(Handle, layerSizes.CvPtr));
+            NativeMethods.ml_ANN_MLP_setLayerSizes(Handle, layerSizes.ToInputProxy()));
 
         GC.KeepAlive(layerSizes);
     }

--- a/src/OpenCvSharp/Modules/ml/EM.cs
+++ b/src/OpenCvSharp/Modules/ml/EM.cs
@@ -214,10 +214,10 @@ public class EM : Algorithm
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainEM(
                 Handle,
-                samples.CvPtr,
-                Cv2.ToPtr(logLikelihoods),
-                Cv2.ToPtr(labels),
-                Cv2.ToPtr(probs),
+                samples.ToInputProxy(),
+                logLikelihoods?.ToOutputProxy() ?? default,
+                labels?.ToOutputProxy() ?? default,
+                probs?.ToOutputProxy() ?? default,
                 out var ret));
 
         logLikelihoods?.Fix();
@@ -277,13 +277,13 @@ public class EM : Algorithm
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainE(
                 Handle,
-                samples.CvPtr,
-                means0.CvPtr,
-                Cv2.ToPtr(covs0),
-                Cv2.ToPtr(weights0),
-                Cv2.ToPtr(logLikelihoods),
-                Cv2.ToPtr(labels),
-                Cv2.ToPtr(probs),
+                samples.ToInputProxy(),
+                means0.ToInputProxy(),
+                covs0?.ToInputProxy() ?? default,
+                weights0?.ToInputProxy() ?? default,
+                logLikelihoods?.ToOutputProxy() ?? default,
+                labels?.ToOutputProxy() ?? default,
+                probs?.ToOutputProxy() ?? default,
                 out var ret));
 
         logLikelihoods?.Fix();
@@ -335,11 +335,11 @@ public class EM : Algorithm
         NativeMethods.HandleException(
             NativeMethods.ml_EM_trainM(
                 Handle,
-                samples.CvPtr,
-                probs0.CvPtr,
-                Cv2.ToPtr(logLikelihoods),
-                Cv2.ToPtr(labels),
-                Cv2.ToPtr(probs), 
+                samples.ToInputProxy(),
+                probs0.ToInputProxy(),
+                logLikelihoods?.ToOutputProxy() ?? default,
+                labels?.ToOutputProxy() ?? default,
+                probs?.ToOutputProxy() ?? default, 
                 out var ret));
 
         logLikelihoods?.Fix();
@@ -370,7 +370,7 @@ public class EM : Algorithm
         probs?.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_EM_predict2(Handle, sample.CvPtr, Cv2.ToPtr(probs), out var ret));
+            NativeMethods.ml_EM_predict2(Handle, sample.ToInputProxy(), probs?.ToOutputProxy() ?? default, out var ret));
         probs?.Fix();
         GC.KeepAlive(sample);
         GC.KeepAlive(probs);

--- a/src/OpenCvSharp/Modules/ml/KNearest.cs
+++ b/src/OpenCvSharp/Modules/ml/KNearest.cs
@@ -166,8 +166,8 @@ public class KNearest : StatModel
         NativeMethods.HandleException(
             NativeMethods.ml_KNearest_findNearest(
                 Handle,
-                samples.CvPtr, k, results.CvPtr,
-                Cv2.ToPtr(neighborResponses), Cv2.ToPtr(dist), out var ret));
+                samples.ToInputProxy(), k, results.ToOutputProxy(),
+                neighborResponses?.ToOutputProxy() ?? default, dist?.ToOutputProxy() ?? default, out var ret));
 
         GC.KeepAlive(samples);
         GC.KeepAlive(results);

--- a/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
+++ b/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
@@ -193,7 +193,7 @@ public class LogisticRegression : StatModel
         results?.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_LogisticRegression_predict(Handle, samples.CvPtr, Cv2.ToPtr(results), flags, out var ret));
+            NativeMethods.ml_LogisticRegression_predict(Handle, samples.ToInputProxy(), results?.ToOutputProxy() ?? default, flags, out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(results);
         results?.Fix();

--- a/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
+++ b/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
@@ -87,7 +87,7 @@ public class NormalBayesClassifier : StatModel
 
         NativeMethods.HandleException(
             NativeMethods.ml_NormalBayesClassifier_predictProb(
-                Handle, inputs.CvPtr, outputs.CvPtr, outputProbs.CvPtr, flags, out var ret));
+                Handle, inputs.ToInputProxy(), outputs.ToOutputProxy(), outputProbs.ToOutputProxy(), flags, out var ret));
         outputs.Fix();
         outputProbs.Fix();
         GC.KeepAlive(inputs);

--- a/src/OpenCvSharp/Modules/ml/SVM.cs
+++ b/src/OpenCvSharp/Modules/ml/SVM.cs
@@ -349,7 +349,7 @@ public class SVM : StatModel
         svidx.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_SVM_getDecisionFunction(Handle, i, alpha.CvPtr, svidx.CvPtr, out var ret));
+            NativeMethods.ml_SVM_getDecisionFunction(Handle, i, alpha.ToOutputProxy(), svidx.ToOutputProxy(), out var ret));
 
         alpha.Fix();
         svidx.Fix();

--- a/src/OpenCvSharp/Modules/ml/StatModel.cs
+++ b/src/OpenCvSharp/Modules/ml/StatModel.cs
@@ -91,7 +91,7 @@ public abstract class StatModel : Algorithm
         responses.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ml_StatModel_train2(Handle, samples.CvPtr, (int)layout, responses.CvPtr, out var ret));
+            NativeMethods.ml_StatModel_train2(Handle, samples.ToInputProxy(), (int)layout, responses.ToInputProxy(), out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(responses);
         return ret != 0;
@@ -131,7 +131,7 @@ public abstract class StatModel : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ml_StatModel_predict(
-                Handle, samples.CvPtr, Cv2.ToPtr(results), (int) flags, out var ret));
+                Handle, samples.ToInputProxy(), results?.ToOutputProxy() ?? default, (int) flags, out var ret));
         GC.KeepAlive(samples);
         GC.KeepAlive(results);
         results?.Fix();

--- a/src/OpenCvSharp/Modules/ptcloud/Odometry.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/Odometry.cs
@@ -129,7 +129,7 @@ public class Odometry : CvObject
         dstFrame.ThrowIfDisposed();
         Rt.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Odometry_compute_Frame(Handle, srcFrame.CvPtr, dstFrame.CvPtr, Rt.CvPtr, out var ret));
+            NativeMethods.ptcloud_Odometry_compute_Frame(Handle, srcFrame.CvPtr, dstFrame.CvPtr, Rt.ToOutputProxy(), out var ret));
         Rt.Fix();
         GC.KeepAlive(srcFrame);
         GC.KeepAlive(dstFrame);
@@ -156,7 +156,7 @@ public class Odometry : CvObject
         dstDepth.ThrowIfDisposed();
         Rt.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Odometry_compute_Depth(Handle, srcDepth.CvPtr, dstDepth.CvPtr, Rt.CvPtr, out var ret));
+            NativeMethods.ptcloud_Odometry_compute_Depth(Handle, srcDepth.ToInputProxy(), dstDepth.ToInputProxy(), Rt.ToOutputProxy(), out var ret));
         Rt.Fix();
         GC.KeepAlive(srcDepth);
         GC.KeepAlive(dstDepth);
@@ -191,7 +191,7 @@ public class Odometry : CvObject
         dstRGB.ThrowIfDisposed();
         Rt.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Odometry_compute_DepthRGB(Handle, srcDepth.CvPtr, srcRGB.CvPtr, dstDepth.CvPtr, dstRGB.CvPtr, Rt.CvPtr, out var ret));
+            NativeMethods.ptcloud_Odometry_compute_DepthRGB(Handle, srcDepth.ToInputProxy(), srcRGB.ToInputProxy(), dstDepth.ToInputProxy(), dstRGB.ToInputProxy(), Rt.ToOutputProxy(), out var ret));
         Rt.Fix();
         GC.KeepAlive(srcDepth);
         GC.KeepAlive(srcRGB);

--- a/src/OpenCvSharp/Modules/ptcloud/OdometryFrame.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/OdometryFrame.cs
@@ -28,10 +28,10 @@ public class OdometryFrame : CvObject
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_OdometryFrame_new(
-                depth?.CvPtr ?? IntPtr.Zero,
-                image?.CvPtr ?? IntPtr.Zero,
-                mask?.CvPtr ?? IntPtr.Zero,
-                normals?.CvPtr ?? IntPtr.Zero,
+                depth?.ToInputProxy() ?? default,
+                image?.ToInputProxy() ?? default,
+                mask?.ToInputProxy() ?? default,
+                normals?.ToInputProxy() ?? default,
                 out var p));
         if (p == IntPtr.Zero)
             throw new OpenCvSharpException($"Failed to create {nameof(OdometryFrame)}");
@@ -71,7 +71,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(image));
         image.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getImage(Handle, image.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getImage(Handle, image.ToOutputProxy()));
         image.Fix();
     }
 
@@ -85,7 +85,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(image));
         image.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getGrayImage(Handle, image.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getGrayImage(Handle, image.ToOutputProxy()));
         image.Fix();
     }
 
@@ -99,7 +99,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(depth));
         depth.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getDepth(Handle, depth.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getDepth(Handle, depth.ToOutputProxy()));
         depth.Fix();
     }
 
@@ -113,7 +113,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(depth));
         depth.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getProcessedDepth(Handle, depth.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getProcessedDepth(Handle, depth.ToOutputProxy()));
         depth.Fix();
     }
 
@@ -127,7 +127,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(mask));
         mask.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getMask(Handle, mask.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getMask(Handle, mask.ToOutputProxy()));
         mask.Fix();
     }
 
@@ -141,7 +141,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(normals));
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getNormals(Handle, normals.CvPtr));
+            NativeMethods.ptcloud_OdometryFrame_getNormals(Handle, normals.ToOutputProxy()));
         normals.Fix();
     }
 
@@ -169,7 +169,7 @@ public class OdometryFrame : CvObject
             throw new ArgumentNullException(nameof(img));
         img.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometryFrame_getPyramidAt(Handle, img.CvPtr, (int)pyrType, new IntPtr(level)));
+            NativeMethods.ptcloud_OdometryFrame_getPyramidAt(Handle, img.ToOutputProxy(), (int)pyrType, new IntPtr(level)));
         img.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/ptcloud/OdometrySettings.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/OdometrySettings.cs
@@ -52,7 +52,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_setCameraMatrix(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_setCameraMatrix(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -66,7 +66,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_getCameraMatrix(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_getCameraMatrix(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -80,7 +80,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_setIterCounts(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_setIterCounts(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -94,7 +94,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_getIterCounts(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_getIterCounts(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -108,7 +108,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_setMinGradientMagnitudes(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_setMinGradientMagnitudes(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -122,7 +122,7 @@ public class OdometrySettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_OdometrySettings_getMinGradientMagnitudes(Handle, val.CvPtr));
+            NativeMethods.ptcloud_OdometrySettings_getMinGradientMagnitudes(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/ptcloud/RgbdNormals.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/RgbdNormals.cs
@@ -51,7 +51,7 @@ public class RgbdNormals : CvPtrObject
         K?.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ptcloud_RgbdNormals_create(
-                rows, cols, depth, K?.CvPtr ?? IntPtr.Zero, windowSize, diffThreshold, (int)method, out var p));
+                rows, cols, depth, K?.ToInputProxy() ?? default, windowSize, diffThreshold, (int)method, out var p));
         GC.KeepAlive(K);
         return new RgbdNormals(p);
     }
@@ -83,7 +83,7 @@ public class RgbdNormals : CvPtrObject
         points.ThrowIfDisposed();
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_RgbdNormals_apply(Handle, points.CvPtr, normals.CvPtr));
+            NativeMethods.ptcloud_RgbdNormals_apply(Handle, points.ToInputProxy(), normals.ToOutputProxy()));
         normals.Fix();
         GC.KeepAlive(points);
     }
@@ -184,7 +184,7 @@ public class RgbdNormals : CvPtrObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_RgbdNormals_getK(Handle, val.CvPtr));
+            NativeMethods.ptcloud_RgbdNormals_getK(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -199,7 +199,7 @@ public class RgbdNormals : CvPtrObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_RgbdNormals_setK(Handle, val.CvPtr));
+            NativeMethods.ptcloud_RgbdNormals_setK(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 

--- a/src/OpenCvSharp/Modules/ptcloud/Volume.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/Volume.cs
@@ -76,7 +76,7 @@ public class Volume : CvObject
         frame.ThrowIfDisposed();
         pose.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_integrateFrame(Handle, frame.CvPtr, pose.CvPtr));
+            NativeMethods.ptcloud_Volume_integrateFrame(Handle, frame.CvPtr, pose.ToInputProxy()));
         GC.KeepAlive(frame);
         GC.KeepAlive(pose);
     }
@@ -96,7 +96,7 @@ public class Volume : CvObject
         depth.ThrowIfDisposed();
         pose.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_integrate(Handle, depth.CvPtr, pose.CvPtr));
+            NativeMethods.ptcloud_Volume_integrate(Handle, depth.ToInputProxy(), pose.ToInputProxy()));
         GC.KeepAlive(depth);
         GC.KeepAlive(pose);
     }
@@ -120,7 +120,7 @@ public class Volume : CvObject
         image.ThrowIfDisposed();
         pose.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_integrateColor(Handle, depth.CvPtr, image.CvPtr, pose.CvPtr));
+            NativeMethods.ptcloud_Volume_integrateColor(Handle, depth.ToInputProxy(), image.ToInputProxy(), pose.ToInputProxy()));
         GC.KeepAlive(depth);
         GC.KeepAlive(image);
         GC.KeepAlive(pose);
@@ -149,7 +149,7 @@ public class Volume : CvObject
         points.ThrowIfNotReady();
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_raycast(Handle, cameraPose.CvPtr, points.CvPtr, normals.CvPtr));
+            NativeMethods.ptcloud_Volume_raycast(Handle, cameraPose.ToInputProxy(), points.ToOutputProxy(), normals.ToOutputProxy()));
         points.Fix();
         normals.Fix();
         GC.KeepAlive(cameraPose);
@@ -178,7 +178,7 @@ public class Volume : CvObject
         normals.ThrowIfNotReady();
         colors.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_raycastColor(Handle, cameraPose.CvPtr, points.CvPtr, normals.CvPtr, colors.CvPtr));
+            NativeMethods.ptcloud_Volume_raycastColor(Handle, cameraPose.ToInputProxy(), points.ToOutputProxy(), normals.ToOutputProxy(), colors.ToOutputProxy()));
         points.Fix();
         normals.Fix();
         colors.Fix();
@@ -210,7 +210,7 @@ public class Volume : CvObject
         points.ThrowIfNotReady();
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_raycastEx(Handle, cameraPose.CvPtr, height, width, K.CvPtr, points.CvPtr, normals.CvPtr));
+            NativeMethods.ptcloud_Volume_raycastEx(Handle, cameraPose.ToInputProxy(), height, width, K.ToInputProxy(), points.ToOutputProxy(), normals.ToOutputProxy()));
         points.Fix();
         normals.Fix();
         GC.KeepAlive(cameraPose);
@@ -246,7 +246,7 @@ public class Volume : CvObject
         normals.ThrowIfNotReady();
         colors.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_raycastExColor(Handle, cameraPose.CvPtr, height, width, K.CvPtr, points.CvPtr, normals.CvPtr, colors.CvPtr));
+            NativeMethods.ptcloud_Volume_raycastExColor(Handle, cameraPose.ToInputProxy(), height, width, K.ToInputProxy(), points.ToOutputProxy(), normals.ToOutputProxy(), colors.ToOutputProxy()));
         points.Fix();
         normals.Fix();
         colors.Fix();
@@ -273,7 +273,7 @@ public class Volume : CvObject
         points.ThrowIfDisposed();
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_fetchNormals(Handle, points.CvPtr, normals.CvPtr));
+            NativeMethods.ptcloud_Volume_fetchNormals(Handle, points.ToInputProxy(), normals.ToOutputProxy()));
         normals.Fix();
         GC.KeepAlive(points);
     }
@@ -293,7 +293,7 @@ public class Volume : CvObject
         points.ThrowIfNotReady();
         normals.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_fetchPointsNormals(Handle, points.CvPtr, normals.CvPtr));
+            NativeMethods.ptcloud_Volume_fetchPointsNormals(Handle, points.ToOutputProxy(), normals.ToOutputProxy()));
         points.Fix();
         normals.Fix();
     }
@@ -317,7 +317,7 @@ public class Volume : CvObject
         normals.ThrowIfNotReady();
         colors.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_fetchPointsNormalsColors(Handle, points.CvPtr, normals.CvPtr, colors.CvPtr));
+            NativeMethods.ptcloud_Volume_fetchPointsNormalsColors(Handle, points.ToOutputProxy(), normals.ToOutputProxy(), colors.ToOutputProxy()));
         points.Fix();
         normals.Fix();
         colors.Fix();
@@ -371,7 +371,7 @@ public class Volume : CvObject
             throw new ArgumentNullException(nameof(bb));
         bb.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_Volume_getBoundingBox(Handle, bb.CvPtr, (int)precision));
+            NativeMethods.ptcloud_Volume_getBoundingBox(Handle, bb.ToOutputProxy(), (int)precision));
         bb.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/ptcloud/VolumeSettings.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/VolumeSettings.cs
@@ -258,7 +258,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_setVolumePose(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_setVolumePose(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -273,7 +273,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_getVolumePose(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_getVolumePose(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -288,7 +288,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_setVolumeResolution(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_setVolumeResolution(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -303,7 +303,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_getVolumeResolution(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_getVolumeResolution(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -318,7 +318,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_getVolumeStrides(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_getVolumeStrides(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -333,7 +333,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -348,7 +348,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 
@@ -363,7 +363,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_setCameraRaycastIntrinsics(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_setCameraRaycastIntrinsics(Handle, val.ToInputProxy()));
         GC.KeepAlive(val);
     }
 
@@ -378,7 +378,7 @@ public class VolumeSettings : CvObject
             throw new ArgumentNullException(nameof(val));
         val.ThrowIfNotReady();
         NativeMethods.HandleException(
-            NativeMethods.ptcloud_VolumeSettings_getCameraRaycastIntrinsics(Handle, val.CvPtr));
+            NativeMethods.ptcloud_VolumeSettings_getCameraRaycastIntrinsics(Handle, val.ToOutputProxy()));
         val.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
+++ b/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
@@ -85,8 +85,7 @@ public static partial class Cv2
             unsafe
             {
                 NativeMethods.HandleException(
-                    NativeMethods.stitching_computeImageFeatures2(
-                        featuresFinder.RawPtr, image.CvPtr, &wImageFeatures, mask?.CvPtr ?? IntPtr.Zero));
+                    NativeMethods.stitching_computeImageFeatures2(featuresFinder.RawPtr, image.ToInputProxy(), &wImageFeatures, mask?.ToInputProxy() ?? default));
             }
             
             GC.KeepAlive(featuresFinder);

--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -276,8 +276,7 @@ namespace OpenCvSharp
             images.ThrowIfDisposed();
 
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_estimateTransform_InputArray1(
-                    Handle, images.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_estimateTransform_InputArray1(Handle, images.ToInputProxy(), out var ret));
 
             GC.KeepAlive(images);
             return (Status)ret;
@@ -293,10 +292,7 @@ namespace OpenCvSharp
 
             using var roisPointer = new ArrayAddress2<Rect>(rois);
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_estimateTransform_InputArray2(
-                    Handle, images.CvPtr,
-                    roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(),
-                    out var ret));
+                NativeMethods.stitching_Stitcher_estimateTransform_InputArray2(Handle, images.ToInputProxy(), roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(), out var ret));
 
             GC.KeepAlive(images);
             return (Status)ret;
@@ -343,8 +339,7 @@ namespace OpenCvSharp
             pano.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_composePanorama1(
-                    Handle, pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_composePanorama1(Handle, pano.ToOutputProxy(), out var ret));
 
             pano.Fix();
             GC.KeepAlive(pano);
@@ -361,8 +356,7 @@ namespace OpenCvSharp
             pano.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_composePanorama2_InputArray(
-                    Handle, images.CvPtr, pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_composePanorama2_InputArray(Handle, images.ToInputProxy(), pano.ToOutputProxy(), out var ret));
 
             pano.Fix();
             GC.KeepAlive(images);
@@ -380,8 +374,7 @@ namespace OpenCvSharp
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_composePanorama2_MatArray(
-                    Handle, imagesPtrs, imagesPtrs.Length, pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_composePanorama2_MatArray(Handle, imagesPtrs, imagesPtrs.Length, pano.ToOutputProxy(), out var ret));
 
             pano.Fix();
             GC.KeepAlive(images);
@@ -405,8 +398,7 @@ namespace OpenCvSharp
             pano.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_stitch1_InputArray(
-                    Handle, images.CvPtr, pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_stitch1_InputArray(Handle, images.ToInputProxy(), pano.ToOutputProxy(), out var ret));
 
             GC.KeepAlive(images);
             GC.KeepAlive(pano);
@@ -432,8 +424,7 @@ namespace OpenCvSharp
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
 
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_stitch1_MatArray(
-                    Handle, imagesPtrs, imagesPtrs.Length, pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_stitch1_MatArray(Handle, imagesPtrs, imagesPtrs.Length, pano.ToOutputProxy(), out var ret));
 
             GC.KeepAlive(images);
             GC.KeepAlive(pano);
@@ -462,10 +453,7 @@ namespace OpenCvSharp
 
             using var roisPointer = new ArrayAddress2<Rect>(rois);
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_stitch2_InputArray(
-                    Handle, images.CvPtr,
-                    roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(),
-                    pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_stitch2_InputArray(Handle, images.ToInputProxy(), roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(), pano.ToOutputProxy(), out var ret));
 
             pano.Fix();
             GC.KeepAlive(images);
@@ -494,10 +482,7 @@ namespace OpenCvSharp
 
             using var roisPointer = new ArrayAddress2<Rect>(rois);
             NativeMethods.HandleException(
-                NativeMethods.stitching_Stitcher_stitch2_MatArray(
-                    Handle, imagesPtrs, imagesPtrs.Length,
-                    roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(),
-                    pano.CvPtr, out var ret));
+                NativeMethods.stitching_Stitcher_stitch2_MatArray(Handle, imagesPtrs, imagesPtrs.Length, roisPointer.GetPointer(), roisPointer.GetDim1Length(), roisPointer.GetDim2Lengths(), pano.ToOutputProxy(), out var ret));
 
             pano.Fix();
             GC.KeepAlive(images);

--- a/src/OpenCvSharp/Modules/ximgproc/Cv2.XImgProc.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Cv2.XImgProc.cs
@@ -142,7 +142,7 @@ public static partial class Cv2
                 rlDest.ThrowIfNotReady();
 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_threshold(src.CvPtr, rlDest.CvPtr, thresh, (int)type));
+                    NativeMethods.ximgproc_rl_threshold(src.ToInputProxy(), rlDest.ToOutputProxy(), thresh, (int)type));
 
                 GC.KeepAlive(src);
                 rlDest.Fix();
@@ -171,7 +171,7 @@ public static partial class Cv2
                 var anchorValue = anchor.GetValueOrDefault(new Point(0, 0));
 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_dilate(rlSrc.CvPtr, rlDest.CvPtr, rlKernel.CvPtr, anchorValue));
+                    NativeMethods.ximgproc_rl_dilate(rlSrc.ToInputProxy(), rlDest.ToOutputProxy(), rlKernel.ToInputProxy(), anchorValue));
 
                 GC.KeepAlive(rlSrc);
                 rlDest.Fix();
@@ -204,7 +204,7 @@ public static partial class Cv2
                 var anchorValue = anchor.GetValueOrDefault(new Point(0, 0));
 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_erode(rlSrc.CvPtr, rlDest.CvPtr, rlKernel.CvPtr, bBoundaryOn ? 1 : 0, anchorValue));
+                    NativeMethods.ximgproc_rl_erode(rlSrc.ToInputProxy(), rlDest.ToOutputProxy(), rlKernel.ToInputProxy(), bBoundaryOn ? 1 : 0, anchorValue));
 
                 GC.KeepAlive(rlSrc);
                 rlDest.Fix();
@@ -241,7 +241,7 @@ public static partial class Cv2
                 rlSrc.ThrowIfDisposed();
 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_paint(image.CvPtr, rlSrc.CvPtr, value));
+                    NativeMethods.ximgproc_rl_paint(image.ToInputOutputProxy(), rlSrc.ToInputProxy(), value));
                 
                 image.Fix();
                 GC.KeepAlive(rlSrc);
@@ -259,7 +259,7 @@ public static partial class Cv2
                     throw new ArgumentNullException(nameof(rlStructuringElement));
                 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_isRLMorphologyPossible(rlStructuringElement.CvPtr, out var ret));
+                    NativeMethods.ximgproc_rl_isRLMorphologyPossible(rlStructuringElement.ToInputProxy(), out var ret));
 
                 GC.KeepAlive(rlStructuringElement);
 
@@ -283,7 +283,7 @@ public static partial class Cv2
                 var sizeValue = size.GetValueOrDefault(new Size(0, 0));
                                 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_createRLEImage(runsArray, runsArray.Length, res.CvPtr, sizeValue));
+                    NativeMethods.ximgproc_rl_createRLEImage(runsArray, runsArray.Length, res.ToOutputProxy(), sizeValue));
 
                 res.Fix();
             }
@@ -315,7 +315,7 @@ public static partial class Cv2
                 var anchorValue = anchor.GetValueOrDefault(new Point(0, 0));
 
                 NativeMethods.HandleException(
-                    NativeMethods.ximgproc_rl_morphologyEx(rlSrc.CvPtr, rlDest.CvPtr, (int)op, rlKernel.CvPtr, bBoundaryOnForErosion ? 1 : 0, anchorValue));
+                    NativeMethods.ximgproc_rl_morphologyEx(rlSrc.ToInputProxy(), rlDest.ToOutputProxy(), (int)op, rlKernel.ToInputProxy(), bBoundaryOnForErosion ? 1 : 0, anchorValue));
 
                 GC.KeepAlive(rlSrc);
                 rlDest.Fix();
@@ -367,7 +367,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_niBlackThreshold(src.CvPtr, dst.CvPtr, maxValue, (int)type, blockSize, k, (int)binarizationMethod, r));
+                NativeMethods.ximgproc_niBlackThreshold(src.ToInputProxy(), dst.ToOutputProxy(), maxValue, (int)type, blockSize, k, (int)binarizationMethod, r));
 
             GC.KeepAlive(src);
             GC.KeepAlive(dst);
@@ -393,7 +393,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_thinning(src.CvPtr, dst.CvPtr, (int)thinningType));
+                NativeMethods.ximgproc_thinning(src.ToInputProxy(), dst.ToOutputProxy(), (int)thinningType));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -418,7 +418,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_anisotropicDiffusion(src.CvPtr, dst.CvPtr, alpha, k, niters));
+                NativeMethods.ximgproc_anisotropicDiffusion(src.ToInputProxy(), dst.ToOutputProxy(), alpha, k, niters));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -469,7 +469,7 @@ public static partial class Cv2
             qimg.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_createQuaternionImage(img.CvPtr, qimg.CvPtr));
+                NativeMethods.ximgproc_createQuaternionImage(img.ToInputProxy(), qimg.ToOutputProxy()));
 
             GC.KeepAlive(img);
             qimg.Fix();
@@ -490,7 +490,7 @@ public static partial class Cv2
             qcimg.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_qconj(qimg.CvPtr, qcimg.CvPtr));
+                NativeMethods.ximgproc_qconj(qimg.ToInputProxy(), qcimg.ToOutputProxy()));
 
             GC.KeepAlive(qimg);
             qcimg.Fix();
@@ -511,7 +511,7 @@ public static partial class Cv2
             qnimg.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_qunitary(qimg.CvPtr, qnimg.CvPtr));
+                NativeMethods.ximgproc_qunitary(qimg.ToInputProxy(), qnimg.ToOutputProxy()));
 
             GC.KeepAlive(qimg);
             qnimg.Fix();
@@ -536,7 +536,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_qmultiply(src1.CvPtr, src2.CvPtr, dst.CvPtr));
+                NativeMethods.ximgproc_qmultiply(src1.ToInputProxy(), src2.ToInputProxy(), dst.ToOutputProxy()));
 
             GC.KeepAlive(src1);
             GC.KeepAlive(src2);
@@ -560,7 +560,7 @@ public static partial class Cv2
             qimg.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_qdft(img.CvPtr, qimg.CvPtr, (int)flags, sideLeft ? 1 : 0));
+                NativeMethods.ximgproc_qdft(img.ToInputProxy(), qimg.ToOutputProxy(), (int)flags, sideLeft ? 1 : 0));
 
             GC.KeepAlive(img);
             qimg.Fix();
@@ -585,7 +585,7 @@ public static partial class Cv2
             result.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_colorMatchTemplate(img.CvPtr, templ.CvPtr, result.CvPtr));
+                NativeMethods.ximgproc_colorMatchTemplate(img.ToInputProxy(), templ.ToInputProxy(), result.ToOutputProxy()));
 
             GC.KeepAlive(img);
             GC.KeepAlive(templ);
@@ -613,7 +613,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_GradientDericheY(op.CvPtr, dst.CvPtr, alpha, omega));
+                NativeMethods.ximgproc_GradientDericheY(op.ToInputProxy(), dst.ToOutputProxy(), alpha, omega));
 
             GC.KeepAlive(op);
             dst.Fix();
@@ -636,7 +636,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_GradientDericheX(op.CvPtr, dst.CvPtr, alpha, omega));
+                NativeMethods.ximgproc_GradientDericheX(op.ToInputProxy(), dst.ToOutputProxy(), alpha, omega));
 
             GC.KeepAlive(op);
             dst.Fix();
@@ -749,7 +749,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_dtFilter(guide.CvPtr, src.CvPtr, dst.CvPtr, sigmaSpatial, sigmaColor, (int)mode, numIters));
+                NativeMethods.ximgproc_dtFilter(guide.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), sigmaSpatial, sigmaColor, (int)mode, numIters));
 
             GC.KeepAlive(guide);
             GC.KeepAlive(src);
@@ -800,7 +800,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_guidedFilter(guide.CvPtr, src.CvPtr, dst.CvPtr, radius, eps, dDepth));
+                NativeMethods.ximgproc_guidedFilter(guide.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), radius, eps, dDepth));
 
             GC.KeepAlive(guide);
             GC.KeepAlive(src);
@@ -850,7 +850,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_amFilter(joint.CvPtr, src.CvPtr, dst.CvPtr, sigmaS, sigmaR, adjustOutliers ? 1 : 0));
+                NativeMethods.ximgproc_amFilter(joint.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), sigmaS, sigmaR, adjustOutliers ? 1 : 0));
 
             GC.KeepAlive(joint);
             GC.KeepAlive(src);
@@ -889,7 +889,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_jointBilateralFilter(
-                    joint.CvPtr, src.CvPtr, dst.CvPtr, d, sigmaColor, sigmaSpace, (int)borderType));
+                    joint.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), d, sigmaColor, sigmaSpace, (int)borderType));
 
             GC.KeepAlive(joint);
             GC.KeepAlive(src);
@@ -920,7 +920,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_bilateralTextureFilter(
-                    src.CvPtr, dst.CvPtr, fr, numIter, sigmaAlpha, sigmaAvg));
+                    src.ToInputProxy(), dst.ToOutputProxy(), fr, numIter, sigmaAlpha, sigmaAvg));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -955,7 +955,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_rollingGuidanceFilter(
-                    src.CvPtr, dst.CvPtr, d, sigmaColor, sigmaSpace, numOfIter, (int)borderType));
+                    src.ToInputProxy(), dst.ToOutputProxy(), d, sigmaColor, sigmaSpace, numOfIter, (int)borderType));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -995,7 +995,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_fastBilateralSolverFilter(
-                    guide.CvPtr, src.CvPtr, confidence.CvPtr, dst.CvPtr, sigmaSpatial, sigmaLuma, sigmaChroma, lambda, numIter, maxTol));
+                    guide.ToInputProxy(), src.ToInputProxy(), confidence.ToInputProxy(), dst.ToOutputProxy(), sigmaSpatial, sigmaLuma, sigmaChroma, lambda, numIter, maxTol));
 
             GC.KeepAlive(guide);
             GC.KeepAlive(src);
@@ -1047,7 +1047,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_fastGlobalSmootherFilter(
-                    guide.CvPtr, src.CvPtr, dst.CvPtr, lambda, sigmaColor, lambdaAttenuation, numIter));
+                    guide.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), lambda, sigmaColor, lambdaAttenuation, numIter));
 
             GC.KeepAlive(guide);
             GC.KeepAlive(src);
@@ -1072,7 +1072,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_l0Smooth(
-                    src.CvPtr, dst.CvPtr, lambda, kappa));
+                    src.ToInputProxy(), dst.ToOutputProxy(), lambda, kappa));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -1099,7 +1099,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_edgePreservingFilter(src.CvPtr, dst.CvPtr, d, threshold));
+                NativeMethods.ximgproc_edgePreservingFilter(src.ToInputProxy(), dst.ToOutputProxy(), d, threshold));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -1134,7 +1134,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_covarianceEstimation(src.CvPtr, dst.CvPtr, windowRows, windowCols));
+                NativeMethods.ximgproc_covarianceEstimation(src.ToInputProxy(), dst.ToOutputProxy(), windowRows, windowCols));
 
             GC.KeepAlive(src);
             GC.KeepAlive(dst);
@@ -1170,7 +1170,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_FastHoughTransform(src.CvPtr, dst.CvPtr, dstMatDepth, (int)angleRange, (int)op, (int)makeSkew));
+                NativeMethods.ximgproc_FastHoughTransform(src.ToInputProxy(), dst.ToOutputProxy(), dstMatDepth, (int)angleRange, (int)op, (int)makeSkew));
 
             GC.KeepAlive(src);
             GC.KeepAlive(dst);
@@ -1203,7 +1203,7 @@ public static partial class Cv2
             srcImgInfo.ThrowIfDisposed();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_HoughPoint2Line(houghPoint, srcImgInfo.CvPtr, (int)angleRange, (int)makeSkew, (int)rules, out Vec4i ret));
+                NativeMethods.ximgproc_HoughPoint2Line(houghPoint, srcImgInfo.ToInputProxy(), (int)angleRange, (int)makeSkew, (int)rules, out Vec4i ret));
             GC.KeepAlive(srcImgInfo);
             return ret;
         }
@@ -1275,7 +1275,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_GradientPaillouY(op.CvPtr, dst.CvPtr, alpha, omega));
+                NativeMethods.ximgproc_GradientPaillouY(op.ToInputProxy(), dst.ToOutputProxy(), alpha, omega));
 
             GC.KeepAlive(op);
             GC.KeepAlive(dst);
@@ -1299,7 +1299,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_GradientPaillouX(op.CvPtr, dst.CvPtr, alpha, omega));
+                NativeMethods.ximgproc_GradientPaillouX(op.ToInputProxy(), dst.ToOutputProxy(), alpha, omega));
 
             GC.KeepAlive(op);
             GC.KeepAlive(dst);
@@ -1327,7 +1327,7 @@ public static partial class Cv2
                 fixed (double* retPointer = ret)
                 {
                     NativeMethods.HandleException(
-                        NativeMethods.ximgproc_PeiLinNormalization_Mat23d(i.CvPtr, retPointer));
+                        NativeMethods.ximgproc_PeiLinNormalization_Mat23d(i.ToInputProxy(), retPointer));
                 }
             }
 
@@ -1350,7 +1350,7 @@ public static partial class Cv2
             t.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.ximgproc_PeiLinNormalization_OutputArray(i.CvPtr, t.CvPtr));
+                NativeMethods.ximgproc_PeiLinNormalization_OutputArray(i.ToInputProxy(), t.ToOutputProxy()));
 
             GC.KeepAlive(i);
             t.Fix();
@@ -1444,7 +1444,7 @@ public static partial class Cv2
         /// the pixel will be ignored when maintaining the joint-histogram.This is useful for applications like optical flow occlusion handling.</param>
         public static void WeightedMedianFilter(
             InputArray joint, InputArray src, OutputArray dst, int r,
-            double sigma = 25.5, WMFWeightType weightType = WMFWeightType.EXP, Mat? mask = null)
+            double sigma = 25.5, WMFWeightType weightType = WMFWeightType.EXP, InputArray? mask = null)
         {
             if (joint is null)
                 throw new ArgumentNullException(nameof(joint));
@@ -1458,7 +1458,7 @@ public static partial class Cv2
 
             NativeMethods.HandleException(
                 NativeMethods.ximgproc_weightedMedianFilter(
-                    joint.CvPtr, src.CvPtr, dst.CvPtr, r, sigma, (int)weightType, mask?.CvPtr ?? IntPtr.Zero));
+                    joint.ToInputProxy(), src.ToInputProxy(), dst.ToOutputProxy(), r, sigma, (int)weightType, mask?.ToInputProxy() ?? default));
 
             GC.KeepAlive(joint);
             GC.KeepAlive(src);

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeBoxes.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeBoxes.cs
@@ -313,7 +313,7 @@ public class EdgeBoxes : Algorithm
         using var boxesVec = new StdVector<Rect>();
         NativeMethods.HandleException(
             NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(
-                Handle, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
+                Handle, edgeMap.ToInputProxy(), orientationMap.ToInputProxy(), boxesVec.CvPtr));
         boxes = boxesVec.ToArray();
 
         GC.KeepAlive(edgeMap);

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
@@ -135,7 +135,7 @@ public class EdgeDrawing : Algorithm
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectEdges(Handle, src.CvPtr));
+            NativeMethods.ximgproc_EdgeDrawing_detectEdges(Handle, src.ToInputProxy()));
         GC.KeepAlive(src);
     }
 
@@ -151,7 +151,7 @@ public class EdgeDrawing : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getEdgeImage(Handle, dst.CvPtr));
+            NativeMethods.ximgproc_EdgeDrawing_getEdgeImage(Handle, dst.ToOutputProxy()));
         dst.Fix();
     }
 
@@ -167,7 +167,7 @@ public class EdgeDrawing : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_getGradientImage(Handle, dst.CvPtr));
+            NativeMethods.ximgproc_EdgeDrawing_getGradientImage(Handle, dst.ToOutputProxy()));
         dst.Fix();
     }
 
@@ -213,7 +213,7 @@ public class EdgeDrawing : Algorithm
         lines.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectLines(Handle, lines.CvPtr));
+            NativeMethods.ximgproc_EdgeDrawing_detectLines(Handle, lines.ToOutputProxy()));
         lines.Fix();
     }
 
@@ -248,7 +248,7 @@ public class EdgeDrawing : Algorithm
         ellipses.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeDrawing_detectEllipses(Handle, ellipses.CvPtr));
+            NativeMethods.ximgproc_EdgeDrawing_detectEllipses(Handle, ellipses.ToOutputProxy()));
         ellipses.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/AdaptiveManifoldFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/AdaptiveManifoldFilter.cs
@@ -194,7 +194,7 @@ public class AdaptiveManifoldFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_AdaptiveManifoldFilter_filter(
-                Handle, src.CvPtr, dst.CvPtr, joint?.CvPtr ?? IntPtr.Zero));
+                Handle, src.ToInputProxy(), dst.ToOutputProxy(), joint?.ToInputProxy() ?? default));
 
         GC.KeepAlive(src);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/DTFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/DTFilter.cs
@@ -40,7 +40,7 @@ public class DTFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createDTFilter(
-                guide.CvPtr, sigmaSpatial, sigmaColor, (int)mode, numIters, out var smartPtr));
+                guide.ToInputProxy(), sigmaSpatial, sigmaColor, (int)mode, numIters, out var smartPtr));
             
         GC.KeepAlive(guide); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_DTFilter_get(smartPtr, out var rawPtr));
@@ -66,7 +66,7 @@ public class DTFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_DTFilter_filter(
-                Handle, src.CvPtr, dst.CvPtr, dDepth));
+                Handle, src.ToInputProxy(), dst.ToOutputProxy(), dDepth));
 
         GC.KeepAlive(src);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastBilateralSolverFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastBilateralSolverFilter.cs
@@ -38,7 +38,7 @@ public class FastBilateralSolverFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createFastBilateralSolverFilter(
-                guide.CvPtr, sigmaSpatial, sigmaLuma, sigmaChroma, lambda, numIter, maxTol, out var smartPtr));
+                guide.ToInputProxy(), sigmaSpatial, sigmaLuma, sigmaChroma, lambda, numIter, maxTol, out var smartPtr));
             
         GC.KeepAlive(guide); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_FastBilateralSolverFilter_get(smartPtr, out var rawPtr));
@@ -66,7 +66,7 @@ public class FastBilateralSolverFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastBilateralSolverFilter_filter(
-                Handle, src.CvPtr, confidence.CvPtr, dst.CvPtr));
+                Handle, src.ToInputProxy(), confidence.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(confidence);

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastGlobalSmootherFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/FastGlobalSmootherFilter.cs
@@ -36,7 +36,7 @@ public class FastGlobalSmootherFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createFastGlobalSmootherFilter(
-                guide.CvPtr, lambda, sigmaColor, lambdaAttenuation, numIter, out var smartPtr));
+                guide.ToInputProxy(), lambda, sigmaColor, lambdaAttenuation, numIter, out var smartPtr));
             
         GC.KeepAlive(guide); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_FastGlobalSmootherFilter_get(smartPtr, out var rawPtr));
@@ -60,7 +60,7 @@ public class FastGlobalSmootherFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastGlobalSmootherFilter_filter(
-                Handle, src.CvPtr, dst.CvPtr));
+                Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/GuidedFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeFilter/GuidedFilter.cs
@@ -35,7 +35,7 @@ public class GuidedFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createGuidedFilter(
-                guide.CvPtr, radius, eps, out var smartPtr));
+                guide.ToInputProxy(), radius, eps, out var smartPtr));
             
         GC.KeepAlive(guide); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_GuidedFilter_get(smartPtr, out var rawPtr));
@@ -60,7 +60,7 @@ public class GuidedFilter : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_GuidedFilter_filter(
-                Handle, src.CvPtr, dst.CvPtr, dDepth));
+                Handle, src.ToInputProxy(), dst.ToOutputProxy(), dDepth));
 
         GC.KeepAlive(src);
         dst.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
@@ -59,7 +59,7 @@ public class FastLineDetector : Algorithm
         lines.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_detect_OutputArray(Handle, image.CvPtr, lines.CvPtr));
+            NativeMethods.ximgproc_FastLineDetector_detect_OutputArray(Handle, image.ToInputProxy(), lines.ToOutputProxy()));
         GC.KeepAlive(image);
         GC.KeepAlive(lines);
         lines.Fix();
@@ -85,7 +85,7 @@ public class FastLineDetector : Algorithm
 
         using var lines = new StdVector<Vec4f>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_detect_vector(Handle, image.CvPtr, lines.CvPtr));
+            NativeMethods.ximgproc_FastLineDetector_detect_vector(Handle, image.ToInputProxy(), lines.CvPtr));
         GC.KeepAlive(image);
         return lines.ToArray();
     }
@@ -106,7 +106,7 @@ public class FastLineDetector : Algorithm
             throw new ArgumentNullException(nameof(lines));
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_FastLineDetector_drawSegments_InputArray(Handle, image.CvPtr, lines.CvPtr, drawArrow ? 1 : 0));
+            NativeMethods.ximgproc_FastLineDetector_drawSegments_InputArray(Handle, image.ToInputOutputProxy(), lines.ToInputProxy(), drawArrow ? 1 : 0));
         GC.KeepAlive(image);
         image.Fix();
         GC.KeepAlive(lines);
@@ -129,7 +129,7 @@ public class FastLineDetector : Algorithm
         using var linesVec = new StdVector<Vec4f>(lines);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_FastLineDetector_drawSegments_vector(
-                Handle, image.CvPtr, linesVec.CvPtr, drawArrow ? 1 : 0));
+                Handle, image.ToInputOutputProxy(), linesVec.CvPtr, drawArrow ? 1 : 0));
             
         GC.KeepAlive(image);
         image.Fix();

--- a/src/OpenCvSharp/Modules/ximgproc/RidgeDetectionFilter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/RidgeDetectionFilter.cs
@@ -65,6 +65,6 @@ public class RidgeDetectionFilter : Algorithm
             throw new ArgumentNullException(nameof(dst));
         ThrowIfDisposed();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/GraphSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/GraphSegmentation.cs
@@ -110,7 +110,7 @@ public class GraphSegmentation : Algorithm
         dst.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_GraphSegmentation_processImage(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_segmentation_GraphSegmentation_processImage(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
@@ -41,7 +41,7 @@ public class SelectiveSearchSegmentation : Algorithm
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(Handle, img.CvPtr));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(Handle, img.ToInputProxy()));
 
         GC.KeepAlive(img);
     }
@@ -96,7 +96,7 @@ public class SelectiveSearchSegmentation : Algorithm
         img.ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addImage(Handle, img.CvPtr));
+            NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentation_addImage(Handle, img.ToInputProxy()));
 
         GC.KeepAlive(img);
     }

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategy.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategy.cs
@@ -46,7 +46,7 @@ public abstract class SelectiveSearchSegmentationStrategy : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
-                Handle, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
+                Handle, img.ToInputProxy(), regions.ToInputProxy(), sizes.ToInputProxy(), imageId));
 
         GC.KeepAlive(img);
         GC.KeepAlive(regions);

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
@@ -38,7 +38,7 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
-                Handle, img.CvPtr, regions.CvPtr, sizes.CvPtr, imageId));
+                Handle, img.ToInputProxy(), regions.ToInputProxy(), sizes.ToInputProxy(), imageId));
 
         GC.KeepAlive(img);
         GC.KeepAlive(regions);

--- a/src/OpenCvSharp/Modules/ximgproc/StructuredEdgeDetection.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/StructuredEdgeDetection.cs
@@ -51,7 +51,7 @@ public class StructuredEdgeDetection : Algorithm
 
         using var boxesVec = new StdVector<Rect>();
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(Handle, edgeMap.CvPtr, orientationMap.CvPtr, boxesVec.CvPtr));
+            NativeMethods.ximgproc_EdgeBoxes_getBoundingBoxes(Handle, edgeMap.ToInputProxy(), orientationMap.ToInputProxy(), boxesVec.CvPtr));
         boxes = boxesVec.ToArray();
 
         GC.KeepAlive(edgeMap);
@@ -75,7 +75,7 @@ public class StructuredEdgeDetection : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_StructuredEdgeDetection_detectEdges(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_StructuredEdgeDetection_detectEdges(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -97,7 +97,7 @@ public class StructuredEdgeDetection : Algorithm
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.ximgproc_StructuredEdgeDetection_computeOrientation(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.ximgproc_StructuredEdgeDetection_computeOrientation(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         dst.Fix();
@@ -129,7 +129,7 @@ public class StructuredEdgeDetection : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_StructuredEdgeDetection_edgesNms(
-                Handle, edgeImage.CvPtr, orientationImage.CvPtr, dst.CvPtr, r, s, m, isParallel ? 1 : 0));
+                Handle, edgeImage.ToInputProxy(), orientationImage.ToInputProxy(), dst.ToOutputProxy(), r, s, m, isParallel ? 1 : 0));
 
         GC.KeepAlive(edgeImage);
         GC.KeepAlive(orientationImage);

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelLSC.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelLSC.cs
@@ -45,7 +45,7 @@ public class SuperpixelLSC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createSuperpixelLSC(
-                image.CvPtr, regionSize, ratio, out var smartPtr));
+                image.ToInputProxy(), regionSize, ratio, out var smartPtr));
             
         GC.KeepAlive(image); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_SuperpixelLSC_get(smartPtr, out var rawPtr));
@@ -104,7 +104,7 @@ public class SuperpixelLSC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_getLabels(
-                Handle, labelsOut.CvPtr));
+                Handle, labelsOut.ToOutputProxy()));
         labelsOut.Fix();
     }
 
@@ -123,7 +123,7 @@ public class SuperpixelLSC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelLSC_getLabelContourMask(
-                Handle, image.CvPtr, thickLine ? 1 : 0));
+                Handle, image.ToOutputProxy(), thickLine ? 1 : 0));
         image.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSEEDS.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSEEDS.cs
@@ -99,7 +99,7 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_iterate(
-                Handle, img.CvPtr, numIterations));
+                Handle, img.ToInputProxy(), numIterations));
 
         GC.KeepAlive(img);
     }
@@ -122,7 +122,7 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_getLabels(
-                Handle, labelsOut.CvPtr));
+                Handle, labelsOut.ToOutputProxy()));
         labelsOut.Fix();
     }
 
@@ -141,7 +141,7 @@ public class SuperpixelSEEDS : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSEEDS_getLabelContourMask(
-                Handle, image.CvPtr, thickLine ? 1 : 0));
+                Handle, image.ToOutputProxy(), thickLine ? 1 : 0));
         image.Fix();
     }
 }

--- a/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSLIC.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Superpixel/SuperpixelSLIC.cs
@@ -45,7 +45,7 @@ public class SuperpixelSLIC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_createSuperpixelSLIC(
-                image.CvPtr, (int)algorithm, regionSize, ruler, out var smartPtr));
+                image.ToInputProxy(), (int)algorithm, regionSize, ruler, out var smartPtr));
             
         GC.KeepAlive(image); 
         NativeMethods.HandleException(NativeMethods.ximgproc_Ptr_SuperpixelSLIC_get(smartPtr, out var rawPtr));
@@ -104,7 +104,7 @@ public class SuperpixelSLIC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_getLabels(
-                Handle, labelsOut.CvPtr));
+                Handle, labelsOut.ToOutputProxy()));
         labelsOut.Fix();
     }
 
@@ -123,7 +123,7 @@ public class SuperpixelSLIC : Algorithm
 
         NativeMethods.HandleException(
             NativeMethods.ximgproc_SuperpixelSLIC_getLabelContourMask(
-                Handle, image.CvPtr, thickLine ? 1 : 0));
+                Handle, image.ToOutputProxy(), thickLine ? 1 : 0));
         image.Fix();
     }
 

--- a/src/OpenCvSharp/Modules/xphoto/Cv2.XPhoto.cs
+++ b/src/OpenCvSharp/Modules/xphoto/Cv2.XPhoto.cs
@@ -69,10 +69,7 @@ public static partial class Cv2
             dstStep2.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.xphoto_bm3dDenoising1(
-                    src.CvPtr, dstStep1.CvPtr, dstStep2.CvPtr, h, templateWindowSize,
-                    searchWindowSize, blockMatchingStep1, blockMatchingStep2, groupSize, slidingStep, beta,
-                    (int) normType, (int) step, (int) transformType));
+                NativeMethods.xphoto_bm3dDenoising1(src.ToInputProxy(), dstStep1.ToInputOutputProxy(), dstStep2.ToOutputProxy(), h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, groupSize, slidingStep, beta, (int) normType, (int) step, (int) transformType));
 
             GC.KeepAlive(src);
             dstStep1.Fix();
@@ -126,10 +123,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.xphoto_bm3dDenoising2(
-                    src.CvPtr, dst.CvPtr, h, templateWindowSize,
-                    searchWindowSize, blockMatchingStep1, blockMatchingStep2, groupSize, slidingStep, beta,
-                    (int) normType, (int) step, (int) transformType));
+                NativeMethods.xphoto_bm3dDenoising2(src.ToInputProxy(), dst.ToOutputProxy(), h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, groupSize, slidingStep, beta, (int) normType, (int) step, (int) transformType));
 
             GC.KeepAlive(src);
             dst.Fix();
@@ -221,9 +215,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.xphoto_oilPainting(
-                    src.CvPtr, dst.CvPtr, size, dynRatio,
-                    code.HasValue ? (int)code : -1));
+                NativeMethods.xphoto_oilPainting(src.ToInputProxy(), dst.ToOutputProxy(), size, dynRatio, code.HasValue ? (int)code : -1));
 
             GC.KeepAlive(src);
             GC.KeepAlive(dst);
@@ -252,7 +244,7 @@ public static partial class Cv2
             dst.ThrowIfNotReady();
 
             NativeMethods.HandleException(
-                NativeMethods.xphoto_applyChannelGains(src.CvPtr, dst.CvPtr, gainB, gainG, gainR));
+                NativeMethods.xphoto_applyChannelGains(src.ToInputProxy(), dst.ToOutputProxy(), gainB, gainG, gainR));
 
             GC.KeepAlive(src);
             GC.KeepAlive(dst);

--- a/src/OpenCvSharp/Modules/xphoto/GrayworldWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/GrayworldWB.cs
@@ -64,7 +64,7 @@ public class GrayworldWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_GrayworldWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_GrayworldWB_balanceWhite(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);

--- a/src/OpenCvSharp/Modules/xphoto/LearningBasedWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/LearningBasedWB.cs
@@ -102,7 +102,7 @@ public class LearningBasedWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_LearningBasedWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_LearningBasedWB_balanceWhite(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);
@@ -124,7 +124,7 @@ public class LearningBasedWB : WhiteBalancer
         dst.ThrowIfNotReady();
 
         NativeMethods.HandleException(
-            NativeMethods.xphoto_LearningBasedWB_extractSimpleFeatures(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_LearningBasedWB_extractSimpleFeatures(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);

--- a/src/OpenCvSharp/Modules/xphoto/SimpleWB.cs
+++ b/src/OpenCvSharp/Modules/xphoto/SimpleWB.cs
@@ -142,7 +142,7 @@ public class SimpleWB : WhiteBalancer
         dst.ThrowIfNotReady();
             
         NativeMethods.HandleException(
-            NativeMethods.xphoto_SimpleWB_balanceWhite(Handle, src.CvPtr, dst.CvPtr));
+            NativeMethods.xphoto_SimpleWB_balanceWhite(Handle, src.ToInputProxy(), dst.ToOutputProxy()));
 
         GC.KeepAlive(src);
         GC.KeepAlive(dst);

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -97,7 +97,7 @@ static cv::aruco::DetectorParameters cpp(const aruco_DetectorParameters& p)
 }
 
 CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
-	cv::_InputOutputArray* image,
+	const interop::InputOutputArrayProxy* image,
 	cv::Point2f** corners,
 	int cornerSize1,
 	int* cornerSize2,
@@ -113,7 +113,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 	if (idx != nullptr)
 		idxVec = std::vector<int>(idx, idx + idxCount);
 
-	cv::aruco::drawDetectedMarkers(*image, cornerVec, idxVec, cpp(borderColor));
+	cv::aruco::drawDetectedMarkers(IoProxy(*image), cornerVec, idxVec, cpp(borderColor));
 	});
 }
 
@@ -196,13 +196,13 @@ CVAPI(ExceptionStatus) aruco_Dictionary_identify(
 
 CVAPI(ExceptionStatus) aruco_Dictionary_getDistanceToId(
 	cv::aruco::Dictionary* obj,
-	cv::_InputArray *bits,
+	const interop::InputArrayProxy* bits,
 	int id,
 	int allRotations,
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->getDistanceToId(*bits, id, allRotations != 0);
+	*returnValue = obj->getDistanceToId(InProxy(*bits), id, allRotations != 0);
 	});
 }
 
@@ -210,11 +210,11 @@ CVAPI(ExceptionStatus) aruco_Dictionary_generateImageMarker(
 	cv::aruco::Dictionary* obj,
 	int id,
 	int sidePixels,
-	cv::_OutputArray *img,
+	const interop::OutputArrayProxy* img,
 	int borderBits)
 {
 	return cvTry([&] {
-	obj->generateImageMarker(id, sidePixels, *img, borderBits);
+	obj->generateImageMarker(id, sidePixels, OutProxy(*img), borderBits);
 	});
 }
 
@@ -240,7 +240,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getBitsFromByteList(
 }
 
 CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
-	cv::_InputOutputArray* image,
+	const interop::InputOutputArrayProxy* image,
 	cv::Point2f** corners,
 	int cornerSize1,
 	int* cornerSize2,
@@ -255,12 +255,12 @@ CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 
 	const cv::_InputArray idArray = (ids != nullptr) ? *ids : static_cast<cv::_InputArray>(cv::noArray());
 
-	cv::aruco::drawDetectedDiamonds(*image, cornerVec, idArray, cpp(borderColor));
+	cv::aruco::drawDetectedDiamonds(IoProxy(*image), cornerVec, idArray, cpp(borderColor));
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
-	cv::_InputOutputArray* image,
+	const interop::InputOutputArrayProxy* image,
 	std::vector<cv::Point2f>* corners,
 	std::vector<int>* ids,
 	interop::Scalar cornerColor)
@@ -268,7 +268,7 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	return cvTry([&] {
 	cv::_InputArray idArray = cv::noArray();
 	if (ids != nullptr) idArray = *ids;
-	cv::aruco::drawDetectedCornersCharuco(*image, *corners, idArray, cpp(cornerColor));
+	cv::aruco::drawDetectedCornersCharuco(IoProxy(*image), *corners, idArray, cpp(cornerColor));
 	});
 }
 
@@ -296,32 +296,32 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_delete(cv::aruco::ArucoDetector* ptr)
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkers(
 	cv::aruco::ArucoDetector* detector,
-	cv::_InputArray* image,
+	const interop::InputArrayProxy* image,
 	std::vector<std::vector<cv::Point2f>>* corners,
 	std::vector<int>* ids,
 	std::vector<std::vector<cv::Point2f>>* rejectedImgPoints)
 {
 	return cvTry([&] {
-	detector->detectMarkers(*image, *corners, *ids, *rejectedImgPoints);
+	detector->detectMarkers(InProxy(*image), *corners, *ids, *rejectedImgPoints);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
 	cv::aruco::ArucoDetector* detector,
-	cv::_InputArray* image,
+	const interop::InputArrayProxy* image,
 	cv::aruco::Board* board,
 	std::vector<std::vector<cv::Point2f>>* detectedCorners,
 	std::vector<int>* detectedIds,
 	std::vector<std::vector<cv::Point2f>>* rejectedCorners,
-	cv::_InputArray* cameraMatrix,
-	cv::_InputArray* distCoeffs,
+	const interop::InputArrayProxy* cameraMatrix,
+	const interop::InputArrayProxy* distCoeffs,
 	std::vector<int>* recoveredIdxs)
 {
 	return cvTry([&] {
 	cv::_OutputArray recoveredIdxsArr = cv::noArray();
 	if (recoveredIdxs != nullptr) recoveredIdxsArr = *recoveredIdxs;
-	detector->refineDetectedMarkers(*image, *board, *detectedCorners, *detectedIds, *rejectedCorners,
-		entity(cameraMatrix), entity(distCoeffs), recoveredIdxsArr);
+	detector->refineDetectedMarkers(InProxy(*image), *board, *detectedCorners, *detectedIds, *rejectedCorners,
+		InProxy(*cameraMatrix), InProxy(*distCoeffs), recoveredIdxsArr);
 	});
 }
 
@@ -385,22 +385,22 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_getLegacyPattern(cv::aruco::CharucoBoa
 CVAPI(ExceptionStatus) aruco_CharucoBoard_generateImage(
 	cv::aruco::CharucoBoard* ptr,
 	interop::Size outSize,
-	cv::_OutputArray* img,
+	const interop::OutputArrayProxy* img,
 	int marginSize,
 	int borderBits)
 {
 	return cvTry([&] {
-	ptr->generateImage(cpp(outSize), *img, marginSize, borderBits);
+	ptr->generateImage(cpp(outSize), OutProxy(*img), marginSize, borderBits);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
 	cv::aruco::CharucoBoard* ptr,
-	cv::_InputArray* charucoIds,
+	const interop::InputArrayProxy* charucoIds,
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->checkCharucoCornersCollinear(*charucoIds) ? 1 : 0;
+	*returnValue = ptr->checkCharucoCornersCollinear(InProxy(*charucoIds)) ? 1 : 0;
 	});
 }
 
@@ -408,8 +408,8 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
 	cv::aruco::CharucoBoard* board,
-	cv::_InputArray* cameraMatrix,
-	cv::_InputArray* distCoeffs,
+	const interop::InputArrayProxy* cameraMatrix,
+	const interop::InputArrayProxy* distCoeffs,
 	int minMarkers,
 	bool tryRefineMarkers,
 	bool checkMarkers,
@@ -419,10 +419,13 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
 {
 	return cvTry([&] {
 	cv::aruco::CharucoParameters cp;
-	if (cameraMatrix != nullptr)
-		cp.cameraMatrix = cameraMatrix->getMat();
-	if (distCoeffs != nullptr)
-		cp.distCoeffs = distCoeffs->getMat();
+	cv::Scalar cameraMatrixScratch, distCoeffsScratch;
+	const cv::_InputArray cameraMatrixArr = fromInputProxy(*cameraMatrix, cameraMatrixScratch);
+	const cv::_InputArray distCoeffsArr = fromInputProxy(*distCoeffs, distCoeffsScratch);
+	if (!cameraMatrixArr.empty())
+		cp.cameraMatrix = cameraMatrixArr.getMat();
+	if (!distCoeffsArr.empty())
+		cp.distCoeffs = distCoeffsArr.getMat();
 	cp.minMarkers = minMarkers;
 	cp.tryRefineMarkers = tryRefineMarkers;
 	cp.checkMarkers = checkMarkers;
@@ -441,7 +444,7 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_delete(cv::aruco::CharucoDetector* 
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 	cv::aruco::CharucoDetector* detector,
-	cv::_InputArray* image,
+	const interop::InputArrayProxy* image,
 	std::vector<cv::Point2f>* charucoCorners,
 	std::vector<int>* charucoIds,
 	std::vector<std::vector<cv::Point2f>>* markerCorners,
@@ -449,7 +452,7 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 {
 	return cvTry([&] {
 	cv::Mat charucoCorners_mat, charucoIds_mat;
-	detector->detectBoard(*image, charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
+	detector->detectBoard(InProxy(*image), charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
 	for (int i = 0; i < charucoCorners_mat.rows; ++i)
 	{
 		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
@@ -460,14 +463,14 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_detectDiamonds(
 	cv::aruco::CharucoDetector* detector,
-	cv::_InputArray* image,
+	const interop::InputArrayProxy* image,
 	std::vector<std::vector<cv::Point2f>>* diamondCorners,
 	std::vector<cv::Vec4i>* diamondIds,
 	std::vector<std::vector<cv::Point2f>>* markerCorners,
 	std::vector<int>* markerIds)
 {
 	return cvTry([&] {
-	detector->detectDiamonds(*image, *diamondCorners, *diamondIds, *markerCorners, *markerIds);
+	detector->detectDiamonds(InProxy(*image), *diamondCorners, *diamondIds, *markerCorners, *markerIds);
 	});
 }
 

--- a/src/OpenCvSharpExtern/features.h
+++ b/src/OpenCvSharpExtern/features.h
@@ -9,21 +9,36 @@
 #include "include_opencv.h"
 
 
-CVAPI(ExceptionStatus) features_drawKeypoints(cv::_InputArray *image, cv::KeyPoint *keypoints, int keypointsLength,
-    cv::_InputOutputArray *outImage, interop::Scalar color, int flags)
+CVAPI(ExceptionStatus) features_drawKeypoints(
+    const interop::InputArrayProxy* image,
+    cv::KeyPoint *keypoints,
+    int keypointsLength,
+    const interop::InputOutputArrayProxy* outImage,
+    interop::Scalar color,
+    int flags)
 {
     return cvTry([&] {
     const std::vector<cv::KeyPoint> keypointsVec(keypoints, keypoints + keypointsLength);
-    cv::drawKeypoints(*image, keypointsVec, *outImage, cpp(color), static_cast<cv::DrawMatchesFlags>(flags));
+    cv::drawKeypoints(InProxy(*image), keypointsVec, IoProxy(*outImage), cpp(color), static_cast<cv::DrawMatchesFlags>(flags));
     });
 }
 
 
-CVAPI(ExceptionStatus) features_drawMatches(cv::Mat *img1, cv::KeyPoint *keypoints1, int keypoints1Length,
-    cv::Mat *img2, cv::KeyPoint *keypoints2, int keypoints2Length,
-    cv::DMatch *matches1to2, int matches1to2Length, cv::Mat *outImg,
-    interop::Scalar matchColor, interop::Scalar singlePointColor,
-    char *matchesMask, int matchesMaskLength, int flags)
+CVAPI(ExceptionStatus) features_drawMatches(
+    cv::Mat *img1,
+    cv::KeyPoint *keypoints1,
+    int keypoints1Length,
+    cv::Mat *img2,
+    cv::KeyPoint *keypoints2,
+    int keypoints2Length,
+    cv::DMatch *matches1to2,
+    int matches1to2Length,
+    cv::Mat *outImg,
+    interop::Scalar matchColor,
+    interop::Scalar singlePointColor,
+    char *matchesMask,
+    int matchesMaskLength,
+    int flags)
 {
     return cvTry([&] {
     const std::vector<cv::KeyPoint> keypoints1Vec(keypoints1, keypoints1 + keypoints1Length);
@@ -37,11 +52,23 @@ CVAPI(ExceptionStatus) features_drawMatches(cv::Mat *img1, cv::KeyPoint *keypoin
     });
 }
 
-CVAPI(ExceptionStatus) features_drawMatchesKnn(cv::Mat *img1, cv::KeyPoint *keypoints1, int keypoints1Length,
-    cv::Mat *img2, cv::KeyPoint *keypoints2, int keypoints2Length,
-    cv::DMatch **matches1to2, int matches1to2Size1, int *matches1to2Size2,
-    cv::Mat *outImg, interop::Scalar matchColor, interop::Scalar singlePointColor,
-    char **matchesMask, int matchesMaskSize1, int *matchesMaskSize2, int flags)
+CVAPI(ExceptionStatus) features_drawMatchesKnn(
+    cv::Mat *img1,
+    cv::KeyPoint *keypoints1,
+    int keypoints1Length,
+    cv::Mat *img2,
+    cv::KeyPoint *keypoints2,
+    int keypoints2Length,
+    cv::DMatch **matches1to2,
+    int matches1to2Size1,
+    int *matches1to2Size2,
+    cv::Mat *outImg,
+    interop::Scalar matchColor,
+    interop::Scalar singlePointColor,
+    char **matchesMask,
+    int matchesMaskSize1,
+    int *matchesMaskSize2,
+    int flags)
 {
     return cvTry([&] {
     const std::vector<cv::KeyPoint> keypoints1Vec(keypoints1, keypoints1 + keypoints1Length);
@@ -71,9 +98,13 @@ CVAPI(ExceptionStatus) features_drawMatchesKnn(cv::Mat *img1, cv::KeyPoint *keyp
 
 
 CVAPI(ExceptionStatus) features_evaluateFeatureDetector(
-    cv::Mat *img1, cv::Mat *img2, cv::Mat *H1to2,
-    std::vector<cv::KeyPoint> *keypoints1, std::vector<cv::KeyPoint> *keypoints2,
-    float *repeatability, int *correspCount/*,
+    cv::Mat *img1,
+    cv::Mat *img2,
+    cv::Mat *H1to2,
+    std::vector<cv::KeyPoint> *keypoints1,
+    std::vector<cv::KeyPoint> *keypoints2,
+    float *repeatability,
+    int *correspCount/*,
     const Ptr<FeatureDetector>& fdetector = Ptr<FeatureDetector>()*/)
 {
     return cvTry([&] {
@@ -84,8 +115,12 @@ CVAPI(ExceptionStatus) features_evaluateFeatureDetector(
 }
 
 CVAPI(ExceptionStatus) features_computeRecallPrecisionCurve(
-    cv::DMatch **matches1to2, int matches1to2Size1, int *matches1to2Size2,
-    uchar **correctMatches1to2Mask, int correctMatches1to2MaskSize1, int *correctMatches1to2MaskSize2,
+    cv::DMatch **matches1to2,
+    int matches1to2Size1,
+    int *matches1to2Size2,
+    uchar **correctMatches1to2Mask,
+    int correctMatches1to2MaskSize1,
+    int *correctMatches1to2MaskSize2,
     std::vector<cv::Point2f> *recallPrecisionCurve)
 {
     return cvTry([&] {
@@ -107,7 +142,10 @@ CVAPI(ExceptionStatus) features_computeRecallPrecisionCurve(
 }
 
 CVAPI(ExceptionStatus) features_getRecall(
-    cv::Point2f *recallPrecisionCurve, int recallPrecisionCurveSize, float l_precision, float *returnValue)
+    cv::Point2f *recallPrecisionCurve,
+    int recallPrecisionCurveSize,
+    float l_precision,
+    float *returnValue)
 {
     return cvTry([&] {
     const std::vector<cv::Point2f> recallPrecisionCurveVec(
@@ -117,7 +155,10 @@ CVAPI(ExceptionStatus) features_getRecall(
 }
 
 CVAPI(ExceptionStatus) features_getNearestPoint(
-    cv::Point2f *recallPrecisionCurve, int recallPrecisionCurveSize, float l_precision, int *returnValue)
+    cv::Point2f *recallPrecisionCurve,
+    int recallPrecisionCurveSize,
+    float l_precision,
+    int *returnValue)
 {
     return cvTry([&] {
     const std::vector<cv::Point2f> recallPrecisionCurveVec(
@@ -130,7 +171,9 @@ CVAPI(ExceptionStatus) features_getNearestPoint(
 #pragma region KeyPointsFilter
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByImageBorder(
-    std::vector<cv::KeyPoint> *keypoints, interop::Size imageSize, int borderSize)
+    std::vector<cv::KeyPoint> *keypoints,
+    interop::Size imageSize,
+    int borderSize)
 {
     return cvTry([&] {
     cv::KeyPointsFilter::runByImageBorder(*keypoints, cpp(imageSize), borderSize);
@@ -138,7 +181,9 @@ CVAPI(ExceptionStatus) features_KeyPointsFilter_runByImageBorder(
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByKeypointSize(
-    std::vector<cv::KeyPoint> *keypoints, float minSize, float maxSize)
+    std::vector<cv::KeyPoint> *keypoints,
+    float minSize,
+    float maxSize)
 {
     return cvTry([&] {
     cv::KeyPointsFilter::runByKeypointSize(*keypoints, minSize, maxSize);

--- a/src/OpenCvSharpExtern/features_ANNIndex.h
+++ b/src/OpenCvSharpExtern/features_ANNIndex.h
@@ -8,7 +8,10 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) features_ANNIndex_create(int dim, int distType, cv::Ptr<cv::ANNIndex> **returnValue)
+CVAPI(ExceptionStatus) features_ANNIndex_create(
+    int dim,
+    int distType,
+    cv::Ptr<cv::ANNIndex> **returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::ANNIndex::create(dim, static_cast<cv::ANNIndex::Distance>(distType));
@@ -30,10 +33,10 @@ CVAPI(ExceptionStatus) features_Ptr_ANNIndex_delete(cv::Ptr<cv::ANNIndex> *ptr)
     });
 }
 
-CVAPI(ExceptionStatus) features_ANNIndex_addItems(cv::ANNIndex *obj, cv::_InputArray *features)
+CVAPI(ExceptionStatus) features_ANNIndex_addItems(cv::ANNIndex *obj, const interop::InputArrayProxy* features)
 {
     return cvTry([&] {
-    obj->addItems(*features);
+    obj->addItems(InProxy(*features));
     });
 }
 
@@ -45,21 +48,32 @@ CVAPI(ExceptionStatus) features_ANNIndex_build(cv::ANNIndex *obj, int trees)
 }
 
 CVAPI(ExceptionStatus) features_ANNIndex_knnSearch(
-    cv::ANNIndex *obj, cv::_InputArray *query, cv::_OutputArray *indices, cv::_OutputArray *dists, int knn, int search_k)
+    cv::ANNIndex *obj,
+    const interop::InputArrayProxy* query,
+    const interop::OutputArrayProxy* indices,
+    const interop::OutputArrayProxy* dists,
+    int knn,
+    int search_k)
 {
     return cvTry([&] {
-    obj->knnSearch(*query, *indices, *dists, knn, search_k);
+    obj->knnSearch(InProxy(*query), OutProxy(*indices), OutProxy(*dists), knn, search_k);
     });
 }
 
-CVAPI(ExceptionStatus) features_ANNIndex_save(cv::ANNIndex *obj, const char *filename, int prefault)
+CVAPI(ExceptionStatus) features_ANNIndex_save(
+    cv::ANNIndex *obj,
+    const char *filename,
+    int prefault)
 {
     return cvTry([&] {
     obj->save(cv::String(filename), prefault != 0);
     });
 }
 
-CVAPI(ExceptionStatus) features_ANNIndex_load(cv::ANNIndex *obj, const char *filename, int prefault)
+CVAPI(ExceptionStatus) features_ANNIndex_load(
+    cv::ANNIndex *obj,
+    const char *filename,
+    int prefault)
 {
     return cvTry([&] {
     obj->load(cv::String(filename), prefault != 0);
@@ -80,7 +94,10 @@ CVAPI(ExceptionStatus) features_ANNIndex_getItemNumber(cv::ANNIndex *obj, int *r
     });
 }
 
-CVAPI(ExceptionStatus) features_ANNIndex_setOnDiskBuild(cv::ANNIndex *obj, const char *filename, int *returnValue)
+CVAPI(ExceptionStatus) features_ANNIndex_setOnDiskBuild(
+    cv::ANNIndex *obj,
+    const char *filename,
+    int *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->setOnDiskBuild(cv::String(filename)) ? 1 : 0;

--- a/src/OpenCvSharpExtern/features_DescriptorMatcher.h
+++ b/src/OpenCvSharpExtern/features_DescriptorMatcher.h
@@ -8,7 +8,10 @@
 #include "include_opencv.h"
 
 #pragma region DescriptorMatcher
-CVAPI(ExceptionStatus) features_DescriptorMatcher_add(cv::DescriptorMatcher *obj, cv::Mat **descriptors, int descriptorLength)
+CVAPI(ExceptionStatus) features_DescriptorMatcher_add(
+    cv::DescriptorMatcher *obj,
+    cv::Mat **descriptors,
+    int descriptorLength)
 {
     return cvTry([&] {
     std::vector<cv::Mat> descriptorsVec(descriptorLength);
@@ -53,8 +56,11 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_train(cv::DescriptorMatcher *o
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_match1(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, 
-    cv::Mat *trainDescriptors, std::vector<cv::DMatch> *matches, cv::Mat *mask)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    cv::Mat *trainDescriptors,
+    std::vector<cv::DMatch> *matches,
+    cv::Mat *mask)
 {
     return cvTry([&] {
     obj->match(*queryDescriptors, *trainDescriptors, *matches, entity(mask));
@@ -62,9 +68,13 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_match1(
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch1(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors,
-    cv::Mat *trainDescriptors, std::vector<std::vector<cv::DMatch> > *matches, int k,
-    cv::Mat *mask, int compactResult)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    cv::Mat *trainDescriptors,
+    std::vector<std::vector<cv::DMatch> > *matches,
+    int k,
+    cv::Mat *mask,
+    int compactResult)
 {
     return cvTry([&] {
     obj->knnMatch(*queryDescriptors, *trainDescriptors, *matches, k, entity(mask), compactResult != 0);
@@ -72,9 +82,13 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch1(
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch1(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, 
-    cv::Mat *trainDescriptors, std::vector<std::vector<cv::DMatch> > *matches, float maxDistance,
-    cv::Mat *mask, int compactResult)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    cv::Mat *trainDescriptors,
+    std::vector<std::vector<cv::DMatch> > *matches,
+    float maxDistance,
+    cv::Mat *mask,
+    int compactResult)
 {
     return cvTry([&] {
     obj->radiusMatch(*queryDescriptors, *trainDescriptors, *matches, maxDistance, entity(mask), compactResult != 0);
@@ -82,8 +96,11 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch1(
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_match2(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<cv::DMatch> *matches,
-    cv::Mat **masks, int masksSize)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    std::vector<cv::DMatch> *matches,
+    cv::Mat **masks,
+    int masksSize)
 {
     return cvTry([&] {
     std::vector<cv::Mat> masksVal;
@@ -100,8 +117,13 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_match2(
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch2(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<std::vector<cv::DMatch> > *matches, 
-    int k, cv::Mat **masks, int masksSize, int compactResult)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    std::vector<std::vector<cv::DMatch> > *matches,
+    int k,
+    cv::Mat **masks,
+    int masksSize,
+    int compactResult)
 {
     return cvTry([&] {
     std::vector<cv::Mat> masksVal;
@@ -118,8 +140,13 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_knnMatch2(
 }
 
 CVAPI(ExceptionStatus) features_DescriptorMatcher_radiusMatch2(
-    cv::DescriptorMatcher *obj, cv::Mat *queryDescriptors, std::vector<std::vector<cv::DMatch> > *matches, 
-    float maxDistance, cv::Mat **masks, int masksSize, int compactResult)
+    cv::DescriptorMatcher *obj,
+    cv::Mat *queryDescriptors,
+    std::vector<std::vector<cv::DMatch> > *matches,
+    float maxDistance,
+    cv::Mat **masks,
+    int masksSize,
+    int compactResult)
 {
     return cvTry([&] {
     std::vector<cv::Mat> masksVal;
@@ -162,7 +189,10 @@ CVAPI(ExceptionStatus) features_Ptr_DescriptorMatcher_delete(cv::Ptr<cv::Descrip
 
 #pragma region BFMatcher
 
-CVAPI(ExceptionStatus) features_BFMatcher_new(int normType, int crossCheck, cv::BFMatcher **returnValue)
+CVAPI(ExceptionStatus) features_BFMatcher_new(
+    int normType,
+    int crossCheck,
+    cv::BFMatcher **returnValue)
 {
     return cvTry([&] {
     *returnValue = new cv::BFMatcher(normType, crossCheck != 0);
@@ -202,7 +232,9 @@ CVAPI(ExceptionStatus) features_Ptr_BFMatcher_delete(cv::Ptr<cv::BFMatcher> *ptr
 #pragma region FlannBasedMatcher
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_new(
-    cv::Ptr<cv::flann::IndexParams> *indexParams, cv::Ptr<cv::flann::SearchParams> *searchParams, cv::FlannBasedMatcher **returnValue)
+    cv::Ptr<cv::flann::IndexParams> *indexParams,
+    cv::Ptr<cv::flann::SearchParams> *searchParams,
+    cv::FlannBasedMatcher **returnValue)
 {
     return cvTry([&] {
     cv::Ptr<cv::flann::IndexParams> indexParamsPtr;
@@ -229,7 +261,9 @@ CVAPI(ExceptionStatus) features_FlannBasedMatcher_delete(cv::FlannBasedMatcher *
 }
 
 CVAPI(ExceptionStatus) features_FlannBasedMatcher_add(
-    cv::FlannBasedMatcher *obj, cv::Mat **descriptors, int descriptorsSize)
+    cv::FlannBasedMatcher *obj,
+    cv::Mat **descriptors,
+    int descriptorsSize)
 {
     return cvTry([&] {
     std::vector<cv::Mat> descriptorsVal(descriptorsSize);
@@ -285,7 +319,10 @@ CVAPI(ExceptionStatus) features_Ptr_FlannBasedMatcher_delete(cv::Ptr<cv::FlannBa
 #pragma region LightGlueMatcher
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_create(
-    const char *modelPath, float scoreThreshold, int backend, int target,
+    const char *modelPath,
+    float scoreThreshold,
+    int backend,
+    int target,
     cv::Ptr<cv::LightGlueMatcher> **returnValue)
 {
     return cvTry([&] {
@@ -295,7 +332,11 @@ CVAPI(ExceptionStatus) features_LightGlueMatcher_create(
 }
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_create_buffer(
-    const uchar *modelData, size_t modelDataLength, float scoreThreshold, int backend, int target,
+    const uchar *modelData,
+    size_t modelDataLength,
+    float scoreThreshold,
+    int backend,
+    int target,
     cv::Ptr<cv::LightGlueMatcher> **returnValue)
 {
     return cvTry([&] {
@@ -306,11 +347,14 @@ CVAPI(ExceptionStatus) features_LightGlueMatcher_create_buffer(
 }
 
 CVAPI(ExceptionStatus) features_LightGlueMatcher_setPairInfo(
-    cv::LightGlueMatcher *obj, cv::_InputArray *queryKpts, cv::_InputArray *trainKpts,
-    interop::Size queryImageSize, interop::Size trainImageSize)
+    cv::LightGlueMatcher *obj,
+    const interop::InputArrayProxy* queryKpts,
+    const interop::InputArrayProxy* trainKpts,
+    interop::Size queryImageSize,
+    interop::Size trainImageSize)
 {
     return cvTry([&] {
-    obj->setPairInfo(*queryKpts, *trainKpts, cpp(queryImageSize), cpp(trainImageSize));
+    obj->setPairInfo(InProxy(*queryKpts), InProxy(*trainKpts), cpp(queryImageSize), cpp(trainImageSize));
     });
 }
 

--- a/src/OpenCvSharpExtern/features_Feature2D.h
+++ b/src/OpenCvSharpExtern/features_Feature2D.h
@@ -23,8 +23,9 @@ CVAPI(ExceptionStatus) features_Feature2D_detect_Mat1(
 
 CVAPI(ExceptionStatus) features_Feature2D_detect_Mat2(
     cv::Feature2D *detector,
-    cv::Mat **images, int imageLength,
-    std::vector<std::vector<cv::KeyPoint> > *keypoints, 
+    cv::Mat **images,
+    int imageLength,
+    std::vector<std::vector<cv::KeyPoint> > *keypoints,
     cv::Mat **mask)
 {
     return cvTry([&] {
@@ -46,25 +47,34 @@ CVAPI(ExceptionStatus) features_Feature2D_detect_Mat2(
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_detect_InputArray(
-    cv::Feature2D *obj, cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, cv::Mat *mask)
+    cv::Feature2D *obj,
+    const interop::InputArrayProxy* image,
+    std::vector<cv::KeyPoint> *keypoints,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-    obj->detect(*image, *keypoints, entity(mask));
+    obj->detect(InProxy(*image), *keypoints, InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_compute1(
     cv::Feature2D *obj,
-    cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, cv::_OutputArray *descriptors)
+    const interop::InputArrayProxy* image,
+    std::vector<cv::KeyPoint> *keypoints,
+    const interop::OutputArrayProxy* descriptors)
 {
     return cvTry([&] {
-    obj->compute(*image, *keypoints, *descriptors);
+    obj->compute(InProxy(*image), *keypoints, OutProxy(*descriptors));
     });
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_compute2(
-    cv::Feature2D *detector, cv::Mat **images, int imageLength,
-    std::vector<std::vector<cv::KeyPoint> > *keypoints, cv::Mat **descriptors, int descriptorsLength)
+    cv::Feature2D *detector,
+    cv::Mat **images,
+    int imageLength,
+    std::vector<std::vector<cv::KeyPoint> > *keypoints,
+    cv::Mat **descriptors,
+    int descriptorsLength)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imageVec(imageLength);
@@ -80,11 +90,15 @@ CVAPI(ExceptionStatus) features_Feature2D_compute2(
 }
 
 CVAPI(ExceptionStatus) features_Feature2D_detectAndCompute(
-    cv::Feature2D *detector, cv::_InputArray *image, cv::_InputArray *mask, 
-    std::vector<cv::KeyPoint> *keypoints, cv::_OutputArray *descriptors, int useProvidedKeypoints)
+    cv::Feature2D *detector,
+    const interop::InputArrayProxy* image,
+    const interop::InputArrayProxy* mask,
+    std::vector<cv::KeyPoint> *keypoints,
+    const interop::OutputArrayProxy* descriptors,
+    int useProvidedKeypoints)
 {
     return cvTry([&] {
-    detector->detectAndCompute(entity(image), entity(mask), *keypoints, *descriptors, useProvidedKeypoints != 0);
+    detector->detectAndCompute(InProxy(*image), InProxy(*mask), *keypoints, OutProxy(*descriptors), useProvidedKeypoints != 0);
     });
 }
 
@@ -140,8 +154,11 @@ CVAPI(ExceptionStatus) features_Feature2D_getDefaultName(cv::Feature2D *obj, std
 #pragma region SIFT
 
 CVAPI(ExceptionStatus) features_SIFT_create(
-    int nfeatures, int nOctaveLayers,
-    double contrastThreshold, double edgeThreshold, double sigma, 
+    int nfeatures,
+    int nOctaveLayers,
+    double contrastThreshold,
+    double edgeThreshold,
+    double sigma,
     cv::Ptr<cv::SIFT> **returnValue)
 {
     return cvTry([&] {
@@ -164,8 +181,15 @@ CVAPI(ExceptionStatus) features_Ptr_SIFT_delete(cv::Ptr<cv::SIFT> *ptr)
 #pragma region ORB
 
 CVAPI(ExceptionStatus) features_ORB_create(
-    int nFeatures, float scaleFactor, int nlevels, int edgeThreshold,
-    int firstLevel, int wtaK, int scoreType, int patchSize, int fastThreshold,
+    int nFeatures,
+    float scaleFactor,
+    int nlevels,
+    int edgeThreshold,
+    int firstLevel,
+    int wtaK,
+    int scoreType,
+    int patchSize,
+    int fastThreshold,
     cv::Ptr<cv::ORB> **returnValue)
 {
     return cvTry([&] {
@@ -302,9 +326,16 @@ CVAPI(ExceptionStatus) features_ORB_getFastThreshold(cv::ORB *obj, int *returnVa
 
 #pragma region MSER
 
-CVAPI(ExceptionStatus) features_MSER_create(int delta, int minArea, int maxArea,
-    double maxVariation, double minDiversity, int maxEvolution,
-    double areaThreshold, double minMargin, int edgeBlurSize,
+CVAPI(ExceptionStatus) features_MSER_create(
+    int delta,
+    int minArea,
+    int maxArea,
+    double maxVariation,
+    double minDiversity,
+    int maxEvolution,
+    double areaThreshold,
+    double minMargin,
+    int edgeBlurSize,
     cv::Ptr<cv::MSER> **returnValue)
 {
     return cvTry([&] {
@@ -322,12 +353,12 @@ CVAPI(ExceptionStatus) features_Ptr_MSER_delete(cv::Ptr<cv::MSER> *ptr)
 
 CVAPI(ExceptionStatus) features_MSER_detectRegions(
     cv::MSER *obj,
-    cv::_InputArray *image,
+    const interop::InputArrayProxy* image,
     std::vector<std::vector<cv::Point> > *msers,
     std::vector<cv::Rect> *bboxes)
 {
     return cvTry([&] {
-    obj->detectRegions(*image, *msers, *bboxes);
+    obj->detectRegions(InProxy(*image), *msers, *bboxes);
     });
 }
 
@@ -387,23 +418,34 @@ CVAPI(ExceptionStatus) features_MSER_getPass2Only(cv::MSER *obj, int *returnValu
 
 #pragma region FastFeatureDetector
 
-CVAPI(ExceptionStatus) features_FAST1(cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, int threshold, int nonmaxSupression)
+CVAPI(ExceptionStatus) features_FAST1(
+    const interop::InputArrayProxy* image,
+    std::vector<cv::KeyPoint> *keypoints,
+    int threshold,
+    int nonmaxSupression)
 {
     return cvTry([&] {
-    cv::FAST(*image, *keypoints, threshold, nonmaxSupression != 0);
+    cv::FAST(InProxy(*image), *keypoints, threshold, nonmaxSupression != 0);
     });
 }
 
-CVAPI(ExceptionStatus) features_FAST2(cv::_InputArray *image, std::vector<cv::KeyPoint> *keypoints, int threshold, int nonmaxSupression, int type)
+CVAPI(ExceptionStatus) features_FAST2(
+    const interop::InputArrayProxy* image,
+    std::vector<cv::KeyPoint> *keypoints,
+    int threshold,
+    int nonmaxSupression,
+    int type)
 {
     return cvTry([&] {
-    cv::FAST(*image, *keypoints, threshold, nonmaxSupression != 0, static_cast<cv::FastFeatureDetector::DetectorType>(type));
+    cv::FAST(InProxy(*image), *keypoints, threshold, nonmaxSupression != 0, static_cast<cv::FastFeatureDetector::DetectorType>(type));
     });
 }
 
 
 CVAPI(ExceptionStatus) features_FastFeatureDetector_create(
-    int threshold, int nonmaxSuppression, cv::Ptr<cv::FastFeatureDetector> **returnValue)
+    int threshold,
+    int nonmaxSuppression,
+    cv::Ptr<cv::FastFeatureDetector> **returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::FastFeatureDetector::create(threshold, nonmaxSuppression != 0);
@@ -462,8 +504,12 @@ CVAPI(ExceptionStatus) features_FastFeatureDetector_getType(cv::FastFeatureDetec
 #pragma region GFTTDetector
 
 CVAPI(ExceptionStatus) features_GFTTDetector_create(
-    int maxCorners, double qualityLevel, double minDistance,
-    int blockSize, int useHarrisDetector, double k,
+    int maxCorners,
+    double qualityLevel,
+    double minDistance,
+    int blockSize,
+    int useHarrisDetector,
+    double k,
     cv::Ptr<cv::GFTTDetector> **returnValue)
 {
     return cvTry([&] {
@@ -640,7 +686,11 @@ CVAPI(ExceptionStatus) features_Ptr_Feature2D_get(cv::Ptr<cv::Feature2D> *obj, c
 #pragma region AffineFeature
 
 CVAPI(ExceptionStatus) features_AffineFeature_create(
-    cv::Ptr<cv::Feature2D> *backend, int maxTilt, int minTilt, float tiltStep, float rotateStepBase,
+    cv::Ptr<cv::Feature2D> *backend,
+    int maxTilt,
+    int minTilt,
+    float tiltStep,
+    float rotateStepBase,
     cv::Ptr<cv::AffineFeature> **returnValue)
 {
     return cvTry([&] {
@@ -650,7 +700,11 @@ CVAPI(ExceptionStatus) features_AffineFeature_create(
 }
 
 CVAPI(ExceptionStatus) features_AffineFeature_setViewParams(
-    cv::AffineFeature *obj, float *tilts, int tiltsLength, float *rolls, int rollsLength)
+    cv::AffineFeature *obj,
+    float *tilts,
+    int tiltsLength,
+    float *rolls,
+    int rollsLength)
 {
     return cvTry([&] {
     const std::vector<float> tiltsVec(tilts, tilts + tiltsLength);
@@ -660,7 +714,9 @@ CVAPI(ExceptionStatus) features_AffineFeature_setViewParams(
 }
 
 CVAPI(ExceptionStatus) features_AffineFeature_getViewParams(
-    cv::AffineFeature *obj, std::vector<float> *tilts, std::vector<float> *rolls)
+    cv::AffineFeature *obj,
+    std::vector<float> *tilts,
+    std::vector<float> *rolls)
 {
     return cvTry([&] {
     obj->getViewParams(*tilts, *rolls);
@@ -682,7 +738,12 @@ CVAPI(ExceptionStatus) features_Ptr_AffineFeature_delete(cv::Ptr<cv::AffineFeatu
 #pragma region DISK
 
 CVAPI(ExceptionStatus) features_DISK_create(
-    const char *modelPath, int maxKeypoints, float scoreThreshold, interop::Size imageSize, int backendId, int targetId,
+    const char *modelPath,
+    int maxKeypoints,
+    float scoreThreshold,
+    interop::Size imageSize,
+    int backendId,
+    int targetId,
     cv::Ptr<cv::DISK> **returnValue)
 {
     return cvTry([&] {
@@ -692,7 +753,13 @@ CVAPI(ExceptionStatus) features_DISK_create(
 }
 
 CVAPI(ExceptionStatus) features_DISK_create_buffer(
-    const uchar *bufferModel, size_t bufferModelLength, int maxKeypoints, float scoreThreshold, interop::Size imageSize, int backendId, int targetId,
+    const uchar *bufferModel,
+    size_t bufferModelLength,
+    int maxKeypoints,
+    float scoreThreshold,
+    interop::Size imageSize,
+    int backendId,
+    int targetId,
     cv::Ptr<cv::DISK> **returnValue)
 {
     return cvTry([&] {
@@ -752,7 +819,12 @@ CVAPI(ExceptionStatus) features_Ptr_DISK_delete(cv::Ptr<cv::DISK> *ptr)
 #pragma region ALIKED
 
 CVAPI(ExceptionStatus) features_ALIKED_create(
-    const char *modelPath, interop::Size inputSize, int normalizeDescriptors, int engine, int backend, int target,
+    const char *modelPath,
+    interop::Size inputSize,
+    int normalizeDescriptors,
+    int engine,
+    int backend,
+    int target,
     cv::Ptr<cv::ALIKED> **returnValue)
 {
     return cvTry([&] {
@@ -768,7 +840,13 @@ CVAPI(ExceptionStatus) features_ALIKED_create(
 }
 
 CVAPI(ExceptionStatus) features_ALIKED_create_buffer(
-    const uchar *modelData, size_t modelDataLength, interop::Size inputSize, int normalizeDescriptors, int engine, int backend, int target,
+    const uchar *modelData,
+    size_t modelDataLength,
+    interop::Size inputSize,
+    int normalizeDescriptors,
+    int engine,
+    int backend,
+    int target,
     cv::Ptr<cv::ALIKED> **returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/ml_ANN_MLP.h
+++ b/src/OpenCvSharpExtern/ml_ANN_MLP.h
@@ -8,7 +8,11 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) ml_ANN_MLP_setTrainMethod(cv::ml::ANN_MLP *obj, int method, double param1, double param2)
+CVAPI(ExceptionStatus) ml_ANN_MLP_setTrainMethod(
+    cv::ml::ANN_MLP *obj,
+    int method,
+    double param1,
+    double param2)
 {
     return cvTry([&] {
     obj->setTrainMethod(method, param1, param2);
@@ -22,17 +26,21 @@ CVAPI(ExceptionStatus) ml_ANN_MLP_getTrainMethod(cv::ml::ANN_MLP *obj, int *retu
     });
 }
 
-CVAPI(ExceptionStatus) ml_ANN_MLP_setActivationFunction(cv::ml::ANN_MLP *obj, int type, double param1, double param2)
+CVAPI(ExceptionStatus) ml_ANN_MLP_setActivationFunction(
+    cv::ml::ANN_MLP *obj,
+    int type,
+    double param1,
+    double param2)
 {
     return cvTry([&] {
     obj->setActivationFunction(type, param1, param2);
     });
 }
 
-CVAPI(ExceptionStatus) ml_ANN_MLP_setLayerSizes(cv::ml::ANN_MLP *obj, cv::_InputArray *_layer_sizes)
+CVAPI(ExceptionStatus) ml_ANN_MLP_setLayerSizes(cv::ml::ANN_MLP *obj, const interop::InputArrayProxy* _layer_sizes)
 {
     return cvTry([&] {
-    obj->setLayerSizes(entity(_layer_sizes));
+    obj->setLayerSizes(InProxy(*_layer_sizes));
     });
 }
 
@@ -148,7 +156,10 @@ CVAPI(ExceptionStatus) ml_ANN_MLP_setRpropDWMax(cv::ml::ANN_MLP *obj, double val
     });
 }
 
-CVAPI(ExceptionStatus) ml_ANN_MLP_getWeights(cv::ml::ANN_MLP *obj, int layerIdx, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) ml_ANN_MLP_getWeights(
+    cv::ml::ANN_MLP *obj,
+    int layerIdx,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     *returnValue = new cv::Mat(obj->getWeights(layerIdx));

--- a/src/OpenCvSharpExtern/ml_EM.h
+++ b/src/OpenCvSharpExtern/ml_EM.h
@@ -79,10 +79,13 @@ CVAPI(ExceptionStatus) ml_EM_getCovs(cv::ml::EM *obj, std::vector<cv::Mat*> *cov
 
 
 CVAPI(ExceptionStatus) ml_EM_predict2(
-    cv::ml::EM *obj, cv::_InputArray *sample, cv::_OutputArray *probs, interop::Vec2d *returnValue)
+    cv::ml::EM *obj,
+    const interop::InputArrayProxy* sample,
+    const interop::OutputArrayProxy* probs,
+    interop::Vec2d *returnValue)
 {
     return cvTry([&] {
-    auto vec = obj->predict2(*sample, *probs);
+    auto vec = obj->predict2(InProxy(*sample), OutProxy(*probs));
     interop::Vec2d ret;
     ret.val[0] = vec[0];
     ret.val[1] = vec[1];
@@ -92,49 +95,49 @@ CVAPI(ExceptionStatus) ml_EM_predict2(
 
 CVAPI(ExceptionStatus) ml_EM_trainEM(
     cv::ml::EM *obj,
-    cv::_InputArray *samples,
-    cv::_OutputArray *logLikelihoods,
-    cv::_OutputArray *labels,
-    cv::_OutputArray *probs, 
+    const interop::InputArrayProxy* samples,
+    const interop::OutputArrayProxy* logLikelihoods,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* probs,
     int *returnValue)
 {
     return cvTry([&] {
-    const auto ret = obj->trainEM(*samples, entity(logLikelihoods), entity(labels), entity(probs));
+    const auto ret = obj->trainEM(InProxy(*samples), OutProxy(*logLikelihoods), OutProxy(*labels), OutProxy(*probs));
     *returnValue = ret ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) ml_EM_trainE(
     cv::ml::EM *obj,
-    cv::_InputArray *samples,
-    cv::_InputArray *means0,
-    cv::_InputArray *covs0,
-    cv::_InputArray *weights0,
-    cv::_OutputArray *logLikelihoods,
-    cv::_OutputArray *labels,
-    cv::_OutputArray *probs, 
+    const interop::InputArrayProxy* samples,
+    const interop::InputArrayProxy* means0,
+    const interop::InputArrayProxy* covs0,
+    const interop::InputArrayProxy* weights0,
+    const interop::OutputArrayProxy* logLikelihoods,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* probs,
     int *returnValue)
 {
     return cvTry([&] {
     const auto ret = obj->trainE(
-        *samples, *means0, entity(covs0), entity(weights0),
-        entity(logLikelihoods), entity(labels), entity(probs));
+        InProxy(*samples), InProxy(*means0), InProxy(*covs0), InProxy(*weights0),
+        OutProxy(*logLikelihoods), OutProxy(*labels), OutProxy(*probs));
     *returnValue = ret ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) ml_EM_trainM(
     cv::ml::EM *obj,
-    cv::_InputArray *samples,
-    cv::_InputArray *probs0,
-    cv::_OutputArray *logLikelihoods,
-    cv::_OutputArray *labels,
-    cv::_OutputArray *probs, 
+    const interop::InputArrayProxy* samples,
+    const interop::InputArrayProxy* probs0,
+    const interop::OutputArrayProxy* logLikelihoods,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* probs,
     int *returnValue)
 {
     return cvTry([&] {
     const auto ret = obj->trainM(
-        *samples, *probs0, entity(logLikelihoods), entity(labels), entity(probs));
+        InProxy(*samples), InProxy(*probs0), OutProxy(*logLikelihoods), OutProxy(*labels), OutProxy(*probs));
     *returnValue = ret ? 1 : 0;
     });
 }

--- a/src/OpenCvSharpExtern/ml_KNearest.h
+++ b/src/OpenCvSharpExtern/ml_KNearest.h
@@ -62,12 +62,18 @@ CVAPI(ExceptionStatus) ml_KNearest_setAlgorithmType(cv::ml::KNearest *obj, int v
 }
 
 
-CVAPI(ExceptionStatus) ml_KNearest_findNearest(cv::ml::KNearest *obj, cv::_InputArray *samples, int k,
-    cv::_OutputArray *results, cv::_OutputArray *neighborResponses, cv::_OutputArray *dist, float *returnValue)
+CVAPI(ExceptionStatus) ml_KNearest_findNearest(
+    cv::ml::KNearest *obj,
+    const interop::InputArrayProxy* samples,
+    int k,
+    const interop::OutputArrayProxy* results,
+    const interop::OutputArrayProxy* neighborResponses,
+    const interop::OutputArrayProxy* dist,
+    float *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->findNearest(
-        entity(samples), k, entity(results), entity(neighborResponses), entity(dist));
+        InProxy(*samples), k, OutProxy(*results), OutProxy(*neighborResponses), OutProxy(*dist));
     });
 }
 

--- a/src/OpenCvSharpExtern/ml_LogisticRegression.h
+++ b/src/OpenCvSharpExtern/ml_LogisticRegression.h
@@ -87,10 +87,14 @@ CVAPI(ExceptionStatus) ml_LogisticRegression_setTermCriteria(cv::ml::LogisticReg
 
 
 CVAPI(ExceptionStatus) ml_LogisticRegression_predict(
-    cv::ml::LogisticRegression *obj, cv::_InputArray *samples, cv::_OutputArray *results, int flags, float *returnValue)
+    cv::ml::LogisticRegression *obj,
+    const interop::InputArrayProxy* samples,
+    const interop::OutputArrayProxy* results,
+    int flags,
+    float *returnValue)
 { 
     return cvTry([&] {
-    *returnValue = obj->predict(entity(samples), entity(results), flags);
+    *returnValue = obj->predict(InProxy(*samples), OutProxy(*results), flags);
     });
 }
 
@@ -117,16 +121,14 @@ CVAPI(ExceptionStatus) ml_Ptr_LogisticRegression_delete(cv::Ptr<cv::ml::Logistic
     });
 }
 
-CVAPI(ExceptionStatus) ml_Ptr_LogisticRegression_get(
-    cv::Ptr<cv::ml::LogisticRegression> *obj, cv::ml::LogisticRegression **returnValue)
+CVAPI(ExceptionStatus) ml_Ptr_LogisticRegression_get(cv::Ptr<cv::ml::LogisticRegression> *obj, cv::ml::LogisticRegression **returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->get();
     });
 }
 
-CVAPI(ExceptionStatus) ml_LogisticRegression_load(
-    const char *filePath, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
+CVAPI(ExceptionStatus) ml_LogisticRegression_load(const char *filePath, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::Algorithm::load<cv::ml::LogisticRegression>(filePath);
@@ -134,8 +136,7 @@ CVAPI(ExceptionStatus) ml_LogisticRegression_load(
     });
 }
 
-CVAPI(ExceptionStatus) ml_LogisticRegression_loadFromString(
-    const char *strModel, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
+CVAPI(ExceptionStatus) ml_LogisticRegression_loadFromString(const char *strModel, cv::Ptr<cv::ml::LogisticRegression> **returnValue)
 {
     return cvTry([&] {
     const auto objName = cv::ml::LogisticRegression::create()->getDefaultName();

--- a/src/OpenCvSharpExtern/ml_NormalBayesClassifier.h
+++ b/src/OpenCvSharpExtern/ml_NormalBayesClassifier.h
@@ -8,11 +8,15 @@
 #include "include_opencv.h"
 
 CVAPI(ExceptionStatus) ml_NormalBayesClassifier_predictProb(
-    cv::ml::NormalBayesClassifier *obj, cv::_InputArray *inputs, 
-    cv::_OutputArray *samples, cv::_OutputArray *outputProbs, int flags, float *returnValue)
+    cv::ml::NormalBayesClassifier *obj,
+    const interop::InputArrayProxy* inputs,
+    const interop::OutputArrayProxy* samples,
+    const interop::OutputArrayProxy* outputProbs,
+    int flags,
+    float *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->predictProb(entity(inputs), entity(samples), entity(outputProbs), flags);
+    *returnValue = obj->predictProb(InProxy(*inputs), OutProxy(*samples), OutProxy(*outputProbs), flags);
     });
 }
 
@@ -31,8 +35,7 @@ CVAPI(ExceptionStatus) ml_Ptr_NormalBayesClassifier_delete(cv::Ptr<cv::ml::Norma
     });
 }
 
-CVAPI(ExceptionStatus) ml_Ptr_NormalBayesClassifier_get(
-    cv::Ptr<cv::ml::NormalBayesClassifier>* obj, cv::ml::NormalBayesClassifier **returnValue)
+CVAPI(ExceptionStatus) ml_Ptr_NormalBayesClassifier_get(cv::Ptr<cv::ml::NormalBayesClassifier>* obj, cv::ml::NormalBayesClassifier **returnValue)
 
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/ml_SVM.h
+++ b/src/OpenCvSharpExtern/ml_SVM.h
@@ -147,10 +147,14 @@ CVAPI(ExceptionStatus) ml_SVM_getSupportVectors(cv::ml::SVM *obj, cv::Mat **retu
 }
 
 CVAPI(ExceptionStatus) ml_SVM_getDecisionFunction(
-    cv::ml::SVM *obj, int i, cv::_OutputArray *alpha, cv::_OutputArray *svidx, double *returnValue)
+    cv::ml::SVM *obj,
+    int i,
+    const interop::OutputArrayProxy* alpha,
+    const interop::OutputArrayProxy* svidx,
+    double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->getDecisionFunction(i, entity(alpha), entity(svidx));
+    *returnValue = obj->getDecisionFunction(i, OutProxy(*alpha), OutProxy(*svidx));
     });
 }
 

--- a/src/OpenCvSharpExtern/ml_StatModel.h
+++ b/src/OpenCvSharpExtern/ml_StatModel.h
@@ -43,7 +43,10 @@ CVAPI(ExceptionStatus) ml_StatModel_isClassifier(cv::ml::StatModel *obj, int *re
 }
 
 /*CVAPI(ExceptionStatus) ml_StatModel_train1(
-    cv::ml::StatModel *obj, cv::Ptr<cv::ml::TrainData> *trainData, int flags, int *returnValue)
+    cv::ml::StatModel *obj,
+    cv::Ptr<cv::ml::TrainData> *trainData,
+    int flags,
+    int *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->train(*trainData, flags) ? 1 : 0;
@@ -51,26 +54,38 @@ CVAPI(ExceptionStatus) ml_StatModel_isClassifier(cv::ml::StatModel *obj, int *re
 }*/
 
 CVAPI(ExceptionStatus) ml_StatModel_train2(
-    cv::ml::StatModel *obj, cv::_InputArray *samples, int layout, cv::_InputArray *responses, int *returnValue)
+    cv::ml::StatModel *obj,
+    const interop::InputArrayProxy* samples,
+    int layout,
+    const interop::InputArrayProxy* responses,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->train(*samples, layout, *responses) ? 1 : 0;
+    *returnValue = obj->train(InProxy(*samples), layout, InProxy(*responses)) ? 1 : 0;
     });
 }
 
 /*CVAPI(ExceptionStatus) ml_StatModel_calcError(
-    cv::ml::StatModel *obj, cv::Ptr<cv::ml::TrainData> *data, int test, cv::_OutputArray *resp, float *returnValue)
+    cv::ml::StatModel *obj,
+    cv::Ptr<cv::ml::TrainData> *data,
+    int test,
+    const interop::OutputArrayProxy* resp,
+    float *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->calcError(*data, test != 0, *resp);
+    *returnValue = obj->calcError(*data, test != 0, OutProxy(*resp));
     });
 }*/
 
 CVAPI(ExceptionStatus) ml_StatModel_predict(
-    cv::ml::StatModel *obj, cv::_InputArray *samples, cv::_OutputArray *results, int flags, float *returnValue)
+    cv::ml::StatModel *obj,
+    const interop::InputArrayProxy* samples,
+    const interop::OutputArrayProxy* results,
+    int flags,
+    float *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->predict(entity(samples), entity(results), flags);
+    *returnValue = obj->predict(InProxy(*samples), OutProxy(*results), flags);
     });
 }
 

--- a/src/OpenCvSharpExtern/photo.h
+++ b/src/OpenCvSharpExtern/photo.h
@@ -9,33 +9,52 @@
 #include "include_opencv.h"
 
 
-CVAPI(ExceptionStatus) photo_inpaint(cv::_InputArray *src, cv::_InputArray *inpaintMask,
-    cv::_OutputArray *dst, double inpaintRadius, int flags)
+CVAPI(ExceptionStatus) photo_inpaint(
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* inpaintMask,
+    const interop::OutputArrayProxy* dst,
+    double inpaintRadius,
+    int flags)
 {
     return cvTry([&] {
-    cv::inpaint(*src, *inpaintMask, *dst, inpaintRadius, flags);
+    cv::inpaint(InProxy(*src), InProxy(*inpaintMask), OutProxy(*dst), inpaintRadius, flags);
     });
 }
 
-CVAPI(ExceptionStatus) photo_fastNlMeansDenoising(cv::_InputArray *src, cv::_OutputArray *dst, float h,
-    int templateWindowSize, int searchWindowSize)
+CVAPI(ExceptionStatus) photo_fastNlMeansDenoising(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float h,
+    int templateWindowSize,
+    int searchWindowSize)
 {
     return cvTry([&] {
-    cv::fastNlMeansDenoising(*src, *dst, h, templateWindowSize, searchWindowSize);
+    cv::fastNlMeansDenoising(InProxy(*src), OutProxy(*dst), h, templateWindowSize, searchWindowSize);
     });
 }
 
-CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColored(cv::_InputArray *src, cv::_OutputArray *dst,
-    float h, float hColor, int templateWindowSize, int searchWindowSize)
+CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColored(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float h,
+    float hColor,
+    int templateWindowSize,
+    int searchWindowSize)
 {
     return cvTry([&] {
-    cv::fastNlMeansDenoisingColored(*src, *dst, h, hColor, templateWindowSize, searchWindowSize);
+    cv::fastNlMeansDenoisingColored(InProxy(*src), OutProxy(*dst), h, hColor, templateWindowSize, searchWindowSize);
     });
 }
 
-CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(cv::Mat **srcImgs, int srcImgsLength,
-    cv::_OutputArray* dst, int imgToDenoiseIndex, int temporalWindowSize,
-    float h, int templateWindowSize, int searchWindowSize)
+CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(
+    cv::Mat **srcImgs,
+    int srcImgsLength,
+    const interop::OutputArrayProxy* dst,
+    int imgToDenoiseIndex,
+    int temporalWindowSize,
+    float h,
+    int templateWindowSize,
+    int searchWindowSize)
 {
     return cvTry([&] {
 
@@ -44,14 +63,21 @@ CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingMulti(cv::Mat **srcImgs, int sr
         srcImgsVec[i] = *srcImgs[i];
 
     cv::fastNlMeansDenoisingMulti(
-        srcImgsVec, *dst, imgToDenoiseIndex, temporalWindowSize, h, templateWindowSize, searchWindowSize);
+        srcImgsVec, OutProxy(*dst), imgToDenoiseIndex, temporalWindowSize, h, templateWindowSize, searchWindowSize);
 
     });
 }
 
-CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColoredMulti(cv::Mat**srcImgs, int srcImgsLength,
-    cv::_OutputArray *dst, int imgToDenoiseIndex, int temporalWindowSize,
-    float h, float hColor, int templateWindowSize, int searchWindowSize)
+CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColoredMulti(
+    cv::Mat**srcImgs,
+    int srcImgsLength,
+    const interop::OutputArrayProxy* dst,
+    int imgToDenoiseIndex,
+    int temporalWindowSize,
+    float h,
+    float hColor,
+    int templateWindowSize,
+    int searchWindowSize)
 {
     return cvTry([&] {
 
@@ -60,13 +86,17 @@ CVAPI(ExceptionStatus) photo_fastNlMeansDenoisingColoredMulti(cv::Mat**srcImgs, 
         srcImgsVec[i] = *srcImgs[i];
 
     cv::fastNlMeansDenoisingColoredMulti(
-        srcImgsVec, *dst, imgToDenoiseIndex, temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize);
+        srcImgsVec, OutProxy(*dst), imgToDenoiseIndex, temporalWindowSize, h, hColor, templateWindowSize, searchWindowSize);
 
     });
 }
 
 CVAPI(ExceptionStatus) photo_denoise_TVL1(
-    cv::Mat **observations, int observationsSize, cv::Mat *result, double lambda, int niters)
+    cv::Mat **observations,
+    int observationsSize,
+    cv::Mat *result,
+    double lambda,
+    int niters)
 {
     return cvTry([&] {
     std::vector<cv::Mat> observationsVec(observationsSize);
@@ -81,79 +111,110 @@ CVAPI(ExceptionStatus) photo_denoise_TVL1(
 
 
 CVAPI(ExceptionStatus) photo_decolor(
-    cv::_InputArray *src, cv::_OutputArray *grayscale, cv::_OutputArray *color_boost)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* grayscale,
+    const interop::OutputArrayProxy* color_boost)
 {
     return cvTry([&] {
-    cv::decolor(*src, *grayscale, *color_boost);
+    cv::decolor(InProxy(*src), OutProxy(*grayscale), OutProxy(*color_boost));
     });
 }
 
 CVAPI(ExceptionStatus) photo_seamlessClone(
-    cv::_InputArray *src, cv::_InputArray *dst, cv::_InputArray *mask, interop::Point p,
-    cv::_OutputArray *blend, int flags)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
+    interop::Point p,
+    const interop::OutputArrayProxy* blend,
+    int flags)
 {
     return cvTry([&] {
-    cv::seamlessClone(*src, *dst, entity(mask), cpp(p), *blend, flags);
+    cv::seamlessClone(InProxy(*src), InProxy(*dst), InProxy(*mask), cpp(p), OutProxy(*blend), flags);
     });
 }
 
 CVAPI(ExceptionStatus) photo_colorChange(
-    cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst, float red_mul,
-    float green_mul, float blue_mul)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* mask,
+    const interop::OutputArrayProxy* dst,
+    float red_mul,
+    float green_mul,
+    float blue_mul)
 {
     return cvTry([&] {
-    cv::colorChange(*src, entity(mask), *dst, red_mul, green_mul, blue_mul);
+    cv::colorChange(InProxy(*src), InProxy(*mask), OutProxy(*dst), red_mul, green_mul, blue_mul);
     });
 }
 
 CVAPI(ExceptionStatus) photo_illuminationChange(
-    cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst,
-    float alpha, float beta = 0.4f)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* mask,
+    const interop::OutputArrayProxy* dst,
+    float alpha,
+    float beta = 0.4f)
 {
     return cvTry([&] {
-    cv::illuminationChange(*src, entity(mask), *dst, alpha, beta);
+    cv::illuminationChange(InProxy(*src), InProxy(*mask), OutProxy(*dst), alpha, beta);
     });
 }
 
 CVAPI(ExceptionStatus) photo_textureFlattening(
-    cv::_InputArray *src, cv::_InputArray *mask, cv::_OutputArray *dst,
-    float low_threshold, float high_threshold, int kernel_size)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* mask,
+    const interop::OutputArrayProxy* dst,
+    float low_threshold,
+    float high_threshold,
+    int kernel_size)
 {
     return cvTry([&] {
-    cv::textureFlattening(*src, entity(mask), *dst, low_threshold, high_threshold, kernel_size);
+    cv::textureFlattening(InProxy(*src), InProxy(*mask), OutProxy(*dst), low_threshold, high_threshold, kernel_size);
     });
 }
 
 CVAPI(ExceptionStatus) photo_edgePreservingFilter(
-    cv::_InputArray *src, cv::_OutputArray *dst, int flags,    float sigma_s, float sigma_r)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int flags,
+    float sigma_s,
+    float sigma_r)
 {
     return cvTry([&] {
-    cv::edgePreservingFilter(*src, *dst, flags, sigma_s, sigma_r);
+    cv::edgePreservingFilter(InProxy(*src), OutProxy(*dst), flags, sigma_s, sigma_r);
     });
 }
 
 CVAPI(ExceptionStatus) photo_detailEnhance(
-    cv::_InputArray *src, cv::_OutputArray *dst, float sigma_s,    float sigma_r)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float sigma_s,
+    float sigma_r)
 {
     return cvTry([&] {
-    cv::detailEnhance(*src, *dst, sigma_s, sigma_r);
+    cv::detailEnhance(InProxy(*src), OutProxy(*dst), sigma_s, sigma_r);
     });
 }
 
 CVAPI(ExceptionStatus) photo_pencilSketch(
-    cv::_InputArray *src, cv::_OutputArray *dst1, cv::_OutputArray *dst2,
-    float sigma_s, float sigma_r, float shade_factor)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst1,
+    const interop::OutputArrayProxy* dst2,
+    float sigma_s,
+    float sigma_r,
+    float shade_factor)
 {
     return cvTry([&] {
-    cv::pencilSketch(*src, *dst1, *dst2, sigma_s, sigma_r, shade_factor);
+    cv::pencilSketch(InProxy(*src), OutProxy(*dst1), OutProxy(*dst2), sigma_s, sigma_r, shade_factor);
     });
 }
 
 CVAPI(ExceptionStatus) photo_stylization(
-    cv::_InputArray *src, cv::_OutputArray *dst, float sigma_s,    float sigma_r)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float sigma_s,
+    float sigma_r)
 {
     return cvTry([&] {
-    cv::stylization(*src, *dst, sigma_s, sigma_r);
+    cv::stylization(InProxy(*src), OutProxy(*dst), sigma_s, sigma_r);
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_Odometry.h
+++ b/src/OpenCvSharpExtern/ptcloud_Odometry.h
@@ -23,7 +23,11 @@ CVAPI(ExceptionStatus) ptcloud_Odometry_new2(int otype, cv::Odometry **returnVal
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Odometry_new3(int otype, cv::OdometrySettings *settings, int algtype, cv::Odometry **returnValue)
+CVAPI(ExceptionStatus) ptcloud_Odometry_new3(
+    int otype,
+    cv::OdometrySettings *settings,
+    int algtype,
+    cv::Odometry **returnValue)
 {
     return cvTry([&] {
     *returnValue = new cv::Odometry(static_cast<cv::OdometryType>(otype), *settings, static_cast<cv::OdometryAlgoType>(algtype));
@@ -44,7 +48,10 @@ CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrame(cv::Odometry *obj, cv::Odom
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrames(cv::Odometry *obj, cv::OdometryFrame *srcFrame, cv::OdometryFrame *dstFrame)
+CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrames(
+    cv::Odometry *obj,
+    cv::OdometryFrame *srcFrame,
+    cv::OdometryFrame *dstFrame)
 {
     return cvTry([&] {
     obj->prepareFrames(*srcFrame, *dstFrame);
@@ -52,27 +59,40 @@ CVAPI(ExceptionStatus) ptcloud_Odometry_prepareFrames(cv::Odometry *obj, cv::Odo
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_Frame(
-    cv::Odometry *obj, cv::OdometryFrame *srcFrame, cv::OdometryFrame *dstFrame, cv::_OutputArray *Rt, int *returnValue)
+    cv::Odometry *obj,
+    cv::OdometryFrame *srcFrame,
+    cv::OdometryFrame *dstFrame,
+    const interop::OutputArrayProxy* Rt,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->compute(*srcFrame, *dstFrame, entity(Rt)) ? 1 : 0;
+    *returnValue = obj->compute(*srcFrame, *dstFrame, OutProxy(*Rt)) ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_Depth(
-    cv::Odometry *obj, cv::_InputArray *srcDepth, cv::_InputArray *dstDepth, cv::_OutputArray *Rt, int *returnValue)
+    cv::Odometry *obj,
+    const interop::InputArrayProxy* srcDepth,
+    const interop::InputArrayProxy* dstDepth,
+    const interop::OutputArrayProxy* Rt,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->compute(entity(srcDepth), entity(dstDepth), entity(Rt)) ? 1 : 0;
+    *returnValue = obj->compute(InProxy(*srcDepth), InProxy(*dstDepth), OutProxy(*Rt)) ? 1 : 0;
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_Odometry_compute_DepthRGB(
-    cv::Odometry *obj, cv::_InputArray *srcDepth, cv::_InputArray *srcRGB, cv::_InputArray *dstDepth, cv::_InputArray *dstRGB,
-    cv::_OutputArray *Rt, int *returnValue)
+    cv::Odometry *obj,
+    const interop::InputArrayProxy* srcDepth,
+    const interop::InputArrayProxy* srcRGB,
+    const interop::InputArrayProxy* dstDepth,
+    const interop::InputArrayProxy* dstRGB,
+    const interop::OutputArrayProxy* Rt,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = obj->compute(entity(srcDepth), entity(srcRGB), entity(dstDepth), entity(dstRGB), entity(Rt)) ? 1 : 0;
+    *returnValue = obj->compute(InProxy(*srcDepth), InProxy(*srcRGB), InProxy(*dstDepth), InProxy(*dstRGB), OutProxy(*Rt)) ? 1 : 0;
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_OdometryFrame.h
+++ b/src/OpenCvSharpExtern/ptcloud_OdometryFrame.h
@@ -9,11 +9,14 @@
 #include <opencv2/ptcloud.hpp>
 
 CVAPI(ExceptionStatus) ptcloud_OdometryFrame_new(
-    cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *mask, cv::_InputArray *normals,
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* image,
+    const interop::InputArrayProxy* mask,
+    const interop::InputArrayProxy* normals,
     cv::OdometryFrame **returnValue)
 {
     return cvTry([&] {
-    *returnValue = new cv::OdometryFrame(entity(depth), entity(image), entity(mask), entity(normals));
+    *returnValue = new cv::OdometryFrame(InProxy(*depth), InProxy(*image), InProxy(*mask), InProxy(*normals));
     });
 }
 
@@ -24,45 +27,45 @@ CVAPI(ExceptionStatus) ptcloud_OdometryFrame_delete(cv::OdometryFrame *obj)
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getImage(cv::OdometryFrame *obj, cv::_OutputArray *image)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getImage(cv::OdometryFrame *obj, const interop::OutputArrayProxy* image)
 {
     return cvTry([&] {
-    obj->getImage(entity(image));
+    obj->getImage(OutProxy(*image));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getGrayImage(cv::OdometryFrame *obj, cv::_OutputArray *image)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getGrayImage(cv::OdometryFrame *obj, const interop::OutputArrayProxy* image)
 {
     return cvTry([&] {
-    obj->getGrayImage(entity(image));
+    obj->getGrayImage(OutProxy(*image));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getDepth(cv::OdometryFrame *obj, cv::_OutputArray *depth)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getDepth(cv::OdometryFrame *obj, const interop::OutputArrayProxy* depth)
 {
     return cvTry([&] {
-    obj->getDepth(entity(depth));
+    obj->getDepth(OutProxy(*depth));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getProcessedDepth(cv::OdometryFrame *obj, cv::_OutputArray *depth)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getProcessedDepth(cv::OdometryFrame *obj, const interop::OutputArrayProxy* depth)
 {
     return cvTry([&] {
-    obj->getProcessedDepth(entity(depth));
+    obj->getProcessedDepth(OutProxy(*depth));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getMask(cv::OdometryFrame *obj, cv::_OutputArray *mask)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getMask(cv::OdometryFrame *obj, const interop::OutputArrayProxy* mask)
 {
     return cvTry([&] {
-    obj->getMask(entity(mask));
+    obj->getMask(OutProxy(*mask));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getNormals(cv::OdometryFrame *obj, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getNormals(cv::OdometryFrame *obj, const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->getNormals(entity(normals));
+    obj->getNormals(OutProxy(*normals));
     });
 }
 
@@ -73,10 +76,14 @@ CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getPyramidLevels(cv::OdometryFrame 
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getPyramidAt(cv::OdometryFrame *obj, cv::_OutputArray *img, int pyrType, size_t level)
+CVAPI(ExceptionStatus) ptcloud_OdometryFrame_getPyramidAt(
+    cv::OdometryFrame *obj,
+    const interop::OutputArrayProxy* img,
+    int pyrType,
+    size_t level)
 {
     return cvTry([&] {
-    obj->getPyramidAt(entity(img), static_cast<cv::OdometryFramePyramidType>(pyrType), level);
+    obj->getPyramidAt(OutProxy(*img), static_cast<cv::OdometryFramePyramidType>(pyrType), level);
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_OdometrySettings.h
+++ b/src/OpenCvSharpExtern/ptcloud_OdometrySettings.h
@@ -22,29 +22,29 @@ CVAPI(ExceptionStatus) ptcloud_OdometrySettings_delete(cv::OdometrySettings *obj
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setCameraMatrix(cv::OdometrySettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setCameraMatrix(cv::OdometrySettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setCameraMatrix(entity(val));
+    obj->setCameraMatrix(InProxy(*val));
     });
 }
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getCameraMatrix(cv::OdometrySettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getCameraMatrix(cv::OdometrySettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getCameraMatrix(entity(val));
+    obj->getCameraMatrix(OutProxy(*val));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setIterCounts(cv::OdometrySettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setIterCounts(cv::OdometrySettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setIterCounts(entity(val));
+    obj->setIterCounts(InProxy(*val));
     });
 }
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getIterCounts(cv::OdometrySettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getIterCounts(cv::OdometrySettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getIterCounts(entity(val));
+    obj->getIterCounts(OutProxy(*val));
     });
 }
 
@@ -217,16 +217,16 @@ CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinGradientMagnitude(cv::Odom
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMinGradientMagnitudes(cv::OdometrySettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_setMinGradientMagnitudes(cv::OdometrySettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setMinGradientMagnitudes(entity(val));
+    obj->setMinGradientMagnitudes(InProxy(*val));
     });
 }
-CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinGradientMagnitudes(cv::OdometrySettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_OdometrySettings_getMinGradientMagnitudes(cv::OdometrySettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getMinGradientMagnitudes(entity(val));
+    obj->getMinGradientMagnitudes(OutProxy(*val));
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_RgbdNormals.h
+++ b/src/OpenCvSharpExtern/ptcloud_RgbdNormals.h
@@ -10,12 +10,18 @@
 #include <opencv2/ptcloud/depth.hpp>
 
 CVAPI(ExceptionStatus) ptcloud_RgbdNormals_create(
-    int rows, int cols, int depth, cv::_InputArray *K, int window_size, float diff_threshold, int method,
+    int rows,
+    int cols,
+    int depth,
+    const interop::InputArrayProxy* K,
+    int window_size,
+    float diff_threshold,
+    int method,
     cv::Ptr<cv::RgbdNormals> **returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::RgbdNormals::create(
-        rows, cols, depth, entity(K), window_size, diff_threshold,
+        rows, cols, depth, InProxy(*K), window_size, diff_threshold,
         static_cast<cv::RgbdNormals::RgbdNormalsMethod>(method));
     *returnValue = clone(ptr);
     });
@@ -35,10 +41,13 @@ CVAPI(ExceptionStatus) ptcloud_Ptr_RgbdNormals_get(cv::Ptr<cv::RgbdNormals> *obj
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_RgbdNormals_apply(cv::RgbdNormals *obj, cv::_InputArray *points, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_RgbdNormals_apply(
+    cv::RgbdNormals *obj,
+    const interop::InputArrayProxy* points,
+    const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->apply(entity(points), entity(normals));
+    obj->apply(InProxy(*points), OutProxy(*normals));
     });
 }
 
@@ -98,17 +107,17 @@ CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getDepth(cv::RgbdNormals *obj, int *r
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getK(cv::RgbdNormals *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_RgbdNormals_getK(cv::RgbdNormals *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getK(entity(val));
+    obj->getK(OutProxy(*val));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setK(cv::RgbdNormals *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_RgbdNormals_setK(cv::RgbdNormals *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setK(entity(val));
+    obj->setK(InProxy(*val));
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_Volume.h
+++ b/src/OpenCvSharpExtern/ptcloud_Volume.h
@@ -8,7 +8,10 @@
 #include "include_opencv.h"
 #include <opencv2/ptcloud.hpp>
 
-CVAPI(ExceptionStatus) ptcloud_Volume_new(int vtype, cv::VolumeSettings *settings, cv::Volume **returnValue)
+CVAPI(ExceptionStatus) ptcloud_Volume_new(
+    int vtype,
+    cv::VolumeSettings *settings,
+    cv::Volume **returnValue)
 {
     return cvTry([&] {
     *returnValue = new cv::Volume(static_cast<cv::VolumeType>(vtype), *settings);
@@ -22,73 +25,117 @@ CVAPI(ExceptionStatus) ptcloud_Volume_delete(cv::Volume *obj)
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_integrateFrame(cv::Volume *obj, cv::OdometryFrame *frame, cv::_InputArray *pose)
+CVAPI(ExceptionStatus) ptcloud_Volume_integrateFrame(
+    cv::Volume *obj,
+    cv::OdometryFrame *frame,
+    const interop::InputArrayProxy* pose)
 {
     return cvTry([&] {
-    obj->integrate(*frame, entity(pose));
+    obj->integrate(*frame, InProxy(*pose));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_integrate(cv::Volume *obj, cv::_InputArray *depth, cv::_InputArray *pose)
+CVAPI(ExceptionStatus) ptcloud_Volume_integrate(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* pose)
 {
     return cvTry([&] {
-    obj->integrate(entity(depth), entity(pose));
+    obj->integrate(InProxy(*depth), InProxy(*pose));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_integrateColor(cv::Volume *obj, cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *pose)
+CVAPI(ExceptionStatus) ptcloud_Volume_integrateColor(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* image,
+    const interop::InputArrayProxy* pose)
 {
     return cvTry([&] {
-    obj->integrate(entity(depth), entity(image), entity(pose));
+    obj->integrate(InProxy(*depth), InProxy(*image), InProxy(*pose));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_raycast(cv::Volume *obj, cv::_InputArray *cameraPose, cv::_OutputArray *points, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_Volume_raycast(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* cameraPose,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->raycast(entity(cameraPose), entity(points), entity(normals));
+    obj->raycast(InProxy(*cameraPose), OutProxy(*points), OutProxy(*normals));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_raycastColor(cv::Volume *obj, cv::_InputArray *cameraPose, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
+CVAPI(ExceptionStatus) ptcloud_Volume_raycastColor(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* cameraPose,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals,
+    const interop::OutputArrayProxy* colors)
 {
     return cvTry([&] {
-    obj->raycast(entity(cameraPose), entity(points), entity(normals), entity(colors));
+    obj->raycast(InProxy(*cameraPose), OutProxy(*points), OutProxy(*normals), OutProxy(*colors));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_raycastEx(cv::Volume *obj, cv::_InputArray *cameraPose, int height, int width, cv::_InputArray *K, cv::_OutputArray *points, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_Volume_raycastEx(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* cameraPose,
+    int height,
+    int width,
+    const interop::InputArrayProxy* K,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->raycast(entity(cameraPose), height, width, entity(K), entity(points), entity(normals));
+    obj->raycast(InProxy(*cameraPose), height, width, InProxy(*K), OutProxy(*points), OutProxy(*normals));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_raycastExColor(cv::Volume *obj, cv::_InputArray *cameraPose, int height, int width, cv::_InputArray *K, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
+CVAPI(ExceptionStatus) ptcloud_Volume_raycastExColor(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* cameraPose,
+    int height,
+    int width,
+    const interop::InputArrayProxy* K,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals,
+    const interop::OutputArrayProxy* colors)
 {
     return cvTry([&] {
-    obj->raycast(entity(cameraPose), height, width, entity(K), entity(points), entity(normals), entity(colors));
+    obj->raycast(InProxy(*cameraPose), height, width, InProxy(*K), OutProxy(*points), OutProxy(*normals), OutProxy(*colors));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_fetchNormals(cv::Volume *obj, cv::_InputArray *points, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_Volume_fetchNormals(
+    cv::Volume *obj,
+    const interop::InputArrayProxy* points,
+    const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->fetchNormals(entity(points), entity(normals));
+    obj->fetchNormals(InProxy(*points), OutProxy(*normals));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormals(cv::Volume *obj, cv::_OutputArray *points, cv::_OutputArray *normals)
+CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormals(
+    cv::Volume *obj,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals)
 {
     return cvTry([&] {
-    obj->fetchPointsNormals(entity(points), entity(normals));
+    obj->fetchPointsNormals(OutProxy(*points), OutProxy(*normals));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormalsColors(cv::Volume *obj, cv::_OutputArray *points, cv::_OutputArray *normals, cv::_OutputArray *colors)
+CVAPI(ExceptionStatus) ptcloud_Volume_fetchPointsNormalsColors(
+    cv::Volume *obj,
+    const interop::OutputArrayProxy* points,
+    const interop::OutputArrayProxy* normals,
+    const interop::OutputArrayProxy* colors)
 {
     return cvTry([&] {
-    obj->fetchPointsNormalsColors(entity(points), entity(normals), entity(colors));
+    obj->fetchPointsNormalsColors(OutProxy(*points), OutProxy(*normals), OutProxy(*colors));
     });
 }
 
@@ -113,10 +160,13 @@ CVAPI(ExceptionStatus) ptcloud_Volume_getTotalVolumeUnits(cv::Volume *obj, size_
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_Volume_getBoundingBox(cv::Volume *obj, cv::_OutputArray *bb, int precision)
+CVAPI(ExceptionStatus) ptcloud_Volume_getBoundingBox(
+    cv::Volume *obj,
+    const interop::OutputArrayProxy* bb,
+    int precision)
 {
     return cvTry([&] {
-    obj->getBoundingBox(entity(bb), precision);
+    obj->getBoundingBox(OutProxy(*bb), precision);
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_VolumeSettings.h
+++ b/src/OpenCvSharpExtern/ptcloud_VolumeSettings.h
@@ -152,62 +152,62 @@ CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getRaycastStepFactor(cv::VolumeSet
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumePose(cv::VolumeSettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumePose(cv::VolumeSettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setVolumePose(entity(val));
+    obj->setVolumePose(InProxy(*val));
     });
 }
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumePose(cv::VolumeSettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumePose(cv::VolumeSettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getVolumePose(entity(val));
-    });
-}
-
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumeResolution(cv::VolumeSettings *obj, cv::_InputArray *val)
-{
-    return cvTry([&] {
-    obj->setVolumeResolution(entity(val));
-    });
-}
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeResolution(cv::VolumeSettings *obj, cv::_OutputArray *val)
-{
-    return cvTry([&] {
-    obj->getVolumeResolution(entity(val));
+    obj->getVolumePose(OutProxy(*val));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeStrides(cv::VolumeSettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setVolumeResolution(cv::VolumeSettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getVolumeStrides(entity(val));
+    obj->setVolumeResolution(InProxy(*val));
+    });
+}
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeResolution(cv::VolumeSettings *obj, const interop::OutputArrayProxy* val)
+{
+    return cvTry([&] {
+    obj->getVolumeResolution(OutProxy(*val));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(cv::VolumeSettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getVolumeStrides(cv::VolumeSettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setCameraIntegrateIntrinsics(entity(val));
-    });
-}
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(cv::VolumeSettings *obj, cv::_OutputArray *val)
-{
-    return cvTry([&] {
-    obj->getCameraIntegrateIntrinsics(entity(val));
+    obj->getVolumeStrides(OutProxy(*val));
     });
 }
 
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraRaycastIntrinsics(cv::VolumeSettings *obj, cv::_InputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraIntegrateIntrinsics(cv::VolumeSettings *obj, const interop::InputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->setCameraRaycastIntrinsics(entity(val));
+    obj->setCameraIntegrateIntrinsics(InProxy(*val));
     });
 }
-CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraRaycastIntrinsics(cv::VolumeSettings *obj, cv::_OutputArray *val)
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraIntegrateIntrinsics(cv::VolumeSettings *obj, const interop::OutputArrayProxy* val)
 {
     return cvTry([&] {
-    obj->getCameraRaycastIntrinsics(entity(val));
+    obj->getCameraIntegrateIntrinsics(OutProxy(*val));
+    });
+}
+
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_setCameraRaycastIntrinsics(cv::VolumeSettings *obj, const interop::InputArrayProxy* val)
+{
+    return cvTry([&] {
+    obj->setCameraRaycastIntrinsics(InProxy(*val));
+    });
+}
+CVAPI(ExceptionStatus) ptcloud_VolumeSettings_getCameraRaycastIntrinsics(cv::VolumeSettings *obj, const interop::OutputArrayProxy* val)
+{
+    return cvTry([&] {
+    obj->getCameraRaycastIntrinsics(OutProxy(*val));
     });
 }
 

--- a/src/OpenCvSharpExtern/ptcloud_depth.h
+++ b/src/OpenCvSharpExtern/ptcloud_depth.h
@@ -10,61 +10,89 @@
 #include <opencv2/ptcloud/depth.hpp>
 
 CVAPI(ExceptionStatus) ptcloud_registerDepth(
-    cv::_InputArray *unregisteredCameraMatrix, cv::_InputArray *registeredCameraMatrix, cv::_InputArray *registeredDistCoeffs,
-    cv::_InputArray *Rt, cv::_InputArray *unregisteredDepth, interop::Size outputImagePlaneSize,
-    cv::_OutputArray *registeredDepth, int depthDilation)
+    const interop::InputArrayProxy* unregisteredCameraMatrix,
+    const interop::InputArrayProxy* registeredCameraMatrix,
+    const interop::InputArrayProxy* registeredDistCoeffs,
+    const interop::InputArrayProxy* Rt,
+    const interop::InputArrayProxy* unregisteredDepth,
+    interop::Size outputImagePlaneSize,
+    const interop::OutputArrayProxy* registeredDepth,
+    int depthDilation)
 {
     return cvTry([&] {
     cv::registerDepth(
-        entity(unregisteredCameraMatrix), entity(registeredCameraMatrix), entity(registeredDistCoeffs),
-        entity(Rt), entity(unregisteredDepth), cpp(outputImagePlaneSize),
-        entity(registeredDepth), depthDilation != 0);
+        InProxy(*unregisteredCameraMatrix), InProxy(*registeredCameraMatrix), InProxy(*registeredDistCoeffs),
+        InProxy(*Rt), InProxy(*unregisteredDepth), cpp(outputImagePlaneSize),
+        OutProxy(*registeredDepth), depthDilation != 0);
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_depthTo3dSparse(
-    cv::_InputArray *depth, cv::_InputArray *in_K, cv::_InputArray *in_points, cv::_OutputArray *points3d)
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* in_K,
+    const interop::InputArrayProxy* in_points,
+    const interop::OutputArrayProxy* points3d)
 {
     return cvTry([&] {
-    cv::depthTo3dSparse(entity(depth), entity(in_K), entity(in_points), entity(points3d));
+    cv::depthTo3dSparse(InProxy(*depth), InProxy(*in_K), InProxy(*in_points), OutProxy(*points3d));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_depthTo3d(
-    cv::_InputArray *depth, cv::_InputArray *K, cv::_OutputArray *points3d, cv::_InputArray *mask)
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* K,
+    const interop::OutputArrayProxy* points3d,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-    cv::depthTo3d(entity(depth), entity(K), entity(points3d), entity(mask));
+    cv::depthTo3d(InProxy(*depth), InProxy(*K), OutProxy(*points3d), InProxy(*mask));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_rescaleDepth(
-    cv::_InputArray *in, int type, cv::_OutputArray *out, double depth_factor)
+    const interop::InputArrayProxy* in,
+    int type,
+    const interop::OutputArrayProxy* out,
+    double depth_factor)
 {
     return cvTry([&] {
-    cv::rescaleDepth(entity(in), type, entity(out), depth_factor);
+    cv::rescaleDepth(InProxy(*in), type, OutProxy(*out), depth_factor);
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_warpFrame(
-    cv::_InputArray *depth, cv::_InputArray *image, cv::_InputArray *mask, cv::_InputArray *Rt, cv::_InputArray *cameraMatrix,
-    cv::_OutputArray *warpedDepth, cv::_OutputArray *warpedImage, cv::_OutputArray *warpedMask)
+    const interop::InputArrayProxy* depth,
+    const interop::InputArrayProxy* image,
+    const interop::InputArrayProxy* mask,
+    const interop::InputArrayProxy* Rt,
+    const interop::InputArrayProxy* cameraMatrix,
+    const interop::OutputArrayProxy* warpedDepth,
+    const interop::OutputArrayProxy* warpedImage,
+    const interop::OutputArrayProxy* warpedMask)
 {
     return cvTry([&] {
     cv::warpFrame(
-        entity(depth), entity(image), entity(mask), entity(Rt), entity(cameraMatrix),
-        entity(warpedDepth), entity(warpedImage), entity(warpedMask));
+        InProxy(*depth), InProxy(*image), InProxy(*mask), InProxy(*Rt), InProxy(*cameraMatrix),
+        OutProxy(*warpedDepth), OutProxy(*warpedImage), OutProxy(*warpedMask));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_findPlanes(
-    cv::_InputArray *points3d, cv::_InputArray *normals, cv::_OutputArray *mask, cv::_OutputArray *plane_coefficients,
-    int block_size, int min_size, double threshold,
-    double sensor_error_a, double sensor_error_b, double sensor_error_c, int method)
+    const interop::InputArrayProxy* points3d,
+    const interop::InputArrayProxy* normals,
+    const interop::OutputArrayProxy* mask,
+    const interop::OutputArrayProxy* plane_coefficients,
+    int block_size,
+    int min_size,
+    double threshold,
+    double sensor_error_a,
+    double sensor_error_b,
+    double sensor_error_c,
+    int method)
 {
     return cvTry([&] {
     cv::findPlanes(
-        entity(points3d), entity(normals), entity(mask), entity(plane_coefficients),
+        InProxy(*points3d), InProxy(*normals), OutProxy(*mask), OutProxy(*plane_coefficients),
         block_size, min_size, threshold,
         sensor_error_a, sensor_error_b, sensor_error_c,
         static_cast<cv::RgbdPlaneMethod>(method));

--- a/src/OpenCvSharpExtern/ptcloud_io.h
+++ b/src/OpenCvSharpExtern/ptcloud_io.h
@@ -10,36 +10,50 @@
 #include <opencv2/ptcloud.hpp>
 
 CVAPI(ExceptionStatus) ptcloud_loadPointCloud(
-    const char *filename, cv::_OutputArray *vertices, cv::_OutputArray *normals, cv::_OutputArray *rgb)
+    const char *filename,
+    const interop::OutputArrayProxy* vertices,
+    const interop::OutputArrayProxy* normals,
+    const interop::OutputArrayProxy* rgb)
 {
     return cvTry([&] {
-    cv::loadPointCloud(filename, *vertices, entity(normals), entity(rgb));
+    cv::loadPointCloud(filename, OutProxy(*vertices), OutProxy(*normals), OutProxy(*rgb));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_savePointCloud(
-    const char *filename, cv::_InputArray *vertices, cv::_InputArray *normals, cv::_InputArray *rgb)
+    const char *filename,
+    const interop::InputArrayProxy* vertices,
+    const interop::InputArrayProxy* normals,
+    const interop::InputArrayProxy* rgb)
 {
     return cvTry([&] {
-    cv::savePointCloud(filename, *vertices, entity(normals), entity(rgb));
+    cv::savePointCloud(filename, InProxy(*vertices), InProxy(*normals), InProxy(*rgb));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_loadMesh(
-    const char *filename, cv::_OutputArray *vertices, std::vector<cv::Mat> *indices,
-    cv::_OutputArray *normals, cv::_OutputArray *colors, cv::_OutputArray *texCoords)
+    const char *filename,
+    const interop::OutputArrayProxy* vertices,
+    std::vector<cv::Mat> *indices,
+    const interop::OutputArrayProxy* normals,
+    const interop::OutputArrayProxy* colors,
+    const interop::OutputArrayProxy* texCoords)
 {
     return cvTry([&] {
-    cv::loadMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
+    cv::loadMesh(filename, OutProxy(*vertices), *indices, OutProxy(*normals), OutProxy(*colors), OutProxy(*texCoords));
     });
 }
 
 CVAPI(ExceptionStatus) ptcloud_saveMesh(
-    const char *filename, cv::_InputArray *vertices, std::vector<cv::Mat> *indices,
-    cv::_InputArray *normals, cv::_InputArray *colors, cv::_InputArray *texCoords)
+    const char *filename,
+    const interop::InputArrayProxy* vertices,
+    std::vector<cv::Mat> *indices,
+    const interop::InputArrayProxy* normals,
+    const interop::InputArrayProxy* colors,
+    const interop::InputArrayProxy* texCoords)
 {
     return cvTry([&] {
-    cv::saveMesh(filename, *vertices, *indices, entity(normals), entity(colors), entity(texCoords));
+    cv::saveMesh(filename, InProxy(*vertices), *indices, InProxy(*normals), InProxy(*colors), InProxy(*texCoords));
     });
 }
 

--- a/src/OpenCvSharpExtern/stitching.h
+++ b/src/OpenCvSharpExtern/stitching.h
@@ -113,26 +113,35 @@ CVAPI(ExceptionStatus) stitching_Stitcher_setWaveCorrectKind(cv::Stitcher *obj, 
 #pragma endregion
 
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_InputArray1(
-    cv::Stitcher *obj, cv::_InputArray *images, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::InputArrayProxy* images,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = static_cast<int>(obj->estimateTransform(*images));
+    *returnValue = static_cast<int>(obj->estimateTransform(InProxy(*images)));
     });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_InputArray2(
-    cv::Stitcher *obj, cv::_InputArray *images,
-    const interop::Rect **rois, const int roisSize1, const int *roisSize2, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::InputArrayProxy* images,
+    const interop::Rect **rois,
+    const int roisSize1,
+    const int *roisSize2,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<std::vector<cv::Rect> > roisVec;
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
-    *returnValue = static_cast<int>(obj->estimateTransform(*images, roisVec));
+    *returnValue = static_cast<int>(obj->estimateTransform(InProxy(*images), roisVec));
     });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray1(
-    cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, int *returnValue)
+    cv::Stitcher *obj,
+    const cv::Mat **images,
+    const int imagesSize,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
@@ -142,8 +151,13 @@ CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray1(
     });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray2(
-    cv::Stitcher *obj, const cv::Mat **images, const int imagesSize,
-    const interop::Rect **rois, const int roisSize1, const int *roisSize2, int *returnValue)
+    cv::Stitcher *obj,
+    const cv::Mat **images,
+    const int imagesSize,
+    const interop::Rect **rois,
+    const int roisSize1,
+    const int *roisSize2,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
@@ -157,69 +171,91 @@ CVAPI(ExceptionStatus) stitching_Stitcher_estimateTransform_MatArray2(
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama1(
-    cv::Stitcher *obj, cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = static_cast<int>(obj->composePanorama(*pano));
+    *returnValue = static_cast<int>(obj->composePanorama(OutProxy(*pano)));
     });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama2_InputArray(
-    cv::Stitcher *obj, cv::_InputArray *images, cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::InputArrayProxy* images,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = static_cast<int>(obj->composePanorama(*images, *pano));
+    *returnValue = static_cast<int>(obj->composePanorama(InProxy(*images), OutProxy(*pano)));
     });
 }
 CVAPI(ExceptionStatus) stitching_Stitcher_composePanorama2_MatArray(
-    cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, 
-    cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const cv::Mat **images,
+    const int imagesSize,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
-    *returnValue = static_cast<int>(obj->composePanorama(imagesVec, *pano));
+    *returnValue = static_cast<int>(obj->composePanorama(imagesVec, OutProxy(*pano)));
     });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch1_InputArray(
-    cv::Stitcher *obj, cv::_InputArray *images, 
-    cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::InputArrayProxy* images,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
-    *returnValue = static_cast<int>(obj->stitch(*images, *pano));
+    *returnValue = static_cast<int>(obj->stitch(InProxy(*images), OutProxy(*pano)));
     });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch1_MatArray(
-    cv::Stitcher *obj, const cv::Mat **images, const int imagesSize, 
-    cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const cv::Mat **images,
+    const int imagesSize,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
     toVec(images, imagesSize, imagesVec);
 
-    *returnValue = static_cast<int>(obj->stitch(imagesVec, *pano));
+    *returnValue = static_cast<int>(obj->stitch(imagesVec, OutProxy(*pano)));
     });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_InputArray(
-    cv::Stitcher *obj, cv::_InputArray *images,
-    const interop::Rect **rois, const int roisSize1, int *roisSize2,
-    cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const interop::InputArrayProxy* images,
+    const interop::Rect **rois,
+    const int roisSize1,
+    int *roisSize2,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<std::vector<cv::Rect> > roisVec;
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
-    *returnValue = static_cast<int>(obj->stitch(*images, roisVec, *pano));
+    *returnValue = static_cast<int>(obj->stitch(InProxy(*images), roisVec, OutProxy(*pano)));
     });
 }
 
 CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_MatArray(
-    cv::Stitcher *obj, const cv::Mat **images, const int imagesSize,
-    const interop::Rect **rois, const int roisSize1, int *roisSize2,
-    cv::_OutputArray *pano, int *returnValue)
+    cv::Stitcher *obj,
+    const cv::Mat **images,
+    const int imagesSize,
+    const interop::Rect **rois,
+    const int roisSize1,
+    int *roisSize2,
+    const interop::OutputArrayProxy* pano,
+    int *returnValue)
 {
     return cvTry([&] {
     std::vector<cv::Mat> imagesVec;
@@ -228,7 +264,7 @@ CVAPI(ExceptionStatus) stitching_Stitcher_stitch2_MatArray(
     std::vector<std::vector<cv::Rect> > roisVec;
     toRectVec(rois, roisSize1, roisSize2, roisVec);
 
-    *returnValue = static_cast<int>(obj->stitch(imagesVec, roisVec, *pano));
+    *returnValue = static_cast<int>(obj->stitch(imagesVec, roisVec, OutProxy(*pano)));
     });
 }
 

--- a/src/OpenCvSharpExtern/stitching_detail_Matchers.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Matchers.h
@@ -46,9 +46,9 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures1(
 
 CVAPI(ExceptionStatus) stitching_computeImageFeatures2(
     cv::Feature2D *featuresFinder,
-    cv::_InputArray *image,
+    const interop::InputArrayProxy* image,
     detail_ImageFeatures *features,
-    cv::_InputArray *mask)
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
 
@@ -56,7 +56,7 @@ CVAPI(ExceptionStatus) stitching_computeImageFeatures2(
     const cv::Ptr<cv::Feature2D> featuresFinderPtr(featuresFinder, [](cv::Feature2D*){});
     
     cv::detail::ImageFeatures rawFeature;
-    cv::detail::computeImageFeatures(featuresFinderPtr, *image, rawFeature, entity(mask));
+    cv::detail::computeImageFeatures(featuresFinderPtr, InProxy(*image), rawFeature, InProxy(*mask));
 
     features->img_idx = rawFeature.img_idx;
     features->img_size = c(rawFeature.img_size);
@@ -73,9 +73,9 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply(
     cv::detail::FeaturesMatcher* obj,
     detail_ImageFeatures *features1,
     detail_ImageFeatures *features2,
-    int *out_src_img_idx, 
+    int *out_src_img_idx,
     int *out_dst_img_idx,
-    std::vector<cv::DMatch> *out_matches, 
+    std::vector<cv::DMatch> *out_matches,
     std::vector<uchar> *out_inliers_mask,
     int *out_num_inliers,
     cv::Mat *out_H,
@@ -112,7 +112,8 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply(
 
 CVAPI(ExceptionStatus) stitching_FeaturesMatcher_apply2(
     cv::detail::FeaturesMatcher* obj,
-    detail_ImageFeatures* features, int featuresSize,
+    detail_ImageFeatures* features,
+    int featuresSize,
     cv::Mat *mask,
     std::vector<int> *out_src_img_idx,
     std::vector<int> *out_dst_img_idx,
@@ -185,7 +186,10 @@ CVAPI(ExceptionStatus) stitching_FeaturesMatcher_collectGarbage(
 // BestOf2NearestMatcher
 
 CVAPI(ExceptionStatus) stitching_BestOf2NearestMatcher_new(
-    int try_use_gpu, float match_conf, int num_matches_thresh1,int num_matches_thresh2,
+    int try_use_gpu,
+    float match_conf,
+    int num_matches_thresh1,
+    int num_matches_thresh2,
     cv::detail::BestOf2NearestMatcher **returnValue)
 {
     return cvTry([&] {
@@ -213,7 +217,10 @@ CVAPI(ExceptionStatus) stitching_BestOf2NearestMatcher_collectGarbage(
 // AffineBestOf2NearestMatcher
 
 CVAPI(ExceptionStatus) stitching_AffineBestOf2NearestMatcher_new(
-    int full_affine, int try_use_gpu, float match_conf, int num_matches_thresh1,
+    int full_affine,
+    int try_use_gpu,
+    float match_conf,
+    int num_matches_thresh1,
     cv::detail::AffineBestOf2NearestMatcher** returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/video_tracking.h
+++ b/src/OpenCvSharpExtern/video_tracking.h
@@ -9,128 +9,178 @@
 #include "include_opencv.h"
 
 CVAPI(ExceptionStatus) video_CamShift(
-    cv::_InputArray *probImage, interop::Rect *window, interop::TermCriteria criteria, interop::RotatedRect *returnValue)
+    const interop::InputArrayProxy* probImage,
+    interop::Rect *window,
+    interop::TermCriteria criteria,
+    interop::RotatedRect *returnValue)
 {
     return cvTry([&] {
     cv::Rect window0 = cpp(*window);
-    const auto ret = cv::CamShift(*probImage, window0, cpp(criteria));
+    const auto ret = cv::CamShift(InProxy(*probImage), window0, cpp(criteria));
     *window = c(window0);
     *returnValue = c(ret);
     });
 }
 
 CVAPI(ExceptionStatus) video_meanShift(
-    cv::_InputArray *probImage, interop::Rect *window, interop::TermCriteria criteria, int *returnValue)
+    const interop::InputArrayProxy* probImage,
+    interop::Rect *window,
+    interop::TermCriteria criteria,
+    int *returnValue)
 {
     return cvTry([&] {
     cv::Rect window0 = cpp(*window);
-    const auto ret = cv::meanShift(*probImage, window0, cpp(criteria));
+    const auto ret = cv::meanShift(InProxy(*probImage), window0, cpp(criteria));
     *window = c(window0);
     *returnValue = ret;
     });
 }
 
 CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid1(
-    cv::_InputArray* img, cv::_OutputArray* pyramid,
-    interop::Size winSize, int maxLevel, int withDerivatives,
-    int pyrBorder, int derivBorder, int tryReuseInputImage,
+    const interop::InputArrayProxy* img,
+    const interop::OutputArrayProxy* pyramid,
+    interop::Size winSize,
+    int maxLevel,
+    int withDerivatives,
+    int pyrBorder,
+    int derivBorder,
+    int tryReuseInputImage,
     int* returnValue)
 {
     return cvTry([&] {
     * returnValue = cv::buildOpticalFlowPyramid(
-        *img, *pyramid, cpp(winSize), maxLevel, withDerivatives != 0,
+        InProxy(*img), OutProxy(*pyramid), cpp(winSize), maxLevel, withDerivatives != 0,
         pyrBorder, derivBorder, tryReuseInputImage != 0);
     });
 }
 CVAPI(ExceptionStatus) video_buildOpticalFlowPyramid2(
-    cv::_InputArray* img, std::vector<cv::Mat>* pyramidVec,
-    interop::Size winSize, int maxLevel, int withDerivatives,
-    int pyrBorder, int derivBorder, int tryReuseInputImage,
+    const interop::InputArrayProxy* img,
+    std::vector<cv::Mat>* pyramidVec,
+    interop::Size winSize,
+    int maxLevel,
+    int withDerivatives,
+    int pyrBorder,
+    int derivBorder,
+    int tryReuseInputImage,
     int* returnValue)
 {
     return cvTry([&] {
     * returnValue = cv::buildOpticalFlowPyramid(
-        *img, *pyramidVec, cpp(winSize), maxLevel, withDerivatives != 0,
+        InProxy(*img), *pyramidVec, cpp(winSize), maxLevel, withDerivatives != 0,
         pyrBorder, derivBorder, tryReuseInputImage != 0);
     });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_InputArray(
-    cv::_InputArray* prevImg, cv::_InputArray* nextImg,
-    cv::_InputArray* prevPts, cv::_InputOutputArray* nextPts,
-    cv::_OutputArray* status, cv::_OutputArray* err,
-    interop::Size winSize, int maxLevel, interop::TermCriteria criteria,
-    int flags, double minEigThreshold)
+    const interop::InputArrayProxy* prevImg,
+    const interop::InputArrayProxy* nextImg,
+    const interop::InputArrayProxy* prevPts,
+    const interop::InputOutputArrayProxy* nextPts,
+    const interop::OutputArrayProxy* status,
+    const interop::OutputArrayProxy* err,
+    interop::Size winSize,
+    int maxLevel,
+    interop::TermCriteria criteria,
+    int flags,
+    double minEigThreshold)
 {
     return cvTry([&] {
-    cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, *prevPts, *nextPts, *status, *err,
+    cv::calcOpticalFlowPyrLK(InProxy(*prevImg), InProxy(*nextImg), InProxy(*prevPts), IoProxy(*nextPts), OutProxy(*status), OutProxy(*err),
         cpp(winSize), maxLevel, cpp(criteria), flags, minEigThreshold);
     });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowPyrLK_vector(
-    cv::_InputArray* prevImg, cv::_InputArray* nextImg,
-    cv::Point2f* prevPts, int prevPtsSize,
+    const interop::InputArrayProxy* prevImg,
+    const interop::InputArrayProxy* nextImg,
+    cv::Point2f* prevPts,
+    int prevPtsSize,
     std::vector<cv::Point2f>* nextPts,
     std::vector<uchar>* status,
     std::vector<float>* err,
-    interop::Size winSize, int maxLevel, interop::TermCriteria criteria,
-    int flags, double minEigThreshold)
+    interop::Size winSize,
+    int maxLevel,
+    interop::TermCriteria criteria,
+    int flags,
+    double minEigThreshold)
 {
     return cvTry([&] {
     const std::vector<cv::Point2f> prevPtsVec(prevPts, prevPts + prevPtsSize);
-    cv::calcOpticalFlowPyrLK(*prevImg, *nextImg, prevPtsVec, *nextPts,
+    cv::calcOpticalFlowPyrLK(InProxy(*prevImg), InProxy(*nextImg), prevPtsVec, *nextPts,
     *status, *err, cpp(winSize), maxLevel, cpp(criteria), flags, minEigThreshold);
     });
 }
 
 CVAPI(ExceptionStatus) video_calcOpticalFlowFarneback(
-    cv::_InputArray* prev, cv::_InputArray* next,
-    cv::_InputOutputArray* flow, double pyrScale, int levels, int winSize,
-    int iterations, int polyN, double polySigma, int flags)
+    const interop::InputArrayProxy* prev,
+    const interop::InputArrayProxy* next,
+    const interop::InputOutputArrayProxy* flow,
+    double pyrScale,
+    int levels,
+    int winSize,
+    int iterations,
+    int polyN,
+    double polySigma,
+    int flags)
 {
     return cvTry([&] {
-    cv::calcOpticalFlowFarneback(*prev, *next, *flow, pyrScale, levels, winSize,
+    cv::calcOpticalFlowFarneback(InProxy(*prev), InProxy(*next), IoProxy(*flow), pyrScale, levels, winSize,
         iterations, polyN, polySigma, flags);
     });
 }
 
 /* deprecated
-CVAPI(ExceptionStatus) video_estimateRigidTransform(cv::_InputArray *src, cv::_InputArray *dst, int fullAffine, cv::Mat *returnValue)
+CVAPI(ExceptionStatus) video_estimateRigidTransform(
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* dst,
+    int fullAffine,
+    cv::Mat *returnValue)
 {
-    *returnValue = cv::estimateRigidTransform(*src, *dst, fullAffine != 0);
+    *returnValue = cv::estimateRigidTransform(InProxy(*src), InProxy(*dst), fullAffine != 0);
 }
 */
 
-CVAPI(ExceptionStatus) video_computeECC(cv::_InputArray *templateImage, cv::_InputArray *inputImage, cv::_InputArray *inputMask, double *returnValue)
+CVAPI(ExceptionStatus) video_computeECC(
+    const interop::InputArrayProxy* templateImage,
+    const interop::InputArrayProxy* inputImage,
+    const interop::InputArrayProxy* inputMask,
+    double *returnValue)
 {
     return cvTry([&] {
-    *returnValue = cv::computeECC(*templateImage, *inputImage, entity(inputMask));
+    *returnValue = cv::computeECC(InProxy(*templateImage), InProxy(*inputImage), InProxy(*inputMask));
     });
 }
 
 CVAPI(ExceptionStatus) video_findTransformECC1(
-    cv::_InputArray *templateImage, cv::_InputArray *inputImage,
-    cv::_InputOutputArray *warpMatrix, int motionType,
+    const interop::InputArrayProxy* templateImage,
+    const interop::InputArrayProxy* inputImage,
+    const interop::InputOutputArrayProxy* warpMatrix,
+    int motionType,
     interop::TermCriteria criteria,
-    cv::_InputArray *inputMask, int gaussFiltSize, double *returnValue)
+    const interop::InputArrayProxy* inputMask,
+    int gaussFiltSize,
+    double *returnValue)
 {
     return cvTry([&] {
     *returnValue = cv::findTransformECC(
-        *templateImage, *inputImage, *warpMatrix, motionType, 
-        cpp(criteria),entity(inputMask), gaussFiltSize);
+        InProxy(*templateImage), InProxy(*inputImage), IoProxy(*warpMatrix), motionType, 
+        cpp(criteria),InProxy(*inputMask), gaussFiltSize);
     });
 }
 
 CVAPI(ExceptionStatus) video_findTransformECC2(
-    cv::_InputArray *templateImage, cv::_InputArray *inputImage,
-    cv::_InputOutputArray *warpMatrix, int motionType,
-    interop::TermCriteria criteria, cv::_InputArray *inputMask, double* returnValue)
+    const interop::InputArrayProxy* templateImage,
+    const interop::InputArrayProxy* inputImage,
+    const interop::InputOutputArrayProxy* warpMatrix,
+    int motionType,
+    interop::TermCriteria criteria,
+    const interop::InputArrayProxy* inputMask,
+    double* returnValue)
 {
     return cvTry([&] {
     *returnValue = cv::findTransformECC(
-        *templateImage, *inputImage, *warpMatrix, motionType,
-        cpp(criteria), entity(inputMask));
+        InProxy(*templateImage), InProxy(*inputImage), IoProxy(*warpMatrix), motionType,
+        cpp(criteria), InProxy(*inputMask));
     });
 }
 
@@ -142,14 +192,24 @@ CVAPI(ExceptionStatus) video_KalmanFilter_new1(cv::KalmanFilter **returnValue)
     *returnValue = new cv::KalmanFilter;
     });
 }
-CVAPI(ExceptionStatus) video_KalmanFilter_new2(int dynamParams, int measureParams, int controlParams, int type, cv::KalmanFilter **returnValue)
+CVAPI(ExceptionStatus) video_KalmanFilter_new2(
+    int dynamParams,
+    int measureParams,
+    int controlParams,
+    int type,
+    cv::KalmanFilter **returnValue)
 {
     return cvTry([&] {
     *returnValue = new cv::KalmanFilter(dynamParams, measureParams, controlParams, type);
     });
 }
 
-CVAPI(ExceptionStatus) video_KalmanFilter_init(cv::KalmanFilter *obj, int dynamParams, int measureParams, int controlParams, int type)
+CVAPI(ExceptionStatus) video_KalmanFilter_init(
+    cv::KalmanFilter *obj,
+    int dynamParams,
+    int measureParams,
+    int controlParams,
+    int type)
 {
     return cvTry([&] {
     obj->init(dynamParams, measureParams, controlParams, type);
@@ -163,14 +223,20 @@ CVAPI(ExceptionStatus) video_KalmanFilter_delete(cv::KalmanFilter *obj)
     });
 }
 
-CVAPI(ExceptionStatus) video_KalmanFilter_predict(cv::KalmanFilter *obj, cv::Mat *control, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) video_KalmanFilter_predict(
+    cv::KalmanFilter *obj,
+    cv::Mat *control,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     const auto result = obj->predict(entity(control));
     *returnValue = new cv::Mat(result);
     });
 }
-CVAPI(ExceptionStatus) video_KalmanFilter_correct(cv::KalmanFilter *obj, cv::Mat *measurement, cv::Mat **returnValue)
+CVAPI(ExceptionStatus) video_KalmanFilter_correct(
+    cv::KalmanFilter *obj,
+    cv::Mat *measurement,
+    cv::Mat **returnValue)
 {
     return cvTry([&] {
     const auto result = obj->correct(*measurement);
@@ -243,14 +309,21 @@ CVAPI(ExceptionStatus) video_KalmanFilter_errorCovPost(cv::KalmanFilter *obj, cv
 
 #pragma region Tracker
 
-CVAPI(ExceptionStatus) video_Tracker_init(cv::Tracker* tracker, const cv::Mat* image, const interop::Rect boundingBox)
+CVAPI(ExceptionStatus) video_Tracker_init(
+    cv::Tracker* tracker,
+    const cv::Mat* image,
+    const interop::Rect boundingBox)
 {
     return cvTry([&] {
     tracker->init(*image, cpp(boundingBox));
     });
 }
 
-CVAPI(ExceptionStatus) video_Tracker_update(cv::Tracker* tracker, const cv::Mat* image, interop::Rect* boundingBox, int* returnValue)
+CVAPI(ExceptionStatus) video_Tracker_update(
+    cv::Tracker* tracker,
+    const cv::Mat* image,
+    interop::Rect* boundingBox,
+    int* returnValue)
 {
     return cvTry([&] {
     cv::Rect bb = cpp(*boundingBox);
@@ -308,10 +381,12 @@ CVAPI(ExceptionStatus) video_Ptr_TrackerMIL_get(cv::Ptr<cv::TrackerMIL>* ptr, cv
 
 /*CVAPI(ExceptionStatus) video_DenseOpticalFlow_calc(
     cv::DenseOpticalFlow *obj,
-    cv::_InputArray *i0, cv::_InputArray *i1, cv::_InputOutputArray *flow)
+    const interop::InputArrayProxy* i0,
+    const interop::InputArrayProxy* i1,
+    const interop::InputOutputArrayProxy* flow)
 {
     return cvTry([&] {
-    obj->calc(*i0, *i1, *flow);
+    obj->calc(InProxy(*i0), InProxy(*i1), IoProxy(*flow));
     });
 }
 

--- a/src/OpenCvSharpExtern/ximgproc.h
+++ b/src/OpenCvSharpExtern/ximgproc.h
@@ -8,32 +8,51 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) ximgproc_niBlackThreshold(cv::_InputArray *src, cv::_OutputArray *dst,
-    double maxValue, int type,
-    int blockSize, double k, int binarizationMethod, double r)
+CVAPI(ExceptionStatus) ximgproc_niBlackThreshold(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double maxValue,
+    int type,
+    int blockSize,
+    double k,
+    int binarizationMethod,
+    double r)
 {
     return cvTry([&] {
-    cv::ximgproc::niBlackThreshold(*src, *dst, maxValue, type, blockSize, k, binarizationMethod, r);
+    cv::ximgproc::niBlackThreshold(InProxy(*src), OutProxy(*dst), maxValue, type, blockSize, k, binarizationMethod, r);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_thinning(cv::_InputArray *src, cv::_OutputArray *dst, int thinningType)
+CVAPI(ExceptionStatus) ximgproc_thinning(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int thinningType)
 {
     return cvTry([&] {
-    cv::ximgproc::thinning(*src, *dst, thinningType);
+    cv::ximgproc::thinning(InProxy(*src), OutProxy(*dst), thinningType);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_anisotropicDiffusion(cv::_InputArray *src, cv::_OutputArray *dst, float alpha, float K, int niters)
+CVAPI(ExceptionStatus) ximgproc_anisotropicDiffusion(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float alpha,
+    float K,
+    int niters)
 {
     return cvTry([&] {
-    cv::ximgproc::anisotropicDiffusion(*src, *dst, alpha, K, niters);
+    cv::ximgproc::anisotropicDiffusion(InProxy(*src), OutProxy(*dst), alpha, K, niters);
     });
 }
 
 // brightedges.hpp
 
-CVAPI(ExceptionStatus) ximgproc_BrightEdges(cv::Mat *original, cv::Mat *edgeview, int contrast, int shortrange, int longrange)
+CVAPI(ExceptionStatus) ximgproc_BrightEdges(
+    cv::Mat *original,
+    cv::Mat *edgeview,
+    int contrast,
+    int shortrange,
+    int longrange)
 {
     return cvTry([&] {
     cv::ximgproc::BrightEdges(*original, *edgeview, contrast, shortrange, longrange);
@@ -42,124 +61,166 @@ CVAPI(ExceptionStatus) ximgproc_BrightEdges(cv::Mat *original, cv::Mat *edgeview
 
 // color_match.hpp
 
-CVAPI(ExceptionStatus) ximgproc_createQuaternionImage(cv::_InputArray *img, cv::_OutputArray *qimg)
+CVAPI(ExceptionStatus) ximgproc_createQuaternionImage(const interop::InputArrayProxy* img, const interop::OutputArrayProxy* qimg)
 {
     return cvTry([&] {
-    cv::ximgproc::createQuaternionImage(*img, *qimg);
+    cv::ximgproc::createQuaternionImage(InProxy(*img), OutProxy(*qimg));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_qconj(cv::_InputArray *qimg, cv::_OutputArray *qcimg)
+CVAPI(ExceptionStatus) ximgproc_qconj(const interop::InputArrayProxy* qimg, const interop::OutputArrayProxy* qcimg)
 {
     return cvTry([&] {
-    cv::ximgproc::qconj(*qimg, *qcimg);
+    cv::ximgproc::qconj(InProxy(*qimg), OutProxy(*qcimg));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_qunitary(cv::_InputArray *qimg, cv::_OutputArray *qnimg)
+CVAPI(ExceptionStatus) ximgproc_qunitary(const interop::InputArrayProxy* qimg, const interop::OutputArrayProxy* qnimg)
 {
     return cvTry([&] {
-    cv::ximgproc::qunitary(*qimg, *qnimg);
+    cv::ximgproc::qunitary(InProxy(*qimg), OutProxy(*qnimg));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_qmultiply(cv::_InputArray *src1, cv::_InputArray *src2, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_qmultiply(
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    cv::ximgproc::qmultiply(*src1, *src2, *dst);
+    cv::ximgproc::qmultiply(InProxy(*src1), InProxy(*src2), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_qdft(cv::_InputArray *img, cv::_OutputArray *qimg, int flags, int sideLeft)
+CVAPI(ExceptionStatus) ximgproc_qdft(
+    const interop::InputArrayProxy* img,
+    const interop::OutputArrayProxy* qimg,
+    int flags,
+    int sideLeft)
 {
     return cvTry([&] {
-    cv::ximgproc::qdft(*img, *qimg, flags, sideLeft != 0);
+    cv::ximgproc::qdft(InProxy(*img), OutProxy(*qimg), flags, sideLeft != 0);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_colorMatchTemplate(cv::_InputArray *img, cv::_InputArray *templ, cv::_OutputArray *result)
+CVAPI(ExceptionStatus) ximgproc_colorMatchTemplate(
+    const interop::InputArrayProxy* img,
+    const interop::InputArrayProxy* templ,
+    const interop::OutputArrayProxy* result)
 {
     return cvTry([&] {
-    cv::ximgproc::colorMatchTemplate(*img, *templ, *result);
+    cv::ximgproc::colorMatchTemplate(InProxy(*img), InProxy(*templ), OutProxy(*result));
     });
 }
 
 // deriche_filter.hpp
 
-CVAPI(ExceptionStatus) ximgproc_GradientDericheY(cv::_InputArray *op, cv::_OutputArray *dst, double alpha, double omega)
+CVAPI(ExceptionStatus) ximgproc_GradientDericheY(
+    const interop::InputArrayProxy* op,
+    const interop::OutputArrayProxy* dst,
+    double alpha,
+    double omega)
 {
     return cvTry([&] {
-    cv::ximgproc::GradientDericheY(*op, *dst, alpha, omega);
+    cv::ximgproc::GradientDericheY(InProxy(*op), OutProxy(*dst), alpha, omega);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_GradientDericheX(cv::_InputArray *op, cv::_OutputArray *dst, double alpha, double omega)
+CVAPI(ExceptionStatus) ximgproc_GradientDericheX(
+    const interop::InputArrayProxy* op,
+    const interop::OutputArrayProxy* dst,
+    double alpha,
+    double omega)
 {
     return cvTry([&] {
-    cv::ximgproc::GradientDericheX(*op, *dst, alpha, omega);
+    cv::ximgproc::GradientDericheX(InProxy(*op), OutProxy(*dst), alpha, omega);
     });
 }
 
 // edgepreserving_filter.hpp
 
-CVAPI(ExceptionStatus) ximgproc_edgePreservingFilter(cv::_InputArray *src, cv::_OutputArray *dst, int d, double threshold)
+CVAPI(ExceptionStatus) ximgproc_edgePreservingFilter(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int d,
+    double threshold)
 {
     return cvTry([&] {
-    cv::ximgproc::edgePreservingFilter(*src, *dst, d, threshold);
+    cv::ximgproc::edgePreservingFilter(InProxy(*src), OutProxy(*dst), d, threshold);
     });
 }
 
 // estimated_covariance.hpp
 
 CVAPI(ExceptionStatus) ximgproc_covarianceEstimation(
-    cv::_InputArray *src, cv::_OutputArray *dst, int windowRows, int windowCols)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int windowRows,
+    int windowCols)
 {
     return cvTry([&] {
-    cv::ximgproc::covarianceEstimation(*src, *dst, windowRows, windowCols);
+    cv::ximgproc::covarianceEstimation(InProxy(*src), OutProxy(*dst), windowRows, windowCols);
     });
 }
 
 // fast_hough_transform.hpp
 
 CVAPI(ExceptionStatus) ximgproc_FastHoughTransform(
-    cv::_InputArray* src, cv::_OutputArray* dst,
-    int dstMatDepth, int angleRange, int op, int makeSkew)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int dstMatDepth,
+    int angleRange,
+    int op,
+    int makeSkew)
 {
     return cvTry([&] {
-    cv::ximgproc::FastHoughTransform(*src, *dst, dstMatDepth, angleRange, op, makeSkew);
+    cv::ximgproc::FastHoughTransform(InProxy(*src), OutProxy(*dst), dstMatDepth, angleRange, op, makeSkew);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_HoughPoint2Line(interop::Point houghPoint, cv::_InputArray* srcImgInfo,
-    int angleRange, int makeSkew, int rules, interop::Vec4i* returnValue)
+CVAPI(ExceptionStatus) ximgproc_HoughPoint2Line(
+    interop::Point houghPoint,
+    const interop::InputArrayProxy* srcImgInfo,
+    int angleRange,
+    int makeSkew,
+    int rules,
+    interop::Vec4i* returnValue)
 {
     return cvTry([&] {
-    *returnValue = c(cv::ximgproc::HoughPoint2Line(cpp(houghPoint), *srcImgInfo, angleRange, makeSkew, rules));
+    *returnValue = c(cv::ximgproc::HoughPoint2Line(cpp(houghPoint), InProxy(*srcImgInfo), angleRange, makeSkew, rules));
     });
 }
 
 // paillou_filter.hpp
 
-CVAPI(ExceptionStatus) ximgproc_GradientPaillouY(cv::_InputArray* op, cv::_OutputArray* dst, double alpha, double omega)
+CVAPI(ExceptionStatus) ximgproc_GradientPaillouY(
+    const interop::InputArrayProxy* op,
+    const interop::OutputArrayProxy* dst,
+    double alpha,
+    double omega)
 {
     return cvTry([&] {
-    cv::ximgproc::GradientPaillouY(*op, *dst, alpha, omega);
+    cv::ximgproc::GradientPaillouY(InProxy(*op), OutProxy(*dst), alpha, omega);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_GradientPaillouX(cv::_InputArray* op, cv::_OutputArray* dst, double alpha, double omega)
+CVAPI(ExceptionStatus) ximgproc_GradientPaillouX(
+    const interop::InputArrayProxy* op,
+    const interop::OutputArrayProxy* dst,
+    double alpha,
+    double omega)
 {
     return cvTry([&] {
-    cv::ximgproc::GradientPaillouX(*op, *dst, alpha, omega);
+    cv::ximgproc::GradientPaillouX(InProxy(*op), OutProxy(*dst), alpha, omega);
     });
 }
 
 // peilin.hpp
 
-CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_Mat23d(cv::_InputArray *I, double *returnValue)
+CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_Mat23d(const interop::InputArrayProxy* I, double *returnValue)
 {
     return cvTry([&] {
-    auto ret = cv::ximgproc::PeiLinNormalization(*I);
+    auto ret = cv::ximgproc::PeiLinNormalization(InProxy(*I));
     for (int r = 0; r < 2; r++)
     {
         for (int c = 0; c < 3; ++c)
@@ -170,40 +231,53 @@ CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_Mat23d(cv::_InputArray *I, d
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_OutputArray(cv::_InputArray *I, cv::_OutputArray *T)
+CVAPI(ExceptionStatus) ximgproc_PeiLinNormalization_OutputArray(const interop::InputArrayProxy* I, const interop::OutputArrayProxy* T)
 {
     return cvTry([&] {
-    cv::ximgproc::PeiLinNormalization(*I, *T);
+    cv::ximgproc::PeiLinNormalization(InProxy(*I), OutProxy(*T));
     });
 }
 
 // run_length_morphology.hpp
 
-CVAPI(ExceptionStatus) ximgproc_rl_threshold(cv::_InputArray *src, cv::_OutputArray *rlDest, double thresh, int type)
+CVAPI(ExceptionStatus) ximgproc_rl_threshold(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* rlDest,
+    double thresh,
+    int type)
 {
     return cvTry([&] {
-    cv::ximgproc::rl::threshold(*src, *rlDest, thresh, type);
+    cv::ximgproc::rl::threshold(InProxy(*src), OutProxy(*rlDest), thresh, type);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_dilate(
-    cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, cv::_InputArray *rlKernel, interop::Point anchor)
+    const interop::InputArrayProxy* rlSrc,
+    const interop::OutputArrayProxy* rlDest,
+    const interop::InputArrayProxy* rlKernel,
+    interop::Point anchor)
 {
     return cvTry([&] {
-    cv::ximgproc::rl::dilate(*rlSrc, *rlDest, *rlKernel, cpp(anchor));
+    cv::ximgproc::rl::dilate(InProxy(*rlSrc), OutProxy(*rlDest), InProxy(*rlKernel), cpp(anchor));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_erode(
-    cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, cv::_InputArray *rlKernel,
-    int bBoundaryOn, interop::Point anchor)
+    const interop::InputArrayProxy* rlSrc,
+    const interop::OutputArrayProxy* rlDest,
+    const interop::InputArrayProxy* rlKernel,
+    int bBoundaryOn,
+    interop::Point anchor)
 {
     return cvTry([&] {
-    cv::ximgproc::rl::erode(*rlSrc, *rlDest, *rlKernel, bBoundaryOn != 0, cpp(anchor));
+    cv::ximgproc::rl::erode(InProxy(*rlSrc), OutProxy(*rlDest), InProxy(*rlKernel), bBoundaryOn != 0, cpp(anchor));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_rl_getStructuringElement(int shape, interop::Size ksize, cv::Mat *outValue)
+CVAPI(ExceptionStatus) ximgproc_rl_getStructuringElement(
+    int shape,
+    interop::Size ksize,
+    cv::Mat *outValue)
 {
     return cvTry([&] {
     auto result = cv::ximgproc::rl::getStructuringElement(shape, cpp(ksize));
@@ -211,21 +285,28 @@ CVAPI(ExceptionStatus) ximgproc_rl_getStructuringElement(int shape, interop::Siz
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_rl_paint(cv::_InputOutputArray *image, cv::_InputArray *rlSrc, interop::Scalar value)
+CVAPI(ExceptionStatus) ximgproc_rl_paint(
+    const interop::InputOutputArrayProxy* image,
+    const interop::InputArrayProxy* rlSrc,
+    interop::Scalar value)
 {
     return cvTry([&] {
-    cv::ximgproc::rl::paint(*image, *rlSrc, cpp(value));
+    cv::ximgproc::rl::paint(IoProxy(*image), InProxy(*rlSrc), cpp(value));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_rl_isRLMorphologyPossible(cv::_InputArray *rlStructuringElement, int *outValue)
+CVAPI(ExceptionStatus) ximgproc_rl_isRLMorphologyPossible(const interop::InputArrayProxy* rlStructuringElement, int *outValue)
 {
     return cvTry([&] {
-    *outValue = cv::ximgproc::rl::isRLMorphologyPossible(*rlStructuringElement) ? 1 : 0;
+    *outValue = cv::ximgproc::rl::isRLMorphologyPossible(InProxy(*rlStructuringElement)) ? 1 : 0;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_rl_createRLEImage(interop::Point3i *runs, size_t runsLength, cv::_OutputArray *res, interop::Size size)
+CVAPI(ExceptionStatus) ximgproc_rl_createRLEImage(
+    interop::Point3i *runs,
+    size_t runsLength,
+    const interop::OutputArrayProxy* res,
+    interop::Size size)
 {
     return cvTry([&] {
     std::vector<cv::Point3i> runsVec(runsLength);
@@ -233,28 +314,37 @@ CVAPI(ExceptionStatus) ximgproc_rl_createRLEImage(interop::Point3i *runs, size_t
     {
         runsVec[i] = cpp(runs[i]);
     }
-    cv::ximgproc::rl::createRLEImage(runsVec, *res, cpp(size));
+    cv::ximgproc::rl::createRLEImage(runsVec, OutProxy(*res), cpp(size));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_rl_morphologyEx(
-    cv::_InputArray *rlSrc, cv::_OutputArray *rlDest, int op, cv::_InputArray *rlKernel,
-    int bBoundaryOnForErosion, interop::Point anchor)
+    const interop::InputArrayProxy* rlSrc,
+    const interop::OutputArrayProxy* rlDest,
+    int op,
+    const interop::InputArrayProxy* rlKernel,
+    int bBoundaryOnForErosion,
+    interop::Point anchor)
 {
     return cvTry([&] {
-    cv::ximgproc::rl::morphologyEx(*rlSrc, *rlDest, op, *rlKernel, bBoundaryOnForErosion != 0, cpp(anchor));
+    cv::ximgproc::rl::morphologyEx(InProxy(*rlSrc), OutProxy(*rlDest), op, InProxy(*rlKernel), bBoundaryOnForErosion != 0, cpp(anchor));
     });
 }
 
 // weighted_median_filter.hpp
 
 CVAPI(ExceptionStatus) ximgproc_weightedMedianFilter(
-    cv::_InputArray* joint, cv::_InputArray* src, cv::_OutputArray* dst,
-    int r, double sigma, int weightType, cv::Mat* mask)
+    const interop::InputArrayProxy* joint,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int r,
+    double sigma,
+    int weightType,
+    const interop::InputArrayProxy* mask)
 {
     return cvTry([&] {
-    cv::ximgproc::weightedMedianFilter(*joint, *src, *dst, r, sigma,
-        static_cast<cv::ximgproc::WMFWeightType>(weightType), entity(mask));
+    cv::ximgproc::weightedMedianFilter(InProxy(*joint), InProxy(*src), OutProxy(*dst), r, sigma,
+        static_cast<cv::ximgproc::WMFWeightType>(weightType), InProxy(*mask));
     });
 }
 

--- a/src/OpenCvSharpExtern/ximgproc_EdgeBoxes.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeBoxes.h
@@ -10,11 +10,13 @@
 
 
 CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_getBoundingBoxes(
-    cv::ximgproc::EdgeBoxes *obj, cv::_InputArray *edge_map, 
-    cv::_InputArray *orientation_map, std::vector<cv::Rect> *boxes)
+    cv::ximgproc::EdgeBoxes *obj,
+    const interop::InputArrayProxy* edge_map,
+    const interop::InputArrayProxy* orientation_map,
+    std::vector<cv::Rect> *boxes)
 {
     return cvTry([&] {
-    obj->getBoundingBoxes(*edge_map, *orientation_map, *boxes);
+    obj->getBoundingBoxes(InProxy(*edge_map), InProxy(*orientation_map), *boxes);
     });
 }
 
@@ -45,8 +47,18 @@ CVAPI(ExceptionStatus) ximgproc_EdgeBoxes_setKappa(cv::ximgproc::EdgeBoxes *obj,
 
 
 CVAPI(ExceptionStatus) ximgproc_createEdgeBoxes(
-    float alpha,  float beta, float eta, float minScore, int maxBoxes, float edgeMinMag, float edgeMergeThr,
-    float clusterMinMag, float maxAspectRatio, float minBoxArea, float gamma, float kappa,
+    float alpha,
+    float beta,
+    float eta,
+    float minScore,
+    int maxBoxes,
+    float edgeMinMag,
+    float edgeMergeThr,
+    float clusterMinMag,
+    float maxAspectRatio,
+    float minBoxArea,
+    float gamma,
+    float kappa,
     cv::Ptr<cv::ximgproc::EdgeBoxes> **returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/ximgproc_EdgeDrawing.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeDrawing.h
@@ -38,16 +38,14 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeDrawing_delete(cv::Ptr<cv::ximgproc::Edg
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeDrawing_get(
-    cv::Ptr<cv::ximgproc::EdgeDrawing> *ptr, cv::ximgproc::EdgeDrawing **returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_EdgeDrawing_get(cv::Ptr<cv::ximgproc::EdgeDrawing> *ptr, cv::ximgproc::EdgeDrawing **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_createEdgeDrawing(
-    cv::Ptr<cv::ximgproc::EdgeDrawing> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_createEdgeDrawing(cv::Ptr<cv::ximgproc::EdgeDrawing> **returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::ximgproc::createEdgeDrawing();
@@ -56,81 +54,70 @@ CVAPI(ExceptionStatus) ximgproc_createEdgeDrawing(
 }
 
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEdges(
-    cv::ximgproc::EdgeDrawing *obj, cv::_InputArray *src)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEdges(cv::ximgproc::EdgeDrawing *obj, const interop::InputArrayProxy* src)
 {
     return cvTry([&] {
-    obj->detectEdges(*src);
+    obj->detectEdges(InProxy(*src));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getEdgeImage(
-    cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getEdgeImage(cv::ximgproc::EdgeDrawing *obj, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->getEdgeImage(*dst);
+    obj->getEdgeImage(OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getGradientImage(
-    cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getGradientImage(cv::ximgproc::EdgeDrawing *obj, const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->getGradientImage(*dst);
+    obj->getGradientImage(OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegments(
-    cv::ximgproc::EdgeDrawing *obj,
-    std::vector<std::vector<cv::Point>> *returnValue)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegments(cv::ximgproc::EdgeDrawing *obj, std::vector<std::vector<cv::Point>> *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getSegments();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegmentIndicesOfLines(
-    cv::ximgproc::EdgeDrawing *obj, std::vector<int> *returnValue)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getSegmentIndicesOfLines(cv::ximgproc::EdgeDrawing *obj, std::vector<int> *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getSegmentIndicesOfLines();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines(
-    cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *lines)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines(cv::ximgproc::EdgeDrawing *obj, const interop::OutputArrayProxy* lines)
+{
+    return cvTry([&] {
+    obj->detectLines(OutProxy(*lines));
+    });
+}
+
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines_vector(cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec4f> *lines)
 {
     return cvTry([&] {
     obj->detectLines(*lines);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectLines_vector(
-    cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec4f> *lines)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses(cv::ximgproc::EdgeDrawing *obj, const interop::OutputArrayProxy* ellipses)
 {
     return cvTry([&] {
-    obj->detectLines(*lines);
+    obj->detectEllipses(OutProxy(*ellipses));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses(
-    cv::ximgproc::EdgeDrawing *obj, cv::_OutputArray *ellipses)
-{
-    return cvTry([&] {
-    obj->detectEllipses(*ellipses);
-    });
-}
-
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses_vector(
-    cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec6d> *ellipses)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_detectEllipses_vector(cv::ximgproc::EdgeDrawing *obj, std::vector<cv::Vec6d> *ellipses)
 {
     return cvTry([&] {
     obj->detectEllipses(*ellipses);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getParams(
-    cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *returnValue)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getParams(cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *returnValue)
 {
     return cvTry([&] {
     const auto &p = obj->params;
@@ -150,8 +137,7 @@ CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_getParams(
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_setParams(
-    cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *params)
+CVAPI(ExceptionStatus) ximgproc_EdgeDrawing_setParams(cv::ximgproc::EdgeDrawing *obj, CvEdgeDrawingParams *params)
 {
     return cvTry([&] {
     cv::ximgproc::EdgeDrawing::Params p;

--- a/src/OpenCvSharpExtern/ximgproc_EdgeFilter.h
+++ b/src/OpenCvSharpExtern/ximgproc_EdgeFilter.h
@@ -10,16 +10,14 @@
 
 // DTFilter
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_delete(
-    cv::Ptr<cv::ximgproc::DTFilter>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_delete(cv::Ptr<cv::ximgproc::DTFilter>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_get(
-    cv::Ptr<cv::ximgproc::DTFilter>* ptr, cv::ximgproc::DTFilter** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_get(cv::Ptr<cv::ximgproc::DTFilter>* ptr, cv::ximgproc::DTFilter** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -28,44 +26,54 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_DTFilter_get(
 
 CVAPI(ExceptionStatus) ximgproc_DTFilter_filter(
     cv::ximgproc::DTFilter* obj,
-    cv::_InputArray *src, cv::_OutputArray *dst, int dDepth)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int dDepth)
 {
     return cvTry([&] {
-    obj->filter(*src, *dst, dDepth);
+    obj->filter(InProxy(*src), OutProxy(*dst), dDepth);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createDTFilter(
-    cv::_InputArray *guide, double sigmaSpatial, double sigmaColor, int mode, int numIters,
+    const interop::InputArrayProxy* guide,
+    double sigmaSpatial,
+    double sigmaColor,
+    int mode,
+    int numIters,
     cv::Ptr<cv::ximgproc::DTFilter>** returnValue)
 {
     return cvTry([&] {
-    const auto ptr = cv::ximgproc::createDTFilter(*guide, sigmaSpatial, sigmaColor, mode, numIters);
+    const auto ptr = cv::ximgproc::createDTFilter(InProxy(*guide), sigmaSpatial, sigmaColor, mode, numIters);
     *returnValue = new cv::Ptr<cv::ximgproc::DTFilter>(ptr);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_dtFilter(
-    cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, double sigmaSpatial, double sigmaColor, int mode, int numIters)
+    const interop::InputArrayProxy* guide,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double sigmaSpatial,
+    double sigmaColor,
+    int mode,
+    int numIters)
 {
     return cvTry([&] {
-    cv::ximgproc::dtFilter(*guide, *src, *dst, sigmaSpatial, sigmaColor, mode, numIters);
+    cv::ximgproc::dtFilter(InProxy(*guide), InProxy(*src), OutProxy(*dst), sigmaSpatial, sigmaColor, mode, numIters);
     });
 }
 
 //////////////////////////////////////////////////////////////////////////
 // GuidedFilter
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_delete(
-    cv::Ptr<cv::ximgproc::GuidedFilter>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_delete(cv::Ptr<cv::ximgproc::GuidedFilter>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_get(
-    cv::Ptr<cv::ximgproc::GuidedFilter>* ptr, cv::ximgproc::GuidedFilter** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_get(cv::Ptr<cv::ximgproc::GuidedFilter>* ptr, cv::ximgproc::GuidedFilter** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -74,44 +82,51 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_GuidedFilter_get(
 
 CVAPI(ExceptionStatus) ximgproc_GuidedFilter_filter(
     cv::ximgproc::GuidedFilter* obj,
-    cv::_InputArray* src, cv::_OutputArray* dst, int dDepth)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int dDepth)
 {
     return cvTry([&] {
-    obj->filter(*src, *dst, dDepth);
+    obj->filter(InProxy(*src), OutProxy(*dst), dDepth);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createGuidedFilter(
-    cv::_InputArray* guide, int radius, double eps, 
+    const interop::InputArrayProxy* guide,
+    int radius,
+    double eps,
     cv::Ptr<cv::ximgproc::GuidedFilter>** returnValue)
 {
     return cvTry([&] {
-    const auto ptr = cv::ximgproc::createGuidedFilter(*guide, radius, eps);
+    const auto ptr = cv::ximgproc::createGuidedFilter(InProxy(*guide), radius, eps);
     *returnValue = new cv::Ptr<cv::ximgproc::GuidedFilter>(ptr);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_guidedFilter(
-    cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, int radius, double eps, int dDepth)
+    const interop::InputArrayProxy* guide,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int radius,
+    double eps,
+    int dDepth)
 {
     return cvTry([&] {
-    cv::ximgproc::guidedFilter(*guide, *src, *dst, radius, eps, dDepth);
+    cv::ximgproc::guidedFilter(InProxy(*guide), InProxy(*src), OutProxy(*dst), radius, eps, dDepth);
     });
 }
 
 //////////////////////////////////////////////////////////////////////////
 // AdaptiveManifoldFilter
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_delete(
-    cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_delete(cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_get(
-    cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* ptr, cv::ximgproc::AdaptiveManifoldFilter** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_get(cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>* ptr, cv::ximgproc::AdaptiveManifoldFilter** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -120,15 +135,16 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_AdaptiveManifoldFilter_get(
 
 CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_filter(
     cv::ximgproc::AdaptiveManifoldFilter* obj,
-    cv::_InputArray* src, cv::_OutputArray* dst, cv::_InputArray *joint)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    const interop::InputArrayProxy* joint)
 {
     return cvTry([&] {
-    obj->filter(*src, *dst, entity(joint));
+    obj->filter(InProxy(*src), OutProxy(*dst), InProxy(*joint));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_collectGarbage(
-    cv::ximgproc::AdaptiveManifoldFilter* obj)
+CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_collectGarbage(cv::ximgproc::AdaptiveManifoldFilter* obj)
 {
     return cvTry([&] {
     obj->collectGarbage();
@@ -209,7 +225,9 @@ CVAPI(ExceptionStatus) ximgproc_AdaptiveManifoldFilter_setUseRNG(cv::ximgproc::A
 }
 
 CVAPI(ExceptionStatus) ximgproc_createAMFilter(
-    double sigma_s, double sigma_r, int adjust_outliers,
+    double sigma_s,
+    double sigma_r,
+    int adjust_outliers,
     cv::Ptr<cv::ximgproc::AdaptiveManifoldFilter>** returnValue)
 {
     return cvTry([&] {
@@ -219,34 +237,59 @@ CVAPI(ExceptionStatus) ximgproc_createAMFilter(
 }
 
 CVAPI(ExceptionStatus) ximgproc_amFilter(
-    cv::_InputArray *joint, cv::_InputArray *src, cv::_OutputArray *dst, double sigma_s, double sigma_r, int adjust_outliers)
+    const interop::InputArrayProxy* joint,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double sigma_s,
+    double sigma_r,
+    int adjust_outliers)
 {
     return cvTry([&] {
-    cv::ximgproc::amFilter(*joint, *src, *dst, sigma_s, sigma_r, adjust_outliers != 0);
+    cv::ximgproc::amFilter(InProxy(*joint), InProxy(*src), OutProxy(*dst), sigma_s, sigma_r, adjust_outliers != 0);
     });
 }
 
 
 //////////////////////////////////////////////////////////////////////////
 
-CVAPI(ExceptionStatus) ximgproc_jointBilateralFilter(cv::_InputArray *joint, cv::_InputArray *src, cv::_OutputArray *dst, int d, double sigmaColor, double sigmaSpace, int borderType)
+CVAPI(ExceptionStatus) ximgproc_jointBilateralFilter(
+    const interop::InputArrayProxy* joint,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int d,
+    double sigmaColor,
+    double sigmaSpace,
+    int borderType)
 {
     return cvTry([&] {
-    cv::ximgproc::jointBilateralFilter(*joint, *src, *dst, d, sigmaColor, sigmaSpace, borderType);
+    cv::ximgproc::jointBilateralFilter(InProxy(*joint), InProxy(*src), OutProxy(*dst), d, sigmaColor, sigmaSpace, borderType);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_bilateralTextureFilter(cv::_InputArray *src, cv::_OutputArray *dst, int fr, int numIter, double sigmaAlpha, double sigmaAvg)
+CVAPI(ExceptionStatus) ximgproc_bilateralTextureFilter(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int fr,
+    int numIter,
+    double sigmaAlpha,
+    double sigmaAvg)
 {
     return cvTry([&] {
-    cv::ximgproc::bilateralTextureFilter(*src, *dst, fr, numIter, sigmaAlpha, sigmaAvg);
+    cv::ximgproc::bilateralTextureFilter(InProxy(*src), OutProxy(*dst), fr, numIter, sigmaAlpha, sigmaAvg);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_rollingGuidanceFilter(cv::_InputArray *src, cv::_OutputArray *dst, int d, double sigmaColor, double sigmaSpace, int numOfIter, int borderType)
+CVAPI(ExceptionStatus) ximgproc_rollingGuidanceFilter(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int d,
+    double sigmaColor,
+    double sigmaSpace,
+    int numOfIter,
+    int borderType)
 {
     return cvTry([&] {
-    cv::ximgproc::rollingGuidanceFilter(*src, *dst, d, sigmaColor, sigmaSpace, numOfIter, borderType);
+    cv::ximgproc::rollingGuidanceFilter(InProxy(*src), OutProxy(*dst), d, sigmaColor, sigmaSpace, numOfIter, borderType);
     });
 }
 
@@ -254,16 +297,14 @@ CVAPI(ExceptionStatus) ximgproc_rollingGuidanceFilter(cv::_InputArray *src, cv::
 //////////////////////////////////////////////////////////////////////////
 // FastBilateralSolverFilter 
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_delete(
-    cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_delete(cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_get(
-    cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* ptr, cv::ximgproc::FastBilateralSolverFilter** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_get(cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>* ptr, cv::ximgproc::FastBilateralSolverFilter** returnValue)
 {
     return cvTry([&] {
     * returnValue = ptr->get();
@@ -272,29 +313,45 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_FastBilateralSolverFilter_get(
 
 CVAPI(ExceptionStatus) ximgproc_FastBilateralSolverFilter_filter(
     cv::ximgproc::FastBilateralSolverFilter* obj,
-    cv::_InputArray* src, cv::_InputArray *confidence, cv::_OutputArray* dst)
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* confidence,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->filter(*src, *confidence , *dst);
+    obj->filter(InProxy(*src), InProxy(*confidence) , OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createFastBilateralSolverFilter(
-    cv::_InputArray *guide, double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, double max_tol,
+    const interop::InputArrayProxy* guide,
+    double sigma_spatial,
+    double sigma_luma,
+    double sigma_chroma,
+    double lambda,
+    int num_iter,
+    double max_tol,
     cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>** returnValue)
 {
     return cvTry([&] {
-    const auto ptr = cv::ximgproc::createFastBilateralSolverFilter(*guide, sigma_spatial, sigma_luma, sigma_chroma, lambda, num_iter, max_tol);
+    const auto ptr = cv::ximgproc::createFastBilateralSolverFilter(InProxy(*guide), sigma_spatial, sigma_luma, sigma_chroma, lambda, num_iter, max_tol);
     *returnValue = new cv::Ptr<cv::ximgproc::FastBilateralSolverFilter>(ptr);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_fastBilateralSolverFilter(
-    cv::_InputArray *guide, cv::_InputArray *src, cv::_InputArray *confidence, cv::_OutputArray *dst, 
-    double sigma_spatial, double sigma_luma, double sigma_chroma, double lambda, int num_iter, double max_tol)
+    const interop::InputArrayProxy* guide,
+    const interop::InputArrayProxy* src,
+    const interop::InputArrayProxy* confidence,
+    const interop::OutputArrayProxy* dst,
+    double sigma_spatial,
+    double sigma_luma,
+    double sigma_chroma,
+    double lambda,
+    int num_iter,
+    double max_tol)
 {
     return cvTry([&] {
-    cv::ximgproc::fastBilateralSolverFilter(*guide, *src, *confidence, *dst,
+    cv::ximgproc::fastBilateralSolverFilter(InProxy(*guide), InProxy(*src), InProxy(*confidence), OutProxy(*dst),
         sigma_spatial, sigma_luma, sigma_chroma, lambda, num_iter, max_tol);
     });
 }
@@ -303,16 +360,14 @@ CVAPI(ExceptionStatus) ximgproc_fastBilateralSolverFilter(
 //////////////////////////////////////////////////////////////////////////
 // FastGlobalSmootherFilter 
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_delete(
-    cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_delete(cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_get(
-    cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* ptr, cv::ximgproc::FastGlobalSmootherFilter** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_get(cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>* ptr, cv::ximgproc::FastGlobalSmootherFilter** returnValue)
 {
     return cvTry([&] {
     * returnValue = ptr->get();
@@ -321,36 +376,51 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_FastGlobalSmootherFilter_get(
 
 CVAPI(ExceptionStatus) ximgproc_FastGlobalSmootherFilter_filter(
     cv::ximgproc::FastGlobalSmootherFilter* obj,
-    cv::_InputArray* src, cv::_OutputArray* dst)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->filter(*src, *dst);
+    obj->filter(InProxy(*src), OutProxy(*dst));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createFastGlobalSmootherFilter(
-    cv::_InputArray *guide, double lambda, double sigma_color, double lambda_attenuation, int num_iter,
+    const interop::InputArrayProxy* guide,
+    double lambda,
+    double sigma_color,
+    double lambda_attenuation,
+    int num_iter,
     cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>** returnValue)
 {
     return cvTry([&] {
-    const auto ptr = cv::ximgproc::createFastGlobalSmootherFilter(*guide, lambda, sigma_color, lambda_attenuation, num_iter);
+    const auto ptr = cv::ximgproc::createFastGlobalSmootherFilter(InProxy(*guide), lambda, sigma_color, lambda_attenuation, num_iter);
     *returnValue = new cv::Ptr<cv::ximgproc::FastGlobalSmootherFilter>(ptr);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_fastGlobalSmootherFilter(
-    cv::_InputArray *guide, cv::_InputArray *src, cv::_OutputArray *dst, double lambda, double sigma_color, double lambda_attenuation, int num_iter)
+    const interop::InputArrayProxy* guide,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double lambda,
+    double sigma_color,
+    double lambda_attenuation,
+    int num_iter)
 {
     return cvTry([&] {
-    cv::ximgproc::fastGlobalSmootherFilter(*guide, *src, *dst,
+    cv::ximgproc::fastGlobalSmootherFilter(InProxy(*guide), InProxy(*src), OutProxy(*dst),
         lambda, sigma_color, lambda_attenuation, num_iter);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_l0Smooth(cv::_InputArray *src, cv::_OutputArray *dst, double lambda, double kappa)
+CVAPI(ExceptionStatus) ximgproc_l0Smooth(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    double lambda,
+    double kappa)
 {
     return cvTry([&] {
-    cv::ximgproc::l0Smooth(*src, *dst, lambda, kappa);
+    cv::ximgproc::l0Smooth(InProxy(*src), OutProxy(*dst), lambda, kappa);
     });
 }
 

--- a/src/OpenCvSharpExtern/ximgproc_FastLineDetector.h
+++ b/src/OpenCvSharpExtern/ximgproc_FastLineDetector.h
@@ -8,16 +8,14 @@
 
 #include "include_opencv.h"
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_delete(
-    cv::Ptr<cv::ximgproc::FastLineDetector> *obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_delete(cv::Ptr<cv::ximgproc::FastLineDetector> *obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_get(
-    cv::Ptr<cv::ximgproc::FastLineDetector> *ptr, cv::ximgproc::FastLineDetector **returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_get(cv::Ptr<cv::ximgproc::FastLineDetector> *ptr, cv::ximgproc::FastLineDetector **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -25,40 +23,55 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_FastLineDetector_get(
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_detect_OutputArray(
-    cv::ximgproc::FastLineDetector *obj, cv::_InputArray *image, cv::_OutputArray *lines)
+    cv::ximgproc::FastLineDetector *obj,
+    const interop::InputArrayProxy* image,
+    const interop::OutputArrayProxy* lines)
 {
     return cvTry([&] {
-    obj->detect(*image, *lines);
+    obj->detect(InProxy(*image), OutProxy(*lines));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_detect_vector(
-    cv::ximgproc::FastLineDetector *obj, cv::_InputArray *image, std::vector<cv::Vec4f> *lines)
+    cv::ximgproc::FastLineDetector *obj,
+    const interop::InputArrayProxy* image,
+    std::vector<cv::Vec4f> *lines)
 {
     return cvTry([&] {
-    obj->detect(*image, *lines);
+    obj->detect(InProxy(*image), *lines);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_drawSegments_InputArray(
-    cv::ximgproc::FastLineDetector *obj, cv::_InputOutputArray *image, cv::_InputArray *lines, int draw_arrow)
+    cv::ximgproc::FastLineDetector *obj,
+    const interop::InputOutputArrayProxy* image,
+    const interop::InputArrayProxy* lines,
+    int draw_arrow)
 {
     return cvTry([&] {
-    obj->drawSegments(*image, *lines, draw_arrow != 0);
+    obj->drawSegments(IoProxy(*image), InProxy(*lines), draw_arrow != 0);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_FastLineDetector_drawSegments_vector(
-    cv::ximgproc::FastLineDetector *obj, cv::_InputOutputArray *image, std::vector<cv::Vec4f> *lines, int draw_arrow)
+    cv::ximgproc::FastLineDetector *obj,
+    const interop::InputOutputArrayProxy* image,
+    std::vector<cv::Vec4f> *lines,
+    int draw_arrow)
 {
     return cvTry([&] {
-    obj->drawSegments(*image, *lines, draw_arrow != 0);
+    obj->drawSegments(IoProxy(*image), *lines, draw_arrow != 0);
     });
 }
 
 
 CVAPI(ExceptionStatus) ximgproc_createFastLineDetector(
-    int length_threshold, float distance_threshold, double canny_th1, double canny_th2, int canny_aperture_size, int do_merge,
+    int length_threshold,
+    float distance_threshold,
+    double canny_th1,
+    double canny_th2,
+    int canny_aperture_size,
+    int do_merge,
     cv::Ptr<cv::ximgproc::FastLineDetector> **returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/ximgproc_RidgeDetectionFilter.h
+++ b/src/OpenCvSharpExtern/ximgproc_RidgeDetectionFilter.h
@@ -5,7 +5,14 @@
 #include "include_opencv.h"
 
 CVAPI(ExceptionStatus) ximgproc_RidgeDetectionFilter_create(
-    int ddepth, int dx, int dy, int ksize, int out_dtype, double scale, double delta, int borderType,
+    int ddepth,
+    int dx,
+    int dy,
+    int ksize,
+    int out_dtype,
+    double scale,
+    double delta,
+    int borderType,
     cv::Ptr<cv::ximgproc::RidgeDetectionFilter> **returnValue)
 {
     return cvTry([&] {
@@ -17,10 +24,11 @@ CVAPI(ExceptionStatus) ximgproc_RidgeDetectionFilter_create(
 
 CVAPI(ExceptionStatus) ximgproc_RidgeDetectionFilter_getRidgeFilteredImage(
     cv::ximgproc::RidgeDetectionFilter *obj,
-    cv::_InputArray *_img, cv::_OutputArray *out)
+    const interop::InputArrayProxy* _img,
+    const interop::OutputArrayProxy* out)
 {
     return cvTry([&] {
-    obj->getRidgeFilteredImage(*_img, *out);
+    obj->getRidgeFilteredImage(InProxy(*_img), OutProxy(*out));
     });
 }
 

--- a/src/OpenCvSharpExtern/ximgproc_Segmentation.h
+++ b/src/OpenCvSharpExtern/ximgproc_Segmentation.h
@@ -11,7 +11,10 @@
 // GraphSegmentation
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_createGraphSegmentation(
-    double sigma, float k, int min_size, cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> **returnValue)
+    double sigma,
+    float k,
+    int min_size,
+    cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createGraphSegmentation(sigma, k, min_size));
@@ -25,19 +28,20 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_GraphSegmentation_delete(cv::Pt
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_GraphSegmentation_get(
-    cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *ptr, 
-    cv::ximgproc::segmentation::GraphSegmentation **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_GraphSegmentation_get(cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *ptr, cv::ximgproc::segmentation::GraphSegmentation **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_processImage(cv::ximgproc::segmentation::GraphSegmentation *obj, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_processImage(
+    cv::ximgproc::segmentation::GraphSegmentation *obj,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->processImage(*src, *dst);
+    obj->processImage(InProxy(*src), OutProxy(*dst));
     });
 }
 
@@ -84,15 +88,22 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_GraphSegmentation_getMinSize(cv::xi
 // SelectiveSearchSegmentationStrategy
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_setImage(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, cv::_InputArray *img, cv::_InputArray *regions, cv::_InputArray *sizes, int image_id)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj,
+    const interop::InputArrayProxy* img,
+    const interop::InputArrayProxy* regions,
+    const interop::InputArrayProxy* sizes,
+    int image_id)
 {
     return cvTry([&] {
-    obj->setImage(*img, *regions, *sizes, image_id);
+    obj->setImage(InProxy(*img), InProxy(*regions), InProxy(*sizes), image_id);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_get(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, int r1, int r2, float *returnValue)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj,
+    int r1,
+    int r2,
+    float *returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->get(r1, r2);
@@ -100,98 +111,84 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy_merge(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj, int r1, int r2)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *obj,
+    int r1,
+    int r2)
 {
     return cvTry([&] {
     obj->merge(r1, r2);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyColor(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyColor(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyColor());
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategySize(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategySize(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategySize());
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyTexture(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyTexture(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyTexture());
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyFill(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyFill(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyFill());
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_delete(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *obj)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_delete(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *obj)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_delete(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *obj)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_delete(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *obj)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_delete(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *ptr, 
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyColor_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyColor **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *ptr, 
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategySize_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategySize **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *ptr, 
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyTexture_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyTexture **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *ptr, 
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyFill_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyFill **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -202,7 +199,9 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStra
 // SelectiveSearchSegmentationStrategyMultiple
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategyMultiple_addStrategy(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple *obj, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *g, float weight)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple *obj,
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *g,
+    float weight)
 {
     return cvTry([&] {
     obj->addStrategy(*g, weight);
@@ -216,24 +215,21 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentationStrategy
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple0(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple0(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(cv::ximgproc::segmentation::createSelectiveSearchSegmentationStrategyMultiple());
     });
 }
-CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple1(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1, 
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple1(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
     return cvTry([&] {
     *returnValue = clone(createSelectiveSearchSegmentationStrategyMultiple(*s1));
     });
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple2(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1, 
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2, 
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1,
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2,
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
     return cvTry([&] {
@@ -243,7 +239,7 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationSt
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple3(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1,
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2,
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s3, 
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s3,
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
     return cvTry([&] {
@@ -252,9 +248,9 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationSt
 }
 CVAPI(ExceptionStatus) ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple4(
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s1,
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2, 
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s3, 
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s4, 
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s2,
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s3,
+    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s4,
     cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> **returnValue)
 {
     return cvTry([&] {
@@ -269,9 +265,7 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStra
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> *ptr, 
-    cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategyMultiple **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
@@ -280,16 +274,17 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStra
 
 // SelectiveSearchSegmentation
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::_InputArray *img)
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_setBaseImage(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, const interop::InputArrayProxy* img)
 {
     return cvTry([&] {
-    obj->setBaseImage(*img);
+    obj->setBaseImage(InProxy(*img));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSingleStrategy(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int k, float sigma)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj,
+    int k,
+    float sigma)
 {
     return cvTry([&] {
     obj->switchToSingleStrategy(k, sigma);
@@ -297,7 +292,10 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchT
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchFast(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int base_k, int inc_k, float sigma)
+    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj,
+    int base_k,
+    int inc_k,
+    float sigma)
 {
     return cvTry([&] {
     obj->switchToSelectiveSearchFast(base_k, inc_k, sigma);
@@ -305,17 +303,20 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchT
 }
 
 CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_switchToSelectiveSearchQuality(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, int base_k, int inc_k, float sigma) 
+    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj,
+    int base_k,
+    int inc_k,
+    float sigma) 
 {
     return cvTry([&] {
     obj->switchToSelectiveSearchQuality(base_k, inc_k, sigma);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addImage(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::_InputArray *img)
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addImage(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, const interop::InputArrayProxy* img)
 {
     return cvTry([&] {
-    obj->addImage(*img);
+    obj->addImage(InProxy(*img));
     });
 }
 
@@ -326,8 +327,7 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearIm
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *g)
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addGraphSegmentation(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::GraphSegmentation> *g)
 {
     return cvTry([&] {
     obj->addGraphSegmentation(*g);
@@ -341,24 +341,21 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearGr
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s)
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_addStrategy(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy> *s)
 {
     return cvTry([&] {
     obj->addStrategy(*s);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj) 
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_clearStrategies(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj) 
 {
     return cvTry([&] {
     obj->clearStrategies();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_process(
-    cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, std::vector<cv::Rect> *rects) 
+CVAPI(ExceptionStatus) ximgproc_segmentation_SelectiveSearchSegmentation_process(cv::ximgproc::segmentation::SelectiveSearchSegmentation *obj, std::vector<cv::Rect> *rects) 
 {
     return cvTry([&] {
     obj->process(*rects);
@@ -379,8 +376,7 @@ CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentation_del
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentation_get(
-    cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentation> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentation **returnValue)
+CVAPI(ExceptionStatus) ximgproc_segmentation_Ptr_SelectiveSearchSegmentation_get(cv::Ptr<cv::ximgproc::segmentation::SelectiveSearchSegmentation> *ptr, cv::ximgproc::segmentation::SelectiveSearchSegmentation **returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();

--- a/src/OpenCvSharpExtern/ximgproc_StructuredEdgeDetection.h
+++ b/src/OpenCvSharpExtern/ximgproc_StructuredEdgeDetection.h
@@ -32,8 +32,14 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_RFFeatureGetter_get(cv::Ptr<cv::ximgproc::RF
 }
 
 CVAPI(ExceptionStatus) ximgproc_RFFeatureGetter_getFeatures(
-    cv::ximgproc::RFFeatureGetter *obj, cv::Mat *src, cv::Mat *features,
-    const int gnrmRad, const int gsmthRad, const int shrink, const int outNum, const int gradNum)
+    cv::ximgproc::RFFeatureGetter *obj,
+    cv::Mat *src,
+    cv::Mat *features,
+    const int gnrmRad,
+    const int gsmthRad,
+    const int shrink,
+    const int outNum,
+    const int gradNum)
 {
     return cvTry([&] {
     obj->getFeatures(*src, *features, gnrmRad, gsmthRad, shrink, outNum, gradNum);
@@ -44,7 +50,9 @@ CVAPI(ExceptionStatus) ximgproc_RFFeatureGetter_getFeatures(
 // StructuredEdgeDetection
 
 CVAPI(ExceptionStatus) ximgproc_createStructuredEdgeDetection(
-    const char *model, cv::Ptr<cv::ximgproc::RFFeatureGetter> *howToGetFeatures, cv::Ptr<cv::ximgproc::StructuredEdgeDetection> **returnValue)
+    const char *model,
+    cv::Ptr<cv::ximgproc::RFFeatureGetter> *howToGetFeatures,
+    cv::Ptr<cv::ximgproc::StructuredEdgeDetection> **returnValue)
 {
     return cvTry([&] {
     if (howToGetFeatures == nullptr)
@@ -68,26 +76,38 @@ CVAPI(ExceptionStatus) ximgproc_Ptr_StructuredEdgeDetection_get(cv::Ptr<cv::ximg
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_detectEdges(cv::ximgproc::StructuredEdgeDetection *obj, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_detectEdges(
+    cv::ximgproc::StructuredEdgeDetection *obj,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->detectEdges(*src, *dst);
+    obj->detectEdges(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_computeOrientation(cv::ximgproc::StructuredEdgeDetection *obj, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_computeOrientation(
+    cv::ximgproc::StructuredEdgeDetection *obj,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    obj->computeOrientation(*src, *dst);
+    obj->computeOrientation(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_edgesNms(cv::ximgproc::StructuredEdgeDetection *obj,
-    cv::_InputArray *edge_image, cv::_InputArray *orientation_image, cv::_OutputArray *dst,
-    int r, int s, float m, int isParallel)
+CVAPI(ExceptionStatus) ximgproc_StructuredEdgeDetection_edgesNms(
+    cv::ximgproc::StructuredEdgeDetection *obj,
+    const interop::InputArrayProxy* edge_image,
+    const interop::InputArrayProxy* orientation_image,
+    const interop::OutputArrayProxy* dst,
+    int r,
+    int s,
+    float m,
+    int isParallel)
 {
     return cvTry([&] {
-    obj->edgesNms(*edge_image, *orientation_image, *dst, r, s, m, isParallel != 0);
+    obj->edgesNms(InProxy(*edge_image), InProxy(*orientation_image), OutProxy(*dst), r, s, m, isParallel != 0);
     });
 }
 

--- a/src/OpenCvSharpExtern/ximgproc_SuperPixel.h
+++ b/src/OpenCvSharpExtern/ximgproc_SuperPixel.h
@@ -10,59 +10,52 @@
 
 // SuperpixelLSC
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_delete(
-    cv::Ptr<cv::ximgproc::SuperpixelLSC>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_delete(cv::Ptr<cv::ximgproc::SuperpixelLSC>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_get(
-    cv::Ptr<cv::ximgproc::SuperpixelLSC>* ptr, cv::ximgproc::SuperpixelLSC** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelLSC_get(cv::Ptr<cv::ximgproc::SuperpixelLSC>* ptr, cv::ximgproc::SuperpixelLSC** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getNumberOfSuperpixels(
-    cv::ximgproc::SuperpixelLSC* obj,
-    int* returnValue)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getNumberOfSuperpixels(cv::ximgproc::SuperpixelLSC* obj, int* returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_iterate(
-    cv::ximgproc::SuperpixelLSC* obj, int num_iterations)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_iterate(cv::ximgproc::SuperpixelLSC* obj, int num_iterations)
 {
     return cvTry([&] {
     obj->iterate(num_iterations);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getLabels(
-    cv::ximgproc::SuperpixelLSC* obj, cv::_OutputArray *labels_out)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getLabels(cv::ximgproc::SuperpixelLSC* obj, const interop::OutputArrayProxy* labels_out)
 {
     return cvTry([&] {
-    obj->getLabels(*labels_out);
+    obj->getLabels(OutProxy(*labels_out));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_getLabelContourMask(
     cv::ximgproc::SuperpixelLSC* obj,
-    cv::_OutputArray *image, int thick_line)
+    const interop::OutputArrayProxy* image,
+    int thick_line)
 {
     return cvTry([&] {
-    obj->getLabelContourMask(*image, thick_line != 0);
+    obj->getLabelContourMask(OutProxy(*image), thick_line != 0);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_enforceLabelConnectivity(
-    cv::ximgproc::SuperpixelLSC* obj,
-    int min_element_size)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_enforceLabelConnectivity(cv::ximgproc::SuperpixelLSC* obj, int min_element_size)
 {
     return cvTry([&] {
     obj->enforceLabelConnectivity(min_element_size);
@@ -70,10 +63,13 @@ CVAPI(ExceptionStatus) ximgproc_SuperpixelLSC_enforceLabelConnectivity(
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelLSC(
-    cv::_InputArray *image, int region_size, float ratio, cv::Ptr<cv::ximgproc::SuperpixelLSC>** returnValue)
+    const interop::InputArrayProxy* image,
+    int region_size,
+    float ratio,
+    cv::Ptr<cv::ximgproc::SuperpixelLSC>** returnValue)
 {
     return cvTry([&] {
-    const auto ptr = cv::ximgproc::createSuperpixelLSC(*image, region_size, ratio);
+    const auto ptr = cv::ximgproc::createSuperpixelLSC(InProxy(*image), region_size, ratio);
     *returnValue = new cv::Ptr<cv::ximgproc::SuperpixelLSC>(ptr);
     });
 }
@@ -81,25 +77,21 @@ CVAPI(ExceptionStatus) ximgproc_createSuperpixelLSC(
 
 // SuperpixelSEEDS
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_delete(
-    cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_delete(cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_get(
-    cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* ptr, cv::ximgproc::SuperpixelSEEDS** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSEEDS_get(cv::Ptr<cv::ximgproc::SuperpixelSEEDS>* ptr, cv::ximgproc::SuperpixelSEEDS** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(
-    cv::ximgproc::SuperpixelSEEDS* obj,
-    int* returnValue)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(cv::ximgproc::SuperpixelSEEDS* obj, int* returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
@@ -107,34 +99,41 @@ CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getNumberOfSuperpixels(
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_iterate(
-    cv::ximgproc::SuperpixelSEEDS* obj, cv::_InputArray *img, int num_iterations)
+    cv::ximgproc::SuperpixelSEEDS* obj,
+    const interop::InputArrayProxy* img,
+    int num_iterations)
 {
     return cvTry([&] {
-    obj->iterate(*img, num_iterations);
+    obj->iterate(InProxy(*img), num_iterations);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getLabels(
-    cv::ximgproc::SuperpixelSEEDS* obj, cv::_OutputArray* labels_out)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getLabels(cv::ximgproc::SuperpixelSEEDS* obj, const interop::OutputArrayProxy* labels_out)
 {
     return cvTry([&] {
-    obj->getLabels(*labels_out);
+    obj->getLabels(OutProxy(*labels_out));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSEEDS_getLabelContourMask(
     cv::ximgproc::SuperpixelSEEDS* obj,
-    cv::_OutputArray* image, int thick_line)
+    const interop::OutputArrayProxy* image,
+    int thick_line)
 {
     return cvTry([&] {
-    obj->getLabelContourMask(*image, thick_line != 0);
+    obj->getLabelContourMask(OutProxy(*image), thick_line != 0);
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelSEEDS(
-    int image_width, int image_height, int image_channels,
-    int num_superpixels, int num_levels, int prior,
-    int histogram_bins, int double_step,
+    int image_width,
+    int image_height,
+    int image_channels,
+    int num_superpixels,
+    int num_levels,
+    int prior,
+    int histogram_bins,
+    int double_step,
     cv::Ptr<cv::ximgproc::SuperpixelSEEDS>** returnValue)
 {
     return cvTry([&] {
@@ -147,59 +146,52 @@ CVAPI(ExceptionStatus) ximgproc_createSuperpixelSEEDS(
 
 // SuperpixelSLIC
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_delete(
-    cv::Ptr<cv::ximgproc::SuperpixelSLIC>* obj)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_delete(cv::Ptr<cv::ximgproc::SuperpixelSLIC>* obj)
 {
     return cvTry([&] {
     delete obj;
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_get(
-    cv::Ptr<cv::ximgproc::SuperpixelSLIC>* ptr, cv::ximgproc::SuperpixelSLIC** returnValue)
+CVAPI(ExceptionStatus) ximgproc_Ptr_SuperpixelSLIC_get(cv::Ptr<cv::ximgproc::SuperpixelSLIC>* ptr, cv::ximgproc::SuperpixelSLIC** returnValue)
 {
     return cvTry([&] {
     *returnValue = ptr->get();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getNumberOfSuperpixels(
-    cv::ximgproc::SuperpixelSLIC* obj,
-    int* returnValue)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getNumberOfSuperpixels(cv::ximgproc::SuperpixelSLIC* obj, int* returnValue)
 {
     return cvTry([&] {
     *returnValue = obj->getNumberOfSuperpixels();
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_iterate(
-    cv::ximgproc::SuperpixelSLIC* obj, int num_iterations)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_iterate(cv::ximgproc::SuperpixelSLIC* obj, int num_iterations)
 {
     return cvTry([&] {
     obj->iterate(num_iterations);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getLabels(
-    cv::ximgproc::SuperpixelSLIC* obj, cv::_OutputArray* labels_out)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getLabels(cv::ximgproc::SuperpixelSLIC* obj, const interop::OutputArrayProxy* labels_out)
 {
     return cvTry([&] {
-    obj->getLabels(*labels_out);
+    obj->getLabels(OutProxy(*labels_out));
     });
 }
 
 CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_getLabelContourMask(
     cv::ximgproc::SuperpixelSLIC* obj,
-    cv::_OutputArray* image, int thick_line)
+    const interop::OutputArrayProxy* image,
+    int thick_line)
 {
     return cvTry([&] {
-    obj->getLabelContourMask(*image, thick_line != 0);
+    obj->getLabelContourMask(OutProxy(*image), thick_line != 0);
     });
 }
 
-CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
-    cv::ximgproc::SuperpixelSLIC* obj,
-    int min_element_size)
+CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_enforceLabelConnectivity(cv::ximgproc::SuperpixelSLIC* obj, int min_element_size)
 {
     return cvTry([&] {
     obj->enforceLabelConnectivity(min_element_size);
@@ -207,12 +199,15 @@ CVAPI(ExceptionStatus) ximgproc_SuperpixelSLIC_enforceLabelConnectivity(
 }
 
 CVAPI(ExceptionStatus) ximgproc_createSuperpixelSLIC(
-    cv::_InputArray *image, int algorithm, int region_size, float ruler,
+    const interop::InputArrayProxy* image,
+    int algorithm,
+    int region_size,
+    float ruler,
     cv::Ptr<cv::ximgproc::SuperpixelSLIC>** returnValue)
 {
     return cvTry([&] {
     const auto ptr = cv::ximgproc::createSuperpixelSLIC(
-        *image, algorithm, region_size, ruler);
+        InProxy(*image), algorithm, region_size, ruler);
     *returnValue = new cv::Ptr<cv::ximgproc::SuperpixelSLIC>(ptr);
     });
 }

--- a/src/OpenCvSharpExtern/xphoto.h
+++ b/src/OpenCvSharpExtern/xphoto.h
@@ -10,7 +10,11 @@
 
 #pragma region inpainting.hpp
 
-CVAPI(ExceptionStatus) xphoto_inpaint(cv::Mat *src, cv::Mat *mask, cv::Mat *dst, int algorithm)
+CVAPI(ExceptionStatus) xphoto_inpaint(
+    cv::Mat *src,
+    cv::Mat *mask,
+    cv::Mat *dst,
+    int algorithm)
 {
     return cvTry([&] {
     cv::xphoto::inpaint(*src, *mask, *dst, static_cast<const cv::xphoto::InpaintTypes>(algorithm));
@@ -21,10 +25,15 @@ CVAPI(ExceptionStatus) xphoto_inpaint(cv::Mat *src, cv::Mat *mask, cv::Mat *dst,
 
 #pragma region white_balance.hpp
 
-CVAPI(ExceptionStatus) xphoto_applyChannelGains(cv::_InputArray *src, cv::_OutputArray *dst, float gainB, float gainG, float gainR)
+CVAPI(ExceptionStatus) xphoto_applyChannelGains(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    float gainB,
+    float gainG,
+    float gainR)
 {
     return cvTry([&] {
-    cv::xphoto::applyChannelGains(*src, *dst, gainB, gainG, gainR);
+    cv::xphoto::applyChannelGains(InProxy(*src), OutProxy(*dst), gainB, gainG, gainR);
     });
 }
 
@@ -49,10 +58,13 @@ CVAPI(ExceptionStatus) xphoto_Ptr_GrayworldWB_get(cv::Ptr<cv::xphoto::GrayworldW
     });
 }
 
-CVAPI(ExceptionStatus) xphoto_GrayworldWB_balanceWhite(cv::xphoto::GrayworldWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) xphoto_GrayworldWB_balanceWhite(
+    cv::xphoto::GrayworldWB* ptr,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    ptr->balanceWhite(*src, *dst);
+    ptr->balanceWhite(InProxy(*src), OutProxy(*dst));
     });
 }
 
@@ -91,17 +103,23 @@ CVAPI(ExceptionStatus) xphoto_Ptr_LearningBasedWB_get(cv::Ptr<cv::xphoto::Learni
     });
 }
 
-CVAPI(ExceptionStatus) xphoto_LearningBasedWB_balanceWhite(cv::xphoto::LearningBasedWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) xphoto_LearningBasedWB_balanceWhite(
+    cv::xphoto::LearningBasedWB* ptr,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    ptr->balanceWhite(*src, *dst);
+    ptr->balanceWhite(InProxy(*src), OutProxy(*dst));
     });
 }
 
-CVAPI(ExceptionStatus) xphoto_LearningBasedWB_extractSimpleFeatures(cv::xphoto::LearningBasedWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) xphoto_LearningBasedWB_extractSimpleFeatures(
+    cv::xphoto::LearningBasedWB* ptr,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    ptr->extractSimpleFeatures(*src, *dst);
+    ptr->extractSimpleFeatures(InProxy(*src), OutProxy(*dst));
     });
 }
 
@@ -165,10 +183,13 @@ CVAPI(ExceptionStatus) xphoto_Ptr_SimpleWB_get(cv::Ptr<cv::xphoto::SimpleWB>* pt
     });
 }
 
-CVAPI(ExceptionStatus) xphoto_SimpleWB_balanceWhite(cv::xphoto::SimpleWB* ptr, cv::_InputArray *src, cv::_OutputArray *dst)
+CVAPI(ExceptionStatus) xphoto_SimpleWB_balanceWhite(
+    cv::xphoto::SimpleWB* ptr,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst)
 {
     return cvTry([&] {
-    ptr->balanceWhite(*src, *dst);
+    ptr->balanceWhite(InProxy(*src), OutProxy(*dst));
     });
 }
 
@@ -242,9 +263,9 @@ CVAPI(ExceptionStatus) xphoto_SimpleWB_P_set(cv::xphoto::SimpleWB* ptr, float va
 #pragma region bm3d_image_denoising.hpp
 
 CVAPI(ExceptionStatus) xphoto_bm3dDenoising1(
-    cv::_InputArray *src,
-    cv::_InputOutputArray *dstStep1,
-    cv::_OutputArray *dstStep2,
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dstStep1,
+    const interop::OutputArrayProxy* dstStep2,
     float h,
     int templateWindowSize,
     int searchWindowSize,
@@ -259,14 +280,14 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising1(
 {
     return cvTry([&] {
     cv::xphoto::bm3dDenoising(
-        *src, *dstStep1, *dstStep2, h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
+        InProxy(*src), IoProxy(*dstStep1), OutProxy(*dstStep2), h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
         groupSize, slidingStep, beta, normType, step, transformType);
     });
 }
 
 CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
-    cv::_InputArray *src,
-    cv::_OutputArray *dst,
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
     float h,
     int templateWindowSize,
     int searchWindowSize,
@@ -281,7 +302,7 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
 {
     return cvTry([&] {
     cv::xphoto::bm3dDenoising(
-        *src, *dst, h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
+        InProxy(*src), OutProxy(*dst), h, templateWindowSize, searchWindowSize, blockMatchingStep1, blockMatchingStep2, 
         groupSize, slidingStep, beta, normType, step, transformType);
     });
 }
@@ -290,7 +311,11 @@ CVAPI(ExceptionStatus) xphoto_bm3dDenoising2(
 
 #pragma region dct_image_denoising.hpp
 
-CVAPI(ExceptionStatus) xphoto_dctDenoising(cv::Mat *src, cv::Mat *dst, const double sigma, const int psize)
+CVAPI(ExceptionStatus) xphoto_dctDenoising(
+    cv::Mat *src,
+    cv::Mat *dst,
+    const double sigma,
+    const int psize)
 {
     return cvTry([&] {
     cv::xphoto::dctDenoising(*src, *dst, sigma, psize);
@@ -302,13 +327,17 @@ CVAPI(ExceptionStatus) xphoto_dctDenoising(cv::Mat *src, cv::Mat *dst, const dou
 #pragma region oilpainting.hpp
 
 CVAPI(ExceptionStatus) xphoto_oilPainting(
-    cv::_InputArray *src, cv::_OutputArray *dst, int size, int dynRatio, int code)
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    int size,
+    int dynRatio,
+    int code)
 {
     return cvTry([&] {
     if (code >= 0)
-        cv::xphoto::oilPainting(*src, *dst, size, dynRatio, code);
+        cv::xphoto::oilPainting(InProxy(*src), OutProxy(*dst), size, dynRatio, code);
     else
-        cv::xphoto::oilPainting(*src, *dst, size, dynRatio);
+        cv::xphoto::oilPainting(InProxy(*src), OutProxy(*dst), size, dynRatio);
     });
 }
 
@@ -369,7 +398,12 @@ CVAPI(ExceptionStatus) xphoto_TonemapDurand_setSigmaColor(cv::xphoto::TonemapDur
 }
 
 CVAPI(ExceptionStatus) xphoto_createTonemapDurand(
-    float gamma, float contrast, float saturation, float sigma_space, float sigma_color, cv::Ptr<cv::xphoto::TonemapDurand> **returnValue)
+    float gamma,
+    float contrast,
+    float saturation,
+    float sigma_space,
+    float sigma_color,
+    cv::Ptr<cv::xphoto::TonemapDurand> **returnValue)
 {
     return cvTry([&] {
     const auto p = cv::xphoto::createTonemapDurand(gamma, contrast, saturation, sigma_space, sigma_color);

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -125,6 +125,39 @@ public class ArucoTest : TestBase
         Assert.Equal(50, dict.MaxCorrectionBits);
     }
 
+    [Fact]
+    public void Dictionary_GenerateImageMarker()
+    {
+        using var dict = Cv2.Aruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        using var img = new Mat();
+
+        dict.GenerateImageMarker(0, 120, img, 1);
+
+        Assert.False(img.Empty());
+        Assert.Equal(120, img.Rows);
+        Assert.Equal(120, img.Cols);
+    }
+
+    [Fact]
+    public void Dictionary_GetDistanceToId()
+    {
+        using var dict = Cv2.Aruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict6X6_250);
+        var markerSize = dict.MarkerSize; // 6
+
+        // Render marker 0 at one pixel per cell (markerSize + 2*borderBits cells),
+        // crop the 1px border away, and normalize 0/255 -> 0/1 to recover the bit matrix.
+        using var marker = new Mat();
+        dict.GenerateImageMarker(0, markerSize + 2, marker, 1);
+        using var cropped = new Mat(marker, new Rect(1, 1, markerSize, markerSize));
+        using var bits = new Mat();
+        Cv2.Threshold(cropped, bits, 127, 1, ThresholdTypes.Binary);
+
+        // The exact bits of marker 0 are at distance 0 from id 0 ...
+        Assert.Equal(0, dict.GetDistanceToId(bits, 0));
+        // ... and at a positive Hamming distance from a different id.
+        Assert.True(dict.GetDistanceToId(bits, 1) > 0);
+    }
+
     // ==================== ArucoDetector ====================
 
     [Fact]
@@ -301,6 +334,39 @@ public class ArucoTest : TestBase
     }
 
     [Fact]
+    public void CharucoDetector_CreateWithCameraMatrix()
+    {
+        // Exercises the cameraMatrix/distCoeffs getMat() path in the native create.
+        using var dict = Cv2.Aruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(5, 7, 0.04f, 0.02f, dict);
+        using var cameraMatrix = Mat.Eye(3, 3, MatType.CV_64FC1).ToMat();
+        using var distCoeffs = Mat.Zeros(1, 5, MatType.CV_64FC1).ToMat();
+
+        using var detector = new CharucoDetector(board, cameraMatrix, distCoeffs);
+        Assert.NotNull(detector);
+    }
+
+    [Fact]
+    public void CharucoDetector_DetectDiamonds()
+    {
+        // Smoke test: a blank image detects no diamonds but must return valid (empty) arrays.
+        // Diamond detection requires the detector's board to be a 3x3 ChArUco board.
+        using var dict = Cv2.Aruco.GetPredefinedDictionary(PredefinedDictionaryType.Dict4X4_50);
+        using var board = new CharucoBoard(3, 3, 0.04f, 0.02f, dict);
+        using var image = Mat.ZerosMat(300, 300, MatType.CV_8UC1);
+
+        using var detector = new CharucoDetector(board);
+        detector.DetectDiamonds(image, out var diamondCorners, out var diamondIds,
+            out var markerCorners, out var markerIds);
+
+        Assert.NotNull(diamondCorners);
+        Assert.NotNull(diamondIds);
+        Assert.NotNull(markerCorners);
+        Assert.NotNull(markerIds);
+        Assert.Empty(diamondIds);
+    }
+
+    [Fact]
     public void CharucoDetector_DetectBoard()
     {
         // Generate a synthetic charuco board image and detect from it
@@ -366,5 +432,27 @@ public class ArucoTest : TestBase
         Cv2.Aruco.DrawDetectedCornersCharuco(outputImage, charucoCorners, charucoIds, new Scalar(0, 255, 0));
         // Without ids (null path)
         Cv2.Aruco.DrawDetectedCornersCharuco(outputImage, charucoCorners, null);
+    }
+
+    [Fact]
+    public void DrawDetectedDiamonds()
+    {
+        using var image = Mat.ZerosMat(200, 200, MatType.CV_8UC3);
+
+        // Synthetic diamond so the drawing path is exercised regardless of detection.
+        var diamondCorners = new[]
+        {
+            new[]
+            {
+                new Point2f(20, 20), new Point2f(80, 20),
+                new Point2f(80, 80), new Point2f(20, 80),
+            },
+        };
+        var diamondIds = new[] { new Vec4i(0, 1, 2, 3) };
+
+        // With ids
+        Cv2.Aruco.DrawDetectedDiamonds(image, diamondCorners, diamondIds, new Scalar(0, 0, 255));
+        // Without ids (null path)
+        Cv2.Aruco.DrawDetectedDiamonds(image, diamondCorners, null);
     }
 }

--- a/test/OpenCvSharp.Tests/features/FeaturesCoverageTest.cs
+++ b/test/OpenCvSharp.Tests/features/FeaturesCoverageTest.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+// ArrayProxy migration coverage (issue #1976): tests for migrated feature methods
+// that previously lacked coverage.
+public class FeaturesCoverageTest : TestBase
+{
+    [Fact]
+    // ReSharper disable once InconsistentNaming
+    public void FAST()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var keypoints = Cv2.FAST(image, 50, nonmaxSupression: true);
+
+        Assert.NotEmpty(keypoints);
+    }
+
+    [Fact]
+    public void DrawKeypoints()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var keypoints = Cv2.FAST(image, 50);
+        using var outImage = new Mat();
+        Cv2.DrawKeypoints(image, keypoints, outImage);
+
+        Assert.Equal(image.Size(), outImage.Size());
+        Assert.False(outImage.Empty());
+    }
+
+    [Fact]
+    public void MserDetectRegions()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var mser = MSER.Create();
+        mser.DetectRegions(image, out var msers, out var bboxes);
+
+        Assert.NotEmpty(msers);
+        Assert.Equal(msers.Length, bboxes.Length);
+    }
+}

--- a/test/OpenCvSharp.Tests/ml/EMTest.cs
+++ b/test/OpenCvSharp.Tests/ml/EMTest.cs
@@ -1,3 +1,4 @@
+using OpenCvSharp.ML;
 using Xunit;
 
 namespace OpenCvSharp.Tests.ML;
@@ -10,5 +11,83 @@ public class EMTest : TestBase
         using var em = EM.Create();
         var name = em.GetDefaultName();
         Assert.Equal("opencv_ml_em", name);
+    }
+
+    // Two well-separated gaussian blobs, 2 columns (features), CV_32F.
+    private static Mat CreateTwoClusterSamples()
+    {
+        var rng = new Random(0);
+        var data = new float[40, 2];
+        for (int i = 0; i < 20; i++)
+        {
+            data[i, 0] = (float)(rng.NextDouble() - 0.5);
+            data[i, 1] = (float)(rng.NextDouble() - 0.5);
+            data[i + 20, 0] = (float)(10 + rng.NextDouble() - 0.5);
+            data[i + 20, 1] = (float)(10 + rng.NextDouble() - 0.5);
+        }
+        return Mat.FromPixelData(40, 2, MatType.CV_32F, data);
+    }
+
+    [Fact]
+    public void TrainEMAndPredict2()
+    {
+        using var samples = CreateTwoClusterSamples();
+        using var em = EM.Create();
+        em.ClustersNumber = 2;
+
+        using var logLikelihoods = new Mat();
+        using var labels = new Mat();
+        using var probs = new Mat();
+        var ok = em.TrainEM(samples, logLikelihoods, labels, probs);
+
+        Assert.True(ok);
+        Assert.Equal(40, labels.Rows);
+        Assert.Equal(40, probs.Rows);
+        Assert.Equal(2, probs.Cols);
+
+        using var sample = samples.Row(0);
+        using var sampleProbs = new Mat();
+        var result = em.Predict2(sample, sampleProbs);
+        Assert.Equal(2, sampleProbs.Cols);
+        Assert.InRange(result.Item1, 0, 1); // predicted cluster index
+    }
+
+    [Fact]
+    public void TrainE()
+    {
+        using var samples = CreateTwoClusterSamples();
+        using var em = EM.Create();
+        em.ClustersNumber = 2;
+
+        // Initial means: one per cluster.
+        var means0Data = new float[,] { { 0, 0 }, { 10, 10 } };
+        using var means0 = Mat.FromPixelData(2, 2, MatType.CV_32F, means0Data);
+
+        using var labels = new Mat();
+        var ok = em.TrainE(samples, means0, null, null, null, labels);
+        Assert.True(ok);
+        Assert.Equal(40, labels.Rows);
+    }
+
+    [Fact]
+    public void TrainM()
+    {
+        using var samples = CreateTwoClusterSamples();
+        using var em = EM.Create();
+        em.ClustersNumber = 2;
+
+        // Initial posterior probabilities: hard assignment by known cluster.
+        var probs0Data = new float[40, 2];
+        for (int i = 0; i < 40; i++)
+        {
+            probs0Data[i, 0] = i < 20 ? 1f : 0f;
+            probs0Data[i, 1] = i < 20 ? 0f : 1f;
+        }
+        using var probs0 = Mat.FromPixelData(40, 2, MatType.CV_32F, probs0Data);
+
+        using var labels = new Mat();
+        var ok = em.TrainM(samples, probs0, null, labels);
+        Assert.True(ok);
+        Assert.Equal(40, labels.Rows);
     }
 }

--- a/test/OpenCvSharp.Tests/ml/NormalBayesClassifierTest.cs
+++ b/test/OpenCvSharp.Tests/ml/NormalBayesClassifierTest.cs
@@ -1,0 +1,37 @@
+using OpenCvSharp.ML;
+using Xunit;
+
+namespace OpenCvSharp.Tests.ML;
+
+// ReSharper disable once InconsistentNaming
+public class NormalBayesClassifierTest : TestBase
+{
+    [Fact]
+    public void PredictProb()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {1, 1},
+            {10, 10},
+            {11, 11},
+        };
+        using var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+        int[] trainLabelsData = [0, 0, 1, 1];
+        using var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32S, trainLabelsData);
+
+        using var model = NormalBayesClassifier.Create();
+        model.Train(trainFeatures, SampleTypes.RowSample, trainLabels);
+
+        float[,] testData = { { 10, 11 } };
+        using var testFeature = Mat.FromPixelData(1, 2, MatType.CV_32F, testData);
+        using var outputs = new Mat();
+        using var outputProbs = new Mat();
+
+        model.PredictProb(testFeature, outputs, outputProbs);
+
+        Assert.False(outputs.Empty());
+        Assert.False(outputProbs.Empty());
+        Assert.Equal(1, outputs.At<int>(0));
+    }
+}

--- a/test/OpenCvSharp.Tests/ml/SVMTest.cs
+++ b/test/OpenCvSharp.Tests/ml/SVMTest.cs
@@ -38,6 +38,34 @@ public class SVMTest : TestBase
     }
 
     [Fact]
+    public void GetDecisionFunction()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {0, 100},
+            {100, 0},
+            {100, 100},
+        };
+        using var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+        int[] trainLabelsData = [+1, -1, +1, -1];
+        using var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32S, trainLabelsData);
+
+        using var model = SVM.Create();
+        model.Type = SVM.Types.CSvc;
+        model.KernelType = SVM.KernelTypes.Linear;
+        model.TermCriteria = new TermCriteria(CriteriaTypes.MaxIter, 100, 1e-6);
+        model.Train(trainFeatures, SampleTypes.RowSample, trainLabels);
+
+        using var alpha = new Mat();
+        using var svidx = new Mat();
+        var rho = model.GetDecisionFunction(0, alpha, svidx);
+
+        Assert.False(alpha.Empty());
+        Assert.False(double.IsNaN(rho));
+    }
+
+    [Fact]
     public void SaveLoadTest()
     {
         float[,] trainFeaturesData =

--- a/test/OpenCvSharp.Tests/photo/PhotoTest.cs
+++ b/test/OpenCvSharp.Tests/photo/PhotoTest.cs
@@ -45,4 +45,133 @@ public class PhotoTest
         if (Debugger.IsAttached)
             Window.ShowImages(src1, src2, dst);
     }
+
+    // --- ArrayProxy migration coverage (issue #1976): one test per migrated Cv2 method ---
+
+    [Fact]
+    public void FastNlMeansDenoisingColored()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.FastNlMeansDenoisingColored(src, dst, 3, 3, 7, 21);
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(src.Type(), dst.Type());
+    }
+
+    [Fact]
+    public void FastNlMeansDenoisingColoredMulti()
+    {
+        using var src1 = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var src2 = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var src3 = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.FastNlMeansDenoisingColoredMulti([src1, src2, src3], dst, 1, 3, 3, 3, 7, 21);
+
+        Assert.Equal(src1.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void Decolor()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var grayscale = new Mat();
+        using var colorBoost = new Mat();
+        Cv2.Decolor(src, grayscale, colorBoost);
+
+        Assert.Equal(src.Size(), grayscale.Size());
+        Assert.Equal(MatType.CV_8UC1, grayscale.Type());
+        Assert.Equal(src.Size(), colorBoost.Size());
+    }
+
+    [Fact]
+    public void SeamlessClone()
+    {
+        using var dst = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var src = new Mat(new Size(100, 100), MatType.CV_8UC3, new Scalar(0, 255, 0));
+        using var mask = new Mat(src.Size(), MatType.CV_8UC1, Scalar.All(255));
+        using var blend = new Mat();
+        Cv2.SeamlessClone(src, dst, mask, new Point(dst.Width / 2, dst.Height / 2), blend, SeamlessCloneFlags.NormalClone);
+
+        Assert.Equal(dst.Size(), blend.Size());
+    }
+
+    [Fact]
+    public void ColorChange()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var mask = new Mat(src.Size(), MatType.CV_8UC1, Scalar.All(0));
+        mask.Rectangle(new Rect(50, 50, 200, 200), Scalar.All(255), -1);
+        using var dst = new Mat();
+        Cv2.ColorChange(src, mask, dst, 1.5f, 0.5f, 1.0f);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void IlluminationChange()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var mask = new Mat(src.Size(), MatType.CV_8UC1, Scalar.All(0));
+        mask.Rectangle(new Rect(50, 50, 200, 200), Scalar.All(255), -1);
+        using var dst = new Mat();
+        Cv2.IlluminationChange(src, mask, dst, 0.2f, 0.4f);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void TextureFlattening()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var mask = new Mat(src.Size(), MatType.CV_8UC1, Scalar.All(0));
+        mask.Rectangle(new Rect(50, 50, 200, 200), Scalar.All(255), -1);
+        using var dst = new Mat();
+        Cv2.TextureFlattening(src, mask, dst, 30, 45, 3);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void EdgePreservingFilter()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.EdgePreservingFilter(src, dst, EdgePreservingMethods.RecursFilter, 60, 0.4f);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void DetailEnhance()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.DetailEnhance(src, dst, 10, 0.15f);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
+
+    [Fact]
+    public void PencilSketch()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst1 = new Mat();
+        using var dst2 = new Mat();
+        Cv2.PencilSketch(src, dst1, dst2, 60, 0.07f, 0.02f);
+
+        Assert.Equal(src.Size(), dst1.Size());
+        Assert.Equal(MatType.CV_8UC1, dst1.Type());
+        Assert.Equal(src.Size(), dst2.Size());
+    }
+
+    [Fact]
+    public void Stylization()
+    {
+        using var src = new Mat("_data/image/mandrill.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.Stylization(src, dst, 60, 0.45f);
+
+        Assert.Equal(src.Size(), dst.Size());
+    }
 }

--- a/test/OpenCvSharp.Tests/ptcloud/PtCloudTest.cs
+++ b/test/OpenCvSharp.Tests/ptcloud/PtCloudTest.cs
@@ -204,6 +204,252 @@ public class PtCloudTest : TestBase
     }
 
     [Fact]
+    public void VolumeSettingsArrayProperties()
+    {
+        using var settings = new VolumeSettings(VolumeType.TSDF);
+
+        using var pose = Mat.Eye(4, 4, MatType.CV_32FC1).ToMat();
+        settings.SetVolumePose(pose);
+        using var poseOut = new Mat();
+        settings.GetVolumePose(poseOut);
+        Assert.False(poseOut.Empty());
+
+        using var resolution = Mat.FromArray(new[] { 128, 128, 128 });
+        settings.SetVolumeResolution(resolution);
+        using var resOut = new Mat();
+        settings.GetVolumeResolution(resOut);
+        Assert.False(resOut.Empty());
+
+        using var strides = new Mat();
+        settings.GetVolumeStrides(strides);
+        Assert.False(strides.Empty());
+
+        using var k = Mat.FromArray(new float[,] { { 525, 0, 320 }, { 0, 525, 240 }, { 0, 0, 1 } });
+        settings.SetCameraRaycastIntrinsics(k);
+        using var kOut = new Mat();
+        settings.GetCameraRaycastIntrinsics(kOut);
+        Assert.False(kOut.Empty());
+    }
+
+    [Fact]
+    public void OdometrySettingsArrayProperties()
+    {
+        using var settings = new OdometrySettings();
+
+        using var cameraMatrix = Mat.FromArray(new float[,] { { 525, 0, 320 }, { 0, 525, 240 }, { 0, 0, 1 } });
+        settings.SetCameraMatrix(cameraMatrix);
+        using var camOut = new Mat();
+        settings.GetCameraMatrix(camOut);
+        Assert.False(camOut.Empty());
+
+        using var minGrad = Mat.FromArray(new[] { 10f, 10f, 10f, 10f });
+        settings.SetMinGradientMagnitudes(minGrad);
+        using var minGradOut = new Mat();
+        settings.GetMinGradientMagnitudes(minGradOut);
+        Assert.False(minGradOut.Empty());
+    }
+
+    [Fact]
+    public void RgbdNormalsApplyAndSetK()
+    {
+        const int rows = 16;
+        const int cols = 16;
+        using var k = Mat.FromArray(new float[,] { { 525, 0, 8 }, { 0, 525, 8 }, { 0, 0, 1 } });
+        using var normalsComputer = RgbdNormals.Create(
+            rows, cols, MatType.CV_32F, k, 5, 50f, RgbdNormalsMethod.RGBD_NORMALS_METHOD_FALS);
+
+        normalsComputer.SetK(k);
+
+        using var points = new Mat(rows, cols, MatType.CV_32FC3, Scalar.All(1.0));
+        using var normals = new Mat();
+        try
+        {
+            normalsComputer.Apply(points, normals);
+            testOutputHelper.WriteLine($"RgbdNormals.Apply produced empty={normals.Empty()}");
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"RgbdNormals.Apply threw (wiring resolved): {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public void OdometryFrameGetters()
+    {
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        using var image = new Mat(48, 64, MatType.CV_8UC3, Scalar.All(100));
+        using var mask = new Mat(48, 64, MatType.CV_8UC1, Scalar.All(255));
+        using var normals = new Mat(48, 64, MatType.CV_32FC4, Scalar.All(0));
+        using var frame = new OdometryFrame(depth, image, mask, normals);
+
+        using var imageOut = new Mat();
+        using var grayOut = new Mat();
+        using var depthOut = new Mat();
+        using var processedDepthOut = new Mat();
+        using var maskOut = new Mat();
+        using var normalsOut = new Mat();
+
+        frame.GetImage(imageOut);
+        frame.GetGrayImage(grayOut);
+        frame.GetDepth(depthOut);
+        frame.GetProcessedDepth(processedDepthOut);
+        frame.GetMask(maskOut);
+        frame.GetNormals(normalsOut);
+
+        using var pyrOut = new Mat();
+        try
+        {
+            frame.GetPyramidAt(pyrOut, OdometryFramePyramidType.PYR_IMAGE, 0);
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"GetPyramidAt threw (wiring resolved): {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public void OdometryComputeMethods()
+    {
+        using var srcDepth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        using var dstDepth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.1));
+        using var srcRgb = new Mat(48, 64, MatType.CV_8UC3, Scalar.All(100));
+        using var dstRgb = new Mat(48, 64, MatType.CV_8UC3, Scalar.All(110));
+        using var odometry = new Odometry(OdometryType.DEPTH);
+        using var rt = new Mat();
+
+        try
+        {
+            odometry.Compute(srcDepth, dstDepth, rt);
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"Compute(depth) threw (wiring resolved): {ex.Message}");
+        }
+
+        try
+        {
+            odometry.Compute(srcDepth, srcRgb, dstDepth, dstRgb, rt);
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"Compute(rgbd) threw (wiring resolved): {ex.Message}");
+        }
+
+        using var srcFrame = new OdometryFrame(srcDepth);
+        using var dstFrame = new OdometryFrame(dstDepth);
+        try
+        {
+            odometry.Compute(srcFrame, dstFrame, rt);
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"Compute(frame) threw (wiring resolved): {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public void VolumeIntegrateRaycastFetch()
+    {
+        using var settings = new VolumeSettings(VolumeType.TSDF);
+        using var volume = new Volume(VolumeType.TSDF, settings);
+
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        using var image = new Mat(48, 64, MatType.CV_8UC3, Scalar.All(100));
+        using var pose = Mat.Eye(4, 4, MatType.CV_32FC1).ToMat();
+        using var k = Mat.FromArray(new float[,] { { 525, 0, 32 }, { 0, 525, 24 }, { 0, 0, 1 } });
+        using var cameraPose = Mat.Eye(4, 4, MatType.CV_32FC1).ToMat();
+
+        void Tolerant(string name, Action action)
+        {
+            try { action(); }
+            catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+            {
+                testOutputHelper.WriteLine($"{name} threw (wiring resolved): {ex.Message}");
+            }
+        }
+
+        Tolerant("Integrate", () => volume.Integrate(depth, pose));
+        Tolerant("IntegrateColor", () => volume.IntegrateColor(depth, image, pose));
+        Tolerant("IntegrateFrame", () =>
+        {
+            using var frame = new OdometryFrame(depth);
+            volume.IntegrateFrame(frame, pose);
+        });
+
+        Tolerant("Raycast", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            volume.Raycast(cameraPose, points, normals);
+        });
+        Tolerant("RaycastColor", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            using var colors = new Mat();
+            volume.RaycastColor(cameraPose, points, normals, colors);
+        });
+        Tolerant("RaycastEx", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            volume.RaycastEx(cameraPose, 48, 64, k, points, normals);
+        });
+        Tolerant("RaycastExColor", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            using var colors = new Mat();
+            volume.RaycastExColor(cameraPose, 48, 64, k, points, normals, colors);
+        });
+
+        Tolerant("FetchNormals", () =>
+        {
+            using var points = new Mat(4, 1, MatType.CV_32FC3, Scalar.All(0));
+            using var normals = new Mat();
+            volume.FetchNormals(points, normals);
+        });
+        Tolerant("FetchPointsNormals", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            volume.FetchPointsNormals(points, normals);
+        });
+        Tolerant("FetchPointsNormalsColors", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            using var colors = new Mat();
+            volume.FetchPointsNormalsColors(points, normals, colors);
+        });
+        Tolerant("GetBoundingBox", () =>
+        {
+            using var bb = new Mat();
+            volume.GetBoundingBox(bb, VolumeBoundingBoxPrecision.VOLUME_UNIT);
+        });
+    }
+
+    [Fact]
+    public void DepthTo3dSparseSmoke()
+    {
+        const int n = 8;
+        using var depth = new Mat(24, 32, MatType.CV_32FC1, Scalar.All(2.0));
+        using var k = Mat.FromArray(new float[,] { { 525, 0, 16 }, { 0, 525, 12 }, { 0, 0, 1 } });
+        using var inPoints = new Mat(n, 1, MatType.CV_32FC2, Scalar.All(5));
+        using var points3d = new Mat();
+
+        try
+        {
+            Cv2.DepthTo3dSparse(depth, k, inPoints, points3d);
+            testOutputHelper.WriteLine($"DepthTo3dSparse produced empty={points3d.Empty()}");
+        }
+        catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+        {
+            testOutputHelper.WriteLine($"DepthTo3dSparse threw (wiring resolved): {ex.Message}");
+        }
+    }
+
+    [Fact]
     public void OdometryGetNormalsComputer()
     {
         using var odometry = new Odometry(OdometryType.RGB_DEPTH);

--- a/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
@@ -64,6 +64,28 @@ public class StitchingTest : TestBase
         return mats.ToArray();
     }
 
+    // ArrayProxy migration coverage (issue #1976): two-step estimate + compose.
+    [Fact]
+    public void ComposePanorama()
+    {
+        Mat[] images = SelectStitchingImages(200, 200, 12);
+        try
+        {
+            using var stitcher = Stitcher.Create(Stitcher.Mode.Scans);
+            using var pano = new Mat();
+            var est = stitcher.EstimateTransform(images);
+            Assert.Equal(Stitcher.Status.OK, est);
+            var status = stitcher.ComposePanorama(pano);
+            Assert.Equal(Stitcher.Status.OK, status);
+            ShowImagesWhenDebugMode(pano);
+        }
+        finally
+        {
+            foreach (Mat image in images)
+                image.Dispose();
+        }
+    }
+
     [Fact]
     public void PropertyRegistrationResol()
     {

--- a/test/OpenCvSharp.Tests/video/VideoTrackingTest.cs
+++ b/test/OpenCvSharp.Tests/video/VideoTrackingTest.cs
@@ -1,0 +1,107 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Video;
+
+// ArrayProxy migration coverage (issue #1976): one test per migrated Cv2 method.
+public class VideoTrackingTest : TestBase
+{
+    private static (Mat prev, Mat next) MakeShiftedPair()
+    {
+        var prev = new Mat(64, 64, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(prev, new Rect(20, 20, 16, 16), Scalar.All(255), -1);
+        var next = new Mat(64, 64, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(next, new Rect(22, 20, 16, 16), Scalar.All(255), -1); // shifted +2 px in x
+        return (prev, next);
+    }
+
+    [Fact]
+    public void CamShift()
+    {
+        using var prob = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(prob, new Rect(40, 40, 20, 20), Scalar.All(255), -1);
+        var window = new Rect(30, 30, 40, 40);
+        var rr = Cv2.CamShift(prob, ref window, new TermCriteria(CriteriaTypes.Eps | CriteriaTypes.MaxIter, 10, 1));
+
+        Assert.True(rr.Size.Width > 0 && rr.Size.Height > 0);
+    }
+
+    [Fact]
+    public void MeanShift()
+    {
+        using var prob = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(prob, new Rect(40, 40, 20, 20), Scalar.All(255), -1);
+        var window = new Rect(20, 20, 40, 40);
+        var iters = Cv2.MeanShift(prob, ref window, new TermCriteria(CriteriaTypes.Eps | CriteriaTypes.MaxIter, 10, 1));
+
+        Assert.True(iters >= 0);
+    }
+
+    [Fact]
+    public void BuildOpticalFlowPyramid()
+    {
+        using var img = new Mat(64, 64, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(img, new Rect(20, 20, 16, 16), Scalar.All(255), -1);
+        var maxLevel = Cv2.BuildOpticalFlowPyramid(img, out var pyramid, new Size(11, 11), 2);
+
+        Assert.True(maxLevel >= 0);
+        Assert.NotEmpty(pyramid);
+        foreach (var p in pyramid)
+            p.Dispose();
+    }
+
+    [Fact]
+    public void CalcOpticalFlowPyrLK()
+    {
+        var (prev, next) = MakeShiftedPair();
+        using (prev)
+        using (next)
+        {
+            using var prevPts = Mat.FromPixelData(1, 1, MatType.CV_32FC2, new float[] { 27, 27 });
+            using var nextPts = new Mat();
+            using var status = new Mat();
+            using var err = new Mat();
+            Cv2.CalcOpticalFlowPyrLK(prev, next, prevPts, nextPts, status, err, new Size(15, 15), 2);
+
+            Assert.False(nextPts.Empty());
+        }
+    }
+
+    [Fact]
+    public void CalcOpticalFlowFarneback()
+    {
+        var (prev, next) = MakeShiftedPair();
+        using (prev)
+        using (next)
+        {
+            using var flow = new Mat();
+            Cv2.CalcOpticalFlowFarneback(prev, next, flow, 0.5, 3, 15, 3, 5, 1.2, OpticalFlowFlags.None);
+
+            Assert.Equal(prev.Size(), flow.Size());
+            Assert.Equal(2, flow.Channels());
+        }
+    }
+
+    [Fact]
+    // ReSharper disable once InconsistentNaming
+    public void ComputeECC()
+    {
+        using var a = new Mat(64, 64, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(a, new Rect(20, 20, 20, 20), Scalar.All(255), -1);
+        var cc = Cv2.ComputeECC(a, a);
+
+        Assert.True(cc > 0.99); // identical inputs -> near-perfect correlation
+    }
+
+    [Fact]
+    // ReSharper disable once InconsistentNaming
+    public void FindTransformECC()
+    {
+        using var a = new Mat(64, 64, MatType.CV_8UC1, Scalar.All(0));
+        Cv2.Rectangle(a, new Rect(16, 16, 28, 28), Scalar.All(255), -1);
+        using var warp = Mat.FromPixelData(2, 3, MatType.CV_32FC1, new float[] { 1, 0, 0, 0, 1, 0 });
+        var cc = Cv2.FindTransformECC(a, a, warp, MotionTypes.Translation,
+            new TermCriteria(CriteriaTypes.Eps | CriteriaTypes.MaxIter, 50, 1e-4), null, 5);
+
+        Assert.True(cc > 0.9); // identical inputs -> near-perfect alignment
+    }
+}

--- a/test/OpenCvSharp.Tests/ximgproc/SegmentationTest.cs
+++ b/test/OpenCvSharp.Tests/ximgproc/SegmentationTest.cs
@@ -1,0 +1,53 @@
+using OpenCvSharp.XImgProc.Segmentation;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XImgProc;
+
+public class SegmentationTest : TestBase
+{
+    [Fact]
+    public void GraphSegmentationProcessImage()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var gs = GraphSegmentation.Create();
+        using var dst = new Mat();
+
+        gs.ProcessImage(src, dst);
+
+        Assert.False(dst.Empty());
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(MatType.CV_32SC1, dst.Type());
+    }
+
+    [Fact]
+    public void SelectiveSearchSetBaseImageAndAddImage()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var ss = SelectiveSearchSegmentation.Create();
+
+        // Both go through the migrated setBaseImage/addImage proxies.
+        ss.SetBaseImage(src);
+        ss.AddImage(src);
+    }
+
+    [Fact]
+    public void SelectiveSearchStrategySetImage()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+
+        // Produce a region map with GraphSegmentation, then feed a colour strategy.
+        using var gs = GraphSegmentation.Create();
+        using var regions = new Mat();
+        gs.ProcessImage(src, regions);
+
+        Cv2.MinMaxLoc(regions, out _, out double maxVal);
+        var numRegions = (int)maxVal + 1;
+        using var sizes = new Mat(1, numRegions, MatType.CV_32SC1, Scalar.All(1));
+
+        using var strategy = SelectiveSearchSegmentationStrategyColor.Create();
+        strategy.SetImage(src, regions, sizes);
+
+        using var multi = SelectiveSearchSegmentationStrategyMultiple.Create();
+        multi.SetImage(src, regions, sizes);
+    }
+}

--- a/test/OpenCvSharp.Tests/ximgproc/XimgProcTest.cs
+++ b/test/OpenCvSharp.Tests/ximgproc/XimgProcTest.cs
@@ -185,6 +185,188 @@ public class XImgProcTest : TestBase
         Assert.Equal(MatType.CV_32SC3, erode.Type());
     }
         
+    // deriche / paillou
+
+    [Fact]
+    public void GradientDericheY()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.GradientDericheY(src, dst, 10.0, 10.0);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void GradientPaillou()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dstX = new Mat();
+        using var dstY = new Mat();
+        Cv2.XImgProc.GradientPaillouX(src, dstX, 10.0, 10.0);
+        Cv2.XImgProc.GradientPaillouY(src, dstY, 10.0, 10.0);
+        Assert.False(dstX.Empty());
+        Assert.False(dstY.Empty());
+    }
+
+    // color_match.hpp (quaternion)
+
+    [Fact]
+    public void QuaternionImageOps()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var qimg = new Mat();
+        Cv2.XImgProc.CreateQuaternionImage(src, qimg);
+        Assert.False(qimg.Empty());
+        Assert.Equal(src.Size(), qimg.Size());
+
+        using var qconj = new Mat();
+        Cv2.XImgProc.QConj(qimg, qconj);
+        Assert.Equal(qimg.Size(), qconj.Size());
+
+        using var qunit = new Mat();
+        Cv2.XImgProc.QUnitary(qimg, qunit);
+        Assert.Equal(qimg.Size(), qunit.Size());
+
+        using var qmul = new Mat();
+        Cv2.XImgProc.QMultiply(qimg, qconj, qmul);
+        Assert.Equal(qimg.Size(), qmul.Size());
+
+        using var qdft = new Mat();
+        Cv2.XImgProc.QDft(qimg, qdft, DftFlags.None, true);
+        Assert.False(qdft.Empty());
+    }
+
+    // edge-aware filters
+
+    [Fact]
+    public void DTFilterStatic()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.DTFilter(src, src, dst, 10.0, 25.0);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void GuidedFilterStatic()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.GuidedFilter(src, src, dst, 5, 100.0);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void AMFilterStatic()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.AMFilter(src, src, dst, 16.0, 0.2);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void JointBilateralFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.JointBilateralFilter(src, src, dst, 7, 25.0, 7.0);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void BilateralTextureFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.BilateralTextureFilter(src, dst);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void RollingGuidanceFilter()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.RollingGuidanceFilter(src, dst);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void FastGlobalSmootherFilterStatic()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.FastGlobalSmootherFilter(src, src, dst, 100.0, 5.0);
+        Assert.False(dst.Empty());
+    }
+
+    [Fact]
+    public void FastBilateralSolverFilterStatic()
+    {
+        using var guide = LoadImage("lenna.png", ImreadModes.Color);
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var confidence = new Mat(src.Size(), MatType.CV_8UC1, Scalar.All(255));
+        using var dst = new Mat();
+        try
+        {
+            Cv2.XImgProc.FastBilateralSolverFilter(guide, src, confidence, dst);
+            Assert.False(dst.Empty());
+        }
+        catch (OpenCVException ex) when (ex.Message.Contains("EIGEN", StringComparison.Ordinal))
+        {
+            // OpenCV built without EIGEN: the P/Invoke proxy wiring still reached
+            // native (the feature guard throws), which is what this test verifies.
+        }
+    }
+
+    [Fact]
+    public void L0Smooth()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Color);
+        using var dst = new Mat();
+        Cv2.XImgProc.L0Smooth(src, dst);
+        Assert.False(dst.Empty());
+    }
+
+    // run_length_morphology.hpp (extra coverage)
+
+    [Fact]
+    public void RLMorphologyEx()
+    {
+        using var src = LoadImage("mandrill.png", ImreadModes.Grayscale);
+        using var binary = new Mat();
+        using var dst = new Mat();
+        Cv2.XImgProc.RL.Threshold(src, binary, 128, ThresholdTypes.Binary);
+        using var se = Cv2.XImgProc.RL.GetStructuringElement(MorphShapes.Rect, new Size(3, 3));
+
+        Cv2.XImgProc.RL.MorphologyEx(binary, dst, MorphTypes.Open, se);
+
+        Assert.False(dst.Empty());
+        Assert.Equal(MatType.CV_32SC3, dst.Type());
+    }
+
+    [Fact]
+    public void RLIsRLMorphologyPossible()
+    {
+        using var se = Cv2.XImgProc.RL.GetStructuringElement(MorphShapes.Rect, new Size(3, 3));
+        Assert.True(Cv2.XImgProc.RL.IsRLMorphologyPossible(se));
+    }
+
+    [Fact]
+    public void RLPaintAndCreateRLEImage()
+    {
+        // Build an RL image from explicit runs, then paint it onto a canvas.
+        var runs = new[] { new Point3i(0, 4, 2), new Point3i(0, 4, 3) };
+        using var rle = new Mat();
+        Cv2.XImgProc.RL.CreateRLEImage(runs, rle, new Size(10, 10));
+        Assert.False(rle.Empty());
+
+        using var canvas = Mat.ZerosMat(10, 10, MatType.CV_8UC1);
+        Cv2.XImgProc.RL.Paint(canvas, rle, Scalar.All(255));
+        Assert.True(canvas.CountNonZero() > 0);
+    }
+
     // peilin.hpp
 
     [Fact]


### PR DESCRIPTION
## Summary
Stacked on #1983. Migrates the remaining non-calib modules to the ArrayProxy ABI, using the **by-pointer** form validated in #1983 from the start (native `const interop::XArrayProxy*`, P/Invoke `in`, CVAPI signatures one parameter per line). No by-value proxies are introduced, so these modules are not subject to the arm64 register-spill class fixed in #1983.

## Modules migrated (one commit each)
| module | proxy funcs | tests |
|---|---|---|
| **photo** | 14 | +10 (uncovered → 0) |
| **video** (tracking) | 7 | +7 new `VideoTrackingTest` (uncovered → 0) |
| **features** (+xfeatures2d callers) | 10 | +3 (FAST/DrawKeypoints/MSER.DetectRegions); rest already covered |
| **xphoto** | 8 | already covered by existing tests |
| **stitching** | 10 | +1 (ComposePanorama); rest covered |
| **aruco** | 12 | +5 (GenerateImageMarker/GetDistanceToId/DetectDiamonds/DrawDetectedDiamonds/CharucoDetector w/ camera matrix) |
| **ximgproc** | 72 (135 args, 10 headers) | +30 (uncovered → 0; filters, quaternion, run-length morphology, gradient, segmentation) |
| **ml** | 12 (34 args) | +5 (EM.TrainEM/TrainE/TrainM/Predict2, NormalBayesClassifier.PredictProb, SVM.GetDecisionFunction) |
| **ptcloud** | 51 (~57 args, 8 headers) | +7 (uncovered → 0; settings get/set, OdometryFrame getters, Odometry.Compute, Volume integrate/raycast/fetch, RgbdNormals.Apply, DepthTo3dSparse) |

## Notes
- Positional call-site rewrite touches **only** the migrated `NativeMethods.*` calls, so class files with un-migrated methods (e.g. background subtractor, `detect_Mat` overloads) are left intact. `cv::Mat**` (vector) and single `cv::Mat*` params are preserved.
- **API unification**: `Feature2D.Detect(InputArray, mask)` — OpenCV's `cv::Feature2D::detect` takes `InputArray mask`, but the binding had narrowed it to `Mat`. The proxy migration lets us widen it back to `InputArray?` (Mat callers still bind via the implicit conversion). Genuinely-`const Mat&` params in OpenCV (e.g. `KeyPointsFilter::runByPixelsMask`) are left as `Mat`.
- **API unification (aruco)**: `Cv2.Aruco.DrawDetectedMarkers/DrawDetectedDiamonds/DrawDetectedCornersCharuco` — OpenCV takes `InputOutputArray image` (drawn on in place), but the binding declared it `InputArray`. The old raw path relied on `_InputArray*`/`_InputOutputArray*` being layout-compatible; the proxy kinds make this explicit, so the param is widened to `InputOutputArray`. `CharucoDetector` keeps nullable `cameraMatrix`/`distCoeffs` by rebuilding named `_InputArray` lvalues via `fromInputProxy` and testing `empty()` instead of the old `nullptr` guard.
- **API unification (ximgproc)**: `Cv2.XImgProc.WeightedMedianFilter` — `mask` widened from `Mat?` to `InputArray?` to match `cv::ximgproc::weightedMedianFilter`.
- **ptcloud io** uses the Windows/NotWindows string-marshalling split with a non-partial dispatcher; migrated by hand (both `EntryPoint` partials and the dispatcher take `in` proxies; the `std::vector<cv::Mat>* indices` param stays `IntPtr`).
- Coverage gaps handled: `LightGlueMatcher.SetPairInfo` needs an ONNX model (not committed) so it is not directly testable here; `FastBilateralSolverFilter` tolerates OpenCV builds without EIGEN; the runtime-heavy ptcloud methods tolerate `OpenCVException` (the P/Invoke proxy wiring still reaches native, which is what these tests verify).
- Native + managed build clean; per-module tests pass locally (x64). calib/stereo/fisheye and geometry (= calib3d) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
