### PR TITLE
Fix cv::fisheye::calibrate throwing on OpenCV 5

### DIFF
--- a/src/OpenCvSharpExtern/calib_fisheye.h
+++ b/src/OpenCvSharpExtern/calib_fisheye.h
@@ -138,8 +138,14 @@ CVAPI(ExceptionStatus) calib_fisheye_calibrate(
         // points Mat). Since OpenCV 5 changed `Mat(vector<T>)` to build a 1xN mat instead of
         // OpenCV 4's Nx1, a column-shaped (Nx1) per-view Mat now mismatches and throws
         // StsUnmatchedSizes. Row-shaped (1xN) input sidesteps the bug, so reshape any Nx1 views
-        // to 1xN before calling into OpenCV (reshape is a metadata-only view for continuous mats).
-        const auto toRow = [](const cv::Mat &m) { return m.rows > m.cols ? m.reshape(0, 1) : m; };
+        // to 1xN before calling into OpenCV. reshape() requires a continuous Mat, which an
+        // ROI/submat view is not, so clone those before reshaping.
+        const auto toRow = [](const cv::Mat &m) {
+            if (m.rows <= m.cols)
+                return m;
+            const cv::Mat continuous = m.isContinuous() ? m : m.clone();
+            return continuous.reshape(0, 1);
+        };
 
         std::vector<cv::Mat> objectPointsRow(objectPoints->size());
         for (size_t i = 0; i < objectPoints->size(); i++)

--- a/src/OpenCvSharpExtern/calib_fisheye.h
+++ b/src/OpenCvSharpExtern/calib_fisheye.h
@@ -131,8 +131,25 @@ CVAPI(ExceptionStatus) calib_fisheye_calibrate(
     double *returnValue)
 {
     return cvTry([&] {
+    // Work around an OpenCV 5 upstream regression: cv::fisheye::calibrate's internal
+    // ComputeJacobians/EstimateUncertainties helpers (modules/calib/src/fisheye.cpp) subtract
+    // a `cv::Mat(std::vector<Point2d>)` from the per-view points Mat without transposing it
+    // (their orientation check tests channels() == 1, which is never true for a 2-channel
+    // points Mat). Since OpenCV 5 changed `Mat(vector<T>)` to build a 1xN mat instead of
+    // OpenCV 4's Nx1, a column-shaped (Nx1) per-view Mat now mismatches and throws
+    // StsUnmatchedSizes. Row-shaped (1xN) input sidesteps the bug, so reshape any Nx1 views
+    // to 1xN before calling into OpenCV (reshape is a metadata-only view for continuous mats).
+    const auto toRow = [](const cv::Mat &m) { return m.rows > m.cols ? m.reshape(0, 1) : m; };
+
+    std::vector<cv::Mat> objectPointsRow(objectPoints->size());
+    for (size_t i = 0; i < objectPoints->size(); i++)
+        objectPointsRow[i] = toRow((*objectPoints)[i]);
+    std::vector<cv::Mat> imagePointsRow(imagePoints->size());
+    for (size_t i = 0; i < imagePoints->size(); i++)
+        imagePointsRow[i] = toRow((*imagePoints)[i]);
+
     *returnValue = cv::fisheye::calibrate(
-        *objectPoints, *imagePoints, cpp(imageSize),
+        objectPointsRow, imagePointsRow, cpp(imageSize),
         IoProxy(*K), IoProxy(*D), *rvecs, *tvecs, flags, cpp(criteria));
     });
 }

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -228,7 +228,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Assert.Contains(distCoeffValues, d => Math.Abs(d) > 1e-20);
     }
 
-    [Fact(Skip = "OpenCV 5: fisheye::calibrate throws an internal size-mismatch error. See https://github.com/shimat/opencvsharp/issues/1906")]
+    [Fact]
     public void FishEyeCalibrate()
     {
         var patternSize = new Size(10, 7);

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -255,6 +255,51 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Assert.NotEmpty(translationVectors);
     }
 
+    [Fact]
+    public void FishEyeCalibrateWithNonContinuousPoints()
+    {
+        var patternSize = new Size(10, 7);
+
+        using var image = LoadImage("calibration/00.jpg");
+        using var corners = new Mat<Point2f>();
+        Cv2.FindChessboardCorners(image, patternSize, corners);
+
+        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
+        var imagePointsArray = corners.ToArray();
+
+        // Build each per-view points Mat as column 0 of a wider (Nx2) Mat, so it is a
+        // non-continuous view. Regression test for the toRow() workaround in
+        // calib_fisheye_calibrate, which used to call reshape() on such a Mat directly
+        // (reshape requires a continuous Mat).
+        using var objectPointsWide = new Mat(objectPointsArray.Length, 2, MatType.CV_32FC3);
+        using var imagePointsWide = new Mat(imagePointsArray.Length, 2, MatType.CV_32FC2);
+        for (var i = 0; i < objectPointsArray.Length; i++)
+        {
+            objectPointsWide.Set(i, 0, objectPointsArray[i]);
+            objectPointsWide.Set(i, 1, objectPointsArray[i]);
+        }
+        for (var i = 0; i < imagePointsArray.Length; i++)
+        {
+            imagePointsWide.Set(i, 0, imagePointsArray[i]);
+            imagePointsWide.Set(i, 1, imagePointsArray[i]);
+        }
+
+        using var objectPoints = objectPointsWide.Col(0);
+        using var imagePoints = imagePointsWide.Col(0);
+        Assert.False(objectPoints.IsContinuous());
+        Assert.False(imagePoints.IsContinuous());
+
+        using var cameraMatrix = Mat.EyeMat(3, 3, MatType.CV_64FC1);
+        using var distCoeffs = new Mat<double>();
+
+        var rms = Cv2.FishEye.Calibrate([objectPoints], [imagePoints], image.Size(), cameraMatrix,
+            distCoeffs, out var rotationVectors, out var translationVectors);
+
+        Assert.True(rms > 8, $"rms = {rms}");
+        Assert.NotEmpty(rotationVectors);
+        Assert.NotEmpty(translationVectors);
+    }
+
     /// <summary>
     /// https://stackoverflow.com/questions/25244603/opencvs-projectpoints-function
     /// </summary>


### PR DESCRIPTION
## Summary
- Fixes #1906: `Cv2.FishEye.Calibrate(...)` threw `OpenCVException: The operation is neither 'array op array' ...` on OpenCV 5.
- Root cause (confirmed with a native repro against the OpenCV 5.0.0 source): OpenCV 5 changed `cv::Mat(const std::vector<_Tp>&)` to build a `1xN` mat (`dims=1, rows=1, cols=N`) instead of OpenCV 4's `Nx1`. `cv::fisheye::calibrate`'s internal `ComputeJacobians`/`EstimateUncertainties` helpers (`modules/calib/src/fisheye.cpp`) subtract such a `Mat(vector<Point2d>)` from the per-view points `Mat`, guarded by an orientation check that tests `image.channels() == 1` — which is never true for a 2-channel points `Mat`, so the transpose never happens. Under OpenCV 4 this was harmless because `Mat(vector<Point2d>)` was already `Nx1`, matching the untransposed (column-shaped) input; under OpenCV 5 the shapes now mismatch and `arithm_op` throws `StsUnmatchedSizes`.
- Fix: in the `calib_fisheye_calibrate` native wrapper, reshape any column-shaped (`Nx1`) per-view object/image point mats to row-shaped (`1xN`) before calling `cv::fisheye::calibrate`. This is a metadata-only reshape for continuous mats (no copy) and sidesteps the upstream bug without touching OpenCV itself.
- Re-enabled the previously `Skip`-ped `FishEyeCalibrate` test.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~Calib3D` — 81 passed, 0 failed (including the re-enabled `FishEyeCalibrate`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fisheye camera calibration stability and accuracy by adjusting how per-view point data is prepared before computing uncertainty metrics, addressing an OpenCV 5 regression.
  * Updated interpretation of calibration point shapes to better match expected input layouts, reducing calibration failures.

* **Tests**
  * Re-enabled the fisheye calibration test so it runs in the suite.
  * Added coverage for fisheye calibration using non-continuous point matrices, verifying valid calibration outputs and reasonable RMS error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->