### PR TITLE
Polish ConnectedComponents wrappers (doc fix + eager-copy / round-trip efficiency)

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -2229,7 +2229,7 @@ static partial class Cv2
     /// <param name="ccltype"></param>
     /// <param name="ltype">output label image type. Currently CV_32S (default) and CV_16U are supported.
     /// CV_16U halves the native label image's memory footprint, at the cost of a 65535 label limit.</param>
-    /// <returns>A <see cref="global::OpenCvSharp.ConnectedComponents"/> instance. Dispose it to release the underlying native label image.</returns>
+    /// <returns></returns>
     public static ConnectedComponents ConnectedComponentsEx(
         InputArray image,
         PixelConnectivity connectivity = PixelConnectivity.Connectivity8,
@@ -2240,37 +2240,50 @@ static partial class Cv2
         if (labelType != MatType.CV_32S && labelType != MatType.CV_16U)
             throw new ArgumentException("ltype must be CV_32S or CV_16U", nameof(ltype));
 
-        var labelsMat = new Mat();
-        try
-        {
-            using var statsMat = new Mat<int>();
-            using var centroidsMat = new Mat<double>();
-            var nLabels = ConnectedComponentsWithStatsWithAlgorithm(
-                image, labelsMat, statsMat, centroidsMat, connectivity, labelType, ccltype);
-            var stats = statsMat.ToRectangularArray();
-            var centroids = centroidsMat.ToRectangularArray();
+        using var labelsMat = new Mat();
+        using var statsMat = new Mat<int>();
+        using var centroidsMat = new Mat<double>();
+        var nLabels = ConnectedComponentsWithStatsWithAlgorithm(
+            image, labelsMat, statsMat, centroidsMat, connectivity, labelType, ccltype);
+        var labels = ToInt32RectangularArray(labelsMat, labelType);
+        var stats = statsMat.ToRectangularArray();
+        var centroids = centroidsMat.ToRectangularArray();
 
-            var blobs = new ConnectedComponents.Blob[nLabels];
-            for (var i = 0; i < nLabels; i++)
-            {
-                blobs[i] = new ConnectedComponents.Blob
-                {
-                    Label = i,
-                    Left = stats[i, 0],
-                    Top = stats[i, 1],
-                    Width = stats[i, 2],
-                    Height = stats[i, 3],
-                    Area = stats[i, 4],
-                    Centroid = new Point2d(centroids[i, 0], centroids[i, 1]),
-                };
-            }
-            return new ConnectedComponents(blobs, labelsMat, nLabels);
-        }
-        catch
+        var blobs = new ConnectedComponents.Blob[nLabels];
+        for (var i = 0; i < nLabels; i++)
         {
-            labelsMat.Dispose();
-            throw;
+            blobs[i] = new ConnectedComponents.Blob
+            {
+                Label = i,
+                Left = stats[i, 0],
+                Top = stats[i, 1],
+                Width = stats[i, 2],
+                Height = stats[i, 3],
+                Area = stats[i, 4],
+                Centroid = new Point2d(centroids[i, 0], centroids[i, 1]),
+            };
         }
+        return new ConnectedComponents(blobs, labels, nLabels);
+    }
+
+    /// <summary>
+    /// Copies a CV_32S or CV_16U label Mat into a managed <c>int[,]</c>, widening CV_16U elements.
+    /// </summary>
+    private static int[,] ToInt32RectangularArray(Mat labelsMat, MatType labelType)
+    {
+        if (labelType == MatType.CV_16U)
+        {
+            using var labelsU16 = new Mat<ushort>(labelsMat);
+            var raw = labelsU16.ToRectangularArray();
+            var widened = new int[raw.GetLength(0), raw.GetLength(1)];
+            for (var y = 0; y < raw.GetLength(0); y++)
+                for (var x = 0; x < raw.GetLength(1); x++)
+                    widened[y, x] = raw[y, x];
+            return widened;
+        }
+
+        using var labelsI32 = new Mat<int>(labelsMat);
+        return labelsI32.ToRectangularArray();
     }
         
     /// <summary>

--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -2227,36 +2227,50 @@ static partial class Cv2
     /// <param name="image">the image to be labeled</param>
     /// <param name="connectivity">8 or 4 for 8-way or 4-way connectivity respectively</param>
     /// <param name="ccltype"></param>
-    /// <returns></returns>
+    /// <param name="ltype">output label image type. Currently CV_32S (default) and CV_16U are supported.
+    /// CV_16U halves the native label image's memory footprint, at the cost of a 65535 label limit.</param>
+    /// <returns>A <see cref="global::OpenCvSharp.ConnectedComponents"/> instance. Dispose it to release the underlying native label image.</returns>
     public static ConnectedComponents ConnectedComponentsEx(
-        InputArray image, 
-        PixelConnectivity connectivity = PixelConnectivity.Connectivity8, 
-        ConnectedComponentsAlgorithmsTypes ccltype = ConnectedComponentsAlgorithmsTypes.Default)
+        InputArray image,
+        PixelConnectivity connectivity = PixelConnectivity.Connectivity8,
+        ConnectedComponentsAlgorithmsTypes ccltype = ConnectedComponentsAlgorithmsTypes.Default,
+        MatType? ltype = null)
     {
-        using var labelsMat = new Mat<int>();
-        using var statsMat = new Mat<int>();
-        using var centroidsMat = new Mat<double>();
-        var nLabels = ConnectedComponentsWithStatsWithAlgorithm(
-            image, labelsMat, statsMat, centroidsMat, connectivity, MatType.CV_32S, ccltype);
-        var labels = labelsMat.ToRectangularArray();
-        var stats = statsMat.ToRectangularArray();
-        var centroids = centroidsMat.ToRectangularArray();
+        var labelType = ltype ?? MatType.CV_32S;
+        if (labelType != MatType.CV_32S && labelType != MatType.CV_16U)
+            throw new ArgumentException("ltype must be CV_32S or CV_16U", nameof(ltype));
 
-        var blobs = new ConnectedComponents.Blob[nLabels];
-        for (var i = 0; i < nLabels; i++)
+        var labelsMat = new Mat();
+        try
         {
-            blobs[i] = new ConnectedComponents.Blob
+            using var statsMat = new Mat<int>();
+            using var centroidsMat = new Mat<double>();
+            var nLabels = ConnectedComponentsWithStatsWithAlgorithm(
+                image, labelsMat, statsMat, centroidsMat, connectivity, labelType, ccltype);
+            var stats = statsMat.ToRectangularArray();
+            var centroids = centroidsMat.ToRectangularArray();
+
+            var blobs = new ConnectedComponents.Blob[nLabels];
+            for (var i = 0; i < nLabels; i++)
             {
-                Label = i,
-                Left = stats[i, 0],
-                Top = stats[i, 1],
-                Width = stats[i, 2],
-                Height = stats[i, 3],
-                Area = stats[i, 4],
-                Centroid = new Point2d(centroids[i, 0], centroids[i, 1]),
-            };
+                blobs[i] = new ConnectedComponents.Blob
+                {
+                    Label = i,
+                    Left = stats[i, 0],
+                    Top = stats[i, 1],
+                    Width = stats[i, 2],
+                    Height = stats[i, 3],
+                    Area = stats[i, 4],
+                    Centroid = new Point2d(centroids[i, 0], centroids[i, 1]),
+                };
+            }
+            return new ConnectedComponents(blobs, labelsMat, nLabels);
         }
-        return new ConnectedComponents(blobs, labels, nLabels);
+        catch
+        {
+            labelsMat.Dispose();
+            throw;
+        }
     }
         
     /// <summary>

--- a/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
+++ b/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
@@ -5,48 +5,65 @@ namespace OpenCvSharp;
 /// <summary>
 /// connected components that is returned from Cv2.ConnectedComponentsEx
 /// </summary>
-public class ConnectedComponents
+public sealed class ConnectedComponents : IDisposable
 {
+    private readonly Mat labelsMat;
+    private ReadOnlyArray2D<int>? labelsCache;
+    private bool disposed;
+
     /// <summary>
-    /// All blobs
+    /// All blobs, including the background blob at index 0 (<see cref="Blob.Label"/> == 0).
+    /// Most callers should skip index 0 unless the background itself is of interest
+    /// (see <see cref="GetLargestBlob"/>, which starts scanning from index 1).
     /// </summary>
     public IReadOnlyList<Blob> Blobs { get; }
 
     /// <summary>
-    /// destination labeled value
+    /// destination labeled value. Materialized from the native label image on first access.
     /// </summary>
-    public ReadOnlyArray2D<int> Labels { get;  }
+    public ReadOnlyArray2D<int> Labels => labelsCache ??= new ReadOnlyArray2D<int>(ToInt32Array(labelsMat));
 
     /// <summary>
-    /// The number of labels -1
+    /// The total number of labels, including the background label (0).
     /// </summary>
-    public int LabelCount { get; internal set; }
+    public int LabelCount { get; }
 
     /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="blobs"></param>
-    /// <param name="labels"></param>
+    /// <param name="labelsMat">The native label image (CV_32S or CV_16U). Ownership is transferred to this instance.</param>
     /// <param name="labelCount"></param>
-    internal ConnectedComponents(IReadOnlyList<Blob> blobs, int[,] labels, int labelCount)
+    internal ConnectedComponents(IReadOnlyList<Blob> blobs, Mat labelsMat, int labelCount)
     {
         Blobs = blobs;
-        Labels = new ReadOnlyArray2D<int>(labels);
+        this.labelsMat = labelsMat;
         LabelCount = labelCount;
     }
 
     /// <summary>
-    /// Filter a image with the specified label value. 
+    /// Releases the underlying native label image.
+    /// </summary>
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        labelsMat.Dispose();
+        disposed = true;
+    }
+
+    /// <summary>
+    /// Filter a image with the specified label value.
     /// </summary>
     /// <param name="src">Source image.</param>
     /// <param name="dst">Destination image.</param>
     /// <param name="labelValue">Label value.</param>
     /// <returns>Filtered image.</returns>
-    public void FilterByLabel(Mat src, Mat dst, int labelValue) 
+    public void FilterByLabel(Mat src, Mat dst, int labelValue)
         => FilterByLabels(src, dst, [labelValue]);
 
     /// <summary>
-    /// Filter a image with the specified label values. 
+    /// Filter a image with the specified label values.
     /// </summary>
     /// <param name="src">Source image.</param>
     /// <param name="dst">Destination image.</param>
@@ -76,13 +93,13 @@ public class ConnectedComponents
         for (var i = 1; i < labelArray.Length; i++)
         {
             using var maskI = GetLabelMask(labelArray[i]);
-            Cv2.BitwiseOr(mask, maskI, mask);                
+            Cv2.BitwiseOr(mask, maskI, mask);
         }
         src.CopyTo(dst, mask);
     }
 
     /// <summary>
-    /// Filter a image with the specified blob object. 
+    /// Filter a image with the specified blob object.
     /// </summary>
     /// <param name="src">Source image.</param>
     /// <param name="dst">Destination image.</param>
@@ -96,7 +113,7 @@ public class ConnectedComponents
     }
 
     /// <summary>
-    /// Filter a image with the specified blob objects. 
+    /// Filter a image with the specified blob objects.
     /// </summary>
     /// <param name="src">Source image.</param>
     /// <param name="dst">Destination image.</param>
@@ -115,35 +132,40 @@ public class ConnectedComponents
     {
         if (img is null)
             throw new ArgumentNullException(nameof(img));
-        /*
-        if (img.Empty())
-            throw new ArgumentException("img is empty");
-        if (img.Type() != MatType.CV_8UC3)
-            throw new ArgumentException("img must be CV_8UC3");*/
         if (Blobs is null || Blobs.Count == 0)
             throw new OpenCvSharpException("Blobs is empty");
-        if (Labels is null)
-            throw new OpenCvSharpException("Labels is empty");
 
-        var height = Labels.GetLength(0);
-        var width = Labels.GetLength(1);
+        var height = labelsMat.Rows;
+        var width = labelsMat.Cols;
         img.Create(new Size(width, height), MatType.CV_8UC3);
 
-        var colors = new Scalar[Blobs.Count];
-        colors[0] = Scalar.All(0);
+        var colors = new Vec3b[Blobs.Count];
         for (var i = 1; i < Blobs.Count; i++)
         {
-            colors[i] = Scalar.RandomColor();
+            colors[i] = Scalar.RandomColor().ToVec3b();
         }
 
-        using var imgt = new Mat<Vec3b>(img);
-        var indexer = imgt.GetIndexer();
-        for (var y = 0; y < height; y++)
+        var imgRows = img.AsRows<Vec3b>();
+        if (labelsMat.Type() == MatType.CV_16U)
         {
-            for (var x = 0; x < width; x++)
+            var labelRows = labelsMat.AsRows<ushort>();
+            for (var y = 0; y < height; y++)
             {
-                var labelValue = Labels[y, x];
-                indexer[y, x] = colors[labelValue].ToVec3b();
+                var labelRow = labelRows[y];
+                var imgRow = imgRows[y];
+                for (var x = 0; x < width; x++)
+                    imgRow[x] = colors[labelRow[x]];
+            }
+        }
+        else
+        {
+            var labelRows = labelsMat.AsRows<int>();
+            for (var y = 0; y < height; y++)
+            {
+                var labelRow = labelRows[y];
+                var imgRow = imgRows[y];
+                for (var x = 0; x < width; x++)
+                    imgRow[x] = colors[labelRow[x]];
             }
         }
     }
@@ -175,13 +197,33 @@ public class ConnectedComponents
     /// <returns></returns>
     private Mat GetLabelMask(int label)
     {
-        var rows = Labels.GetLength(0);
-        var cols = Labels.GetLength(1);
-        using var labels = Mat.FromPixelData(rows, cols, MatType.CV_32SC1, Labels.GetBuffer());
-        using var cmp = new Mat(rows, cols, MatType.CV_32SC1, Scalar.All(label));
         var result = new Mat();
-        Cv2.Compare(labels, cmp, result, CmpTypes.EQ);
+        Cv2.Compare(labelsMat, new Scalar(label), result, CmpTypes.EQ);
         return result;
+    }
+
+    /// <summary>
+    /// Copies the native label image (CV_32S or CV_16U) into a managed <c>int[,]</c>.
+    /// </summary>
+    private static int[,] ToInt32Array(Mat mat)
+    {
+        if (mat.Type() == MatType.CV_16U)
+        {
+            var rows = mat.Rows;
+            var cols = mat.Cols;
+            var result = new int[rows, cols];
+            var srcRows = mat.AsRows<ushort>();
+            for (var y = 0; y < rows; y++)
+            {
+                var srcRow = srcRows[y];
+                for (var x = 0; x < cols; x++)
+                    result[y, x] = srcRow[x];
+            }
+            return result;
+        }
+
+        using var int32Mat = new Mat<int>(mat);
+        return int32Mat.ToRectangularArray();
     }
 
 #pragma warning disable CA1034
@@ -191,7 +233,7 @@ public class ConnectedComponents
     public class Blob
     {
         /// <summary>
-        /// Label value
+        /// Label value. 0 is the background label (see <see cref="Blobs"/>).
         /// </summary>
         public int Label { get; internal set; }
 

--- a/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
+++ b/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
@@ -5,12 +5,8 @@ namespace OpenCvSharp;
 /// <summary>
 /// connected components that is returned from Cv2.ConnectedComponentsEx
 /// </summary>
-public sealed class ConnectedComponents : IDisposable
+public class ConnectedComponents
 {
-    private readonly Mat labelsMat;
-    private ReadOnlyArray2D<int>? labelsCache;
-    private bool disposed;
-
     /// <summary>
     /// All blobs, including the background blob at index 0 (<see cref="Blob.Label"/> == 0).
     /// Most callers should skip index 0 unless the background itself is of interest
@@ -19,37 +15,26 @@ public sealed class ConnectedComponents : IDisposable
     public IReadOnlyList<Blob> Blobs { get; }
 
     /// <summary>
-    /// destination labeled value. Materialized from the native label image on first access.
+    /// destination labeled value
     /// </summary>
-    public ReadOnlyArray2D<int> Labels => labelsCache ??= new ReadOnlyArray2D<int>(ToInt32Array(labelsMat));
+    public ReadOnlyArray2D<int> Labels { get; }
 
     /// <summary>
     /// The total number of labels, including the background label (0).
     /// </summary>
-    public int LabelCount { get; }
+    public int LabelCount { get; internal set; }
 
     /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="blobs"></param>
-    /// <param name="labelsMat">The native label image (CV_32S or CV_16U). Ownership is transferred to this instance.</param>
+    /// <param name="labels"></param>
     /// <param name="labelCount"></param>
-    internal ConnectedComponents(IReadOnlyList<Blob> blobs, Mat labelsMat, int labelCount)
+    internal ConnectedComponents(IReadOnlyList<Blob> blobs, int[,] labels, int labelCount)
     {
         Blobs = blobs;
-        this.labelsMat = labelsMat;
+        Labels = new ReadOnlyArray2D<int>(labels);
         LabelCount = labelCount;
-    }
-
-    /// <summary>
-    /// Releases the underlying native label image.
-    /// </summary>
-    public void Dispose()
-    {
-        if (disposed)
-            return;
-        labelsMat.Dispose();
-        disposed = true;
     }
 
     /// <summary>
@@ -88,11 +73,12 @@ public sealed class ConnectedComponents : IDisposable
         }
 
         // マスク用Matを用意し、Andで切り抜く
-        using var mask = GetLabelMask(labelArray[0]);
+        using var labelsView = Mat.FromPixelData(Labels.GetLength(0), Labels.GetLength(1), MatType.CV_32SC1, Labels.GetBuffer());
+        using var mask = GetLabelMask(labelsView, labelArray[0]);
 
         for (var i = 1; i < labelArray.Length; i++)
         {
-            using var maskI = GetLabelMask(labelArray[i]);
+            using var maskI = GetLabelMask(labelsView, labelArray[i]);
             Cv2.BitwiseOr(mask, maskI, mask);
         }
         src.CopyTo(dst, mask);
@@ -134,9 +120,11 @@ public sealed class ConnectedComponents : IDisposable
             throw new ArgumentNullException(nameof(img));
         if (Blobs is null || Blobs.Count == 0)
             throw new OpenCvSharpException("Blobs is empty");
+        if (Labels is null)
+            throw new OpenCvSharpException("Labels is empty");
 
-        var height = labelsMat.Rows;
-        var width = labelsMat.Cols;
+        var height = Labels.GetLength(0);
+        var width = Labels.GetLength(1);
         img.Create(new Size(width, height), MatType.CV_8UC3);
 
         var colors = new Vec3b[Blobs.Count];
@@ -145,28 +133,15 @@ public sealed class ConnectedComponents : IDisposable
             colors[i] = Scalar.RandomColor().ToVec3b();
         }
 
+        // Reads straight from the plain int[,] buffer (fast array indexing) and writes via
+        // Mat.AsRows (no P/Invoke per pixel), instead of the previous Mat<Vec3b> generic indexer.
+        var labelsBuffer = Labels.GetBuffer();
         var imgRows = img.AsRows<Vec3b>();
-        if (labelsMat.Type() == MatType.CV_16U)
+        for (var y = 0; y < height; y++)
         {
-            var labelRows = labelsMat.AsRows<ushort>();
-            for (var y = 0; y < height; y++)
-            {
-                var labelRow = labelRows[y];
-                var imgRow = imgRows[y];
-                for (var x = 0; x < width; x++)
-                    imgRow[x] = colors[labelRow[x]];
-            }
-        }
-        else
-        {
-            var labelRows = labelsMat.AsRows<int>();
-            for (var y = 0; y < height; y++)
-            {
-                var labelRow = labelRows[y];
-                var imgRow = imgRows[y];
-                for (var x = 0; x < width; x++)
-                    imgRow[x] = colors[labelRow[x]];
-            }
+            var imgRow = imgRows[y];
+            for (var x = 0; x < width; x++)
+                imgRow[x] = colors[labelsBuffer[y, x]];
         }
     }
 
@@ -193,37 +168,14 @@ public sealed class ConnectedComponents : IDisposable
     /// <summary>
     /// 指定したラベル値のところのみを非0で残したマスク画像を返す
     /// </summary>
+    /// <param name="labelsView">Zero-copy Mat view over the <see cref="Labels"/> buffer.</param>
     /// <param name="label"></param>
     /// <returns></returns>
-    private Mat GetLabelMask(int label)
+    private static Mat GetLabelMask(Mat labelsView, int label)
     {
         var result = new Mat();
-        Cv2.Compare(labelsMat, new Scalar(label), result, CmpTypes.EQ);
+        Cv2.Compare(labelsView, new Scalar(label), result, CmpTypes.EQ);
         return result;
-    }
-
-    /// <summary>
-    /// Copies the native label image (CV_32S or CV_16U) into a managed <c>int[,]</c>.
-    /// </summary>
-    private static int[,] ToInt32Array(Mat mat)
-    {
-        if (mat.Type() == MatType.CV_16U)
-        {
-            var rows = mat.Rows;
-            var cols = mat.Cols;
-            var result = new int[rows, cols];
-            var srcRows = mat.AsRows<ushort>();
-            for (var y = 0; y < rows; y++)
-            {
-                var srcRow = srcRows[y];
-                for (var x = 0; x < cols; x++)
-                    result[y, x] = srcRow[x];
-            }
-            return result;
-        }
-
-        using var int32Mat = new Mat<int>(mat);
-        return int32Mat.ToRectangularArray();
     }
 
 #pragma warning disable CA1034

--- a/test/OpenCvSharp.Tests/imgproc/ConnectedComponentsTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ConnectedComponentsTest.cs
@@ -16,7 +16,7 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Threshold(src, binary, 128, 255, ThresholdTypes.BinaryInv);
         ShowImagesWhenDebugMode(src, binary);
 
-        using var cc = Cv2.ConnectedComponentsEx(binary, connectivity, algorithmType);
+        var cc = Cv2.ConnectedComponentsEx(binary, connectivity, algorithmType);
             
         Assert.Equal(27, cc.LabelCount);
         Assert.NotEmpty(cc.Labels.GetBuffer());
@@ -35,7 +35,7 @@ public class ConnectedComponentsTest : TestBase
         using var binary = new Mat();
         Cv2.Threshold(src, binary, 128, 255, ThresholdTypes.BinaryInv);
 
-        using var cc = Cv2.ConnectedComponentsEx(
+        var cc = Cv2.ConnectedComponentsEx(
             binary, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default, MatType.CV_16U);
 
         Assert.Equal(27, cc.LabelCount);
@@ -55,7 +55,7 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Rectangle(src, new Rect(50, 60, 20, 30), Scalar.White, -1); // greater
         ShowImagesWhenDebugMode(src);
 
-        using var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
+        var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
             
         var largestBlob = cc.GetLargestBlob();
         Assert.Equal(50, largestBlob.Left);
@@ -74,7 +74,7 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Rectangle(src, new Rect(10, 20, 10, 20), Scalar.White, -1);
         Cv2.Rectangle(src, new Rect(50, 60, 20, 30), Scalar.White, -1); // greater
 
-        using var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
+        var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
 
         using var dst = new Mat();
         cc.FilterByLabel(src, dst, 1);

--- a/test/OpenCvSharp.Tests/imgproc/ConnectedComponentsTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ConnectedComponentsTest.cs
@@ -16,10 +16,29 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Threshold(src, binary, 128, 255, ThresholdTypes.BinaryInv);
         ShowImagesWhenDebugMode(src, binary);
 
-        var cc = Cv2.ConnectedComponentsEx(binary, connectivity, algorithmType);
+        using var cc = Cv2.ConnectedComponentsEx(binary, connectivity, algorithmType);
             
         Assert.Equal(27, cc.LabelCount);
         Assert.NotEmpty(cc.Labels.GetBuffer());
+        Assert.Equal(src.Rows, cc.Labels.GetLength(0));
+        Assert.Equal(src.Cols, cc.Labels.GetLength(1));
+
+        using var render = new Mat();
+        cc.RenderBlobs(render);
+        ShowImagesWhenDebugMode(render);
+    }
+
+    [Fact]
+    public void RunWithCv16ULabelType()
+    {
+        using var src = LoadImage("alphabet.png", ImreadModes.Grayscale);
+        using var binary = new Mat();
+        Cv2.Threshold(src, binary, 128, 255, ThresholdTypes.BinaryInv);
+
+        using var cc = Cv2.ConnectedComponentsEx(
+            binary, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default, MatType.CV_16U);
+
+        Assert.Equal(27, cc.LabelCount);
         Assert.Equal(src.Rows, cc.Labels.GetLength(0));
         Assert.Equal(src.Cols, cc.Labels.GetLength(1));
 
@@ -36,7 +55,7 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Rectangle(src, new Rect(50, 60, 20, 30), Scalar.White, -1); // greater
         ShowImagesWhenDebugMode(src);
 
-        var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
+        using var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
             
         var largestBlob = cc.GetLargestBlob();
         Assert.Equal(50, largestBlob.Left);
@@ -55,7 +74,7 @@ public class ConnectedComponentsTest : TestBase
         Cv2.Rectangle(src, new Rect(10, 20, 10, 20), Scalar.White, -1);
         Cv2.Rectangle(src, new Rect(50, 60, 20, 30), Scalar.White, -1); // greater
 
-        var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
+        using var cc = Cv2.ConnectedComponentsEx(src, PixelConnectivity.Connectivity8, ConnectedComponentsAlgorithmsTypes.Default);
 
         using var dst = new Mat();
         cc.FilterByLabel(src, dst, 1);


### PR DESCRIPTION
## Summary
Addresses the polish items from #1985 for the `ConnectedComponents` family wrappers.

- Fixed the `LabelCount` XML doc: it is the full label count including the background label (N), not "the number of labels - 1".
- `FilterByLabel(s)` / `GetLabelMask` now wrap the managed `Labels` buffer via the existing zero-copy `Mat.FromPixelData` and compare directly against a `Scalar` (`Cv2.Compare(labelsView, new Scalar(label), ...)`), removing the extra full-size scalar-filled comparison `Mat` the old code allocated.
- `RenderBlobs` now reads straight from the plain `int[,]` buffer and writes via `Mat.AsRows<T>` (zero-P/Invoke-per-element row access) instead of going through the generic `Mat<Vec3b>` indexer, avoiding per-pixel indexer overhead.
- Documented that `Blobs[0]` is the background blob.
- Added an optional `ltype` parameter to `ConnectedComponentsEx` so callers can opt into `CV_16U` labels (halves the native label image's memory footprint during the native call, at the cost of a 65535 label limit), matching what the native API already supports. The result is still always widened to a plain `int[,]` for `Labels`.

`ConnectedComponents` intentionally stays a plain (non-`IDisposable`) type: an earlier version of this PR made it retain the native label `Mat` for lazy materialization, but that forced `IDisposable` onto every caller for a convenience API that previously never needed disposal. `Labels` is still eagerly materialized to a managed `int[,]` in `ConnectedComponentsEx`, same as before.

Closes #1985.

## Test plan
- [x] `dotnet build` for `OpenCvSharp` and `OpenCvSharp.Tests` — no warnings/errors.
- [x] `dotnet test --filter FullyQualifiedName~ConnectedComponents` — all pass, including a new test covering the `CV_16U` `ltype` option.
- [x] `dotnet test --filter FullyQualifiedName~ImgProc` — full ImgProc suite (243 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connected component results now let you choose the output label image type (including 16-bit labels) when running `ConnectedComponentsEx`.
* **Bug Fixes**
  * Rendering blobs and filtering by label were updated to correctly handle the supported label types.
* **Tests**
  * Added a new test covering 16-bit label output (`RunWithCv16ULabelType`) and validating label count and dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->