### PR TITLE
Add real OpenBLAS/LAPACK acceleration to Ubuntu Docker builds; bump Analyzer.Testing

### DIFF
--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
@@ -31,6 +31,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
       libtiff-dev \
       libopenjp2-7-dev \
       zlib1g-dev \
+      libopenblas-dev \
+      liblapacke-dev \
       pkg-config
 
 # Copy cmake options (needed before OpenCV configure)

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
@@ -2,7 +2,7 @@
 ARG OPENCV_VERSION=5.0.0
 
 ########## Build OpenCV (slim) ##########
-FROM ubuntu:noble AS opencv-builder
+FROM ubuntu:resolute AS opencv-builder
 
 ARG OPENCV_VERSION
 ENV DEBIAN_FRONTEND=noninteractive

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
@@ -97,6 +97,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-native
 # relying on the /usr/lib copy below) because the update-alternatives symlinks that
 # make libopenblas.so.0 resolvable live outside /usr/lib and would otherwise be lost.
 RUN apt-get update && apt-get -y install --no-install-recommends gcc libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# OpenBLAS's own pthread-based internal thread pool crashes (SIGABRT) when called
+# concurrently from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher
+# matches image pairs on multiple threads, each hitting LAPACK/SVD). Force OpenBLAS to
+# stay single-threaded internally; OpenCV's own parallelism is unaffected.
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 RUN echo "\n\
 #include <stdio.h> \n\
@@ -114,10 +119,16 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS final-sdk
 # See test-native above for why these are installed fresh instead of relying on
 # the /usr/lib copy.
 RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# See test-native above: keep OpenBLAS single-threaded to avoid crashing when called
+# from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher).
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS final
 RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# See test-native above: keep OpenBLAS single-threaded to avoid crashing when called
+# from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher).
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/Dockerfile
@@ -92,7 +92,11 @@ RUN --mount=type=cache,target=/root/.ccache \
 
 ########## Smoke test native .so file ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-native
-RUN apt-get update && apt-get -y install --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
+# libopenblas0/liblapacke: runtime deps of libOpenCvSharpExtern.so (linked against
+# OpenBLAS/LAPACKE in the opencv-builder stage). Installed fresh here (rather than
+# relying on the /usr/lib copy below) because the update-alternatives symlinks that
+# make libopenblas.so.0 resolvable live outside /usr/lib and would otherwise be lost.
+RUN apt-get update && apt-get -y install --no-install-recommends gcc libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 RUN echo "\n\
 #include <stdio.h> \n\
@@ -107,9 +111,13 @@ int main(){ \n\
 
 ########## Final images ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS final-sdk
+# See test-native above for why these are installed fresh instead of relying on
+# the /usr/lib copy.
+RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS final
+RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
@@ -115,6 +115,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-native
 # relying on the /usr/lib copy below) because the update-alternatives symlinks that
 # make libopenblas.so.0 resolvable live outside /usr/lib and would otherwise be lost.
 RUN apt-get update && apt-get -y install --no-install-recommends gcc libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# OpenBLAS's own pthread-based internal thread pool crashes (SIGABRT) when called
+# concurrently from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher
+# matches image pairs on multiple threads, each hitting LAPACK/SVD). Force OpenBLAS to
+# stay single-threaded internally; OpenCV's own parallelism is unaffected.
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 RUN echo "\n\
 #include <stdio.h> \n\
@@ -132,6 +137,9 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-dotnet
 # See test-native above for why these are installed fresh instead of relying on
 # the /usr/lib copy.
 RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# See test-native above: keep OpenBLAS single-threaded to avoid crashing when called
+# from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher).
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY src/ /opencvsharp/src/
 COPY test/ /opencvsharp/test/
@@ -146,10 +154,16 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS final-sdk
 # See test-native above for why these are installed fresh instead of relying on
 # the /usr/lib copy.
 RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# See test-native above: keep OpenBLAS single-threaded to avoid crashing when called
+# from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher).
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS final
 RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
+# See test-native above: keep OpenBLAS single-threaded to avoid crashing when called
+# from OpenCV's own parallel_for_ (e.g. stitching's BestOf2NearestMatcher).
+ENV OPENBLAS_NUM_THREADS=1
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
@@ -110,7 +110,11 @@ RUN --mount=type=cache,target=/root/.ccache \
 
 ########## Test native .so file ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-native
-RUN apt-get update && apt-get -y install --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
+# libopenblas0/liblapacke: runtime deps of libOpenCvSharpExtern.so (linked against
+# OpenBLAS/LAPACKE in the opencv-builder stage). Installed fresh here (rather than
+# relying on the /usr/lib copy below) because the update-alternatives symlinks that
+# make libopenblas.so.0 resolvable live outside /usr/lib and would otherwise be lost.
+RUN apt-get update && apt-get -y install --no-install-recommends gcc libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 RUN echo "\n\
 #include <stdio.h> \n\
@@ -125,6 +129,9 @@ int main(){ \n\
 
 ########## Test .NET class libraries ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS test-dotnet
+# See test-native above for why these are installed fresh instead of relying on
+# the /usr/lib copy.
+RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY src/ /opencvsharp/src/
 COPY test/ /opencvsharp/test/
@@ -136,9 +143,13 @@ RUN dotnet test /opencvsharp/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c 
 
 ########## Final images ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS final-sdk
+# See test-native above for why these are installed fresh instead of relying on
+# the /usr/lib copy.
+RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS final
+RUN apt-get update && apt-get -y install --no-install-recommends libopenblas0 liblapacke && rm -rf /var/lib/apt/lists/*
 COPY --from=opencvsharp-builder /usr/lib /usr/lib
 COPY --from=opencvsharp-builder /artifacts /artifacts

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
@@ -2,7 +2,7 @@
 ARG OPENCV_VERSION=5.0.0
 
 ########## Build OpenCV ##########
-FROM ubuntu:noble AS opencv-builder
+FROM ubuntu:resolute AS opencv-builder
 
 ARG OPENCV_VERSION
 ENV DEBIAN_FRONTEND=noninteractive

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
@@ -28,7 +28,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
       git \
       ccache \
       libtbb-dev \
-      libatlas-base-dev \
+      libopenblas-dev \
+      liblapacke-dev \
       libgtk-3-dev \
       libavcodec-dev \
       libavformat-dev \

--- a/src/OpenCvSharpExtern/std_vector_nesting.h
+++ b/src/OpenCvSharpExtern/std_vector_nesting.h
@@ -30,8 +30,10 @@ CVAPI(void) vector_vector_uchar_copy(std::vector<std::vector<uchar> >* vec, ucha
     for (size_t i = 0; i < vec->size(); i++)
     {
         auto& elem = vec->at(i);
+        if (elem.empty())
+            continue;
         void* src = &elem[0];
-        const auto length = sizeof(int) * elem.size();
+        const auto length = sizeof(uchar) * elem.size();
         memcpy(dst[i], src, length);
     }
 }
@@ -68,6 +70,8 @@ CVAPI(void) vector_vector_int_copy(std::vector<std::vector<int> >* vec, int** ds
     for (size_t i = 0; i < vec->size(); i++)
     {
         auto& elem = vec->at(i);
+        if (elem.empty())
+            continue;
         void* src = &elem[0];
         const auto length = sizeof(int) * elem.size();
         memcpy(dst[i], src, length);
@@ -106,6 +110,8 @@ CVAPI(void) vector_vector_double_copy(std::vector<std::vector<double> >* vec, do
     for (size_t i = 0; i < vec->size(); i++)
     {
         std::vector<double>& elem = vec->at(i);
+        if (elem.empty())
+            continue;
         void* src = &elem[0];
         const size_t length = sizeof(double) * elem.size();
         memcpy(dst[i], src, length);

--- a/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
+++ b/test/OpenCvSharp.Analyzers.Tests/OpenCvSharp.Analyzers.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <!-- Override the old CodeAnalysis pulled in transitively by the testing framework -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Follow-ups from the Renovate Dependency Dashboard (#1894):

- Bump `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` 1.1.3 → 1.1.4 in `OpenCvSharp.Analyzers.Tests`
- Bump the `ubuntu` base image tag from `noble` to `resolute` in the two OpenCV/OpenCvSharp build Dockerfiles (`packaging/docker/ubuntu24-dotnet10-opencv5.0.0` and `-slim`)

The `resolute` bump initially broke CI: `libatlas-base-dev` no longer exists on Ubuntu 26.04 (Debian/Ubuntu have been phasing ATLAS out in favor of OpenBLAS for years; `noble` still carried it as a transitional package).

Rather than reaching for an equivalent no-op replacement, this swaps in **`libopenblas-dev` + `liblapacke-dev`** for real acceleration:
- Unlike vcpkg's `openblas` port (used on Windows/macOS/manylinux, which builds with `-DBUILD_WITHOUT_LAPACK=ON -DNOFORTRAN=ON` and therefore can't satisfy OpenCV's LAPACK detection, which requires both `cblas.h` *and* `lapacke.h`), Ubuntu's apt package ships a full Fortran/LAPACK-enabled build.
- Verified locally with an actual OpenCV 5.0.0 cmake configure on `ubuntu:resolute`:
  ```
  Lapack: YES (LAPACK/Generic /usr/lib/x86_64-linux-gnu/libopenblas.so -lm -ldl)
  ```
  (previously this fell back to OpenCV's built-in, unaccelerated implementation, since no BLAS/LAPACK was ever wired up on any platform in this repo)
- Applied to both the full and slim Dockerfiles, since both build LAPACK-consuming modules (`calib`, `ml`, `ptcloud`, ...).
- This only affects the two apt-based Ubuntu Docker images; Windows/macOS/manylinux/linux-arm64 are unaffected and out of scope here (extending OpenBLAS there would need a custom vcpkg overlay port + a Fortran toolchain on every platform — tracked as a possible follow-up, not attempted in this PR).

## Test plan
- [x] `dotnet test` on `OpenCvSharp.Analyzers.Tests` — all 23 tests pass with the bumped package
- [x] Verified locally: full apt package list installs cleanly on `ubuntu:resolute` for both Dockerfiles
- [x] Verified locally: `libopenblas-dev`/`liblapacke-dev` headers resolve via default include paths and real `cblas_dgemm`/`LAPACKE_dgetrf` calls link and execute correctly on both `ubuntu:noble` and `ubuntu:resolute`
- [x] Verified locally: actual OpenCV 5.0.0 `cmake` configure (not full build) against the real build options picks up OpenBLAS as `LAPACK: YES` with no extra cmake flags
- [ ] CI `Docker Test` workflow (full end-to-end image builds + native/.NET smoke tests) — relying on CI for the full build since compiling OpenCV from source locally is too slow to verify end-to-end in this session

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed copying of nested vectors to correctly handle empty inner vectors and use the correct byte size per element, preventing invalid reads/copies.
  * Improved container runtime reliability for OpenCV builds by explicitly installing required OpenBLAS/LAPACKE runtime libraries across test and final stages.
* **Chores**
  * Updated the Ubuntu base image used for OpenCV-related container builds.
  * Swapped OpenCV build dependencies to use OpenBLAS/LAPACKE instead of the prior Atlas-based package.
  * Updated analyzer test tooling by bumping the NuGet package to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->