### PR TITLE
Migrate OpenCvSharp.Analyzers.Tests to xunit v3

### DIFF
--- a/test/OpenCvSharp.Analyzers.Tests/MatPropertyInLoopConditionAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/MatPropertyInLoopConditionAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using OpenCvSharp.Analyzers;
 using Xunit;
 
@@ -24,7 +23,7 @@ public class MatPropertyInLoopConditionAnalyzerTests
 
     private static Task Verify(string source, params DiagnosticResult[] expected)
     {
-        var test = new CSharpAnalyzerTest<MatPropertyInLoopConditionAnalyzer, XUnitVerifier>
+        var test = new CSharpAnalyzerTest<MatPropertyInLoopConditionAnalyzer, DefaultVerifier>
         {
             TestCode = MatStub + source,
         };

--- a/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
+++ b/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <!-- Override the old CodeAnalysis pulled in transitively by the testing framework -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>

--- a/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowAtAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using OpenCvSharp.Analyzers;
 using Xunit;
 
@@ -25,7 +24,7 @@ public class RowAtAnalyzerTests
 
     private static Task Verify(string source, params DiagnosticResult[] expected)
     {
-        var test = new CSharpAnalyzerTest<RowAtAnalyzer, XUnitVerifier>
+        var test = new CSharpAnalyzerTest<RowAtAnalyzer, DefaultVerifier>
         {
             TestCode = MatStub + source,
         };

--- a/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColInLoopBodyAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using OpenCvSharp.Analyzers;
 using Xunit;
 
@@ -22,7 +21,7 @@ public class RowColInLoopBodyAnalyzerTests
 
     private static Task Verify(string source, params DiagnosticResult[] expected)
     {
-        var test = new CSharpAnalyzerTest<RowColInLoopBodyAnalyzer, XUnitVerifier>
+        var test = new CSharpAnalyzerTest<RowColInLoopBodyAnalyzer, DefaultVerifier>
         {
             TestCode = MatStub + source,
         };

--- a/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
+++ b/test/OpenCvSharp.Analyzers.Tests/RowColNotDisposedAnalyzerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using OpenCvSharp.Analyzers;
 using Xunit;
 
@@ -26,7 +25,7 @@ public class RowColNotDisposedAnalyzerTests
 
     private static Task Verify(string source, params DiagnosticResult[] expected)
     {
-        var test = new CSharpAnalyzerTest<RowColNotDisposedAnalyzer, XUnitVerifier>
+        var test = new CSharpAnalyzerTest<RowColNotDisposedAnalyzer, DefaultVerifier>
         {
             TestCode = MatStub + source,
         };


### PR DESCRIPTION
## Summary
- Referenced in the Renovate Dependency Dashboard (#1894): `test/OpenCvSharp.Analyzers.Tests` was the only test project still on xunit v2, blocking the deprecated `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` / `xunit` v2 dependencies from being auto-updated by Renovate.
- Replaced `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` with the framework-agnostic `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` package, and swapped `XUnitVerifier` for `DefaultVerifier` in the four analyzer test files.
- Bumped `xunit` → `xunit.v3` (3.2.2) and `xunit.runner.visualstudio` → 3.1.5, matching the other test projects (`OpenCvSharp.Tests`, `OpenCvSharp.Tests.Windows`).

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 23 tests pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated analyzer test infrastructure to use the newer verifier setup across several test suites.
  * Modernized test project dependencies to align with the latest xUnit and analyzer testing packages.
* **Chores**
  * Removed obsolete test imports and streamlined test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->