### PR TITLE
Fix stale FFmpeg plugin DLL reference in test project

### DIFF
--- a/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
+++ b/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj
@@ -50,7 +50,7 @@
     <None Update="OpenCvSharpExtern.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="opencv_videoio_ffmpeg4130_64.dll">
+    <None Update="opencv_videoio_ffmpeg500_64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- `test/OpenCvSharp.Tests.csproj` still referenced `opencv_videoio_ffmpeg4130_64.dll`, the plugin filename from the OpenCV 4.13.0 line the repo used before the 5.x migration.
- OpenCV 5.0.0 ships `opencv_videoio_ffmpeg500_64.dll` (already reflected correctly in `packaging/nuget/OpenCvSharp5.runtime.win.csproj`, and computed dynamically as `500` by `src/OpenCvSharpExtern/CMakeLists.txt`'s `OPENCV_VER_STR`).
- Because the test csproj's `<None Update="...">` filename no longer matched what the CMake build actually copies into the test project directory, the FFmpeg plugin DLL was never copied into the test output directory at all.

## Test plan
- [x] Rebuilt `OpenCvSharp.Tests` and confirmed `opencv_videoio_ffmpeg500_64.dll` is now copied to `bin/Debug/net10.0/`
- [x] `VideoCaptureTest` / `VideoWriterTest` pass locally (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test project to include the newer FFmpeg native DLL in output copies, keeping test runs aligned with the latest video I/O runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->