### PR TITLE
Fix wrong CALIB_FIX_S1_S2_S3_S4 value and add missing CalibrationFlags

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -324,7 +324,7 @@ static partial class Cv2
     /// <param name="e">Output essential matrix.</param>
     /// <param name="f">Output fundamental matrix.</param>
     /// <param name="perViewErrors">Output per-view RMS reprojection errors.</param>
-    /// <param name="flags">Operation flags.</param>
+    /// <param name="flags">Operation flags. Only <see cref="CalibrationFlags.UseExtrinsicGuess"/> is supported.</param>
     /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
     /// <returns>Overall RMS reprojection error.</returns>
     public static double RegisterCameras(
@@ -333,7 +333,7 @@ static partial class Cv2
         InputArray cameraMatrix1, InputArray distCoeffs1, CameraModel cameraModel1,
         InputArray cameraMatrix2, InputArray distCoeffs2, CameraModel cameraModel2,
         InputOutputArray r, InputOutputArray t, OutputArray e, OutputArray f,
-        OutputArray perViewErrors, int flags = 0, TermCriteria? criteria = null)
+        OutputArray perViewErrors, CalibrationFlags flags = CalibrationFlags.None, TermCriteria? criteria = null)
     {
         if (objectPoints1 is null)
             throw new ArgumentNullException(nameof(objectPoints1));
@@ -356,7 +356,7 @@ static partial class Cv2
                 op1, op1.Length, op2, op2.Length, ip1, ip1.Length, ip2, ip2.Length,
                 cameraMatrix1.Proxy, distCoeffs1.Proxy, (int)cameraModel1,
                 cameraMatrix2.Proxy, distCoeffs2.Proxy, (int)cameraModel2,
-                r.Proxy, t.Proxy, e.Proxy, f.Proxy, perViewErrors.Proxy, flags, criteria0, out var ret));
+                r.Proxy, t.Proxy, e.Proxy, f.Proxy, perViewErrors.Proxy, (int)flags, criteria0, out var ret));
 
         GC.KeepAlive(cameraMatrix1.Source);
         GC.KeepAlive(distCoeffs1.Source);
@@ -390,7 +390,8 @@ static partial class Cv2
     /// <param name="rs">Output per-camera rotation matrices relative to camera 0.</param>
     /// <param name="ts">Output per-camera translation vectors relative to camera 0.</param>
     /// <param name="flagsForIntrinsics">Optional per-camera intrinsics-calibration flags (NUM_CAMERAS x 1, CV_32S).</param>
-    /// <param name="flags">Common multi-view calibration flags.</param>
+    /// <param name="flags">Common multi-view calibration flags.
+    /// Only <see cref="CalibrationFlags.UseIntrinsicGuess"/> and <see cref="CalibrationFlags.UseExtrinsicGuess"/> are supported.</param>
     /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
     /// <returns>Overall RMS reprojection error.</returns>
     public static double CalibrateMultiview(
@@ -401,7 +402,7 @@ static partial class Cv2
         InputArray models,
         out Mat[] ks, out Mat[] distortions, out Mat[] rs, out Mat[] ts,
         InputArray flagsForIntrinsics = default,
-        int flags = 0,
+        CalibrationFlags flags = CalibrationFlags.None,
         TermCriteria? criteria = null)
     {
         if (objPoints is null)
@@ -440,7 +441,7 @@ static partial class Cv2
                 imageSizeArray, imageSizeArray.Length,
                 detectionMask.Proxy, models.Proxy,
                 ksVec.CvPtr, distVec.CvPtr, rsVec.CvPtr, tsVec.CvPtr,
-                flagsForIntrinsics.Proxy, flags, criteria0, out var ret));
+                flagsForIntrinsics.Proxy, (int)flags, criteria0, out var ret));
 
         ks = ksVec.ToArray();
         distortions = distVec.ToArray();

--- a/src/OpenCvSharp/Modules/calib/Enum/CalibrationFlags.cs
+++ b/src/OpenCvSharp/Modules/calib/Enum/CalibrationFlags.cs
@@ -77,16 +77,36 @@ public enum CalibrationFlags
     RationalModel = 0x04000,
 
     /// <summary>
-    /// 
+    /// For pinhole model only. Use thin prism distortion model with coefficients s1..s4.
     /// </summary>
     ThinPrismModel = 0x08000,
 
     /// <summary>
-    /// 
+    /// For pinhole model only. The thin prism distortion coefficients are not changed during the optimization.
+    /// 0 value is used, if UseIntrinsicGuess is not set.
     /// </summary>
-#pragma warning disable CA1069 // Enums should not have duplicate values
-    FixS1S2S3S4 = 0x08000,
-#pragma warning restore CA1069
+    FixS1S2S3S4 = 0x10000,
+
+    /// <summary>
+    /// For pinhole model only. Coefficients tauX and tauY are enabled in camera matrix.
+    /// </summary>
+    TiltedModel = 0x40000,
+
+    /// <summary>
+    /// For pinhole model only. The tauX and tauY coefficients are not changed during the optimization.
+    /// 0 value is used, if UseIntrinsicGuess is not set.
+    /// </summary>
+    FixTauXTauY = 0x80000,
+
+    /// <summary>
+    /// Use QR instead of SVD decomposition for solving. Faster but potentially less precise.
+    /// </summary>
+    UseQr = 0x100000,
+
+    /// <summary>
+    /// For pinhole model only. Tangential distortion coefficients (p1, p2) are set to zeros and stay zero.
+    /// </summary>
+    FixTangentDist = 0x200000,
 
     /// <summary>
     /// If it is set, camera_matrix1,2, as well as dist_coeffs1,2 are fixed, so that only extrinsic parameters are optimized.
@@ -102,4 +122,27 @@ public enum CalibrationFlags
     /// for stereo rectification
     /// </summary>
     ZeroDisparity = 0x00400,
+
+    /// <summary>
+    /// Use LU instead of SVD decomposition for solving. Much faster but potentially less precise.
+    /// </summary>
+    UseLu = 1 << 17,
+
+    /// <summary>
+    /// Disable Schur complement (use Bouguet calibration engine).
+    /// </summary>
+#pragma warning disable CA1069 // Enums should not have duplicate values (matches native CALIB_TILTED_MODEL, per opencv2/calib.hpp)
+    DisableSchurComplement = 1 << 18,
+#pragma warning restore CA1069
+
+    /// <summary>
+    /// For stereo and multi-view calibration. Use user provided extrinsics (R, T) as initial point for optimization.
+    /// </summary>
+    UseExtrinsicGuess = 1 << 22,
+
+    /// <summary>
+    /// For multiview calibration only. Use stereo correspondence approach for initial extrinsics guess.
+    /// Limitation: all cameras should have the same type.
+    /// </summary>
+    StereoRegistration = 1 << 26,
 }


### PR DESCRIPTION
## Summary
- `CalibrationFlags.FixS1S2S3S4` duplicated `ThinPrismModel`'s value (`0x08000`, suppressed via `#pragma warning disable CA1069`); fixed to `0x10000` to match native `CALIB_FIX_S1_S2_S3_S4` in `opencv2/calib.hpp`, and removed the now-unnecessary pragma.
- Added flags that were entirely missing from `CalibrationFlags`: `TiltedModel`, `FixTauXTauY`, `UseQr`, `FixTangentDist`, `UseLu`, `DisableSchurComplement`, `UseExtrinsicGuess`, `StereoRegistration`. `DisableSchurComplement` (`1 << 18`) genuinely collides with `TiltedModel` (`0x40000`) in the native header itself, so a `CA1069` suppression was added for that pair.
- Retyped `RegisterCameras`/`CalibrateMultiview`'s `flags` parameter from raw `int` to `CalibrationFlags` for consistency with `CalibrateCamera`/`StereoCalibrate`, and documented which subset of flags each of the four functions actually honors (native docs restrict this per-function even though all four share one flat flag namespace).
- Verified no existing code (`Cv2_calib.cs`, tests) relied on the old wrong value, and confirmed the separate `StereoRectificationFlags.ZeroDisparity` is unaffected/correct.

## Test plan
- [x] `dotnet build src/OpenCvSharp/OpenCvSharp.csproj` succeeds with 0 warnings/errors
- [ ] Run `Calib3dTest`/`MultiviewCalibrationTest` on a machine with the native `OpenCvSharpExtern` binary available (not buildable in this sandboxed worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration-related APIs now accept strongly typed calibration flags, making them easier and safer to use.
  * Added support for additional calibration flag options for multi-camera and stereo workflows.

* **Bug Fixes**
  * Corrected a flag value conflict in calibration settings to improve consistency and avoid incorrect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->