### PR TITLE
Add SACSegmentation and RegionGrowing3D wrappers for geometry module

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
@@ -616,4 +616,157 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus geometry_rotatedRectangleIntersection_vector(
         RotatedRect rect1, RotatedRect rect2, IntPtr intersectingRegion, out int returnValue);
+
+    // SACSegmentation
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_createSACSegmentation(
+        int sacModelType, int sacMethod, double threshold, int maxIterations, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_Ptr_SACSegmentation_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_Ptr_SACSegmentation_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_SACSegmentation_segment(
+        OpenCvSafeHandle obj, in InputArrayProxy inputPts, in OutputArrayProxy labels, in OutputArrayProxy modelsCoefficients,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setSacModelType(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getSacModelType(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setSacMethodType(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getSacMethodType(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setDistanceThreshold(OpenCvSafeHandle obj, double value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getDistanceThreshold(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setRadiusLimits(OpenCvSafeHandle obj, double radiusMin, double radiusMax);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getRadiusLimits(OpenCvSafeHandle obj, out double radiusMin, out double radiusMax);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setMaxIterations(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getMaxIterations(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setConfidence(OpenCvSafeHandle obj, double value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getConfidence(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setNumberOfModelsExpected(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getNumberOfModelsExpected(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setParallel(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_isParallel(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setRandomGeneratorState(OpenCvSafeHandle obj, ulong value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_getRandomGeneratorState(OpenCvSafeHandle obj, out ulong returnValue);
+
+    // LibraryImport does not support marshaling delegate parameters, so this one uses classic DllImport.
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    public static extern ExceptionStatus geometry_SACSegmentation_setCustomModelConstraints(
+        OpenCvSafeHandle obj, SacModelConstraintNativeCallback? callback);
+
+    // RegionGrowing3D
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_createRegionGrowing3D(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_Ptr_RegionGrowing3D_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_Ptr_RegionGrowing3D_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_RegionGrowing3D_segment(
+        OpenCvSafeHandle obj, IntPtr regionsIdx, in OutputArrayProxy labels,
+        in InputArrayProxy inputPts, in InputArrayProxy normals, in InputArrayProxy nnIdx,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setMinSize(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getMinSize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setMaxSize(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getMaxSize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setSmoothModeFlag(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getSmoothModeFlag(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setSmoothnessThreshold(OpenCvSafeHandle obj, double value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getSmoothnessThreshold(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setCurvatureThreshold(OpenCvSafeHandle obj, double value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getCurvatureThreshold(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setMaxNumberOfNeighbors(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getMaxNumberOfNeighbors(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setNumberOfRegions(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getNumberOfRegions(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_setNeedSort(OpenCvSafeHandle obj, int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_RegionGrowing3D_getNeedSort(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_RegionGrowing3D_setSeeds(OpenCvSafeHandle obj, in InputArrayProxy seeds);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_RegionGrowing3D_getSeeds(OpenCvSafeHandle obj, in OutputArrayProxy seeds);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_RegionGrowing3D_setCurvatures(OpenCvSafeHandle obj, in InputArrayProxy curvatures);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus geometry_RegionGrowing3D_getCurvatures(OpenCvSafeHandle obj, in OutputArrayProxy curvatures);
 }

--- a/src/OpenCvSharp/Modules/geometry/Enum/SacMethod.cs
+++ b/src/OpenCvSharp/Modules/geometry/Enum/SacMethod.cs
@@ -1,0 +1,13 @@
+namespace OpenCvSharp;
+
+// ReSharper disable InconsistentNaming
+/// <summary>
+/// Type of the robust estimation algorithm used by <see cref="SACSegmentation"/>.
+/// </summary>
+public enum SacMethod
+{
+    /// <summary>
+    /// The RANSAC algorithm described in @cite fischler1981random.
+    /// </summary>
+    SAC_METHOD_RANSAC = 0,
+}

--- a/src/OpenCvSharp/Modules/geometry/Enum/SacModelType.cs
+++ b/src/OpenCvSharp/Modules/geometry/Enum/SacModelType.cs
@@ -1,0 +1,21 @@
+namespace OpenCvSharp;
+
+// ReSharper disable InconsistentNaming
+/// <summary>
+/// Type of the sample consensus model used by <see cref="SACSegmentation"/>.
+/// </summary>
+public enum SacModelType
+{
+    /// <summary>
+    /// The 3D PLANE model coefficients in list [a, b, c, d], corresponding to the coefficients
+    /// of equation ax + by + cz + d = 0.
+    /// </summary>
+    SAC_MODEL_PLANE = 0,
+
+    /// <summary>
+    /// The 3D SPHERE model coefficients in list [center_x, center_y, center_z, radius],
+    /// corresponding to the coefficients of equation
+    /// (x - center_x)^2 + (y - center_y)^2 + (z - center_z)^2 = radius^2.
+    /// </summary>
+    SAC_MODEL_SPHERE = 1,
+}

--- a/src/OpenCvSharp/Modules/geometry/RegionGrowing3D.cs
+++ b/src/OpenCvSharp/Modules/geometry/RegionGrowing3D.cs
@@ -1,0 +1,273 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Region Growing algorithm in 3D point cloud.
+/// </summary>
+/// <remarks>
+/// The key idea of region growing is to merge the nearest neighbor points that satisfy a certain
+/// angle threshold into the same region according to the normal between the two points, so as to
+/// achieve the purpose of segmentation.
+/// </remarks>
+public class RegionGrowing3D : Algorithm
+{
+    private RegionGrowing3D(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.geometry_Ptr_RegionGrowing3D_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a RegionGrowing3D object.
+    /// </summary>
+    /// <returns>RegionGrowing3D instance</returns>
+    public static RegionGrowing3D Create()
+    {
+        NativeMethods.HandleException(NativeMethods.geometry_createRegionGrowing3D(out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.geometry_Ptr_RegionGrowing3D_get(smartPtr, out var rawPtr));
+        return new RegionGrowing3D(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Executes segmentation using the Region Growing algorithm.
+    /// </summary>
+    /// <param name="regionsIdx">Index information of all points in each region.</param>
+    /// <param name="labels">The label corresponds to the model number, 0 means it does not belong to
+    /// any model, range [0, Number of final resultant models obtained].</param>
+    /// <param name="inputPts">Original point cloud, support vector&lt;Point3f&gt; and Mat of size Nx3/3xN.</param>
+    /// <param name="normals">Normal of each point, support vector&lt;Point3f&gt; and Mat of size Nx3.</param>
+    /// <param name="nnIdx">Index information of nearest neighbors of all points. The first nearest
+    /// neighbor of each point is itself. Support Mat of size NxK. If the information in a row is
+    /// [0, 2, 1, -5, -1, 4, 7 ... negative number] it will use only non-negative indexes until it
+    /// meets a negative number or bound of this row i.e. [0, 2, 1].</param>
+    /// <returns>Number of final resultant regions obtained by segmentation.</returns>
+    public virtual int Segment(out int[][] regionsIdx, OutputArray labels, InputArray inputPts, InputArray normals, InputArray nnIdx)
+    {
+        ThrowIfDisposed();
+
+        using var regionsIdxVec = new VectorOfVectorInt32();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_RegionGrowing3D_segment(
+                Handle, regionsIdxVec.CvPtr, labels.Proxy, inputPts.Proxy, normals.Proxy, nnIdx.Proxy, out var ret));
+        GC.KeepAlive(inputPts.Source);
+        GC.KeepAlive(normals.Source);
+        GC.KeepAlive(nnIdx.Source);
+        regionsIdx = regionsIdxVec.ToArray();
+        return ret;
+    }
+
+    /// <summary>
+    /// The minimum size of region. Setting to a non-positive number or default will be unlimited.
+    /// </summary>
+    public virtual int MinSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getMinSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setMinSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The maximum size of region. Setting to a non-positive number or default will be unlimited.
+    /// </summary>
+    public virtual int MaxSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getMaxSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setMaxSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Whether to use the smoothness mode. Default is true.
+    /// If true it will check the angle between the normal of the current point and the normal of its
+    /// neighbor. Otherwise, it will check the angle between the normal of the seed point and the normal
+    /// of the current neighbor.
+    /// </summary>
+    public virtual bool SmoothModeFlag
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getSmoothModeFlag(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setSmoothModeFlag(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Threshold value of the angle between normals, in radian. Default is 30(degree)*PI/180.
+    /// </summary>
+    public virtual double SmoothnessThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getSmoothnessThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setSmoothnessThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Threshold value of curvature. Default is 0.05.
+    /// Only points with curvature less than the threshold will be considered to belong to the same region.
+    /// If the curvature of each point is not set, this option will not work.
+    /// </summary>
+    public virtual double CurvatureThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getCurvatureThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setCurvatureThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The maximum number of neighbors to use including itself.
+    /// Setting to a non-positive number or default will use the information from nnIdx.
+    /// </summary>
+    public virtual int MaxNumberOfNeighbors
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getMaxNumberOfNeighbors(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setMaxNumberOfNeighbors(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The maximum number of regions you want. Setting to a non-positive number or default will be unlimited.
+    /// </summary>
+    public virtual int NumberOfRegions
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getNumberOfRegions(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setNumberOfRegions(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Whether the results need to be sorted in descending order by the number of points.
+    /// </summary>
+    public virtual bool NeedSort
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_getNeedSort(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_RegionGrowing3D_setNeedSort(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Sets the seed points, it will grow according to the seeds.
+    /// If not set (or set to an empty array), the default method will be used:
+    /// 1. If the curvature of each point is set, the seeds will be sorted in ascending order of curvatures.
+    /// 2. Otherwise, the natural order of the point cloud will be used.
+    /// </summary>
+    public virtual void SetSeeds(InputArray seeds)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_RegionGrowing3D_setSeeds(Handle, seeds.Proxy));
+        GC.KeepAlive(seeds.Source);
+    }
+
+    /// <summary>
+    /// Gets the seed points.
+    /// </summary>
+    public virtual void GetSeeds(OutputArray seeds)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_RegionGrowing3D_getSeeds(Handle, seeds.Proxy));
+    }
+
+    /// <summary>
+    /// Sets the curvature of each point. If not available, pass an empty array.
+    /// </summary>
+    public virtual void SetCurvatures(InputArray curvatures)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_RegionGrowing3D_setCurvatures(Handle, curvatures.Proxy));
+        GC.KeepAlive(curvatures.Source);
+    }
+
+    /// <summary>
+    /// Gets the curvature of each point, if set.
+    /// </summary>
+    public virtual void GetCurvatures(OutputArray curvatures)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_RegionGrowing3D_getCurvatures(Handle, curvatures.Proxy));
+    }
+}

--- a/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
+++ b/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
@@ -1,0 +1,295 @@
+using System.Runtime.InteropServices;
+using OpenCvSharp.Internal;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// The native-shaped (double*, length) form of <see cref="SACSegmentation.ModelConstraintFunction"/>,
+/// used to marshal the callback across the P/Invoke boundary.
+/// </summary>
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+public delegate int SacModelConstraintNativeCallback(IntPtr coefficients, int length);
+
+/// <summary>
+/// Sample Consensus algorithm segmentation of 3D point cloud model.
+/// </summary>
+/// <remarks>
+/// See <see cref="SacMethod"/> for supported algorithms and <see cref="SacModelType"/> for supported models.
+/// </remarks>
+public class SACSegmentation : Algorithm
+{
+    /// <summary>
+    /// Custom function that takes the model coefficients and returns whether the model is acceptable or not.
+    /// </summary>
+    /// <param name="modelCoefficients">
+    /// The content of modelCoefficients depends on the model. Refer to the comments inside <see cref="SacModelType"/>.
+    /// </param>
+    public delegate bool ModelConstraintFunction(double[] modelCoefficients);
+
+    // Roots the native-shaped delegate for the lifetime of this instance so the GC does not collect it
+    // while native code may still invoke the callback during Segment().
+    private SacModelConstraintNativeCallback? customModelConstraintsNative;
+    private ModelConstraintFunction? customModelConstraints;
+
+    private SACSegmentation(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.geometry_Ptr_SACSegmentation_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a SACSegmentation object.
+    /// </summary>
+    /// <param name="sacModelType">The type of sample consensus model to use.</param>
+    /// <param name="sacMethod">The type of sample consensus method to use.</param>
+    /// <param name="threshold">The distance to the model threshold.</param>
+    /// <param name="maxIterations">The maximum number of iterations to attempt.</param>
+    /// <returns>SACSegmentation instance</returns>
+    public static SACSegmentation Create(
+        SacModelType sacModelType = SacModelType.SAC_MODEL_PLANE,
+        SacMethod sacMethod = SacMethod.SAC_METHOD_RANSAC,
+        double threshold = 0.5,
+        int maxIterations = 1000)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.geometry_createSACSegmentation((int)sacModelType, (int)sacMethod, threshold, maxIterations, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.geometry_Ptr_SACSegmentation_get(smartPtr, out var rawPtr));
+        return new SACSegmentation(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Executes segmentation using the sample consensus method.
+    /// </summary>
+    /// <param name="inputPts">Original point cloud, vector of Point3 or Mat of size Nx3/3xN.</param>
+    /// <param name="labels">The label corresponds to the model number, 0 means it does not belong to
+    /// any model, range [0, Number of final resultant models obtained].</param>
+    /// <param name="modelsCoefficients">The resultant models coefficients. Placed in a matrix of NxK
+    /// with depth CV_64F, where N is the number of models and K is the number of coefficients of one model.</param>
+    /// <returns>Number of final resultant models obtained by segmentation.</returns>
+    public virtual int Segment(InputArray inputPts, OutputArray labels, OutputArray modelsCoefficients)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.geometry_SACSegmentation_segment(Handle, inputPts.Proxy, labels.Proxy, modelsCoefficients.Proxy, out var ret));
+        GC.KeepAlive(inputPts.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// The type of sample consensus model to use.
+    /// </summary>
+    public virtual SacModelType SacModelType
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getSacModelType(Handle, out var ret));
+            return (SacModelType)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setSacModelType(Handle, (int)value));
+        }
+    }
+
+    /// <summary>
+    /// The type of sample consensus method to use.
+    /// </summary>
+    public virtual SacMethod SacMethodType
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getSacMethodType(Handle, out var ret));
+            return (SacMethod)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setSacMethodType(Handle, (int)value));
+        }
+    }
+
+    /// <summary>
+    /// The distance to the model threshold. Considered as inlier point if distance to the model
+    /// is less than threshold.
+    /// </summary>
+    public virtual double DistanceThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getDistanceThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setDistanceThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Sets the minimum and maximum radius limits for the model.
+    /// Only used for models whose model parameters include a radius.
+    /// </summary>
+    public virtual void SetRadiusLimits(double radiusMin, double radiusMax)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_SACSegmentation_setRadiusLimits(Handle, radiusMin, radiusMax));
+    }
+
+    /// <summary>
+    /// Gets the minimum and maximum radius limits for the model.
+    /// </summary>
+    public virtual void GetRadiusLimits(out double radiusMin, out double radiusMax)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.geometry_SACSegmentation_getRadiusLimits(Handle, out radiusMin, out radiusMax));
+    }
+
+    /// <summary>
+    /// The maximum number of iterations to attempt.
+    /// </summary>
+    public virtual int MaxIterations
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getMaxIterations(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setMaxIterations(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The confidence that ensures at least one of the selections is an error-free set of data points.
+    /// </summary>
+    public virtual double Confidence
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getConfidence(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setConfidence(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The number of models expected.
+    /// </summary>
+    public virtual int NumberOfModelsExpected
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getNumberOfModelsExpected(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setNumberOfModelsExpected(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Whether to use parallelism or not. The number of threads is set by <see cref="Cv2.SetNumThreads"/>.
+    /// </summary>
+    public virtual bool IsParallel
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_isParallel(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setParallel(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// State used to initialize the RNG (Random Number Generator).
+    /// </summary>
+    public virtual ulong RandomGeneratorState
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_getRandomGeneratorState(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.geometry_SACSegmentation_setRandomGeneratorState(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Sets a custom model coefficient constraint function.
+    /// A custom function that takes model coefficients and returns whether the model is acceptable or not.
+    /// Pass null to clear a previously set constraint function.
+    /// </summary>
+    public virtual void SetCustomModelConstraints(ModelConstraintFunction? customModelConstraints)
+    {
+        ThrowIfDisposed();
+
+        this.customModelConstraints = customModelConstraints;
+        customModelConstraintsNative = customModelConstraints is null
+            ? null
+            : (coefficients, length) =>
+            {
+                var managedCoefficients = new double[length];
+                Marshal.Copy(coefficients, managedCoefficients, 0, length);
+                return customModelConstraints(managedCoefficients) ? 1 : 0;
+            };
+
+        NativeMethods.HandleException(
+            NativeMethods.geometry_SACSegmentation_setCustomModelConstraints(Handle, customModelConstraintsNative));
+    }
+
+    /// <summary>
+    /// Gets the custom model coefficient constraint function previously set via
+    /// <see cref="SetCustomModelConstraints"/>, or null if none is set.
+    /// </summary>
+    public virtual ModelConstraintFunction? GetCustomModelConstraints()
+    {
+        ThrowIfDisposed();
+        return customModelConstraints;
+    }
+}

--- a/src/OpenCvSharpExtern/geometry.h
+++ b/src/OpenCvSharpExtern/geometry.h
@@ -1916,4 +1916,370 @@ CVAPI(ExceptionStatus) geometry_rotatedRectangleIntersection_vector(
     });
 }
 
+
+// SACSegmentation
+
+typedef int (*SacModelConstraintNativeCallback)(const double *coefficients, int length);
+
+CVAPI(ExceptionStatus) geometry_createSACSegmentation(
+    int sacModelType,
+    int sacMethod,
+    double threshold,
+    int maxIterations,
+    cv::Ptr<cv::SACSegmentation> **returnValue)
+{
+    return cvTry([&] {
+    *returnValue = clone(cv::SACSegmentation::create(
+        static_cast<cv::SacModelType>(sacModelType), static_cast<cv::SacMethod>(sacMethod), threshold, maxIterations));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_Ptr_SACSegmentation_delete(cv::Ptr<cv::SACSegmentation> *obj)
+{
+    return cvTry([&] {
+    delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_Ptr_SACSegmentation_get(cv::Ptr<cv::SACSegmentation> *ptr, cv::SACSegmentation **returnValue)
+{
+    return cvTry([&] {
+    *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_segment(
+    cv::SACSegmentation *obj,
+    const interop::InputArrayProxy* inputPts,
+    const interop::OutputArrayProxy* labels,
+    const interop::OutputArrayProxy* modelsCoefficients,
+    int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->segment(InProxy(*inputPts), OutProxy(*labels), OutProxy(*modelsCoefficients));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setSacModelType(cv::SACSegmentation *obj, int value)
+{
+    return cvTry([&] {
+    obj->setSacModelType(static_cast<cv::SacModelType>(value));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getSacModelType(cv::SACSegmentation *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = static_cast<int>(obj->getSacModelType());
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setSacMethodType(cv::SACSegmentation *obj, int value)
+{
+    return cvTry([&] {
+    obj->setSacMethodType(static_cast<cv::SacMethod>(value));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getSacMethodType(cv::SACSegmentation *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = static_cast<int>(obj->getSacMethodType());
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setDistanceThreshold(cv::SACSegmentation *obj, double value)
+{
+    return cvTry([&] {
+    obj->setDistanceThreshold(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getDistanceThreshold(cv::SACSegmentation *obj, double *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getDistanceThreshold();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setRadiusLimits(cv::SACSegmentation *obj, double radiusMin, double radiusMax)
+{
+    return cvTry([&] {
+    obj->setRadiusLimits(radiusMin, radiusMax);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getRadiusLimits(cv::SACSegmentation *obj, double *radiusMin, double *radiusMax)
+{
+    return cvTry([&] {
+    obj->getRadiusLimits(*radiusMin, *radiusMax);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setMaxIterations(cv::SACSegmentation *obj, int value)
+{
+    return cvTry([&] {
+    obj->setMaxIterations(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getMaxIterations(cv::SACSegmentation *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getMaxIterations();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setConfidence(cv::SACSegmentation *obj, double value)
+{
+    return cvTry([&] {
+    obj->setConfidence(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getConfidence(cv::SACSegmentation *obj, double *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getConfidence();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setNumberOfModelsExpected(cv::SACSegmentation *obj, int value)
+{
+    return cvTry([&] {
+    obj->setNumberOfModelsExpected(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getNumberOfModelsExpected(cv::SACSegmentation *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getNumberOfModelsExpected();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setParallel(cv::SACSegmentation *obj, int value)
+{
+    return cvTry([&] {
+    obj->setParallel(value != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_isParallel(cv::SACSegmentation *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->isParallel() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setRandomGeneratorState(cv::SACSegmentation *obj, uint64_t value)
+{
+    return cvTry([&] {
+    obj->setRandomGeneratorState(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_getRandomGeneratorState(cv::SACSegmentation *obj, uint64_t *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getRandomGeneratorState();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_SACSegmentation_setCustomModelConstraints(
+    cv::SACSegmentation *obj,
+    SacModelConstraintNativeCallback callback)
+{
+    return cvTry([&] {
+    if (callback == nullptr)
+    {
+        obj->setCustomModelConstraints(cv::SACSegmentation::ModelConstraintFunction());
+    }
+    else
+    {
+        obj->setCustomModelConstraints([callback](const std::vector<double> &coefficients) -> bool {
+            return callback(coefficients.data(), static_cast<int>(coefficients.size())) != 0;
+        });
+    }
+    });
+}
+
+
+// RegionGrowing3D
+
+CVAPI(ExceptionStatus) geometry_createRegionGrowing3D(cv::Ptr<cv::RegionGrowing3D> **returnValue)
+{
+    return cvTry([&] {
+    *returnValue = clone(cv::RegionGrowing3D::create());
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_Ptr_RegionGrowing3D_delete(cv::Ptr<cv::RegionGrowing3D> *obj)
+{
+    return cvTry([&] {
+    delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_Ptr_RegionGrowing3D_get(cv::Ptr<cv::RegionGrowing3D> *ptr, cv::RegionGrowing3D **returnValue)
+{
+    return cvTry([&] {
+    *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_segment(
+    cv::RegionGrowing3D *obj,
+    std::vector<std::vector<int>> *regionsIdx,
+    const interop::OutputArrayProxy* labels,
+    const interop::InputArrayProxy* inputPts,
+    const interop::InputArrayProxy* normals,
+    const interop::InputArrayProxy* nnIdx,
+    int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->segment(*regionsIdx, OutProxy(*labels), InProxy(*inputPts), InProxy(*normals), InProxy(*nnIdx));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setMinSize(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setMinSize(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getMinSize(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getMinSize();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setMaxSize(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setMaxSize(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getMaxSize(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getMaxSize();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setSmoothModeFlag(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setSmoothModeFlag(value != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getSmoothModeFlag(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getSmoothModeFlag() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setSmoothnessThreshold(cv::RegionGrowing3D *obj, double value)
+{
+    return cvTry([&] {
+    obj->setSmoothnessThreshold(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getSmoothnessThreshold(cv::RegionGrowing3D *obj, double *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getSmoothnessThreshold();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setCurvatureThreshold(cv::RegionGrowing3D *obj, double value)
+{
+    return cvTry([&] {
+    obj->setCurvatureThreshold(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getCurvatureThreshold(cv::RegionGrowing3D *obj, double *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getCurvatureThreshold();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setMaxNumberOfNeighbors(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setMaxNumberOfNeighbors(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getMaxNumberOfNeighbors(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getMaxNumberOfNeighbors();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setNumberOfRegions(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setNumberOfRegions(value);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getNumberOfRegions(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getNumberOfRegions();
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setNeedSort(cv::RegionGrowing3D *obj, int value)
+{
+    return cvTry([&] {
+    obj->setNeedSort(value != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getNeedSort(cv::RegionGrowing3D *obj, int *returnValue)
+{
+    return cvTry([&] {
+    *returnValue = obj->getNeedSort() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setSeeds(cv::RegionGrowing3D *obj, const interop::InputArrayProxy* seeds)
+{
+    return cvTry([&] {
+    obj->setSeeds(InProxy(*seeds));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getSeeds(cv::RegionGrowing3D *obj, const interop::OutputArrayProxy* seeds)
+{
+    return cvTry([&] {
+    obj->getSeeds(OutProxy(*seeds));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_setCurvatures(cv::RegionGrowing3D *obj, const interop::InputArrayProxy* curvatures)
+{
+    return cvTry([&] {
+    obj->setCurvatures(InProxy(*curvatures));
+    });
+}
+
+CVAPI(ExceptionStatus) geometry_RegionGrowing3D_getCurvatures(cv::RegionGrowing3D *obj, const interop::OutputArrayProxy* curvatures)
+{
+    return cvTry([&] {
+    obj->getCurvatures(OutProxy(*curvatures));
+    });
+}
+
 #endif // NO_GEOMETRY

--- a/test/OpenCvSharp.Tests/calib3d/RegionGrowing3DTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/RegionGrowing3DTest.cs
@@ -1,0 +1,105 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Calib3D;
+
+public class RegionGrowing3DTest : TestBase
+{
+    private static readonly int[] SampleSeedIndices = { 0, 2, 4 };
+    private static readonly float[] SampleCurvatures = { 0.01f, 0.02f, 0.03f };
+
+    private static (Mat inputPts, Mat normals, Mat nnIdx) MakeFlatPatch()
+    {
+        var pts = new[]
+        {
+            new Point3f(0, 0, 0),
+            new Point3f(1, 0, 0),
+            new Point3f(0, 1, 0),
+            new Point3f(1, 1, 0),
+            new Point3f(0.5f, 0.5f, 0),
+        };
+        var inputPts = Mat.FromPixelData(pts.Length, 1, MatType.CV_32FC3, pts);
+
+        var nnIdxData = new int[pts.Length, pts.Length];
+        for (var i = 0; i < pts.Length; i++)
+            for (var j = 0; j < pts.Length; j++)
+                nnIdxData[i, j] = j;
+        var nnIdx = Mat.FromArray(nnIdxData);
+
+        var normals = new Mat();
+        using var curvatures = new Mat();
+        Cv2.NormalEstimate(normals, curvatures, inputPts, nnIdx);
+
+        return (inputPts, normals, nnIdx);
+    }
+
+    [Fact]
+    public void SegmentGroupsFlatPatchIntoOneRegion()
+    {
+        var (inputPts, normals, nnIdx) = MakeFlatPatch();
+        using var _1 = inputPts;
+        using var _2 = normals;
+        using var _3 = nnIdx;
+
+        using var rg = RegionGrowing3D.Create();
+        using var labels = new Mat();
+
+        var numRegions = rg.Segment(out var regionsIdx, labels, inputPts, normals, nnIdx);
+
+        Assert.Equal(1, numRegions);
+        Assert.Single(regionsIdx);
+        Assert.Equal(inputPts.Rows, regionsIdx[0].Length);
+        Assert.Equal(inputPts.Rows, labels.Rows);
+    }
+
+    [Fact]
+    public void GetSetProperties()
+    {
+        using var rg = RegionGrowing3D.Create();
+
+        rg.MinSize = 3;
+        Assert.Equal(3, rg.MinSize);
+
+        rg.MaxSize = 1000;
+        Assert.Equal(1000, rg.MaxSize);
+
+        rg.SmoothModeFlag = false;
+        Assert.False(rg.SmoothModeFlag);
+        rg.SmoothModeFlag = true;
+        Assert.True(rg.SmoothModeFlag);
+
+        rg.SmoothnessThreshold = 0.5;
+        Assert.Equal(0.5, rg.SmoothnessThreshold, 6);
+
+        rg.CurvatureThreshold = 0.1;
+        Assert.Equal(0.1, rg.CurvatureThreshold, 6);
+
+        rg.MaxNumberOfNeighbors = 10;
+        Assert.Equal(10, rg.MaxNumberOfNeighbors);
+
+        rg.NumberOfRegions = 5;
+        Assert.Equal(5, rg.NumberOfRegions);
+
+        rg.NeedSort = false;
+        Assert.False(rg.NeedSort);
+        rg.NeedSort = true;
+        Assert.True(rg.NeedSort);
+    }
+
+    [Fact]
+    public void SeedsAndCurvaturesRoundTrip()
+    {
+        using var rg = RegionGrowing3D.Create();
+
+        using var seedsIn = Mat.FromArray(SampleSeedIndices);
+        rg.SetSeeds(seedsIn);
+        using var seedsOut = new Mat();
+        rg.GetSeeds(seedsOut);
+        Assert.Equal(seedsIn.Total(), seedsOut.Total());
+
+        using var curvaturesIn = Mat.FromArray(SampleCurvatures);
+        rg.SetCurvatures(curvaturesIn);
+        using var curvaturesOut = new Mat();
+        rg.GetCurvatures(curvaturesOut);
+        Assert.Equal(curvaturesIn.Total(), curvaturesOut.Total());
+    }
+}

--- a/test/OpenCvSharp.Tests/calib3d/SACSegmentationTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/SACSegmentationTest.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+#pragma warning disable CA5394 // Do not use insecure randomness
+
+namespace OpenCvSharp.Tests.Calib3D;
+
+public class SACSegmentationTest : TestBase
+{
+    private static Mat MakePlaneWithOutliers(Random rng, int inlierCount, int outlierCount)
+    {
+        var pts = new List<Point3f>();
+        for (var i = 0; i < inlierCount; i++)
+            pts.Add(new Point3f((float)rng.NextDouble(), (float)rng.NextDouble(), 0));
+        for (var i = 0; i < outlierCount; i++)
+            pts.Add(new Point3f((float)rng.NextDouble() * 5, (float)rng.NextDouble() * 5, 2 + (float)rng.NextDouble() * 5));
+
+        return Mat.FromPixelData(pts.Count, 1, MatType.CV_32FC3, pts.ToArray());
+    }
+
+    [Fact]
+    public void SegmentFindsPlane()
+    {
+        var rng = new Random(41);
+        using var inputPts = MakePlaneWithOutliers(rng, 200, 20);
+        using var seg = SACSegmentation.Create(SacModelType.SAC_MODEL_PLANE, SacMethod.SAC_METHOD_RANSAC, 0.05, 1000);
+        using var labels = new Mat();
+        using var modelsCoefficients = new Mat();
+
+        var numModels = seg.Segment(inputPts, labels, modelsCoefficients);
+
+        Assert.True(numModels >= 1);
+        Assert.Equal((long)inputPts.Rows, labels.Total());
+        Assert.Equal(4, modelsCoefficients.Cols);
+
+        // Plane coefficients [a, b, c, d] for z=0: the (unnormalized) normal (a, b, c)
+        // should point mostly along z regardless of its overall scale.
+        var a = modelsCoefficients.Get<double>(0, 0);
+        var b = modelsCoefficients.Get<double>(0, 1);
+        var c = modelsCoefficients.Get<double>(0, 2);
+        var cosZ = Math.Abs(c) / Math.Sqrt(a * a + b * b + c * c);
+        Assert.True(cosZ > 0.9, $"expected normal close to z-axis, got ({a},{b},{c}) cosZ={cosZ}");
+    }
+
+    [Fact]
+    public void GetSetProperties()
+    {
+        using var seg = SACSegmentation.Create();
+
+        seg.SacModelType = SacModelType.SAC_MODEL_SPHERE;
+        Assert.Equal(SacModelType.SAC_MODEL_SPHERE, seg.SacModelType);
+
+        seg.SacMethodType = SacMethod.SAC_METHOD_RANSAC;
+        Assert.Equal(SacMethod.SAC_METHOD_RANSAC, seg.SacMethodType);
+
+        seg.DistanceThreshold = 0.25;
+        Assert.Equal(0.25, seg.DistanceThreshold, 6);
+
+        seg.SetRadiusLimits(0.1, 2.0);
+        seg.GetRadiusLimits(out var radiusMin, out var radiusMax);
+        Assert.Equal(0.1, radiusMin, 6);
+        Assert.Equal(2.0, radiusMax, 6);
+
+        seg.MaxIterations = 500;
+        Assert.Equal(500, seg.MaxIterations);
+
+        seg.Confidence = 0.9;
+        Assert.Equal(0.9, seg.Confidence, 6);
+
+        seg.NumberOfModelsExpected = 2;
+        Assert.Equal(2, seg.NumberOfModelsExpected);
+
+        seg.IsParallel = true;
+        Assert.True(seg.IsParallel);
+        seg.IsParallel = false;
+        Assert.False(seg.IsParallel);
+
+        seg.RandomGeneratorState = 12345UL;
+        Assert.Equal(12345UL, seg.RandomGeneratorState);
+    }
+
+    [Fact]
+    public void CustomModelConstraintsRejectingAllModelsYieldsZeroModels()
+    {
+        var rng = new Random(43);
+        using var inputPts = MakePlaneWithOutliers(rng, 200, 20);
+        using var seg = SACSegmentation.Create(SacModelType.SAC_MODEL_PLANE, SacMethod.SAC_METHOD_RANSAC, 0.05, 1000);
+        using var labels = new Mat();
+        using var modelsCoefficients = new Mat();
+
+        var invoked = false;
+        seg.SetCustomModelConstraints(coefficients =>
+        {
+            invoked = true;
+            Assert.Equal(4, coefficients.Length);
+            return false;
+        });
+
+        var numModels = seg.Segment(inputPts, labels, modelsCoefficients);
+
+        Assert.True(invoked);
+        Assert.Equal(0, numModels);
+        Assert.NotNull(seg.GetCustomModelConstraints());
+
+        seg.SetCustomModelConstraints(null);
+        Assert.Null(seg.GetCustomModelConstraints());
+    }
+}


### PR DESCRIPTION
## Summary
- Stacked on #2000. Wraps `cv::SACSegmentation` and `cv::RegionGrowing3D` from `opencv2/geometry/segment.hpp`, which were left unwrapped in that PR.
- `SACSegmentation`: RANSAC-based plane/sphere segmentation (`Create`, `Segment`, all getters/setters, and the `ModelConstraintFunction` custom-constraint callback bridged through a native function pointer).
- `RegionGrowing3D`: normal-based region growing segmentation (`Create`, `Segment` returning `regions_idx` as `int[][]` via `VectorOfVectorInt32`, and all getters/setters including Seeds/Curvatures).
- Adds `SacMethod` / `SacModelType` enums.

## Test plan
- [x] `SACSegmentationTest`: plane fitting recovers a normal aligned with the z-axis, property round-trips, custom model-constraint callback rejecting all models yields 0 models.
- [x] `RegionGrowing3DTest`: a flat coplanar patch segments into a single region, property round-trips, Seeds/Curvatures round-trip.
- [x] Native `OpenCvSharpExtern` rebuilt successfully with the new extern functions.
- [x] `dotnet test` for the new tests plus the full `Calib3D`/`PtCloud` suites: all passing (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)