### PR TITLE
Enable the parked line_descriptor LSDDetector wrapper

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
@@ -334,22 +334,17 @@ static partial class NativeMethods
 
     #endregion
     #region cv::line_descriptor::KeyLine
-#if false
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial IntPtr vector_KeyLine_new1();
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_KeyLine_new1();
 
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial nuint vector_KeyLine_getSize(OpenCvSafeHandle vector);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nuint vector_KeyLine_getSize(OpenCvSafeHandle vector);
 
-        //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        //public static extern void vector_KeyLine_getElements(IntPtr vector, [Out] KeyLine[] dst);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_KeyLine_getPointer(OpenCvSafeHandle vector);
 
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial IntPtr vector_KeyLine_getPointer(OpenCvSafeHandle vector);
-
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial void vector_KeyLine_delete(IntPtr vector);
-#endif
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_KeyLine_delete(IntPtr vector);
     #endregion
 
     #region vector<uchar>
@@ -459,17 +454,15 @@ static partial class NativeMethods
     public static partial void vector_string_delete(IntPtr vector);
     #endregion
     #region vector<cv::line_descriptor::KeyLine>
-#if false
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial IntPtr vector_vector_KeyLine_new1();
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial nuint vector_vector_KeyLine_getSize1(OpenCvSafeHandle vector);
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial void vector_vector_KeyLine_getSize2(OpenCvSafeHandle vector, [In, Out] nuint[] size);
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial void vector_vector_KeyLine_copy(OpenCvSafeHandle vec, IntPtr[] dst);
-        [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        public static partial void vector_vector_KeyLine_delete(IntPtr vector);
-#endif
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_vector_KeyLine_new1();
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nuint vector_vector_KeyLine_getSize1(OpenCvSafeHandle vector);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_vector_KeyLine_getSize2(OpenCvSafeHandle vector, [In, Out] nuint[] size);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_vector_KeyLine_copy(OpenCvSafeHandle vec, IntPtr[] dst);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_vector_KeyLine_delete(IntPtr vector);
     #endregion
 }

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfKeyLine.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfKeyLine.cs
@@ -1,8 +1,8 @@
-#if false
+using OpenCvSharp.LineDescriptor;
 
 namespace OpenCvSharp.Internal.Vectors
 {
-    /// <summary> 
+    /// <summary>
     /// </summary>
     public class VectorOfKeyLine : CvObject, IStdVector<KeyLine>
     {
@@ -31,8 +31,7 @@ namespace OpenCvSharp.Internal.Vectors
         {
             get
             {
-                var res = NativeMethods.vector_KeyLine_getSize(CvPtr);
-                GC.KeepAlive(this);
+                var res = NativeMethods.vector_KeyLine_getSize(Handle);
                 return (int)res;
             }
         }
@@ -44,7 +43,7 @@ namespace OpenCvSharp.Internal.Vectors
         {
             get
             {
-                var res = NativeMethods.vector_KeyLine_getPointer(CvPtr);
+                var res = NativeMethods.vector_KeyLine_getPointer(Handle);
                 GC.KeepAlive(this);
                 return res;
             }
@@ -71,5 +70,3 @@ namespace OpenCvSharp.Internal.Vectors
         }
     }
 }
-
-#endif

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfVectorKeyLine.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfVectorKeyLine.cs
@@ -1,8 +1,9 @@
-#if false
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.LineDescriptor;
 
 namespace OpenCvSharp.Internal.Vectors
 {
-    /// <summary> 
+    /// <summary>
     /// </summary>
     // ReSharper disable once InconsistentNaming
     public class VectorOfVectorKeyLine : CvObject, IStdVector<KeyLine[]>
@@ -73,5 +74,3 @@ namespace OpenCvSharp.Internal.Vectors
         }
     }
 }
-
-#endif

--- a/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
@@ -1,9 +1,9 @@
-﻿
+﻿using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
 
 // ReSharper disable UnusedMember.Global
 
 // https://github.com/opencv/opencv_contrib/blob/33ae078b0989b44ac8d262d210335b04bb268b4d/modules/line_descriptor/src/binary_descriptor.cpp#L1030
-#if false
 namespace OpenCvSharp.LineDescriptor
 {
     /// <summary>
@@ -133,5 +133,3 @@ namespace OpenCvSharp.LineDescriptor
         }
     }
 }
-
-#endif

--- a/src/OpenCvSharpExtern/line_descriptor.h
+++ b/src/OpenCvSharpExtern/line_descriptor.h
@@ -63,8 +63,10 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
     cv::Mat** masks, int32_t masksSize)
 {
     return cvTry([&] {
+    // LSDDetector::detect(images, keylines, ..., masks) indexes both `keylines` and `masks`
+    // by images.size() without resizing them itself, so both must be pre-sized here.
     std::vector<cv::Mat> imagesVec(imagesSize);
-    std::vector<cv::Mat> masksVec(masksSize);
+    std::vector<cv::Mat> masksVec(imagesSize);
     for (int i = 0; i < imagesSize; i++)
     {
         imagesVec[i] = *images[i];
@@ -73,7 +75,8 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
     {
         masksVec[i] = *masks[i];
     }
-    
+
+    keylines->resize(imagesSize);
     obj->detect(imagesVec, *keylines, scale, numOctaves, masksVec);
 
     });

--- a/src/OpenCvSharpExtern/line_descriptor.h
+++ b/src/OpenCvSharpExtern/line_descriptor.h
@@ -71,7 +71,8 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
     {
         imagesVec[i] = *images[i];
     }
-    for (int i = 0; i < masksSize; i++)
+    const int maskCount = std::min(masksSize, imagesSize);
+    for (int i = 0; i < maskCount; i++)
     {
         masksVec[i] = *masks[i];
     }

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -263,26 +263,6 @@ extern "C"
         cv::Mat* descriptors;
     };
 
-    /*
-    struct line_descriptor_KeyLine
-    {
-        float angle;
-        int class_id;
-        int octave;
-        interop::Point2f pt;
-        float response;
-        float size;
-        float startPointX;
-        float startPointY;
-        float endPointX;
-        float endPointY;
-        float sPointInOctaveX;
-        float sPointInOctaveY;
-        float ePointInOctaveX;
-        float ePointInOctaveY;
-        float lineLength;
-        int numOfPixels;
-    };*/
 }
 
 // bit_cast-based converter pair for layout-identical POD <-> cv:: types.

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -273,8 +273,8 @@ CVAPI(void) vector_ImageFeatures_delete(std::vector<cv::detail::ImageFeatures>* 
 #pragma endregion
 #endif // NO_STITCHING
 
+#ifndef NO_CONTRIB
 #pragma region cv::line_descriptor::KeyLine
-#if 0
 CVAPI(std::vector<cv::line_descriptor::KeyLine>*) vector_KeyLine_new1()
 {
     return new std::vector<cv::line_descriptor::KeyLine>;
@@ -285,26 +285,6 @@ CVAPI(size_t) vector_KeyLine_getSize(std::vector<cv::line_descriptor::KeyLine>* 
     return vector->size();
 }
 
-/*
-CVAPI(void) vector_KeyLine_getElements(
-    std::vector<cv::line_descriptor::KeyLine>* vector, line_descriptor_KeyLine* dst)
-{
-    for (size_t i = 0; i < vector->size(); i++)
-    {
-        const auto &k = vector->at(i);
-        const line_descriptor_KeyLine kl{
-            k.angle, k.class_id, k.octave,
-            {k.pt.x, k.pt.y},
-            k.response,  k.size,
-            k.startPointX, k.startPointY,
-            k.endPointX, k.endPointY,
-            k.sPointInOctaveX, k.sPointInOctaveY,
-            k.ePointInOctaveX, k.ePointInOctaveY,
-            k.lineLength, k.numOfPixels };
-        dst[i] = kl;
-    }
-}*/
-
 CVAPI(cv::line_descriptor::KeyLine*) vector_KeyLine_getPointer(std::vector<cv::line_descriptor::KeyLine>* vector)
 {
     return &(vector->at(0));
@@ -314,5 +294,5 @@ CVAPI(void) vector_KeyLine_delete(std::vector<cv::line_descriptor::KeyLine>* vec
 {
     delete vector;
 }
-#endif
 #pragma endregion
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/std_vector_nesting.h
+++ b/src/OpenCvSharpExtern/std_vector_nesting.h
@@ -256,9 +256,9 @@ CVAPI(void) vector_vector_Point2f_delete(std::vector<std::vector<cv::Point2f> >*
 
 #pragma endregion
 
+#ifndef NO_CONTRIB
 #pragma region vector<cv::line_descriptor::KeyLine>
 
-#if 0
 CVAPI(std::vector<std::vector<cv::line_descriptor::KeyLine> >*) vector_vector_KeyLine_new1()
 {
     return new std::vector<std::vector<cv::line_descriptor::KeyLine> >;
@@ -286,5 +286,5 @@ CVAPI(void) vector_vector_KeyLine_delete(std::vector<std::vector<cv::line_descri
 {
     delete vec;
 }
-#endif
 #pragma endregion
+#endif // NO_CONTRIB

--- a/test/OpenCvSharp.Tests/line_descriptor/LSDDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/line_descriptor/LSDDetectorTest.cs
@@ -72,4 +72,21 @@ public class LSDDetectorTest : TestBase
         Assert.NotEmpty(keyLines[0]);
         Assert.NotEmpty(keyLines[1]);
     }
+
+    [Fact]
+    public void DetectMultipleImagesWithMoreMasksThanImages()
+    {
+        using var src1 = LoadImage("building.jpg");
+        using var gray1 = new Mat();
+        Cv2.CvtColor(src1, gray1, ColorConversionCodes.BGR2GRAY);
+        using var mask1 = new Mat(gray1.Size(), MatType.CV_8UC1, Scalar.All(255));
+        using var mask2 = new Mat(gray1.Size(), MatType.CV_8UC1, Scalar.All(255));
+
+        using var lsd = new LSDDetector();
+        // More masks than images: the native wrapper must not write past the
+        // pre-sized (images.Length) masks vector.
+        var keyLines = lsd.Detect([gray1], 2, 1, [mask1, mask2]);
+
+        Assert.Single(keyLines);
+    }
 }

--- a/test/OpenCvSharp.Tests/line_descriptor/LSDDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/line_descriptor/LSDDetectorTest.cs
@@ -1,50 +1,75 @@
-#if false
+#pragma warning disable CA5394 // Do not use insecure randomness
 
-namespace OpenCvSharp.Tests.LineDescriptor
+using System.Diagnostics;
+using OpenCvSharp.LineDescriptor;
+using Xunit;
+
+namespace OpenCvSharp.Tests.LineDescriptor;
+
+// ReSharper disable once InconsistentNaming
+public class LSDDetectorTest : TestBase
 {
-    // ReSharper disable once InconsistentNaming
-    public class LSDDetectorTest
+    [Fact]
+    public void New()
     {
-        [Fact]
-        public void New()
+        using var lsd = new LSDDetector();
+        GC.KeepAlive(lsd);
+    }
+
+    [Fact]
+    public void NewWithParam()
+    {
+        var lsdParam = new LSDParam();
+        using var lsd = new LSDDetector(lsdParam);
+        GC.KeepAlive(lsd);
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var src = LoadImage("building.jpg");
+        using var gray = new Mat();
+        Cv2.CvtColor(src, gray, ColorConversionCodes.BGR2GRAY);
+
+        using var lsd = new LSDDetector();
+        var keyLines = lsd.Detect(gray, 2, 1);
+        Assert.NotEmpty(keyLines);
+
+        foreach (var kl in keyLines)
         {
-            using var lsd = new LSDDetector();
-            GC.KeepAlive(lsd);
+            Assert.True(kl.LineLength > 0);
+            Assert.True(kl.NumOfPixels > 0);
         }
 
-        [Fact]
-        public void NewWithParam()
+        if (Debugger.IsAttached)
         {
-            var lsdParam = new LSDParam();
-            using var lsd = new LSDDetector(lsdParam);
-            GC.KeepAlive(lsd);
-        }
+            var random = new Random();
 
-        [Fact]
-        public void Detect()
-        {
-            using var src = new Mat("_data/image/building.jpg", ImreadModes.Color);
-            using var gray = new Mat();
-            Cv2.CvtColor(src, gray, ColorConversionCodes.BGR2GRAY);
-
-            using var lsd = new LSDDetector();
-            var keyLines = lsd.Detect(gray, 2, 1);
-            Assert.NotEmpty(keyLines);
-
-            if (Debugger.IsAttached)
+            foreach (var kl in keyLines)
             {
-                var random = new Random();
-
-                foreach (var kl in keyLines)
-                {
-                    var color = new Scalar(random.Next(256), random.Next(256), random.Next(256));
-
-                    Cv2.Line(src, (Point)kl.GetStartPoint(), (Point)kl.GetEndPoint(), color, 3);
-                }
-
-                Window.ShowImages(src);
+                var color = new Scalar(random.Next(256), random.Next(256), random.Next(256));
+                Cv2.Line(src, (Point)kl.StartPoint, (Point)kl.EndPoint, color, 3);
             }
+
+            Window.ShowImages(src);
         }
     }
+
+    [Fact]
+    public void DetectMultipleImages()
+    {
+        using var src1 = LoadImage("building.jpg");
+        using var src2 = LoadImage("lenna.png");
+        using var gray1 = new Mat();
+        using var gray2 = new Mat();
+        Cv2.CvtColor(src1, gray1, ColorConversionCodes.BGR2GRAY);
+        Cv2.CvtColor(src2, gray2, ColorConversionCodes.BGR2GRAY);
+
+        using var lsd = new LSDDetector();
+        var keyLines = lsd.Detect([gray1, gray2], 2, 1);
+
+        Assert.Equal(2, keyLines.Length);
+        Assert.NotEmpty(keyLines[0]);
+        Assert.NotEmpty(keyLines[1]);
+    }
 }
-#endif


### PR DESCRIPTION
## Summary
- Removes the `#if false` guards from `LSDDetector`, `VectorOfKeyLine`, `VectorOfVectorKeyLine`, and their P/Invoke declarations/native implementations (`vector_KeyLine_*` / `vector_vector_KeyLine_*`), which had been parked since `2ea1ce87`.
- The native `vector_KeyLine_*` / `vector_vector_KeyLine_*` blocks were also disabled with `#if 0` on the C++ side; re-enabled them and gated with `#ifndef NO_CONTRIB` (matching the existing `NO_STITCHING` pattern for other contrib-only vector wrappers), since `line_descriptor` is a contrib module.
- Verified `cv::line_descriptor::KeyLine`'s field layout still matches the managed `KeyLine` struct exactly (checked against `opencv_contrib/modules/line_descriptor/include/opencv2/line_descriptor/descriptor.hpp`), so no marshalling changes were needed.
- **Fixed a real crash** found while testing: `line_descriptor_LSDDetector_detect2`'s multi-image overload sized `masksVec` to the caller-supplied mask count (often 0) instead of `imagesSize`, and never resized the output `keylines` vector. OpenCV's `LSDDetector::detect(images, keylines, ..., masks)` indexes both by `images.size()` without resizing them itself, so calling it with no masks caused an out-of-bounds vector access / access violation. Fixed by pre-sizing both to `imagesSize`.
- Re-enabled the smoke tests in `LSDDetectorTest.cs`, refreshed to the current `TestBase` conventions, and added a multi-image detect test.

Closes #1971

## Test plan
- [x] `dotnet build` on `OpenCvSharp.sln` (managed) succeeds with 0 warnings/errors
- [x] Native `OpenCvSharpExtern` rebuilt via CMake (Release) succeeds
- [x] `LSDDetectorTest` (New, NewWithParam, Detect, DetectMultipleImages) all pass
- [x] Full `OpenCvSharp.Tests` suite (1268 tests) passes with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for line descriptor detection (single- and multi-image) via the LSDDetector APIs.
  * Enabled KeyLine vector wrappers so detected line data can be created, queried, and passed through the library.

* **Bug Fixes**
  * Fixed multi-image detection result handling and mask/keyline preparation to align with expected sizing and indexing.

* **Tests**
  * Activated and expanded LSDDetector tests with image loading, per-line validation, multi-image coverage, and a “more masks than images” scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->