### PR TITLE
Internal: remove dead KeepAlive/ElemPtr, add OpenCvSafeHandle.Null for optional args

### DIFF
--- a/src/OpenCvSharp/Fundamentals/OpenCvSafeHandle.cs
+++ b/src/OpenCvSharp/Fundamentals/OpenCvSafeHandle.cs
@@ -44,4 +44,11 @@ public abstract class OpenCvSafeHandle : SafeHandle
 
     /// <inheritdoc />
     public override bool IsInvalid => handle == IntPtr.Zero;
+
+    /// <summary>
+    /// A non-owning handle wrapping a null native pointer. Pass this for an optional
+    /// SafeHandle-typed P/Invoke argument (e.g. a mask) when the caller has none, instead
+    /// of overloading the parameter type with a plain <see cref="IntPtr"/>.
+    /// </summary>
+    public static OpenCvSafeHandle Null { get; } = new OpenCvPtrSafeHandle(IntPtr.Zero, ownsHandle: false, releaseAction: null);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_line_descriptor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_line_descriptor.cs
@@ -29,7 +29,7 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus line_descriptor_LSDDetector_detect1(
-        OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, int scale, int numOctaves, IntPtr mask);
+        OpenCvSafeHandle obj, IntPtr image, IntPtr keypoints, int scale, int numOctaves, OpenCvSafeHandle mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus line_descriptor_LSDDetector_detect2(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
@@ -282,8 +282,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial nuint vector_Mat_getSize(OpenCvSafeHandle vector);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial IntPtr vector_Mat_getPointer(OpenCvSafeHandle vector);
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void vector_Mat_delete(IntPtr vector);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void vector_Mat_assignToArray(OpenCvSafeHandle vector, [MarshalAs(UnmanagedType.LPArray)] IntPtr[] arr);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
@@ -80,9 +80,9 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_read_String(OpenCvSafeHandle node, IntPtr value, [MarshalAs(UnmanagedType.LPStr)] string? defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_Mat(OpenCvSafeHandle node, IntPtr mat, IntPtr defaultMat);
+    public static partial ExceptionStatus core_FileNode_read_Mat(OpenCvSafeHandle node, IntPtr mat, OpenCvSafeHandle defaultMat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_FileNode_read_SparseMat(OpenCvSafeHandle node, IntPtr mat, IntPtr defaultMat);
+    public static partial ExceptionStatus core_FileNode_read_SparseMat(OpenCvSafeHandle node, IntPtr mat, OpenCvSafeHandle defaultMat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_read_vectorOfKeyPoint(OpenCvSafeHandle node, IntPtr keypoints);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Mat.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Mat.cs
@@ -107,9 +107,9 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_Mat_assignTo(OpenCvSafeHandle self, IntPtr m, int type);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_Mat_setTo_Scalar(OpenCvSafeHandle self, Scalar value, IntPtr mask);
+    public static partial ExceptionStatus core_Mat_setTo_Scalar(OpenCvSafeHandle self, Scalar value, OpenCvSafeHandle mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_Mat_setTo_InputArray(OpenCvSafeHandle self, in InputArrayProxy value, IntPtr mask);
+    internal static partial ExceptionStatus core_Mat_setTo_InputArray(OpenCvSafeHandle self, in InputArrayProxy value, OpenCvSafeHandle mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_Mat_reshape1(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_UMat.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_UMat.cs
@@ -84,9 +84,9 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_UMat_assignTo(OpenCvSafeHandle self, IntPtr m, int type);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_UMat_setTo_Scalar(OpenCvSafeHandle self, Scalar value, IntPtr mask);
+    public static partial ExceptionStatus core_UMat_setTo_Scalar(OpenCvSafeHandle self, Scalar value, OpenCvSafeHandle mask);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus core_UMat_setTo_InputArray(OpenCvSafeHandle self, in InputArrayProxy value, IntPtr mask);
+    internal static partial ExceptionStatus core_UMat_setTo_InputArray(OpenCvSafeHandle self, in InputArrayProxy value, OpenCvSafeHandle mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_UMat_reshape1(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
@@ -45,7 +45,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus stitching_FeaturesMatcher_apply2(
         OpenCvSafeHandle obj,
         WImageFeatures[] features, int featuresSize,
-        IntPtr mask,
+        OpenCvSafeHandle mask,
         IntPtr outSrcImgIdx,
         IntPtr outDstImgIdx,
         IntPtr outMatches,

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/video/NativeMethods_video_tracking.cs
@@ -79,7 +79,7 @@ static partial class NativeMethods
     public static partial ExceptionStatus video_KalmanFilter_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus video_KalmanFilter_predict(OpenCvSafeHandle obj, IntPtr control, out IntPtr returnValue);
+    public static partial ExceptionStatus video_KalmanFilter_predict(OpenCvSafeHandle obj, OpenCvSafeHandle control, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus video_KalmanFilter_correct(OpenCvSafeHandle obj, IntPtr measurement, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfMat.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfMat.cs
@@ -73,20 +73,6 @@ public class VectorOfMat : CvObject, IStdVector<Mat>
     }
 
     /// <summary>
-    /// &amp;vector[0]
-    /// </summary>
-    public IntPtr ElemPtr
-    {
-        get
-        {
-            var res = NativeMethods.vector_Mat_getPointer(Handle);
-            // Returns an interior pointer into this vector; keep it alive for the caller's dereference.
-            GC.KeepAlive(this);
-            return res;
-        }
-    }
-
-    /// <summary>
     /// Converts std::vector to managed array
     /// </summary>
     /// <returns></returns>

--- a/src/OpenCvSharp/Modules/core/FileNode.cs
+++ b/src/OpenCvSharp/Modules/core/FileNode.cs
@@ -512,8 +512,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         try
         {
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_read_Mat(Handle, value.CvPtr, Cv2.ToPtr(defaultMat)));
-            GC.KeepAlive(defaultMat);
+                NativeMethods.core_FileNode_read_Mat(Handle, value.CvPtr, defaultMat?.Handle ?? OpenCvSafeHandle.Null));
         }
         catch
         {
@@ -534,8 +533,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         try
         {
             NativeMethods.HandleException(
-                NativeMethods.core_FileNode_read_SparseMat(Handle, value.CvPtr, Cv2.ToPtr(defaultMat)));
-            GC.KeepAlive(defaultMat);
+                NativeMethods.core_FileNode_read_SparseMat(Handle, value.CvPtr, defaultMat?.Handle ?? OpenCvSafeHandle.Null));
         }
         catch
         {

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -1461,7 +1461,6 @@ public partial class Mat : CvObject
             ThrowIfDisposed();
             NativeMethods.HandleException(
                 NativeMethods.core_Mat_mul(Handle, proxy, scale, out var ret));
-            GC.KeepAlive(this);
             GC.KeepAlive(source);
             return new NativeMatExpr(ret);
         });

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -1350,11 +1350,9 @@ public partial class Mat : CvObject
     {
         ThrowIfDisposed();
 
-        var maskPtr = Cv2.ToPtr(mask);
         NativeMethods.HandleException(
-            NativeMethods.core_Mat_setTo_Scalar(Handle, value, maskPtr));
+            NativeMethods.core_Mat_setTo_Scalar(Handle, value, mask?.Handle ?? OpenCvSafeHandle.Null));
 
-        GC.KeepAlive(mask);
         return this;
     }
 
@@ -1368,12 +1366,10 @@ public partial class Mat : CvObject
     {
         ThrowIfDisposed();
 
-        var maskPtr = Cv2.ToPtr(mask);
         NativeMethods.HandleException(
-            NativeMethods.core_Mat_setTo_InputArray(Handle, value.Proxy, maskPtr));
+            NativeMethods.core_Mat_setTo_InputArray(Handle, value.Proxy, mask?.Handle ?? OpenCvSafeHandle.Null));
 
         GC.KeepAlive(value.Source);
-        GC.KeepAlive(mask);
         return this;
     }
         

--- a/src/OpenCvSharp/Modules/core/Mat/UMat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/UMat.cs
@@ -769,11 +769,9 @@ public class UMat : CvObject
     {
         ThrowIfDisposed();
 
-        var maskPtr = Cv2.ToPtr(mask);
         NativeMethods.HandleException(
-            NativeMethods.core_UMat_setTo_Scalar(Handle, value, maskPtr));
+            NativeMethods.core_UMat_setTo_Scalar(Handle, value, mask?.Handle ?? OpenCvSafeHandle.Null));
 
-        GC.KeepAlive(mask);
         return this;
     }
 
@@ -787,12 +785,10 @@ public class UMat : CvObject
     {
         ThrowIfDisposed();
 
-        var maskPtr = Cv2.ToPtr(mask);
         NativeMethods.HandleException(
-            NativeMethods.core_UMat_setTo_InputArray(Handle, value.Proxy, maskPtr));
+            NativeMethods.core_UMat_setTo_InputArray(Handle, value.Proxy, mask?.Handle ?? OpenCvSafeHandle.Null));
 
         GC.KeepAlive(value.Source);
-        GC.KeepAlive(mask);
         return this;
     }
 

--- a/src/OpenCvSharp/Modules/core/NativeMatExpr_CvMethods.cs
+++ b/src/OpenCvSharp/Modules/core/NativeMatExpr_CvMethods.cs
@@ -11,7 +11,6 @@ partial class NativeMatExpr
     public NativeMatExpr Abs()
     {
         NativeMethods.HandleException(NativeMethods.core_abs_MatExpr(CvPtr, out var ret));
-        GC.KeepAlive(this);
         return new NativeMatExpr(ret);
     }
 }

--- a/src/OpenCvSharp/Modules/core/SparseMat.cs
+++ b/src/OpenCvSharp/Modules/core/SparseMat.cs
@@ -134,7 +134,6 @@ public class SparseMat : CvObject
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_clone(Handle, out var p));
-        GC.KeepAlive(this);
         return new SparseMat(p);
     }
 
@@ -402,7 +401,6 @@ public class SparseMat : CvObject
             NativeMethods.HandleException(
                 NativeMethods.core_SparseMat_erase_nd(Handle, index.ToArray(), null));
         }
-        GC.KeepAlive(this);
     }
 
     #endregion
@@ -614,7 +612,6 @@ public sealed class SparseMat<T> : SparseMat
                             Handle, dims, (IntPtr)indicesPtr, (IntPtr)valuesPtr, (nuint)Unsafe.SizeOf<T>()));
                 }
             }
-            GC.KeepAlive(this);
         }
         return Enumerate(indices, values, count, dims);
 
@@ -637,7 +634,6 @@ public sealed class SparseMat<T> : SparseMat
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_clone(Handle, out var p));
-        GC.KeepAlive(this);
         return new SparseMat<T>(p);
     }
 }

--- a/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
@@ -82,10 +82,9 @@ namespace OpenCvSharp.LineDescriptor
             using var keypointsVec = new VectorOfKeyLine();
             NativeMethods.HandleException(
                 NativeMethods.line_descriptor_LSDDetector_detect1(
-                    Handle, image.CvPtr, keypointsVec.CvPtr, scale, numOctaves, mask?.CvPtr ?? IntPtr.Zero));
+                    Handle, image.CvPtr, keypointsVec.CvPtr, scale, numOctaves, mask?.Handle ?? OpenCvSafeHandle.Null));
 
             GC.KeepAlive(image);
-            GC.KeepAlive(mask);
 
             return keypointsVec.ToArray();
         }

--- a/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
@@ -126,7 +126,7 @@ public abstract class FeaturesMatcher : CvObject
                 NativeMethods.stitching_FeaturesMatcher_apply2(
                     Handle, 
                     wImageFeatures, wImageFeatures.Length,
-                    mask?.CvPtr ?? IntPtr.Zero,
+                    mask?.Handle ?? OpenCvSafeHandle.Null,
                     srcImgIndexVecs.CvPtr,
                     dstImgIndexVecs.CvPtr,
                     matchesVec.CvPtr,

--- a/src/OpenCvSharp/Modules/video/KalmanFilter.cs
+++ b/src/OpenCvSharp/Modules/video/KalmanFilter.cs
@@ -310,8 +310,7 @@ public class KalmanFilter : CvObject
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
-            NativeMethods.video_KalmanFilter_predict(Handle, Cv2.ToPtr(control), out var ret));
-        GC.KeepAlive(control);
+            NativeMethods.video_KalmanFilter_predict(Handle, control?.Handle ?? OpenCvSafeHandle.Null, out var ret));
         return new Mat(ret);
     }
 

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -157,11 +157,6 @@ CVAPI(size_t) vector_Mat_getSize(std::vector<cv::Mat>* vector)
     return vector->size();
 }
 
-CVAPI(cv::Mat*) vector_Mat_getPointer(std::vector<cv::Mat>* vector)
-{
-    return &(vector->at(0));
-}
-
 CVAPI(void) vector_Mat_assignToArray(std::vector<cv::Mat>* vector, cv::Mat** arr)
 {
     for (size_t i = 0; i < vector->size(); i++)

--- a/test/OpenCvSharp.Tests/video/KalmanTest.cs
+++ b/test/OpenCvSharp.Tests/video/KalmanTest.cs
@@ -174,6 +174,33 @@ public class KalmanTest : TestBase
         IsDataEqual(mat, kalman.ErrorCovPost);
     }
 
+    [Fact]
+    public void PredictWithoutControl()
+    {
+        using var kalman = new KalmanFilter();
+        kalman.Init(2, 1);
+
+        using var predicted = kalman.Predict();
+
+        Assert.NotNull(predicted);
+        Assert.False(predicted.Empty());
+    }
+
+    [Fact]
+    public void PredictWithControl()
+    {
+        using var kalman = new KalmanFilter();
+        kalman.Init(2, 1, controlParams: 1);
+
+        using var control = Mat.FromPixelData(1, 1, MatType.CV_32F, ControlData);
+        using var predicted = kalman.Predict(control);
+
+        Assert.NotNull(predicted);
+        Assert.False(predicted.Empty());
+    }
+
+    private static readonly float[] ControlData = [1.0f];
+
     private static void IsDataEqual(Mat lhs, Mat rhs)
     {
         Assert.Equal(lhs.Size(), rhs.Size());


### PR DESCRIPTION
Closes #1938

## Summary
Two small, independent cleanups that close out issue #1938 (Internal layer modernization):

- Removed `VectorOfMat.ElemPtr` (dead code, no callers anywhere) and six `GC.KeepAlive(this)` calls that guarded native calls returning a newly-created, independent handle rather than a pointer aliasing `this`'s buffer (`Mat.Mul`, `SparseMat.Clone` x2, `SparseMat.EraseElement`, `SparseMat.EnumerateNonZero`, `NativeMatExpr.Abs`).
- Added `OpenCvSafeHandle.Null`, a non-owning handle wrapping a null pointer, and migrated the optional "another object" arguments that were still raw `IntPtr` (while the method's own `this` handle was already `OpenCvSafeHandle`) to use it: `LSDDetector.Detect(mask)`, `FeaturesMatcher.Apply(mask)`, `KalmanFilter.Predict(control)`, `Mat`/`UMat.SetTo(mask)`, `FileNode.ReadMat`/`ReadSparseMat(defaultValue)`. Each now passes `x?.Handle ?? OpenCvSafeHandle.Null` and drops the now-redundant manual `GC.KeepAlive` for that argument.

A handful of similar optional-argument call sites were deliberately left as-is (`FlannBasedMatcher` ctor via `SmartPtr`, `StructuredEdgeDetection.Create` via `PtrObj`, `DescriptorMatcher.Match`/`KnnMatch`/`RadiusMatch` cascading through `BFMatcher`/`FlannBasedMatcher` overrides) — the benefit of migrating them is the same small, cosmetic win as the ones done here, but their accessor shape differs enough to warrant separate consideration if ever revisited. Not worth tracking as a dedicated follow-up.

## Test plan
- [x] `cmake --build src/build --config Release --target OpenCvSharpExtern` — native rebuild, 0 errors
- [x] `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test test/OpenCvSharp.Tests -c Release -f net10.0` — 1244 passed, 27 skipped, 0 failed
- [x] Added `KalmanTest.PredictWithoutControl`/`PredictWithControl` (previously untested method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional masks and control inputs across several computer vision APIs, making calls without these inputs more reliable.
  * Updated matrix, file, stitching, tracking, and feature-matching operations to work consistently when optional native objects are absent.
  * Removed some low-level pointer accessors from vector handling to reduce unsafe usage.
* **Tests**
  * Added coverage for prediction behavior with and without control input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->