### PR TITLE
Adopt ArgumentNullException/ArgumentOutOfRangeException/ObjectDisposedException Throw helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ public class SomeClass : Algorithm
 
     public virtual void SomeMethod(InputArray src) {
         ThrowIfDisposed();
-        if (src is null) throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         src.ThrowIfDisposed();
         NativeMethods.HandleException(NativeMethods.<module>_SomeClass_someMethod(RawPtr, src.CvPtr));
         GC.KeepAlive(this);

--- a/src/OpenCvSharp.GdipExtensions/BitmapConverter.cs
+++ b/src/OpenCvSharp.GdipExtensions/BitmapConverter.cs
@@ -21,8 +21,7 @@ public static class BitmapConverter
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             throw new NotSupportedException("Non-Windows OS are not supported");
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var w = src.Width;
         var h = src.Height;
@@ -48,10 +47,8 @@ public static class BitmapConverter
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             throw new NotSupportedException("Non-Windows OS are not supported");
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
         if (dst.IsDisposed)
             throw new ArgumentException("The specified dst is disposed.", nameof(dst));
         if (dst.Depth() != MatType.CV_8U)
@@ -317,8 +314,7 @@ public static class BitmapConverter
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             throw new NotSupportedException("Non-Windows OS are not supported");
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         var pf = src.Channels() switch
         {
             1 => PixelFormat.Format8bppIndexed,
@@ -340,8 +336,7 @@ public static class BitmapConverter
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             throw new NotSupportedException("Non-Windows OS are not supported");
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         src.ThrowIfDisposed();
 
         var bitmap = new Bitmap(src.Width, src.Height, pf);
@@ -360,10 +355,8 @@ public static class BitmapConverter
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             throw new NotSupportedException("Non-Windows OS are not supported");
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
         if (src.IsDisposed)
             throw new ArgumentException("The image is disposed.", nameof(src));
         if (src.Depth() != MatType.CV_8U)

--- a/src/OpenCvSharp.WpfExtensions/BitmapSourceConverter.cs
+++ b/src/OpenCvSharp.WpfExtensions/BitmapSourceConverter.cs
@@ -48,8 +48,7 @@ public static class BitmapSourceConverter
     /// <returns>BitmapSource</returns>
     public static BitmapSource ToBitmapSource(this Bitmap src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         if (Application.Current?.Dispatcher is null)
         {
@@ -104,10 +103,7 @@ public static class BitmapSourceConverter
     /// <returns>IplImage</returns>
     public static Mat ToMat(this BitmapSource src)
     {
-        if (src is null)
-        {
-            throw new ArgumentNullException(nameof(src));
-        }
+        ArgumentNullException.ThrowIfNull(src);
 
         int w = src.PixelWidth;
         int h = src.PixelHeight;
@@ -124,10 +120,8 @@ public static class BitmapSourceConverter
     /// <param name="dst">Output Mat</param>
     public static void ToMat(this BitmapSource src, Mat dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
         if (src.PixelWidth != dst.Width || src.PixelHeight != dst.Height)
             throw new ArgumentException("size of src must be equal to size of dst");
         if (dst.Dims > 2)
@@ -241,8 +235,7 @@ public static class BitmapSourceConverter
     /// <returns></returns>
     public static void CopyFrom(this Mat mat, BitmapSource wb)
     {
-        if (wb is null)
-            throw new ArgumentNullException(nameof(wb));
+        ArgumentNullException.ThrowIfNull(wb);
 
         ToMat(wb, mat);
     }

--- a/src/OpenCvSharp.WpfExtensions/WriteableBitmapConverter.cs
+++ b/src/OpenCvSharp.WpfExtensions/WriteableBitmapConverter.cs
@@ -166,8 +166,7 @@ public static class WriteableBitmapConverter
     public static WriteableBitmap ToWriteableBitmap(this Mat src, double dpiX, double dpiY, PixelFormat pf,
         BitmapPalette? bp)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         
         var wb = new WriteableBitmap(src.Width, src.Height, dpiX, dpiY, pf, bp);
         ToWriteableBitmap(src, wb);
@@ -192,8 +191,7 @@ public static class WriteableBitmapConverter
     /// <returns>WriteableBitmap</returns>
     public static WriteableBitmap ToWriteableBitmap(this Mat src)
     {
-        if (src is null) 
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         PixelFormat pf = GetOptimumPixelFormats(src.Type());
         Mat swappedMat = SwapChannelsIfNeeded(src);
@@ -216,10 +214,8 @@ public static class WriteableBitmapConverter
     /// <param name="dst">Output WriteableBitmap</param>
     public static void ToWriteableBitmap(Mat src, WriteableBitmap dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
         if (src.Width != dst.PixelWidth || src.Height != dst.PixelHeight)
             throw new ArgumentException("size of src must be equal to size of dst");
         //if (src.Depth != BitDepth.U8)
@@ -332,8 +328,7 @@ public static class WriteableBitmapConverter
     /// <returns>IplImage</returns>
     public static Mat ToMat(this WriteableBitmap src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var w = src.PixelWidth;
         var h = src.PixelHeight;
@@ -350,10 +345,8 @@ public static class WriteableBitmapConverter
     /// <param name="dst">Output Mat</param>
     public static void ToMat(this WriteableBitmap src, Mat dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
         if (src.PixelWidth != dst.Width || src.PixelHeight != dst.Height)
             throw new ArgumentException("size of src must be equal to size of dst");
         //if (dst.Depth != BitDepth.U8)

--- a/src/OpenCvSharp/Cv2/Cv2_calib.FishEye.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.FishEye.cs
@@ -234,10 +234,8 @@ static partial class Cv2
             out IEnumerable<Mat> rvecs, out IEnumerable<Mat> tvecs,
             FishEyeCalibrationFlags flags = 0, TermCriteria? criteria = null)
         {
-            if (objectPoints is null)
-                throw new ArgumentNullException(nameof(objectPoints));
-            if (imagePoints is null)
-                throw new ArgumentNullException(nameof(imagePoints));
+            ArgumentNullException.ThrowIfNull(objectPoints);
+            ArgumentNullException.ThrowIfNull(imagePoints);
 
             var criteriaVal = criteria.GetValueOrDefault(
                 new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
@@ -339,12 +337,9 @@ static partial class Cv2
             OutputArray r, OutputArray t, FishEyeCalibrationFlags flags = FishEyeCalibrationFlags.FixIntrinsic,
             TermCriteria? criteria = null)
         {
-            if (objectPoints is null)
-                throw new ArgumentNullException(nameof(objectPoints));
-            if (imagePoints1 is null)
-                throw new ArgumentNullException(nameof(imagePoints1));
-            if (imagePoints2 is null)
-                throw new ArgumentNullException(nameof(imagePoints2));
+            ArgumentNullException.ThrowIfNull(objectPoints);
+            ArgumentNullException.ThrowIfNull(imagePoints1);
+            ArgumentNullException.ThrowIfNull(imagePoints2);
 
             var criteriaVal = criteria.GetValueOrDefault(
                 new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));

--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -28,10 +28,8 @@ static partial class Cv2
         Size imageSize,
         double aspectRatio = 1.0)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
 
         var objectPointsPtrs = objectPoints.Select(x => x.CvPtr).ToArray();
         var imagePointsPtrs = imagePoints.Select(x => x.CvPtr).ToArray();
@@ -58,10 +56,8 @@ static partial class Cv2
         Size imageSize,
         double aspectRatio = 1.0)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
 
         using var opArray = new ArrayAddress2<Point3f>(objectPoints);
         using var ipArray = new ArrayAddress2<Point2f>(imagePoints);
@@ -206,10 +202,8 @@ static partial class Cv2
         CalibrationFlags flags = CalibrationFlags.None,
         TermCriteria? criteria = null)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
 
         var criteria0 = criteria.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, Double.Epsilon));
@@ -270,14 +264,10 @@ static partial class Cv2
         CalibrationFlags flags = CalibrationFlags.None,
         TermCriteria? criteria = null)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
-        if (distCoeffs is null)
-            throw new ArgumentNullException(nameof(distCoeffs));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
+        ArgumentNullException.ThrowIfNull(distCoeffs);
 
         var criteria0 = criteria.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, Double.Epsilon));
@@ -335,14 +325,10 @@ static partial class Cv2
         InputOutputArray r, InputOutputArray t, OutputArray e, OutputArray f,
         OutputArray perViewErrors, CalibrationFlags flags = CalibrationFlags.None, TermCriteria? criteria = null)
     {
-        if (objectPoints1 is null)
-            throw new ArgumentNullException(nameof(objectPoints1));
-        if (objectPoints2 is null)
-            throw new ArgumentNullException(nameof(objectPoints2));
-        if (imagePoints1 is null)
-            throw new ArgumentNullException(nameof(imagePoints1));
-        if (imagePoints2 is null)
-            throw new ArgumentNullException(nameof(imagePoints2));
+        ArgumentNullException.ThrowIfNull(objectPoints1);
+        ArgumentNullException.ThrowIfNull(objectPoints2);
+        ArgumentNullException.ThrowIfNull(imagePoints1);
+        ArgumentNullException.ThrowIfNull(imagePoints2);
 
         var criteria0 = criteria.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, 1e-6));
@@ -405,12 +391,9 @@ static partial class Cv2
         CalibrationFlags flags = CalibrationFlags.None,
         TermCriteria? criteria = null)
     {
-        if (objPoints is null)
-            throw new ArgumentNullException(nameof(objPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
-        if (imageSize is null)
-            throw new ArgumentNullException(nameof(imageSize));
+        ArgumentNullException.ThrowIfNull(objPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
+        ArgumentNullException.ThrowIfNull(imageSize);
 
         var criteria0 = criteria.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, double.Epsilon));
@@ -486,12 +469,9 @@ static partial class Cv2
         CalibrationFlags flags = CalibrationFlags.FixIntrinsic,
         TermCriteria? criteria = null)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints1 is null)
-            throw new ArgumentNullException(nameof(imagePoints1));
-        if (imagePoints2 is null)
-            throw new ArgumentNullException(nameof(imagePoints2));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints1);
+        ArgumentNullException.ThrowIfNull(imagePoints2);
 
         var opPtrs = objectPoints.Select(x => x.CvPtr).ToArray();
         var ip1Ptrs = imagePoints1.Select(x => x.CvPtr).ToArray();
@@ -554,20 +534,13 @@ static partial class Cv2
         CalibrationFlags flags = CalibrationFlags.FixIntrinsic,
         TermCriteria? criteria = null)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints1 is null)
-            throw new ArgumentNullException(nameof(imagePoints1));
-        if (imagePoints2 is null)
-            throw new ArgumentNullException(nameof(imagePoints2));
-        if (cameraMatrix1 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix1));
-        if (distCoeffs1 is null)
-            throw new ArgumentNullException(nameof(distCoeffs1));
-        if (cameraMatrix2 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix2));
-        if (distCoeffs2 is null)
-            throw new ArgumentNullException(nameof(distCoeffs2));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints1);
+        ArgumentNullException.ThrowIfNull(imagePoints2);
+        ArgumentNullException.ThrowIfNull(cameraMatrix1);
+        ArgumentNullException.ThrowIfNull(distCoeffs1);
+        ArgumentNullException.ThrowIfNull(cameraMatrix2);
+        ArgumentNullException.ThrowIfNull(distCoeffs2);
 
         var criteria0 = criteria.GetValueOrDefault(
             new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, 1e-6));
@@ -642,14 +615,10 @@ static partial class Cv2
         OutputArray t_cam2gripper,
         HandEyeCalibrationMethod method = HandEyeCalibrationMethod.TSAI)
     {
-        if (R_gripper2base is null)
-            throw new ArgumentNullException(nameof(R_gripper2base));
-        if (t_gripper2base is null)
-            throw new ArgumentNullException(nameof(t_gripper2base));
-        if (R_target2cam is null)
-            throw new ArgumentNullException(nameof(R_target2cam));
-        if (t_target2cam is null)
-            throw new ArgumentNullException(nameof(t_target2cam));
+        ArgumentNullException.ThrowIfNull(R_gripper2base);
+        ArgumentNullException.ThrowIfNull(t_gripper2base);
+        ArgumentNullException.ThrowIfNull(R_target2cam);
+        ArgumentNullException.ThrowIfNull(t_target2cam);
 
         var R_gripper2baseArray = R_gripper2base as Mat[] ?? R_gripper2base.ToArray();
         var t_gripper2baseArray = t_gripper2base as Mat[] ?? t_gripper2base.ToArray();
@@ -726,14 +695,10 @@ static partial class Cv2
         OutputArray t_gripper2cam,
         RobotWorldHandEyeCalibrationMethod method = RobotWorldHandEyeCalibrationMethod.SHAH)
     {
-        if (R_world2cam is null)
-            throw new ArgumentNullException(nameof(R_world2cam));
-        if (t_world2cam is null)
-            throw new ArgumentNullException(nameof(t_world2cam));
-        if (R_base2gripper is null)
-            throw new ArgumentNullException(nameof(R_base2gripper));
-        if (t_base2gripper is null)
-            throw new ArgumentNullException(nameof(t_base2gripper));
+        ArgumentNullException.ThrowIfNull(R_world2cam);
+        ArgumentNullException.ThrowIfNull(t_world2cam);
+        ArgumentNullException.ThrowIfNull(R_base2gripper);
+        ArgumentNullException.ThrowIfNull(t_base2gripper);
         var R_world2camArray = R_world2cam as Mat[] ?? R_world2cam.ToArray();
         var t_world2camArray = t_world2cam as Mat[] ?? t_world2cam.ToArray();
         var R_base2gripperArray = R_base2gripper as Mat[] ?? R_base2gripper.ToArray();
@@ -805,14 +770,10 @@ static partial class Cv2
         out double[] t_gripper2cam,
         RobotWorldHandEyeCalibrationMethod method = RobotWorldHandEyeCalibrationMethod.SHAH)
     {
-        if (R_world2cam is null)
-            throw new ArgumentNullException(nameof(R_world2cam));
-        if (t_world2cam is null)
-            throw new ArgumentNullException(nameof(t_world2cam));
-        if (R_base2gripper is null)
-            throw new ArgumentNullException(nameof(R_base2gripper));
-        if (t_base2gripper is null)
-            throw new ArgumentNullException(nameof(t_base2gripper));
+        ArgumentNullException.ThrowIfNull(R_world2cam);
+        ArgumentNullException.ThrowIfNull(t_world2cam);
+        ArgumentNullException.ThrowIfNull(R_base2gripper);
+        ArgumentNullException.ThrowIfNull(t_base2gripper);
         var R_world2camArray = R_world2cam as Mat[] ?? R_world2cam.ToArray();
         var t_world2camArray = t_world2cam as Mat[] ?? t_world2cam.ToArray();
         var R_base2gripperArray = R_base2gripper as Mat[] ?? R_base2gripper.ToArray();

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -284,8 +284,7 @@ public static partial class Cv2
     /// and the same depth as lut</param>
     public static void LUT(InputArray src, byte[] lut, OutputArray dst)
     {
-        if (lut is null)
-            throw new ArgumentNullException(nameof(lut));
+        ArgumentNullException.ThrowIfNull(lut);
         if (lut.Length != 256)
             throw new ArgumentException("lut.Length != 256");
 
@@ -626,10 +625,8 @@ public static partial class Cv2
     public static void MinMaxIdx(InputArray src, out double minVal, out double maxVal,
         int[] minIdx, int[] maxIdx, InputArray mask = default)
     {
-        if (minIdx is null)
-            throw new ArgumentNullException(nameof(minIdx));
-        if (maxIdx is null)
-            throw new ArgumentNullException(nameof(maxIdx));
+        ArgumentNullException.ThrowIfNull(minIdx);
+        ArgumentNullException.ThrowIfNull(maxIdx);
 
         NativeMethods.HandleException(
             NativeMethods.core_minMaxIdx2(
@@ -668,8 +665,7 @@ public static partial class Cv2
     {
         if (mv.Length == 0)
             throw new ArgumentException("mv is empty", nameof(mv));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(dst);
 
         Span<IntPtr> handles = mv.Length <= MaxStackAllocHandles
             ? stackalloc IntPtr[mv.Length]
@@ -700,8 +696,7 @@ public static partial class Cv2
     /// The arrays themselves will be reallocated if needed</param>
     public static void Split(Mat src, out Mat[] mv)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         src.ThrowIfDisposed();
 
         using var vec = new VectorOfMat();
@@ -732,8 +727,7 @@ public static partial class Cv2
     /// <param name="fromTo"></param>
     public static void MixChannels(ReadOnlySpan<Mat> src, ReadOnlySpan<Mat> dst, int[] fromTo)
     {
-        if (fromTo is null)
-            throw new ArgumentNullException(nameof(fromTo));
+        ArgumentNullException.ThrowIfNull(fromTo);
         if (src.Length == 0)
             throw new ArgumentException("Length == 0", nameof(src));
         if (dst.Length == 0)
@@ -854,8 +848,7 @@ public static partial class Cv2
     /// <returns></returns>
     public static Mat Repeat(Mat src, int ny, int nx)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         src.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1131,12 +1124,9 @@ public static partial class Cv2
     /// <param name="dst"></param>
     public static void Min(Mat src1, Mat src2, Mat dst)
     {
-        if (src1 is null)
-            throw new ArgumentNullException(nameof(src1));
-        if (src2 is null)
-            throw new ArgumentNullException(nameof(src2));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src1);
+        ArgumentNullException.ThrowIfNull(src2);
+        ArgumentNullException.ThrowIfNull(dst);
         src1.ThrowIfDisposed();
         src2.ThrowIfDisposed();
         dst.ThrowIfDisposed();
@@ -1157,10 +1147,8 @@ public static partial class Cv2
     /// <param name="dst"></param>
     public static void Min(Mat src1, double src2, Mat dst)
     {
-        if (src1 is null)
-            throw new ArgumentNullException(nameof(src1));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src1);
+        ArgumentNullException.ThrowIfNull(dst);
         src1.ThrowIfDisposed();
         dst.ThrowIfDisposed();
 
@@ -1195,12 +1183,9 @@ public static partial class Cv2
     /// <param name="dst"></param>
     public static void Max(Mat src1, Mat src2, Mat dst)
     {
-        if (src1 is null)
-            throw new ArgumentNullException(nameof(src1));
-        if (src2 is null)
-            throw new ArgumentNullException(nameof(src2));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src1);
+        ArgumentNullException.ThrowIfNull(src2);
+        ArgumentNullException.ThrowIfNull(dst);
         src1.ThrowIfDisposed();
         src2.ThrowIfDisposed();
         dst.ThrowIfDisposed();
@@ -1221,10 +1206,8 @@ public static partial class Cv2
     /// <param name="dst"></param>
     public static void Max(Mat src1, double src2, Mat dst)
     {
-        if (src1 is null)
-            throw new ArgumentNullException(nameof(src1));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src1);
+        ArgumentNullException.ThrowIfNull(dst);
         src1.ThrowIfDisposed();
         dst.ThrowIfDisposed();
 
@@ -1521,10 +1504,8 @@ public static partial class Cv2
     /// <returns>The destination array; it will have the same size and same type as src</returns>
     public static Point2f[] PerspectiveTransform(IEnumerable<Point2f> src, Mat m)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(m);
 
         using var srcMat = Mat.FromArray(src);
         using var dstMat = new Mat<Point2f>();
@@ -1545,10 +1526,8 @@ public static partial class Cv2
     /// <returns>The destination array; it will have the same size and same type as src</returns>
     public static Point2d[] PerspectiveTransform(IEnumerable<Point2d> src, Mat m)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(m);
 
         using var srcMat = Mat.FromArray(src);
         using var dstMat = new Mat<Point2d>();
@@ -1569,10 +1548,8 @@ public static partial class Cv2
     /// <returns>The destination array; it will have the same size and same type as src</returns>
     public static Point3f[] PerspectiveTransform(IEnumerable<Point3f> src, Mat m)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(m);
 
         using var srcMat = Mat.FromArray(src);
         using var dstMat = new Mat<Point3f>();
@@ -1593,10 +1570,8 @@ public static partial class Cv2
     /// <returns>The destination array; it will have the same size and same type as src</returns>
     public static Point3d[] PerspectiveTransform(IEnumerable<Point3d> src, Mat m)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(m);
 
         using var srcMat = Mat.FromArray(src);
         using var dstMat = new Mat<Point3d>();
@@ -1840,10 +1815,8 @@ public static partial class Cv2
         ReadOnlySpan<Mat> samples, Mat covar, Mat mean,
         CovarFlags flags, MatType? ctype = null)
     {
-        if (covar is null)
-            throw new ArgumentNullException(nameof(covar));
-        if (mean is null)
-            throw new ArgumentNullException(nameof(mean));
+        ArgumentNullException.ThrowIfNull(covar);
+        ArgumentNullException.ThrowIfNull(mean);
         covar.ThrowIfDisposed();
         mean.ThrowIfDisposed();
 
@@ -2754,8 +2727,7 @@ public static partial class Cv2
     /// <returns></returns>
     public static MatExpr Abs(Mat src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         return MatExpr.From(src).Abs();
     }
         
@@ -2782,10 +2754,8 @@ public static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static int Partition<T>(IEnumerable<T> vec, out int[] labels, PartitionPredicate<T> predicate)
     {
-        if (vec is null) 
-            throw new ArgumentNullException(nameof(vec));
-        if (predicate is null) 
-            throw new ArgumentNullException(nameof(predicate));
+        ArgumentNullException.ThrowIfNull(vec);
+        ArgumentNullException.ThrowIfNull(predicate);
 
         var vecArray = vec as T[] ?? vec.ToArray();
         labels = new int[vecArray.Length];

--- a/src/OpenCvSharp/Cv2/Cv2_features.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_features.cs
@@ -81,8 +81,7 @@ static partial class Cv2
         Scalar? color = null,
         DrawMatchesFlags flags = DrawMatchesFlags.Default)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         var keypointsArray = keypoints.CastOrToArray();
         var color0 = color.GetValueOrDefault(Scalar.All(-1));
@@ -122,18 +121,12 @@ static partial class Cv2
         IEnumerable<byte>? matchesMask = null,
         DrawMatchesFlags flags = DrawMatchesFlags.Default)
     {
-        if (img1 is null)
-            throw new ArgumentNullException(nameof(img1));
-        if (img2 is null)
-            throw new ArgumentNullException(nameof(img2));
-        if (outImg is null)
-            throw new ArgumentNullException(nameof(outImg));
-        if (keypoints1 is null)
-            throw new ArgumentNullException(nameof(keypoints1));
-        if (keypoints2 is null)
-            throw new ArgumentNullException(nameof(keypoints2));
-        if (matches1To2 is null)
-            throw new ArgumentNullException(nameof(matches1To2));
+        ArgumentNullException.ThrowIfNull(img1);
+        ArgumentNullException.ThrowIfNull(img2);
+        ArgumentNullException.ThrowIfNull(outImg);
+        ArgumentNullException.ThrowIfNull(keypoints1);
+        ArgumentNullException.ThrowIfNull(keypoints2);
+        ArgumentNullException.ThrowIfNull(matches1To2);
         img1.ThrowIfDisposed();
         img2.ThrowIfDisposed();
         outImg.ThrowIfDisposed();
@@ -188,18 +181,12 @@ static partial class Cv2
         IEnumerable<IEnumerable<byte>>? matchesMask = null,
         DrawMatchesFlags flags = DrawMatchesFlags.Default)
     {
-        if (img1 is null)
-            throw new ArgumentNullException(nameof(img1));
-        if (img2 is null)
-            throw new ArgumentNullException(nameof(img2));
-        if (outImg is null)
-            throw new ArgumentNullException(nameof(outImg));
-        if (keypoints1 is null)
-            throw new ArgumentNullException(nameof(keypoints1));
-        if (keypoints2 is null)
-            throw new ArgumentNullException(nameof(keypoints2));
-        if (matches1To2 is null)
-            throw new ArgumentNullException(nameof(matches1To2));
+        ArgumentNullException.ThrowIfNull(img1);
+        ArgumentNullException.ThrowIfNull(img2);
+        ArgumentNullException.ThrowIfNull(outImg);
+        ArgumentNullException.ThrowIfNull(keypoints1);
+        ArgumentNullException.ThrowIfNull(keypoints2);
+        ArgumentNullException.ThrowIfNull(matches1To2);
         img1.ThrowIfDisposed();
         img2.ThrowIfDisposed();
         outImg.ThrowIfDisposed();
@@ -257,16 +244,11 @@ static partial class Cv2
         ref KeyPoint[] keypoints1, ref KeyPoint[] keypoints2,
         out float repeatability, out int correspCount)
     {
-        if (img1 is null) 
-            throw new ArgumentNullException(nameof(img1));
-        if (img2 is null) 
-            throw new ArgumentNullException(nameof(img2));
-        if (H1to2 is null) 
-            throw new ArgumentNullException(nameof(H1to2));
-        if (keypoints1 is null) 
-            throw new ArgumentNullException(nameof(keypoints1));
-        if (keypoints2 is null) 
-            throw new ArgumentNullException(nameof(keypoints2));
+        ArgumentNullException.ThrowIfNull(img1);
+        ArgumentNullException.ThrowIfNull(img2);
+        ArgumentNullException.ThrowIfNull(H1to2);
+        ArgumentNullException.ThrowIfNull(keypoints1);
+        ArgumentNullException.ThrowIfNull(keypoints2);
 
         using var keypoints1Vec = new StdVector<KeyPoint>(keypoints1);
         using var keypoints2Vec = new StdVector<KeyPoint>(keypoints2);
@@ -291,10 +273,8 @@ static partial class Cv2
     public static Point2f[] ComputeRecallPrecisionCurve(
         DMatch[][] matches1to2, byte[][] correctMatches1to2Mask)
     {
-        if (matches1to2 is null)
-            throw new ArgumentNullException(nameof(matches1to2));
-        if (correctMatches1to2Mask is null)
-            throw new ArgumentNullException(nameof(correctMatches1to2Mask));
+        ArgumentNullException.ThrowIfNull(matches1to2);
+        ArgumentNullException.ThrowIfNull(correctMatches1to2Mask);
 
         using var dm = new ArrayAddress2<DMatch>(matches1to2);
         using var cm = new ArrayAddress2<byte>(correctMatches1to2Mask);
@@ -316,8 +296,7 @@ static partial class Cv2
     public static float GetRecall(
         IEnumerable<Point2f> recallPrecisionCurve, float lPrecision)
     {
-        if (recallPrecisionCurve is null)
-            throw new ArgumentNullException(nameof(recallPrecisionCurve));
+        ArgumentNullException.ThrowIfNull(recallPrecisionCurve);
 
         var recallPrecisionCurveArray = recallPrecisionCurve.CastOrToArray();
         NativeMethods.HandleException( 
@@ -335,8 +314,7 @@ static partial class Cv2
     public static int GetNearestPoint(
         IEnumerable<Point2f> recallPrecisionCurve, float lPrecision)
     {
-        if (recallPrecisionCurve is null)
-            throw new ArgumentNullException(nameof(recallPrecisionCurve));
+        ArgumentNullException.ThrowIfNull(recallPrecisionCurve);
 
         var recallPrecisionCurveArray = recallPrecisionCurve.CastOrToArray();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Cv2/Cv2_geometry.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_geometry.cs
@@ -37,8 +37,7 @@ static partial class Cv2
     /// <param name="jacobian">Optional output Jacobian matrix, 3x9, which is a matrix of partial derivatives of the output array components with respect to the input array components.</param>
     public static void Rodrigues(double[] vector, out double[,] matrix, out double[,] jacobian)
     {
-        if (vector is null)
-            throw new ArgumentNullException(nameof(vector));
+        ArgumentNullException.ThrowIfNull(vector);
         if (vector.Length != 3)
             throw new ArgumentException("Length != 3", nameof(vector));
 
@@ -58,8 +57,7 @@ static partial class Cv2
     /// <param name="jacobian">Optional output Jacobian matrix, 3x9, which is a matrix of partial derivatives of the output array components with respect to the input array components.</param>
     public static void Rodrigues(double[,] matrix, out double[] vector, out double[,] jacobian)
     {
-        if (matrix is null)
-            throw new ArgumentNullException(nameof(matrix));
+        ArgumentNullException.ThrowIfNull(matrix);
         if (matrix.GetLength(0) != 3 || matrix.GetLength(1) != 3)
             throw new ArgumentException("matrix must be double[3,3]");
 
@@ -124,10 +122,8 @@ static partial class Cv2
         int maxIters = 2000,
         double confidence = 0.995)
     {
-        if (srcPoints is null)
-            throw new ArgumentNullException(nameof(srcPoints));
-        if (dstPoints is null)
-            throw new ArgumentNullException(nameof(dstPoints));
+        ArgumentNullException.ThrowIfNull(srcPoints);
+        ArgumentNullException.ThrowIfNull(dstPoints);
 
         var srcPointsArray = srcPoints as Point2d[] ?? srcPoints.ToArray();
         var dstPointsArray = dstPoints as Point2d[] ?? dstPoints.ToArray();
@@ -219,8 +215,7 @@ static partial class Cv2
     public static Vec3d RQDecomp3x3(double[,] src, out double[,] mtxR, out double[,] mtxQ,
         out double[,] qx, out double[,] qy, out double[,] qz)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
         if (src.GetLength(0) != 3 || src.GetLength(1) != 3)
             throw new ArgumentException("src must be double[3,3]");
 
@@ -300,8 +295,7 @@ static partial class Cv2
         out double[,] rotMatrixZ,
         out double[] eulerAngles)
     {
-        if (projMatrix is null)
-            throw new ArgumentNullException(nameof(projMatrix));
+        ArgumentNullException.ThrowIfNull(projMatrix);
         var dim0 = projMatrix.GetLength(0);
         var dim1 = projMatrix.GetLength(1);
         if (!((dim0 == 3 && dim1 == 4) || (dim0 == 4 && dim1 == 3)))
@@ -438,14 +432,10 @@ static partial class Cv2
         out double[,] dt3dr1, out double[,] dt3dt1,
         out double[,] dt3dr2, out double[,] dt3dt2)
     {
-        if (rvec1 is null)
-            throw new ArgumentNullException(nameof(rvec1));
-        if (tvec1 is null)
-            throw new ArgumentNullException(nameof(tvec1));
-        if (rvec2 is null)
-            throw new ArgumentNullException(nameof(rvec2));
-        if (tvec2 is null)
-            throw new ArgumentNullException(nameof(tvec2));
+        ArgumentNullException.ThrowIfNull(rvec1);
+        ArgumentNullException.ThrowIfNull(tvec1);
+        ArgumentNullException.ThrowIfNull(rvec2);
+        ArgumentNullException.ThrowIfNull(tvec2);
 
         using var rvec1M = Mat.FromPixelData(3, 1, MatType.CV_64FC1, rvec1);
         using var tvec1M = Mat.FromPixelData(3, 1, MatType.CV_64FC1, tvec1);
@@ -579,18 +569,14 @@ static partial class Cv2
         out double[,] jacobian,
         double aspectRatio = 0)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (rvec is null)
-            throw new ArgumentNullException(nameof(rvec));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(rvec);
         if (rvec.Length != 3)
             throw new ArgumentException($"{nameof(rvec)}.Length != 3");
-        if (tvec is null)
-            throw new ArgumentNullException(nameof(tvec));
+        ArgumentNullException.ThrowIfNull(tvec);
         if (tvec.Length != 3)
             throw new ArgumentException($"{nameof(tvec)}.Length != 3");
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
         if (cameraMatrix.GetLength(0) != 3 || cameraMatrix.GetLength(1) != 3)
             throw new ArgumentException("cameraMatrix must be double[3,3]");
 
@@ -675,12 +661,9 @@ static partial class Cv2
         bool useExtrinsicGuess = false,
         SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
         if (cameraMatrix.GetLength(0) != 3 || cameraMatrix.GetLength(1) != 3)
             throw new ArgumentException("");
 
@@ -814,12 +797,9 @@ static partial class Cv2
         double confidence = 0.99,
         SolvePnPMethod flags = SolvePnPMethod.Iterative)
     {
-        if (objectPoints is null)
-            throw new ArgumentNullException(nameof(objectPoints));
-        if (imagePoints is null)
-            throw new ArgumentNullException(nameof(imagePoints));
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
 
         if (cameraMatrix.GetLength(0) != 3 || cameraMatrix.GetLength(1) != 3)
             throw new ArgumentException($"Size of {nameof(cameraMatrix)} must be 3x3");
@@ -890,8 +870,7 @@ static partial class Cv2
         out double fovx, out double fovy, out double focalLength,
         out Point2d principalPoint, out double aspectRatio)
     {
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
         if (cameraMatrix.GetLength(0) != 3 || cameraMatrix.GetLength(1) != 3)
             throw new ArgumentException("cameraMatrix must be 3x3");
 
@@ -961,10 +940,8 @@ static partial class Cv2
         Size imageSize, double alpha, Size newImgSize,
         out Rect validPixROI, bool centerPrincipalPoint = false)
     {
-        if (cameraMatrix is null)
-            throw new ArgumentNullException(nameof(cameraMatrix));
-        if (distCoeffs is null)
-            throw new ArgumentNullException(nameof(distCoeffs));
+        ArgumentNullException.ThrowIfNull(cameraMatrix);
+        ArgumentNullException.ThrowIfNull(distCoeffs);
 
         IntPtr matPtr;
         unsafe
@@ -1007,8 +984,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Vec3f[] ConvertPointsToHomogeneous(IEnumerable<Vec2f> src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var srcA = src as Vec2f[] ?? src.ToArray();
         var dstA = new Vec3f[srcA.Length];
@@ -1025,8 +1001,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Vec4f[] ConvertPointsToHomogeneous(IEnumerable<Vec3f> src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var srcA = src as Vec3f[] ?? src.ToArray();
         var dstA = new Vec4f[srcA.Length];
@@ -1055,8 +1030,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Vec2f[] ConvertPointsFromHomogeneous(IEnumerable<Vec3f> src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var srcA = src as Vec3f[] ?? src.ToArray();
         var dstA = new Vec2f[srcA.Length];
@@ -1073,8 +1047,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Vec3f[] ConvertPointsFromHomogeneous(IEnumerable<Vec4f> src)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var srcA = src as Vec4f[] ?? src.ToArray();
         var dstA = new Vec3f[srcA.Length];
@@ -1151,10 +1124,8 @@ static partial class Cv2
         double param2 = 0.99,
         OutputArray mask = default)
     {
-        if (points1 is null)
-            throw new ArgumentNullException(nameof(points1));
-        if (points2 is null)
-            throw new ArgumentNullException(nameof(points2));
+        ArgumentNullException.ThrowIfNull(points1);
+        ArgumentNullException.ThrowIfNull(points2);
 
         var points1Array = points1 as Point2f[] ?? points1.ToArray();
         var points2Array = points2 as Point2f[] ?? points2.ToArray();
@@ -1192,10 +1163,8 @@ static partial class Cv2
         double param2 = 0.99,
         OutputArray mask = default)
     {
-        if (points1 is null)
-            throw new ArgumentNullException(nameof(points1));
-        if (points2 is null)
-            throw new ArgumentNullException(nameof(points2));
+        ArgumentNullException.ThrowIfNull(points1);
+        ArgumentNullException.ThrowIfNull(points2);
 
         var points1Array = points1 as Point2d[] ?? points1.ToArray();
         var points2Array = points2 as Point2d[] ?? points2.ToArray();
@@ -1263,10 +1232,8 @@ static partial class Cv2
     public static Point3f[] ComputeCorrespondEpilines(IEnumerable<Point2d> points,
         int whichImage, double[,] F)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
-        if (F is null)
-            throw new ArgumentNullException(nameof(F));
+        ArgumentNullException.ThrowIfNull(points);
+        ArgumentNullException.ThrowIfNull(F);
         if (F.GetLength(0) != 3 && F.GetLength(1) != 3)
             throw new ArgumentException("F != double[3,3]");
 
@@ -1298,10 +1265,8 @@ static partial class Cv2
     public static Point3f[] ComputeCorrespondEpilines(IEnumerable<Point3d> points,
         int whichImage, double[,] F)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
-        if (F is null)
-            throw new ArgumentNullException(nameof(F));
+        ArgumentNullException.ThrowIfNull(points);
+        ArgumentNullException.ThrowIfNull(F);
         if (F.GetLength(0) != 3 && F.GetLength(1) != 3)
             throw new ArgumentException("F != double[3,3]");
 
@@ -1366,14 +1331,10 @@ static partial class Cv2
         IEnumerable<Point2d> projPoints1, 
         IEnumerable<Point2d> projPoints2)
     {
-        if (projMatr1 is null)
-            throw new ArgumentNullException(nameof(projMatr1));
-        if (projMatr2 is null)
-            throw new ArgumentNullException(nameof(projMatr2));
-        if (projPoints1 is null)
-            throw new ArgumentNullException(nameof(projPoints1));
-        if (projPoints2 is null)
-            throw new ArgumentNullException(nameof(projPoints2));
+        ArgumentNullException.ThrowIfNull(projMatr1);
+        ArgumentNullException.ThrowIfNull(projMatr2);
+        ArgumentNullException.ThrowIfNull(projPoints1);
+        ArgumentNullException.ThrowIfNull(projPoints2);
         if (projMatr1.GetLength(0) != 3 && projMatr1.GetLength(1) != 4)
             throw new ArgumentException($"{nameof(projMatr1)} != double[3,4]");
         if (projMatr2.GetLength(0) != 3 && projMatr2.GetLength(1) != 4)
@@ -1438,12 +1399,9 @@ static partial class Cv2
         out Point2d[] newPoints1,
         out Point2d[] newPoints2)
     {
-        if (F is null)
-            throw new ArgumentNullException(nameof(F));
-        if (points1 is null)
-            throw new ArgumentNullException(nameof(points1));
-        if (points2 is null)
-            throw new ArgumentNullException(nameof(points2));
+        ArgumentNullException.ThrowIfNull(F);
+        ArgumentNullException.ThrowIfNull(points1);
+        ArgumentNullException.ThrowIfNull(points2);
 
         var points1Array = points1 as Point2d[] ?? points1.ToArray();
         var points2Array = points2 as Point2d[] ?? points2.ToArray();
@@ -1687,8 +1645,7 @@ static partial class Cv2
     /// <remarks>https://github.com/opencv/opencv/blob/master/modules/calib3d/src/fundam.cpp#L1109</remarks>
     public static double SampsonDistance(Point3d pt1, Point3d pt2, double[,] f)
     {
-        if (f is null)
-            throw new ArgumentNullException(nameof(f));
+        ArgumentNullException.ThrowIfNull(f);
         if (f.GetLength(0) != 3 || f.GetLength(1) != 3)
             throw new ArgumentException("f should be 3x3 matrix", nameof(f));
 
@@ -1823,10 +1780,8 @@ static partial class Cv2
         OutputArray possibleSolutions,
         InputArray pointsMask = default)
     {
-        if (rotations is null)
-            throw new ArgumentNullException(nameof(rotations));
-        if (normals is null)
-            throw new ArgumentNullException(nameof(normals));
+        ArgumentNullException.ThrowIfNull(rotations);
+        ArgumentNullException.ThrowIfNull(normals);
 
         using var rotationsVec = new VectorOfMat(rotations);
         using var normalsVec = new VectorOfMat(normals);
@@ -2133,10 +2088,8 @@ static partial class Cv2
     /// <returns>The edges of the resulting MST, or null if a valid MST could not be built.</returns>
     public static MSTEdge[]? BuildMST(int numNodes, MSTEdge[] inputEdges, MSTAlgorithm algorithm, int root = 0)
     {
-        if (inputEdges is null)
-            throw new ArgumentNullException(nameof(inputEdges));
-        if (numNodes <= 0)
-            throw new ArgumentOutOfRangeException(nameof(numNodes));
+        ArgumentNullException.ThrowIfNull(inputEdges);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numNodes);
 
         var resultingEdges = new MSTEdge[numNodes - 1];
         NativeMethods.HandleException(
@@ -2300,10 +2253,8 @@ static partial class Cv2
     /// <returns></returns>
     public static Mat GetPerspectiveTransform(IEnumerable<Point2f> src, IEnumerable<Point2f> dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
 
         var srcArray = src.ToArray();
         var dstArray = dst.ToArray();
@@ -2339,10 +2290,8 @@ static partial class Cv2
     /// <returns></returns>
     public static Mat GetAffineTransform(IEnumerable<Point2f> src, IEnumerable<Point2f> dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
 
         var srcArray = src.ToArray();
         var dstArray = dst.ToArray();
@@ -2404,8 +2353,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Point[] ApproxPolyDP(IEnumerable<Point> curve, double epsilon, bool closed)
     {
-        if(curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve as Point[] ?? curve.ToArray();
         using var approxCurveVec = new StdVector<Point>();
         NativeMethods.HandleException(
@@ -2428,8 +2376,7 @@ static partial class Cv2
     [SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code")]
     public static Point2f[] ApproxPolyDP(IEnumerable<Point2f> curve, double epsilon, bool closed)
     {
-        if (curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve as Point2f[] ?? curve.ToArray();
         using var approxCurveVec = new StdVector<Point2f>();
         NativeMethods.HandleException(
@@ -2462,8 +2409,7 @@ static partial class Cv2
     /// <returns></returns>
     public static double ArcLength(IEnumerable<Point> curve, bool closed)
     {
-        if (curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve.ToArray();
             
         NativeMethods.HandleException(
@@ -2480,8 +2426,7 @@ static partial class Cv2
     /// <returns></returns>
     public static double ArcLength(IEnumerable<Point2f> curve, bool closed)
     {
-        if (curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve.ToArray();
 
         NativeMethods.HandleException(
@@ -2511,8 +2456,7 @@ static partial class Cv2
     /// <returns>Minimal up-right bounding rectangle for the specified point set.</returns>
     public static Rect BoundingRect(IEnumerable<Point> curve)
     {
-        if (curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve.ToArray();
 
         NativeMethods.HandleException(
@@ -2528,8 +2472,7 @@ static partial class Cv2
     /// <returns>Minimal up-right bounding rectangle for the specified point set.</returns>
     public static Rect BoundingRect(IEnumerable<Point2f> curve)
     {
-        if (curve is null)
-            throw new ArgumentNullException(nameof(curve));
+        ArgumentNullException.ThrowIfNull(curve);
         var curveArray = curve.ToArray();
 
         NativeMethods.HandleException(
@@ -2561,8 +2504,7 @@ static partial class Cv2
     /// <returns></returns>
     public static double ContourArea(IEnumerable<Point> contour, bool oriented = false)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
 
         NativeMethods.HandleException(
@@ -2579,8 +2521,7 @@ static partial class Cv2
     /// <returns></returns>
     public static double ContourArea(IEnumerable<Point2f> contour, bool oriented = false)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
 
         NativeMethods.HandleException(
@@ -2610,8 +2551,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect MinAreaRect(IEnumerable<Point> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -2627,8 +2567,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect MinAreaRect(IEnumerable<Point2f> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -2696,8 +2635,7 @@ static partial class Cv2
     /// <param name="radius">The output radius of the circle</param>
     public static void MinEnclosingCircle(IEnumerable<Point> points, out Point2f center, out float radius)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         NativeMethods.HandleException(
             NativeMethods.geometry_minEnclosingCircle_Point(pointsArray, pointsArray.Length, out center, out radius));
@@ -2712,8 +2650,7 @@ static partial class Cv2
     /// <param name="radius">The output radius of the circle</param>
     public static void MinEnclosingCircle(IEnumerable<Point2f> points, out Point2f center, out float radius)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         NativeMethods.HandleException(
             NativeMethods.geometry_minEnclosingCircle_Point2f(pointsArray, pointsArray.Length, out center, out radius));
@@ -2745,8 +2682,7 @@ static partial class Cv2
     /// <returns>Triangle area</returns>
     public static double MinEnclosingTriangle(IEnumerable<Point> points, out Point2f[] triangle)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
 
         var pointsArray = points.ToArray();
         using var triangleVec = new StdVector<Point2f>();
@@ -2768,8 +2704,7 @@ static partial class Cv2
     /// <returns>Triangle area</returns>
     public static double MinEnclosingTriangle(IEnumerable<Point2f> points, out Point2f[] triangle)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
 
         var pointsArray = points.ToArray();
         using var triangleVec = new StdVector<Point2f>();
@@ -2813,10 +2748,8 @@ static partial class Cv2
     public static double MatchShapes(IEnumerable<Point> contour1, IEnumerable<Point> contour2,
         ShapeMatchModes method, double parameter = 0)
     {
-        if (contour1 is null)
-            throw new ArgumentNullException(nameof(contour1));
-        if (contour2 is null)
-            throw new ArgumentNullException(nameof(contour2));
+        ArgumentNullException.ThrowIfNull(contour1);
+        ArgumentNullException.ThrowIfNull(contour2);
         var contour1Array = contour1.ToArray();
         var contour2Array = contour2.ToArray();
 
@@ -2864,8 +2797,7 @@ static partial class Cv2
     /// the hull (must have the same type as the input points).</returns>
     public static Point[] ConvexHull(IEnumerable<Point> points, bool clockwise = false)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         using var hullVec = new StdVector<Point>();
@@ -2889,8 +2821,7 @@ static partial class Cv2
     /// the hull (must have the same type as the input points).</returns>
     public static Point2f[] ConvexHull(IEnumerable<Point2f> points, bool clockwise = false)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         using var hullVec = new StdVector<Point2f>();
@@ -2913,8 +2844,7 @@ static partial class Cv2
     /// hull points in the original array (since the set of convex hull points is a subset of the original point set).</returns>
     public static int[] ConvexHullIndices(IEnumerable<Point> points, bool clockwise = false)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         using var hullVec = new StdVector<int>();
@@ -2937,8 +2867,7 @@ static partial class Cv2
     /// hull points in the original array (since the set of convex hull points is a subset of the original point set).</returns>
     public static int[] ConvexHullIndices(IEnumerable<Point2f> points, bool clockwise = false)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         using var hullVec = new StdVector<int>();
@@ -2990,10 +2919,8 @@ static partial class Cv2
     /// That is, to get the floating-point value of the depth will be fixpt_depth/256.0. </returns>
     public static Vec4i[] ConvexityDefects(IEnumerable<Point> contour, IEnumerable<int> convexHull)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
-        if (convexHull is null)
-            throw new ArgumentNullException(nameof(convexHull));
+        ArgumentNullException.ThrowIfNull(contour);
+        ArgumentNullException.ThrowIfNull(convexHull);
 
         var contourArray = contour.ToArray();
         var convexHullArray = convexHull.ToArray();
@@ -3022,10 +2949,8 @@ static partial class Cv2
     /// That is, to get the floating-point value of the depth will be fixpt_depth/256.0. </returns>
     public static Vec4i[] ConvexityDefects(IEnumerable<Point2f> contour, IEnumerable<int> convexHull)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
-        if (convexHull is null)
-            throw new ArgumentNullException(nameof(convexHull));
+        ArgumentNullException.ThrowIfNull(contour);
+        ArgumentNullException.ThrowIfNull(convexHull);
 
         var contourArray = contour.ToArray();
         var convexHullArray = convexHull.ToArray();
@@ -3062,8 +2987,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool IsContourConvex(IEnumerable<Point> contour)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
 
         NativeMethods.HandleException(
@@ -3080,8 +3004,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool IsContourConvex(IEnumerable<Point2f> contour)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
 
         NativeMethods.HandleException(
@@ -3122,10 +3045,8 @@ static partial class Cv2
     public static float IntersectConvexConvex(IEnumerable<Point> p1, IEnumerable<Point> p2,
         out Point[] p12, bool handleNested = true)
     {
-        if (p1 is null)
-            throw new ArgumentNullException(nameof(p1));
-        if (p2 is null)
-            throw new ArgumentNullException(nameof(p2));
+        ArgumentNullException.ThrowIfNull(p1);
+        ArgumentNullException.ThrowIfNull(p2);
         var p1Array = p1.ToArray();
         var p2Array = p2.ToArray();
 
@@ -3151,10 +3072,8 @@ static partial class Cv2
     public static float IntersectConvexConvex(IEnumerable<Point2f> p1, IEnumerable<Point2f> p2,
         out Point2f[] p12, bool handleNested = true)
     {
-        if (p1 is null)
-            throw new ArgumentNullException(nameof(p1));
-        if (p2 is null)
-            throw new ArgumentNullException(nameof(p2));
+        ArgumentNullException.ThrowIfNull(p1);
+        ArgumentNullException.ThrowIfNull(p2);
         var p1Array = p1.ToArray();
         var p2Array = p2.ToArray();
 
@@ -3192,8 +3111,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipse(IEnumerable<Point> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3209,8 +3127,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipse(IEnumerable<Point2f> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3249,8 +3166,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipseAMS(IEnumerable<Point> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3270,8 +3186,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipseAMS(IEnumerable<Point2f> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3310,8 +3225,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipseDirect(IEnumerable<Point> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3331,8 +3245,7 @@ static partial class Cv2
     /// <returns></returns>
     public static RotatedRect FitEllipseDirect(IEnumerable<Point2f> points)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
 
         NativeMethods.HandleException(
@@ -3386,8 +3299,7 @@ static partial class Cv2
     public static Line2D FitLine(IEnumerable<Point> points, DistanceTypes distType,
         double param, double reps, double aeps)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         var line = new float[4];
         NativeMethods.HandleException(
@@ -3412,8 +3324,7 @@ static partial class Cv2
     public static Line2D FitLine(IEnumerable<Point2f> points, DistanceTypes distType,
         double param, double reps, double aeps)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         var line = new float[4];
         NativeMethods.HandleException(
@@ -3438,8 +3349,7 @@ static partial class Cv2
     public static Line3D FitLine(IEnumerable<Point3i> points, DistanceTypes distType,
         double param, double reps, double aeps)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         var line = new float[6];
         NativeMethods.HandleException(
@@ -3464,8 +3374,7 @@ static partial class Cv2
     public static Line3D FitLine(IEnumerable<Point3f> points, DistanceTypes distType,
         double param, double reps, double aeps)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
         var pointsArray = points.ToArray();
         var line = new float[6];
         NativeMethods.HandleException(
@@ -3501,8 +3410,7 @@ static partial class Cv2
     /// <returns></returns>
     public static double PointPolygonTest(IEnumerable<Point> contour, Point2f pt, bool measureDist)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
         NativeMethods.HandleException(
             NativeMethods.geometry_pointPolygonTest_Point(
@@ -3523,8 +3431,7 @@ static partial class Cv2
     /// <returns>Positive (inside), negative (outside), or zero (on an edge) value.</returns>
     public static double PointPolygonTest(IEnumerable<Point2f> contour, Point2f pt, bool measureDist)
     {
-        if (contour is null)
-            throw new ArgumentNullException(nameof(contour));
+        ArgumentNullException.ThrowIfNull(contour);
         var contourArray = contour.ToArray();
         NativeMethods.HandleException(
             NativeMethods.geometry_pointPolygonTest_Point2f(

--- a/src/OpenCvSharp/Cv2/Cv2_geometry.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_geometry.cs
@@ -936,12 +936,11 @@ static partial class Cv2
     /// subset of the source image (determined by alpha) to the corrected image.</param>
     /// <returns>optimal new camera matrix</returns>
     public static double[,]? GetOptimalNewCameraMatrix(
-        double[,] cameraMatrix, double[] distCoeffs,
+        double[,] cameraMatrix, double[]? distCoeffs,
         Size imageSize, double alpha, Size newImgSize,
         out Rect validPixROI, bool centerPrincipalPoint = false)
     {
         ArgumentNullException.ThrowIfNull(cameraMatrix);
-        ArgumentNullException.ThrowIfNull(distCoeffs);
 
         IntPtr matPtr;
         unsafe
@@ -950,7 +949,7 @@ static partial class Cv2
             {
                 NativeMethods.HandleException(
                     NativeMethods.geometry_getOptimalNewCameraMatrix_array(
-                        cameraMatrixPtr, distCoeffs, distCoeffs.Length,
+                        cameraMatrixPtr, distCoeffs, distCoeffs?.Length ?? 0,
                         imageSize, alpha, newImgSize,
                         out validPixROI, centerPrincipalPoint ? 1 : 0, out matPtr));
                 if (matPtr == IntPtr.Zero)

--- a/src/OpenCvSharp/Cv2/Cv2_highgui.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_highgui.cs
@@ -138,8 +138,7 @@ static partial class Cv2
     {
         if (string.IsNullOrEmpty(winName))
             throw new ArgumentException("null or empty string.", nameof(winName));
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_imshow(winName, mat.CvPtr));
@@ -259,8 +258,7 @@ static partial class Cv2
     {
         if (string.IsNullOrEmpty(windowName))
             throw new ArgumentNullException(nameof(windowName));
-        if (onMouse is null)
-            throw new ArgumentNullException(nameof(onMouse));
+        ArgumentNullException.ThrowIfNull(onMouse);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_setMouseCallback(windowName, onMouse, userData));
@@ -381,10 +379,8 @@ static partial class Cv2
     public static int CreateTrackbar(string trackbarName, string winName,
         ref int value, int count, TrackbarCallbackNative? onChange = null, IntPtr userData = default)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
-        if (winName is null)
-            throw new ArgumentNullException(nameof(winName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
+        ArgumentNullException.ThrowIfNull(winName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_createTrackbar(trackbarName, winName, ref value, count, onChange, userData, out var ret));
@@ -413,10 +409,8 @@ static partial class Cv2
     public static int CreateTrackbar(string trackbarName, string winName,
         int count, TrackbarCallbackNative? onChange = null, IntPtr userData = default)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
-        if (winName is null)
-            throw new ArgumentNullException(nameof(winName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
+        ArgumentNullException.ThrowIfNull(winName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_createTrackbar(trackbarName, winName, IntPtr.Zero, count, onChange, userData, out var ret));
@@ -434,8 +428,7 @@ static partial class Cv2
     /// <returns>trackbar position</returns>
     public static int GetTrackbarPos(string trackbarName, string winName)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_getTrackbarPos(trackbarName, winName, out var ret));
@@ -450,8 +443,7 @@ static partial class Cv2
     /// <param name="pos">New position.</param>
     public static void SetTrackbarPos(string trackbarName, string winName, int pos)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_setTrackbarPos(trackbarName, winName, pos));
@@ -466,8 +458,7 @@ static partial class Cv2
     /// <param name="maxVal">New maximum position.</param>
     public static void SetTrackbarMax(string trackbarName, string winName, int maxVal)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_setTrackbarMax(trackbarName, winName, maxVal));
@@ -482,8 +473,7 @@ static partial class Cv2
     /// <param name="minVal">New minimum position.</param>
     public static void SetTrackbarMin(string trackbarName, string winName, int minVal)
     {
-        if (trackbarName is null)
-            throw new ArgumentNullException(nameof(trackbarName));
+        ArgumentNullException.ThrowIfNull(trackbarName);
 
         NativeMethods.HandleException(
             NativeMethods.highgui_setTrackbarMin(trackbarName, winName, minVal));

--- a/src/OpenCvSharp/Cv2/Cv2_imgcodecs.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgcodecs.cs
@@ -32,8 +32,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool ImReadMulti(string filename, out Mat[] mats, ImreadModes flags = ImreadModes.AnyColor)
     {
-        if (filename is null) 
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         using var matsVec = new VectorOfMat();
         NativeMethods.HandleException(
@@ -53,8 +52,7 @@ static partial class Cv2
     {
         if (string.IsNullOrEmpty(fileName))
             throw new ArgumentNullException(nameof(fileName));
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         prms ??= [];
 
         NativeMethods.HandleException(
@@ -72,8 +70,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool ImWrite(string fileName, Mat img, params ImageEncodingParam[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
         if (prms.Length <= 0) 
             return ImWrite(fileName, img);
 
@@ -97,8 +94,7 @@ static partial class Cv2
     {
         if (string.IsNullOrEmpty(fileName))
             throw new ArgumentNullException(nameof(fileName));
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         prms ??= [];
 
         using var imgVec = new VectorOfMat(img);
@@ -117,8 +113,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool ImWrite(string fileName, IEnumerable<Mat> img, params ImageEncodingParam[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
         if (prms.Length <= 0)
             return ImWrite(fileName, img);
 
@@ -139,8 +134,7 @@ static partial class Cv2
     /// <returns></returns>
     public static Mat ImDecode(Mat buf, ImreadModes flags)
     {
-        if (buf is null)
-            throw new ArgumentNullException(nameof(buf));
+        ArgumentNullException.ThrowIfNull(buf);
         buf.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -171,8 +165,7 @@ static partial class Cv2
     /// <returns></returns>
     public static Mat ImDecode(byte[] buf, ImreadModes flags)
     {
-        if (buf is null)
-            throw new ArgumentNullException(nameof(buf));
+        ArgumentNullException.ThrowIfNull(buf);
         var ret = ImDecode(new ReadOnlySpan<byte>(buf), flags);
         GC.KeepAlive(buf);
         return ret;
@@ -230,8 +223,7 @@ static partial class Cv2
     /// <param name="prms">Format-specific parameters.</param>
     public static void ImEncode(string ext, InputArray img, out byte[] buf, params ImageEncodingParam[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
         var p = new List<int>();
         foreach (var item in prms)
         {
@@ -248,8 +240,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool HaveImageReader(string fileName)
     {
-        if (fileName is null) 
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         NativeMethods.HandleException(
             NativeMethods.imgcodecs_haveImageReader(fileName, out var ret));
@@ -263,8 +254,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool HaveImageWriter(string fileName)
     {
-        if (fileName is null) 
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         NativeMethods.HandleException(
             NativeMethods.imgcodecs_haveImageWriter(fileName, out var ret));

--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -549,8 +549,7 @@ static partial class Cv2
     public static Point2f[] CornerSubPix(InputArray image, IEnumerable<Point2f> inputCorners,
         Size winSize, Size zeroZone, TermCriteria criteria)
     {
-        if (inputCorners is null)
-            throw new ArgumentNullException(nameof(inputCorners));
+        ArgumentNullException.ThrowIfNull(inputCorners);
 
         var inputCornersSrc = inputCorners.ToArray();
         var inputCornersCopy = new Point2f[inputCornersSrc.Length];
@@ -879,8 +878,7 @@ static partial class Cv2
         Scalar? borderValue = null,
         AlgorithmHint hint = AlgorithmHint.Default)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         var borderValue0 = borderValue.GetValueOrDefault(Scalar.All(0));
         var mRow = m.GetLength(0);
@@ -1223,8 +1221,7 @@ static partial class Cv2
     public static void BuildPyramid(InputArray src, VectorOfMat dst,int maxlevel,
          BorderTypes borderType = BorderTypes.Default)
     {
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
+        ArgumentNullException.ThrowIfNull(dst);
         dst.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.imgproc_buildPyramid(src.Proxy, dst.CvPtr, maxlevel,(int)borderType));
@@ -1268,8 +1265,7 @@ static partial class Cv2
         OutputArray hist, int dims, int[] histSize,
         Rangef[] ranges, bool uniform = true, bool accumulate = false)
     {
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(ranges);
         var rangesFloat = ranges.Select(r => new [] {r.Start, r.End}).ToArray();
         CalcHist(images, channels, mask, hist, dims, 
             histSize, rangesFloat, uniform, accumulate);
@@ -1292,14 +1288,10 @@ static partial class Cv2
         OutputArray hist, int dims, int[] histSize,
         float[][] ranges, bool uniform = true, bool accumulate = false)
     {
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
-        if (channels is null)
-            throw new ArgumentNullException(nameof(channels));
-        if (histSize is null)
-            throw new ArgumentNullException(nameof(histSize));
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(histSize);
+        ArgumentNullException.ThrowIfNull(ranges);
 
         var imagesPtr = images.Select(x => x.CvPtr).ToArray();
         using (var rangesPtr = new ArrayAddress2<float>(ranges))
@@ -1327,12 +1319,9 @@ static partial class Cv2
         int[] channels, InputArray hist, OutputArray backProject, 
         Rangef[] ranges, bool uniform = true)
     {
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
-        if (channels is null)
-            throw new ArgumentNullException(nameof(channels));
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(channels);
+        ArgumentNullException.ThrowIfNull(ranges);
 
         var imagesPtr =images.Select(x => x.CvPtr).ToArray();
         var rangesFloat = ranges.Select(r => new [] {r.Start, r.End}).ToArray();
@@ -2482,8 +2471,7 @@ static partial class Cv2
     public static void Rectangle(
         Mat img, Rect rect, Scalar color, int thickness = 1, LineTypes lineType = LineTypes.Link8, int shift = 0)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_rectangle_Mat_Rect(img.CvPtr, rect, color, thickness, (int) lineType, shift));
@@ -2505,8 +2493,7 @@ static partial class Cv2
         Mat img, Point pt1, Point pt2, Scalar color, int thickness = 1,
         LineTypes lineType = LineTypes.Link8, int shift = 0)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_rectangle_Mat_Point(img.CvPtr, pt1, pt2, color, thickness, (int)lineType, shift));
@@ -2623,8 +2610,7 @@ static partial class Cv2
     public static void FillConvexPoly(Mat img, IEnumerable<Point> pts, Scalar color,
         LineTypes lineType = LineTypes.Link8, int shift = 0)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var ptsArray = pts.ToArray();
@@ -2666,8 +2652,7 @@ static partial class Cv2
         Mat img, IEnumerable<IEnumerable<Point>> pts, Scalar color,
         LineTypes lineType = LineTypes.Link8, int shift = 0, Point? offset = null)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
 
         img.ThrowIfDisposed();
         var offset0 = offset.GetValueOrDefault(new Point());
@@ -2733,8 +2718,7 @@ static partial class Cv2
         LineTypes lineType = LineTypes.Link8, 
         int shift = 0)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var ptsList = new List<Point[]>();
@@ -2804,8 +2788,7 @@ static partial class Cv2
         int maxLevel = int.MaxValue,
         Point? offset = null)
     {
-        if (contours is null)
-            throw new ArgumentNullException(nameof(contours));
+        ArgumentNullException.ThrowIfNull(contours);
 
         var offset0 = offset.GetValueOrDefault(new Point());
         var contoursArray = contours.Select(c => c.ToArray()).ToArray();
@@ -2858,8 +2841,7 @@ static partial class Cv2
         int maxLevel = int.MaxValue,
         Point? offset = null)
     {
-        if (contours is null)
-            throw new ArgumentNullException(nameof(contours));
+        ArgumentNullException.ThrowIfNull(contours);
 
         var offset0 = offset.GetValueOrDefault(new Point());
         var contoursPtr = contours.Select(x => x.CvPtr).ToArray();
@@ -2961,7 +2943,7 @@ static partial class Cv2
         int thickness = 1, LineTypes lineType = LineTypes.Link8, bool bottomLeftOrigin = false)
     {
         if (string.IsNullOrEmpty(text))
-            throw new ArgumentNullException(text);
+            throw new ArgumentNullException(nameof(text));
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_putText(img.Proxy, text, org, (int) fontFace, fontScale, color,
@@ -2983,7 +2965,7 @@ static partial class Cv2
         double fontScale, int thickness, out int baseLine)
     {
         if (string.IsNullOrEmpty(text))
-            throw new ArgumentNullException(text);
+            throw new ArgumentNullException(nameof(text));
 
         NativeMethods.HandleException(
             NativeMethods.imgproc_getTextSize(text, (int)fontFace, fontScale, thickness, out baseLine, out var ret));
@@ -3022,10 +3004,8 @@ static partial class Cv2
         InputOutputArray img, string text, Point org, Scalar color, FontFace fontFace, int size,
         int weight = 0, PutTextFlags flags = PutTextFlags.AlignLeft, Range? wrap = null)
     {
-        if (text is null)
-            throw new ArgumentNullException(nameof(text));
-        if (fontFace is null)
-            throw new ArgumentNullException(nameof(fontFace));
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(fontFace);
         fontFace.ThrowIfDisposed();
 
         var w = wrap ?? new Range(0, 0);
@@ -3054,10 +3034,8 @@ static partial class Cv2
         Size imgsize, string text, Point org, FontFace fontFace, int size,
         int weight = 0, PutTextFlags flags = PutTextFlags.AlignLeft, Range? wrap = null)
     {
-        if (text is null)
-            throw new ArgumentNullException(nameof(text));
-        if (fontFace is null)
-            throw new ArgumentNullException(nameof(fontFace));
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(fontFace);
         fontFace.ThrowIfDisposed();
 
         var w = wrap ?? new Range(0, 0);

--- a/src/OpenCvSharp/Cv2/Cv2_objdetect.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_objdetect.cs
@@ -14,8 +14,7 @@ static partial class Cv2
     /// <param name="eps"></param>
     public static void GroupRectangles(IList<Rect> rectList, int groupThreshold, double eps = 0.2)
     {
-        if (rectList is null)
-            throw new ArgumentNullException(nameof(rectList));
+        ArgumentNullException.ThrowIfNull(rectList);
 
         using var rectListVec = new StdVector<Rect>(rectList);
 
@@ -34,8 +33,7 @@ static partial class Cv2
     /// <param name="eps">Relative difference between sides of the rectangles to merge them into a group.</param>
     public static void GroupRectangles(IList<Rect> rectList, out int[] weights, int groupThreshold, double eps = 0.2)
     {
-        if (rectList is null)
-            throw new ArgumentNullException(nameof(rectList));
+        ArgumentNullException.ThrowIfNull(rectList);
 
         using var rectListVec = new StdVector<Rect>(rectList);
         using var weightsVec = new StdVector<int>();
@@ -57,8 +55,7 @@ static partial class Cv2
     /// <param name="levelWeights"></param>
     public static void GroupRectangles(IList<Rect> rectList, int groupThreshold, double eps, out int[] weights, out double[] levelWeights)
     {
-        if (rectList is null)
-            throw new ArgumentNullException(nameof(rectList));
+        ArgumentNullException.ThrowIfNull(rectList);
 
         using var rectListVec = new StdVector<Rect>(rectList);
         using var weightsVec = new StdVector<int>();
@@ -83,8 +80,7 @@ static partial class Cv2
     /// <param name="eps"></param>
     public static void GroupRectangles(IList<Rect> rectList, out int[] rejectLevels, out double[] levelWeights, int groupThreshold, double eps = 0.2)
     {
-        if (rectList is null)
-            throw new ArgumentNullException(nameof(rectList));
+        ArgumentNullException.ThrowIfNull(rectList);
 
         using var rectListVec = new StdVector<Rect>(rectList);
         using var rejectLevelsVec = new StdVector<int>();
@@ -110,8 +106,7 @@ static partial class Cv2
     public static void GroupRectanglesMeanshift(IList<Rect> rectList, out double[] foundWeights,
         out double[] foundScales, double detectThreshold = 0.0, Size? winDetSize = null)
     {
-        if (rectList is null)
-            throw new ArgumentNullException(nameof(rectList));
+        ArgumentNullException.ThrowIfNull(rectList);
 
         var winDetSize0 = winDetSize.GetValueOrDefault(new Size(64, 128));
 
@@ -218,8 +213,7 @@ static partial class Cv2
     /// <returns></returns>
     public static bool Find4QuadCornerSubpix(InputArray img, Point2f[] corners, Size regionSize)
     {
-        if (corners is null)
-            throw new ArgumentNullException(nameof(corners));
+        ArgumentNullException.ThrowIfNull(corners);
 
         using var cornersVec = new StdVector<Point2f>(corners);
         NativeMethods.HandleException(
@@ -263,8 +257,7 @@ static partial class Cv2
     public static void DrawChessboardCorners(InputOutputArray image, Size patternSize,
         IEnumerable<Point2f> corners, bool patternWasFound)
     {
-        if (corners is null)
-            throw new ArgumentNullException(nameof(corners));
+        ArgumentNullException.ThrowIfNull(corners);
 
         var cornersArray = corners as Point2f[] ?? corners.ToArray();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Cv2/Cv2_photo.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_photo.cs
@@ -89,8 +89,7 @@ static partial class Cv2
         int imgToDenoiseIndex, int temporalWindowSize,
         float h = 3, int templateWindowSize = 7, int searchWindowSize = 21)
     {
-        if (srcImgs is null)
-            throw new ArgumentNullException(nameof(srcImgs));
+        ArgumentNullException.ThrowIfNull(srcImgs);
 
         var srcImgPtrs = srcImgs.Select(x => x.CvPtr).ToArray();
 
@@ -123,8 +122,7 @@ static partial class Cv2
         int imgToDenoiseIndex, int temporalWindowSize, float h = 3, float hColor = 3,
         int templateWindowSize = 7, int searchWindowSize = 21)
     {
-        if (srcImgs is null)
-            throw new ArgumentNullException(nameof(srcImgs));
+        ArgumentNullException.ThrowIfNull(srcImgs);
         var srcImgPtrs = srcImgs.Select(x => x.CvPtr).ToArray();
 
         NativeMethods.HandleException(
@@ -156,10 +154,8 @@ static partial class Cv2
     public static void DenoiseTVL1(
         IEnumerable<Mat> observations, Mat result, double lambda = 1.0, int niters = 30)
     {
-        if (observations is null)
-            throw new ArgumentNullException(nameof(observations));
-        if (result is null) 
-            throw new ArgumentNullException(nameof(result));
+        ArgumentNullException.ThrowIfNull(observations);
+        ArgumentNullException.ThrowIfNull(result);
 
         var observationsPtrs = observations.Select(x => x.CvPtr).ToArray();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_ptcloud.cs
@@ -154,8 +154,7 @@ static partial class Cv2
     /// <param name="rgb">Output per-vertex colors, each value contains 3 floats (optional).</param>
     public static void LoadPointCloud(string filename, OutputArray vertices, OutputArray normals = default, OutputArray rgb = default)
     {
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_loadPointCloud(filename, vertices.Proxy, normals.Proxy, rgb.Proxy));
@@ -171,8 +170,7 @@ static partial class Cv2
     /// <param name="rgb">Per-vertex colors, each value contains 3 floats (optional).</param>
     public static void SavePointCloud(string filename, InputArray vertices, InputArray normals = default, InputArray rgb = default)
     {
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         NativeMethods.HandleException(
             NativeMethods.ptcloud_savePointCloud(filename, vertices.Proxy, normals.Proxy, rgb.Proxy));
@@ -195,8 +193,7 @@ static partial class Cv2
         string filename, OutputArray vertices, out Mat[] indices,
         OutputArray normals = default, OutputArray colors = default, OutputArray texCoords = default)
     {
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         using var indicesVec = new VectorOfMat();
         NativeMethods.HandleException(
@@ -219,10 +216,8 @@ static partial class Cv2
         string filename, InputArray vertices, IEnumerable<Mat> indices,
         InputArray normals = default, InputArray colors = default, InputArray texCoords = default)
     {
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
-        if (indices is null)
-            throw new ArgumentNullException(nameof(indices));
+        ArgumentNullException.ThrowIfNull(filename);
+        ArgumentNullException.ThrowIfNull(indices);
 
         var indicesArray = indices as Mat[] ?? indices.ToArray();
         using var indicesVec = new VectorOfMat(indicesArray);

--- a/src/OpenCvSharp/Cv2/Cv2_stereo.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_stereo.cs
@@ -194,18 +194,12 @@ static partial class Cv2
         double alpha, Size newImageSize,
         out Rect validPixROI1, out Rect validPixROI2)
     {
-        if (cameraMatrix1 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix1));
-        if (distCoeffs1 is null)
-            throw new ArgumentNullException(nameof(distCoeffs1));
-        if (cameraMatrix2 is null)
-            throw new ArgumentNullException(nameof(cameraMatrix2));
-        if (distCoeffs2 is null)
-            throw new ArgumentNullException(nameof(distCoeffs2));
-        if (R is null)
-            throw new ArgumentNullException(nameof(R));
-        if (T is null)
-            throw new ArgumentNullException(nameof(T));
+        ArgumentNullException.ThrowIfNull(cameraMatrix1);
+        ArgumentNullException.ThrowIfNull(distCoeffs1);
+        ArgumentNullException.ThrowIfNull(cameraMatrix2);
+        ArgumentNullException.ThrowIfNull(distCoeffs2);
+        ArgumentNullException.ThrowIfNull(R);
+        ArgumentNullException.ThrowIfNull(T);
 
         R1 = new double[3, 3];
         R2 = new double[3, 3];
@@ -292,12 +286,9 @@ static partial class Cv2
         out double[,] H1, out double[,] H2,
         double threshold = 5)
     {
-        if (points1 is null)
-            throw new ArgumentNullException(nameof(points1));
-        if (points2 is null)
-            throw new ArgumentNullException(nameof(points2));
-        if (F is null)
-            throw new ArgumentNullException(nameof(F));
+        ArgumentNullException.ThrowIfNull(points1);
+        ArgumentNullException.ThrowIfNull(points2);
+        ArgumentNullException.ThrowIfNull(F);
         if (F.GetLength(0) != 3 || F.GetLength(1) != 3)
             throw new ArgumentException("F != double[3,3]");
 
@@ -364,10 +355,8 @@ static partial class Cv2
         OutputArray Q, double alpha, Size newImgSize,
         out Rect roi1, out Rect roi2, StereoRectificationFlags flags)
     {
-        if (imgpt1 is null)
-            throw new ArgumentNullException(nameof(imgpt1));
-        if (imgpt3 is null)
-            throw new ArgumentNullException(nameof(imgpt3));
+        ArgumentNullException.ThrowIfNull(imgpt1);
+        ArgumentNullException.ThrowIfNull(imgpt3);
 
         var imgpt1Ptrs = imgpt1.Select(x => x.CvPtr).ToArray();
         var imgpt3Ptrs = imgpt3.Select(x => x.CvPtr).ToArray();

--- a/src/OpenCvSharp/Cv2/Cv2_video.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_video.cs
@@ -163,10 +163,8 @@ static partial class Cv2
         OpticalFlowFlags flags = OpticalFlowFlags.None,
         double minEigThreshold = 1e-4)
     {
-        if (prevPts is null)
-            throw new ArgumentNullException(nameof(prevPts));
-        if (nextPts is null)
-            throw new ArgumentNullException(nameof(nextPts));
+        ArgumentNullException.ThrowIfNull(prevPts);
+        ArgumentNullException.ThrowIfNull(nextPts);
 
         var winSize0 = winSize.GetValueOrDefault(new Size(21, 21));
         var criteria0 = criteria.GetValueOrDefault(

--- a/src/OpenCvSharp/Fundamentals/CvObject.cs
+++ b/src/OpenCvSharp/Fundamentals/CvObject.cs
@@ -58,7 +58,8 @@ public abstract class CvObject : IDisposable
     /// <param name="safeHandle">The safe handle wrapping the native pointer.</param>
     protected CvObject(OpenCvSafeHandle safeHandle)
     {
-        this.safeHandle = safeHandle ?? throw new ArgumentNullException(nameof(safeHandle));
+        ArgumentNullException.ThrowIfNull(safeHandle);
+        this.safeHandle = safeHandle;
     }
 
     /// <summary>
@@ -68,8 +69,9 @@ public abstract class CvObject : IDisposable
     /// <param name="handle">The safe handle wrapping the native pointer.</param>
     protected void SetSafeHandle(OpenCvSafeHandle handle)
     {
+        ArgumentNullException.ThrowIfNull(handle);
         var old = safeHandle;
-        safeHandle = handle ?? throw new ArgumentNullException(nameof(handle));
+        safeHandle = handle;
 
         // If we're replacing an existing SafeHandle (e.g. derived class overrides base),
         // invalidate the old one so its finalizer won't call the wrong delete function.
@@ -146,8 +148,7 @@ public abstract class CvObject : IDisposable
     /// </summary>
     public void ThrowIfDisposed()
     {
-        if (IsDisposed)
-            throw new ObjectDisposedException(GetType().FullName);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Fundamentals/MatMemoryManager.cs
+++ b/src/OpenCvSharp/Fundamentals/MatMemoryManager.cs
@@ -17,8 +17,7 @@ public sealed unsafe class MatMemoryManager<T> : MemoryManager<T>
     /// <remarks>It is assumed that the span provided is already unmanaged or externally pinned</remarks>
     public MatMemoryManager(Mat mat, bool isDataOwner = true)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         if (!mat.IsContinuous())
             throw new ArgumentException("mat is not continuous", nameof(mat));
 
@@ -33,8 +32,8 @@ public sealed unsafe class MatMemoryManager<T> : MemoryManager<T>
     /// </summary>
     public override MemoryHandle Pin(int elementIndex = 0)
     {
-        if (elementIndex < 0 || elementIndex >= wrapped.Total())
-            throw new ArgumentOutOfRangeException(nameof(elementIndex));
+        ArgumentOutOfRangeException.ThrowIfNegative(elementIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((long)elementIndex, wrapped.Total(), nameof(elementIndex));
 
         var dims = wrapped.Dims;
         var idxs = new int[dims];

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
@@ -128,7 +128,7 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static unsafe partial ExceptionStatus geometry_getOptimalNewCameraMatrix_array(
         double* cameraMatrix,
-        [In] double[] distCoeffs, int distCoeffsSize,
+        [In] double[]? distCoeffs, int distCoeffsSize,
         Size imageSize, double alpha, Size newImgSize,
         out Rect validPixROI, int centerPrincipalPoint,
         out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/StdString.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/StdString.cs
@@ -23,8 +23,7 @@ public class StdString : CvObject
     /// <param name="str"></param>
     public StdString(string str)
     {
-        if (str is null)
-            throw new ArgumentNullException(nameof(str));
+        ArgumentNullException.ThrowIfNull(str);
 
         var utf8Bytes = Encoding.UTF8.GetBytes(str);
         var p = NativeMethods.string_new2(utf8Bytes);

--- a/src/OpenCvSharp/Internal/Util/ArrayAddress2.cs
+++ b/src/OpenCvSharp/Internal/Util/ArrayAddress2.cs
@@ -20,7 +20,8 @@ public ref struct ArrayAddress2<T>
     /// <param name="array"></param>
     public ArrayAddress2(T[][] array)
     {
-        this.array = array ?? throw new ArgumentNullException(nameof(array));
+        ArgumentNullException.ThrowIfNull(array);
+        this.array = array;
 
         // Convert T[][] into an array of pinned-row pointers (IntPtr[]).
         ptr = new IntPtr[array.Length];

--- a/src/OpenCvSharp/Internal/Util/ReadOnlyArray2D.cs
+++ b/src/OpenCvSharp/Internal/Util/ReadOnlyArray2D.cs
@@ -14,7 +14,8 @@ public class ReadOnlyArray2D<T>
     /// <param name="data"></param>
     public ReadOnlyArray2D(T[,] data)
     {
-        this.data = data ?? throw new ArgumentNullException(nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
+        this.data = data;
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Internal/Vectors/StdVector.cs
+++ b/src/OpenCvSharp/Internal/Vectors/StdVector.cs
@@ -44,8 +44,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
 
     private static IntPtr New3FromEnumerable(IEnumerable<T> data)
     {
-        if (data is null)
-            throw new ArgumentNullException(nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
         var array = data as T[] ?? data.ToArray();
         return New3(array, (nuint)array.Length);
     }

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfMat.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfMat.cs
@@ -19,8 +19,7 @@ public class VectorOfMat : CvObject, IStdVector<Mat>
     /// <param name="size"></param>
     public VectorOfMat(int size)
     {
-        if (size < 0)
-            throw new ArgumentOutOfRangeException(nameof(size));
+        ArgumentOutOfRangeException.ThrowIfNegative(size);
         var p = NativeMethods.vector_Mat_new2((uint)size);
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
     }
@@ -31,8 +30,7 @@ public class VectorOfMat : CvObject, IStdVector<Mat>
     /// <param name="mats"></param>
     public VectorOfMat(IEnumerable<Mat> mats)
     {
-        if (mats is null)
-            throw new ArgumentNullException(nameof(mats));
+        ArgumentNullException.ThrowIfNull(mats);
 
         var matsArray = mats.ToArray();
         var matPointers = matsArray.Select(x => x.CvPtr).ToArray();

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
@@ -19,11 +19,10 @@ public class VectorOfString : CvObject, IStdVector<string?>
     /// Constructor
     /// </summary>
     /// <param name="size"></param>
-    public VectorOfString(nuint size)
+    public VectorOfString(int size)
     {
-        if (size < 0)
-            throw new ArgumentOutOfRangeException(nameof(size));
-        var p = NativeMethods.vector_string_new2(size);
+        ArgumentOutOfRangeException.ThrowIfNegative(size);
+        var p = NativeMethods.vector_string_new2((nuint)size);
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
     }
 

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfVectorKeyPoint.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfVectorKeyPoint.cs
@@ -21,8 +21,7 @@ public class VectorOfVectorKeyPoint : CvObject, IStdVector<KeyPoint[]>
     /// <param name="values"></param>
     public VectorOfVectorKeyPoint(KeyPoint[][] values)
     {
-        if (values is null)
-            throw new ArgumentNullException(nameof(values));
+        ArgumentNullException.ThrowIfNull(values);
 
         using var aa = new ArrayAddress2<KeyPoint>(values);
         var p = NativeMethods.vector_vector_KeyPoint_new3(

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfVectorPoint.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfVectorPoint.cs
@@ -19,11 +19,10 @@ public class VectorOfVectorPoint : CvObject, IStdVector<Point[]>
     /// Constructor
     /// </summary>
     /// <param name="size"></param>
-    public VectorOfVectorPoint(nuint size)
+    public VectorOfVectorPoint(int size)
     {
-        if (size < 0)
-            throw new ArgumentOutOfRangeException(nameof(size));
-        var p = NativeMethods.vector_vector_Point_new2(size);
+        ArgumentOutOfRangeException.ThrowIfNegative(size);
+        var p = NativeMethods.vector_vector_Point_new2((nuint)size);
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
     }
 

--- a/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/ArucoDetector.cs
@@ -21,8 +21,7 @@ public class ArucoDetector : CvObject
     /// </summary>
     public ArucoDetector(Dictionary dictionary, DetectorParameters detectorParams, RefineParameters refineParams)
     {
-        if (dictionary is null)
-            throw new ArgumentNullException(nameof(dictionary));
+        ArgumentNullException.ThrowIfNull(dictionary);
         dictionary.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoBoard.cs
@@ -17,8 +17,7 @@ public class CharucoBoard : CvObject
     /// <param name="dictionary">dictionary of markers</param>
     public CharucoBoard(int squaresX, int squaresY, float squareLength, float markerLength, Dictionary dictionary)
     {
-        if (dictionary is null)
-            throw new ArgumentNullException(nameof(dictionary));
+        ArgumentNullException.ThrowIfNull(dictionary);
         dictionary.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
+++ b/src/OpenCvSharp/Modules/aruco/CharucoDetector.cs
@@ -29,8 +29,7 @@ public class CharucoDetector : CvObject
         DetectorParameters? detectorParams = null,
         RefineParameters? refineParams = null)
     {
-        if (board is null)
-            throw new ArgumentNullException(nameof(board));
+        ArgumentNullException.ThrowIfNull(board);
         board.ThrowIfDisposed();
         if (cameraMatrix.IsEmpty != distCoeffs.IsEmpty)
             throw new ArgumentException("cameraMatrix and distCoeffs must both be omitted or both provided.");

--- a/src/OpenCvSharp/Modules/aruco/Cv2.Aruco.cs
+++ b/src/OpenCvSharp/Modules/aruco/Cv2.Aruco.cs
@@ -35,8 +35,7 @@ public static partial class Cv2
         ///  are calculated based on this one to improve visualization.</param>
         public static void DrawDetectedMarkers(InputOutputArray image, Point2f[][] corners, IEnumerable<int>? ids, Scalar borderColor)
         {
-            if (corners is null)
-                throw new ArgumentNullException(nameof(corners));
+            ArgumentNullException.ThrowIfNull(corners);
 
             using var cornersAddress = new ArrayAddress2<Point2f>(corners);
             if (ids is null)
@@ -113,8 +112,7 @@ public static partial class Cv2
         public static void DrawDetectedDiamonds(InputOutputArray image,
             Point2f[][] diamondCorners, IEnumerable<Vec4i>? diamondIds, Scalar borderColor)
         {
-            if (diamondCorners is null)
-                throw new ArgumentNullException(nameof(diamondCorners));
+            ArgumentNullException.ThrowIfNull(diamondCorners);
 
             using var cornersAddress = new ArrayAddress2<Point2f>(diamondCorners);
 
@@ -159,8 +157,7 @@ public static partial class Cv2
         public static void DrawDetectedCornersCharuco(InputOutputArray image,
             Point2f[] charucoCorners, IEnumerable<int>? charucoIds, Scalar cornerColor)
         {
-            if (charucoCorners is null)
-                throw new ArgumentNullException(nameof(charucoCorners));
+            ArgumentNullException.ThrowIfNull(charucoCorners);
 
             using var charucoCornersVec = new StdVector<Point2f>(charucoCorners);
 

--- a/src/OpenCvSharp/Modules/aruco/Dictionary.cs
+++ b/src/OpenCvSharp/Modules/aruco/Dictionary.cs
@@ -98,8 +98,7 @@ public class Dictionary : CvObject
     /// <returns></returns>
     public bool Identify(Mat onlyBits, out int idx, out int rotation, double maxCorrectionRate)
     {
-        if (onlyBits is null)
-            throw new ArgumentNullException(nameof(onlyBits));
+        ArgumentNullException.ThrowIfNull(onlyBits);
         onlyBits.ThrowIfDisposed();
         ThrowIfDisposed();
 
@@ -150,8 +149,7 @@ public class Dictionary : CvObject
     /// <returns></returns>
     public static Mat GetByteListFromBits(Mat bits)
     {
-        if (bits is null)
-            throw new ArgumentNullException(nameof(bits));
+        ArgumentNullException.ThrowIfNull(bits);
         bits.ThrowIfDisposed();
 
         var ret = new Mat();
@@ -168,8 +166,7 @@ public class Dictionary : CvObject
     /// <returns></returns>
     public static Mat GetBitsFromByteList(Mat byteList, int markerSize)
     {
-        if (byteList is null)
-            throw new ArgumentNullException(nameof(byteList));
+        ArgumentNullException.ThrowIfNull(byteList);
         byteList.ThrowIfDisposed();
         
         var ret = new Mat();

--- a/src/OpenCvSharp/Modules/barcode/BarcodeDetector.cs
+++ b/src/OpenCvSharp/Modules/barcode/BarcodeDetector.cs
@@ -64,8 +64,7 @@ public class BarcodeDetector : CvObject
     /// <param name="sizes">box filter sizes, relative to minimum dimension of the image (default [0.01, 0.03, 0.06, 0.08]).</param>
     public void SetDetectorScales(IEnumerable<float> sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         using var sizesVec = new StdVector<float>(sizes);
         NativeMethods.HandleException(
             NativeMethods.barcode_BarcodeDetector_setDetectorScales(Handle, sizesVec.CvPtr));

--- a/src/OpenCvSharp/Modules/core/Algorithm.cs
+++ b/src/OpenCvSharp/Modules/core/Algorithm.cs
@@ -30,8 +30,7 @@ public abstract class Algorithm : CvPtrObject
     public virtual void Write(FileStorage fs)
     {
         ThrowIfDisposed();
-        if (fs is null)
-            throw new ArgumentNullException(nameof(fs));
+        ArgumentNullException.ThrowIfNull(fs);
 
         NativeMethods.HandleException(
             NativeMethods.core_Algorithm_write(Handle, fs.CvPtr));
@@ -45,8 +44,7 @@ public abstract class Algorithm : CvPtrObject
     public virtual void Read(FileNode fn)
     {
         ThrowIfDisposed();
-        if (fn is null)
-            throw new ArgumentNullException(nameof(fn));
+        ArgumentNullException.ThrowIfNull(fn);
 
         NativeMethods.HandleException(
             NativeMethods.core_Algorithm_read(Handle, fn.CvPtr));
@@ -77,8 +75,7 @@ public abstract class Algorithm : CvPtrObject
     public virtual void Save(string fileName)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         NativeMethods.HandleException(
             NativeMethods.core_Algorithm_save(Handle, fileName));

--- a/src/OpenCvSharp/Modules/core/FileNode.cs
+++ b/src/OpenCvSharp/Modules/core/FileNode.cs
@@ -56,8 +56,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// <returns></returns>
     public static explicit operator int(FileNode node)
     {
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         return node.ToInt32();
     }
 
@@ -82,8 +81,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// <returns></returns>
     public static explicit operator float(FileNode node)
     {
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         return node.ToSingle();
     }
 
@@ -108,8 +106,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// <returns></returns>
     public static explicit operator double(FileNode node)
     {
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         return node.ToDouble();
     }
 
@@ -134,8 +131,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// <returns></returns>
     public static explicit operator string(FileNode node)
     {
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         return node.ToString();
     }
 
@@ -161,8 +157,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// <returns></returns>
     public static explicit operator Mat(FileNode node)
     {
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         return node.ToMat();
     }
 
@@ -193,8 +188,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         get
         {
             ThrowIfDisposed();
-            if (nodeName is null)
-                throw new ArgumentNullException(nameof(nodeName));
+            ArgumentNullException.ThrowIfNull(nodeName);
 
             NativeMethods.HandleException(
                 NativeMethods.core_FileNode_operatorThis_byString(Handle, nodeName, out var node));
@@ -444,8 +438,7 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     public void ReadRaw(string fmt, IntPtr vec, long len)
     {
         ThrowIfDisposed();
-        if (fmt is null)
-            throw new ArgumentNullException(nameof(fmt));
+        ArgumentNullException.ThrowIfNull(fmt);
         NativeMethods.HandleException(
             NativeMethods.core_FileNode_readRaw(Handle, fmt, vec, new IntPtr(len)));
     }

--- a/src/OpenCvSharp/Modules/core/FileNodeIterator.cs
+++ b/src/OpenCvSharp/Modules/core/FileNodeIterator.cs
@@ -50,8 +50,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
     /// <returns></returns>
     public FileNodeIterator ReadRaw(string fmt, IntPtr vec, long maxCount = int.MaxValue)
     {
-        if (fmt is null)
-            throw new ArgumentNullException(nameof(fmt));
+        ArgumentNullException.ThrowIfNull(fmt);
         NativeMethods.HandleException(
             NativeMethods.core_FileNodeIterator_readRaw(Handle, fmt, vec, new IntPtr(maxCount)));
         return this;
@@ -113,10 +112,8 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
     /// <returns></returns>
     public FileNodeIterator ReadRaw(string fmt, byte[] vec, long maxCount = int.MaxValue)
     {
-        if (fmt is null)
-            throw new ArgumentNullException(nameof(fmt));
-        if (vec is null)
-            throw new ArgumentNullException(nameof(vec));
+        ArgumentNullException.ThrowIfNull(fmt);
+        ArgumentNullException.ThrowIfNull(vec);
         unsafe
         {
             fixed (byte* vecPtr = vec)
@@ -155,8 +152,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         
     public long Minus(FileNodeIterator it)
     {
-        if (it is null)
-            throw new ArgumentNullException(nameof(it));
+        ArgumentNullException.ThrowIfNull(it);
         ThrowIfDisposed();
         it.ThrowIfDisposed();
 
@@ -170,8 +166,7 @@ public class FileNodeIterator : CvObject, IEquatable<FileNodeIterator>, IEnumera
         
     public bool LessThan(FileNodeIterator it)
     {
-        if (it is null)
-            throw new ArgumentNullException(nameof(it));
+        ArgumentNullException.ThrowIfNull(it);
         ThrowIfDisposed();
         it.ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -39,8 +39,7 @@ public class FileStorage : CvObject
     /// currently and you should use 8-bit encoding instead of it.</param>
     public FileStorage(string source, Modes flags, string? encoding = null)
     {
-        if (source is null)
-            throw new ArgumentNullException(nameof(source));
+        ArgumentNullException.ThrowIfNull(source);
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_new2(source, (int)flags, encoding, out var p));
         InitSafeHandle(p);
@@ -70,8 +69,7 @@ public class FileStorage : CvObject
         get
         {
             ThrowIfDisposed();
-            if (nodeName is null)
-                throw new ArgumentNullException(nameof(nodeName));
+            ArgumentNullException.ThrowIfNull(nodeName);
 
             NativeMethods.HandleException(
                 NativeMethods.core_FileStorage_indexer(Handle, nodeName, out var node));
@@ -131,8 +129,7 @@ public class FileStorage : CvObject
     public virtual bool Open(string fileName, Modes flags, string? encoding = null)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_open(Handle, fileName, (int)flags, encoding, out var ret));
         return ret != 0;
@@ -222,8 +219,7 @@ public class FileStorage : CvObject
     /// <param name="len">Number of the uchar elements to write.</param>
     public void WriteRaw(string fmt, IntPtr vec, int len)
     {
-        if (fmt is null) 
-            throw new ArgumentNullException(nameof(fmt));
+        ArgumentNullException.ThrowIfNull(fmt);
         if (vec == IntPtr.Zero) 
             throw new ArgumentException("vec == IntPtr.Zero", nameof(vec));
         ThrowIfDisposed();
@@ -242,8 +238,7 @@ public class FileStorage : CvObject
     /// Else if the comment is multi-line, or if it does not fit at the end of the current line, the comment starts a new line.</param>
     public void WriteComment(string comment, bool append = false)
     {
-        if (comment is null) 
-            throw new ArgumentNullException(nameof(comment));
+        ArgumentNullException.ThrowIfNull(comment);
         ThrowIfDisposed();
             
         NativeMethods.HandleException(
@@ -281,8 +276,7 @@ public class FileStorage : CvObject
     /// <returns></returns>
     public static string GetDefaultObjectName(string fileName)
     {
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         using var buf = new StdString();
         NativeMethods.HandleException(
@@ -300,8 +294,7 @@ public class FileStorage : CvObject
     public void Write(string name, int value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
+        ArgumentNullException.ThrowIfNull(name);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_int(Handle, name, value));
@@ -315,8 +308,7 @@ public class FileStorage : CvObject
     public void Write(string name, float value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
+        ArgumentNullException.ThrowIfNull(name);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_float(Handle, name, value));
@@ -330,8 +322,7 @@ public class FileStorage : CvObject
     public void Write(string name, double value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
+        ArgumentNullException.ThrowIfNull(name);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_double(Handle, name, value));
@@ -345,10 +336,8 @@ public class FileStorage : CvObject
     public void Write(string name, string value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_String(Handle, name, value));
@@ -362,10 +351,8 @@ public class FileStorage : CvObject
     public void Write(string name, Mat value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_Mat(Handle, name, value.CvPtr));
@@ -380,10 +367,8 @@ public class FileStorage : CvObject
     public void Write(string name, SparseMat value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
 
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_SparseMat(Handle, name, value.CvPtr));
@@ -398,10 +383,8 @@ public class FileStorage : CvObject
     public void Write(string name, IEnumerable<KeyPoint> value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
 
         using var valueVector = new StdVector<KeyPoint>(value);
         NativeMethods.HandleException(
@@ -416,10 +399,8 @@ public class FileStorage : CvObject
     public void Write(string name, IEnumerable<DMatch> value)
     {
         ThrowIfDisposed();
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
 
         using var valueVector = new StdVector<DMatch>(value);
         NativeMethods.HandleException(
@@ -466,8 +447,7 @@ public class FileStorage : CvObject
     public void WriteScalar(string value)
     {
         ThrowIfDisposed();
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(value);
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_writeScalar_String(Handle, value));
     }
@@ -482,8 +462,7 @@ public class FileStorage : CvObject
     /// <param name="val"></param>
     public FileStorage Add(string val)
     {
-        if (val is null)
-            throw new ArgumentNullException(nameof(val));
+        ArgumentNullException.ThrowIfNull(val);
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_shift_String(Handle, val));
@@ -532,8 +511,7 @@ public class FileStorage : CvObject
     /// <param name="val"></param>
     public FileStorage Add(Mat val)
     {
-        if (val is null)
-            throw new ArgumentNullException(nameof(val));
+        ArgumentNullException.ThrowIfNull(val);
         ThrowIfDisposed();
         val.ThrowIfDisposed();
         NativeMethods.HandleException(
@@ -547,8 +525,7 @@ public class FileStorage : CvObject
     /// <param name="val"></param>
     public FileStorage Add(SparseMat val)
     {
-        if (val is null)
-            throw new ArgumentNullException(nameof(val));
+        ArgumentNullException.ThrowIfNull(val);
         ThrowIfDisposed();
         val.ThrowIfDisposed();
         NativeMethods.HandleException( 
@@ -598,8 +575,7 @@ public class FileStorage : CvObject
     /// <param name="val"></param>
     public FileStorage Add(IEnumerable<KeyPoint> val)
     {
-        if (val is null)
-            throw new ArgumentNullException(nameof(val));
+        ArgumentNullException.ThrowIfNull(val);
         ThrowIfDisposed();
         using (var valVec = new StdVector<KeyPoint>(val))
         {
@@ -615,8 +591,7 @@ public class FileStorage : CvObject
     /// <param name="val"></param>
     public FileStorage Add(IEnumerable<DMatch> val)
     {
-        if (val is null)
-            throw new ArgumentNullException(nameof(val));
+        ArgumentNullException.ThrowIfNull(val);
         ThrowIfDisposed();
         using (var valVec = new StdVector<DMatch>(val))
         {

--- a/src/OpenCvSharp/Modules/core/LDA.cs
+++ b/src/OpenCvSharp/Modules/core/LDA.cs
@@ -75,8 +75,7 @@ public class LDA : CvObject
     public void Save(string fileName)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
         NativeMethods.HandleException(
             NativeMethods.core_LDA_save_String(Handle, fileName));
     }
@@ -88,8 +87,7 @@ public class LDA : CvObject
     public void Load(string fileName)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
         NativeMethods.HandleException(
             NativeMethods.core_LDA_load_String(Handle, fileName));
     }
@@ -101,8 +99,7 @@ public class LDA : CvObject
     public void Save(FileStorage fs)
     {
         ThrowIfDisposed();
-        if (fs is null)
-            throw new ArgumentNullException(nameof(fs));
+        ArgumentNullException.ThrowIfNull(fs);
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -118,8 +115,7 @@ public class LDA : CvObject
     public void Load(FileStorage node)
     {
         ThrowIfDisposed();
-        if (node is null)
-            throw new ArgumentNullException(nameof(node));
+        ArgumentNullException.ThrowIfNull(node);
         node.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/core/Mat/Mat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/Mat.cs
@@ -81,8 +81,7 @@ public partial class Mat : CvObject
     /// <param name="m"></param>
     protected Mat(Mat m)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -181,8 +180,7 @@ public partial class Mat : CvObject
     /// <param name="colRange">Range of the m columns to take. Use Range.All to take all the columns.</param>
     public Mat(Mat m, Range rowRange, Range? colRange = null)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         IntPtr p;
@@ -205,10 +203,8 @@ public partial class Mat : CvObject
     /// <param name="ranges">Array of selected ranges of m along each dimensionality.</param>
     public Mat(Mat m, params Range[] ranges)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(ranges);
         if (ranges.Length == 0)
             throw new ArgumentException("empty ranges", nameof(ranges));
         m.ThrowIfDisposed();
@@ -230,8 +226,7 @@ public partial class Mat : CvObject
     /// <param name="roi">Region of interest.</param>
     public Mat(Mat m, Rect roi)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -335,8 +330,7 @@ public partial class Mat : CvObject
     /// If not specified, the matrix is assumed to be continuous.</param>
     public static Mat FromPixelData(IEnumerable<int> sizes, MatType type, IntPtr data, IEnumerable<long>? steps = null)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         if (data == IntPtr.Zero)
             throw new ArgumentNullException(nameof(data));
 #pragma warning disable CA1508
@@ -372,10 +366,8 @@ public partial class Mat : CvObject
     /// If not specified, the matrix is assumed to be continuous.</param>
     protected Mat(IEnumerable<int> sizes, MatType type, Array data, IEnumerable<long>? steps = null)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
-        if (data is null)
-            throw new ArgumentNullException(nameof(data));
+        ArgumentNullException.ThrowIfNull(sizes);
+        ArgumentNullException.ThrowIfNull(data);
 
         pinLifetime = new ArrayPinningLifetime(data);
 #pragma warning disable CA1508
@@ -421,8 +413,7 @@ public partial class Mat : CvObject
     /// or MatType. CV_8UC(n), ..., CV_64FC(n) to create multi-channel matrices.</param>
     public Mat(IEnumerable<int> sizes, MatType type)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
 #pragma warning disable CA1508
         var sizesArray = sizes as int[] ?? sizes.ToArray();
@@ -442,8 +433,7 @@ public partial class Mat : CvObject
     /// To set all the matrix elements to the particular value after the construction, use SetTo(Scalar s) method .</param>
     public Mat(IEnumerable<int> sizes, MatType type, Scalar s)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 #pragma warning disable CA1508
         var sizesArray = sizes as int[] ?? sizes.ToArray();
 #pragma warning restore CA1508
@@ -508,8 +498,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public static Mat FromStream(Stream stream, ImreadModes mode)
     {
-        if (stream is null)
-            throw new ArgumentNullException(nameof(stream));
+        ArgumentNullException.ThrowIfNull(stream);
         if (stream.Length > int.MaxValue)
             throw new ArgumentException("Not supported stream (too long)");
 
@@ -527,8 +516,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public static Mat ImDecode(byte[] imageBytes, ImreadModes mode = ImreadModes.Color)
     {
-        if (imageBytes is null)
-            throw new ArgumentNullException(nameof(imageBytes));
+        ArgumentNullException.ThrowIfNull(imageBytes);
         return Cv2.ImDecode(imageBytes, mode);
     }
 
@@ -572,8 +560,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public static Mat Diag(Mat d)
     {
-        if (d is null)            
-            throw new ArgumentNullException(nameof(d));            
+        ArgumentNullException.ThrowIfNull(d);            
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_diag_static(d.CvPtr, out var ret));
@@ -614,8 +601,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public static MatExpr Zeros(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         return MatExpr.FromExpr(() =>
         {
@@ -671,8 +657,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public static MatExpr Ones(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         return MatExpr.FromExpr(() =>
         {
@@ -798,8 +783,7 @@ public partial class Mat : CvObject
     public static Mat<TElem> FromArray<TElem>(params TElem[] arr)
         where TElem : unmanaged
     {
-        if (arr is null)            
-            throw new ArgumentNullException(nameof(arr));
+        ArgumentNullException.ThrowIfNull(arr);
         if (arr.Length == 0)
             throw new ArgumentException("arr.Length == 0");
 
@@ -817,8 +801,7 @@ public partial class Mat : CvObject
     public static Mat<TElem> FromArray<TElem>(TElem[,] arr)
         where TElem : unmanaged
     {
-        if (arr is null)
-            throw new ArgumentNullException(nameof(arr));
+        ArgumentNullException.ThrowIfNull(arr);
         if (arr.Length == 0)
             throw new ArgumentException("arr.Length == 0");
 
@@ -991,8 +974,7 @@ public partial class Mat : CvObject
         get => SubMat(rowStart, rowEnd, colStart, colEnd);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -1019,8 +1001,7 @@ public partial class Mat : CvObject
         get => SubMat(rowRange, colRange);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -1047,8 +1028,7 @@ public partial class Mat : CvObject
         get => SubMat(rowRange, colRange);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -1073,8 +1053,7 @@ public partial class Mat : CvObject
         get => SubMat(roi);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -1099,8 +1078,7 @@ public partial class Mat : CvObject
         get => SubMat(ranges);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -1294,8 +1272,7 @@ public partial class Mat : CvObject
     public void CopyTo(Mat m, InputArray mask = default)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1331,8 +1308,7 @@ public partial class Mat : CvObject
     public void AssignTo(Mat m, MatType? type = null)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_assignTo(Handle, m.CvPtr, type?.Value ?? -1));
@@ -1398,8 +1374,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public Mat Reshape(int cn, params int[] newDims)
     {
-        if (newDims is null)
-            throw new ArgumentNullException(nameof(newDims));
+        ArgumentNullException.ThrowIfNull(newDims);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1523,8 +1498,7 @@ public partial class Mat : CvObject
     /// <param name="type">New matrix type.</param>
     public void Create(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         if (sizes.Length < 2)
             throw new ArgumentException("sizes.Length < 2");
         NativeMethods.HandleException(
@@ -2033,8 +2007,7 @@ public partial class Mat : CvObject
     public void PushBack(Mat m)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_Mat_push_back_Mat(Handle, m.CvPtr));
@@ -2140,8 +2113,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public Mat SubMat(params Range[] ranges)
     {
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(ranges);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -3158,8 +3130,7 @@ public partial class Mat : CvObject
     {
         ThrowIfDisposed();
 
-        if (data is null)
-            throw new ArgumentNullException(nameof(data));
+        ArgumentNullException.ThrowIfNull(data);
 
         if (!dataDimensionMap.TryGetValue(typeof(T), out var dataDimension))
             throw new ArgumentException($"Type argument {typeof(T)} is not supported");
@@ -3344,8 +3315,7 @@ public partial class Mat : CvObject
     /// <returns></returns>
     public void WriteToStream(Stream stream, string ext = ".png", params ImageEncodingParam[] prms)
     {
-        if (stream is null)
-            throw new ArgumentNullException(nameof(stream));
+        ArgumentNullException.ThrowIfNull(stream);
         var imageBytes = ToBytes(ext, prms);
         stream.Write(imageBytes, 0, imageBytes.Length);
     }
@@ -3396,8 +3366,7 @@ public partial class Mat : CvObject
     public void ForEachAsByte(MatForeachFunctionByte operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_uchar(Handle, operation));
@@ -3411,8 +3380,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec2b(MatForeachFunctionVec2b operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_Vec2b(Handle, operation));
@@ -3426,8 +3394,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec3b(MatForeachFunctionVec3b operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_Vec3b(Handle, operation));
@@ -3441,8 +3408,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec4b(MatForeachFunctionVec4b operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec4b(Handle, operation));
@@ -3456,8 +3422,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec6b(MatForeachFunctionVec6b operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_Vec6b(Handle, operation));
@@ -3471,8 +3436,7 @@ public partial class Mat : CvObject
     public void ForEachAsInt16(MatForeachFunctionInt16 operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_short(Handle, operation));
@@ -3486,8 +3450,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec2s(MatForeachFunctionVec2s operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec2s(Handle, operation));
@@ -3501,8 +3464,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec3s(MatForeachFunctionVec3s operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec3s(Handle, operation));
@@ -3516,8 +3478,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec4s(MatForeachFunctionVec4s operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(   
             NativeMethods.core_Mat_forEach_Vec4s(Handle, operation));
@@ -3531,8 +3492,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec6s(MatForeachFunctionVec6s operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec6s(Handle, operation));
@@ -3546,8 +3506,7 @@ public partial class Mat : CvObject
     public void ForEachAsInt32(MatForeachFunctionInt32 operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_int(Handle, operation));
@@ -3561,8 +3520,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec2i(MatForeachFunctionVec2i operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec2i(Handle, operation));
@@ -3576,8 +3534,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec3i(MatForeachFunctionVec3i operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_Vec3i(Handle, operation));
@@ -3591,8 +3548,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec4i(MatForeachFunctionVec4i operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec4i(Handle, operation));
@@ -3606,8 +3562,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec6i(MatForeachFunctionVec6i operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec6i(Handle, operation));
@@ -3621,8 +3576,7 @@ public partial class Mat : CvObject
     public void ForEachAsFloat(MatForeachFunctionFloat operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_float(Handle, operation));
@@ -3636,8 +3590,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec2f(MatForeachFunctionVec2f operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec2f(Handle, operation));
@@ -3651,8 +3604,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec3f(MatForeachFunctionVec3f operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec3f(Handle, operation));
@@ -3666,8 +3618,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec4f(MatForeachFunctionVec4f operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec4f(Handle, operation));
@@ -3681,8 +3632,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec6f(MatForeachFunctionVec6f operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec6f(Handle, operation));
@@ -3697,8 +3647,7 @@ public partial class Mat : CvObject
     public void ForEachAsDouble(MatForeachFunctionDouble operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_double(Handle, operation));
@@ -3712,8 +3661,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec2d(MatForeachFunctionVec2d operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec2d(Handle, operation));
@@ -3727,8 +3675,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec3d(MatForeachFunctionVec3d operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(  
             NativeMethods.core_Mat_forEach_Vec3d(Handle, operation));
@@ -3742,8 +3689,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec4d(MatForeachFunctionVec4d operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException( 
             NativeMethods.core_Mat_forEach_Vec4d(Handle, operation));
@@ -3757,8 +3703,7 @@ public partial class Mat : CvObject
     public void ForEachAsVec6d(MatForeachFunctionVec6d operation)
     {
         ThrowIfDisposed();
-        if (operation is null)
-            throw new ArgumentNullException(nameof(operation));
+        ArgumentNullException.ThrowIfNull(operation);
 
         NativeMethods.HandleException(
             NativeMethods.core_Mat_forEach_Vec6d(Handle, operation));
@@ -3782,8 +3727,7 @@ public partial class Mat : CvObject
         ThrowIfDisposed();
         if (Dims != 2)
             throw new InvalidOperationException("RowSpan is only supported for 2D matrices.");
-        if ((uint)row >= (uint)Rows)
-            throw new ArgumentOutOfRangeException(nameof(row));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)row, (uint)Rows, nameof(row));
         var rowPtr = DataPointer + (nint)Step(0) * row;
         return new Span<T>(rowPtr, Cols * ElemSize() / sizeof(T));
     }

--- a/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatOfT.cs
@@ -232,8 +232,7 @@ public class Mat<TElem> : Mat, IEnumerable<TElem>
     public static Mat<TElem> FromPixelData(IEnumerable<int> sizes, IntPtr data, IEnumerable<long>? steps = null)
 #pragma warning restore CA1000
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         if (data == IntPtr.Zero)
             throw new ArgumentNullException(nameof(data));
 #pragma warning disable CA1508
@@ -493,8 +492,7 @@ public class Mat<TElem> : Mat, IEnumerable<TElem>
     /// <returns></returns>
     protected Mat<TElem> Wrap(Mat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
 
         var ret = new Mat<TElem>();
         mat.AssignTo(ret);

--- a/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/MatRowAccessor.cs
@@ -68,8 +68,7 @@ public readonly ref struct MatRowAccessor<T> where T : unmanaged
         get
         {
 #if DEBUG
-            if ((uint)row >= (uint)Count)
-                throw new ArgumentOutOfRangeException(nameof(row));
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)row, (uint)Count, nameof(row));
 #endif
             return new Span<T>((void*)(_data + _step * row), _cols);
         }

--- a/src/OpenCvSharp/Modules/core/Mat/UMat.cs
+++ b/src/OpenCvSharp/Modules/core/Mat/UMat.cs
@@ -61,8 +61,7 @@ public class UMat : CvObject
     /// <param name="m"></param>
     protected UMat(UMat m)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -150,8 +149,7 @@ public class UMat : CvObject
     /// <param name="usageFlags">usage flags for allocator</param>
     public UMat(UMat m, Range rowRange, Range colRange, UMatUsageFlags usageFlags = UMatUsageFlags.None)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.core_UMat_new7(m.ptr, rowRange, colRange, (int)usageFlags, out var p));
@@ -170,10 +168,8 @@ public class UMat : CvObject
     /// <param name="ranges">Array of selected ranges of m along each dimensionality.</param>
     public UMat(UMat m, params Range[] ranges)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(ranges);
         if (ranges.Length == 0)
             throw new ArgumentException("empty ranges", nameof(ranges));
         m.ThrowIfDisposed();
@@ -195,8 +191,7 @@ public class UMat : CvObject
     /// <param name="roi">Region of interest.</param>
     public UMat(UMat m, Rect roi)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -213,8 +208,7 @@ public class UMat : CvObject
     /// or MatType. CV_8UC(n), ..., CV_64FC(n) to create multi-channel matrices.</param>
     public UMat(IEnumerable<int> sizes, MatType type)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         var sizesArray = sizes.ToArray();
         NativeMethods.HandleException(
@@ -232,8 +226,7 @@ public class UMat : CvObject
     /// To set all the matrix elements to the particular value after the construction, use SetTo(Scalar s) method .</param>
     public UMat(IEnumerable<int> sizes, MatType type, Scalar s)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         var sizesArray = sizes.ToArray();
         NativeMethods.HandleException(
             NativeMethods.core_UMat_new5(sizesArray.Length, sizesArray, type, s, out var p));
@@ -270,8 +263,7 @@ public class UMat : CvObject
     /// <returns></returns>
     public static UMat Diag(UMat d)
     {
-        if (d is null)
-            throw new ArgumentNullException(nameof(d));
+        ArgumentNullException.ThrowIfNull(d);
 
         NativeMethods.HandleException(
             NativeMethods.core_UMat_diag_static(d.CvPtr, out var ret));
@@ -314,8 +306,7 @@ public class UMat : CvObject
     /// <returns></returns>
     public static UMat Zeros(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         NativeMethods.HandleException(
             NativeMethods.core_UMat_zeros2(sizes.Length, sizes, type.Value, out var ret));
@@ -357,8 +348,7 @@ public class UMat : CvObject
     /// <returns></returns>
     public static UMat Ones(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         NativeMethods.HandleException(
             NativeMethods.core_UMat_ones2(sizes.Length, sizes, type, out var ret));
@@ -411,8 +401,7 @@ public class UMat : CvObject
         get => SubMat(rowStart, rowEnd, colStart, colEnd);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -439,8 +428,7 @@ public class UMat : CvObject
         get => SubMat(rowRange, colRange);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -467,8 +455,7 @@ public class UMat : CvObject
         get => SubMat(rowRange, colRange);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -493,8 +480,7 @@ public class UMat : CvObject
         get => SubMat(roi);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -519,8 +505,7 @@ public class UMat : CvObject
         get => SubMat(ranges);
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
             //if (Type() != value.Type())
             //    throw new ArgumentException("Mat type mismatch");
@@ -713,8 +698,7 @@ public class UMat : CvObject
     public void CopyTo(UMat m, InputArray mask = default)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -750,8 +734,7 @@ public class UMat : CvObject
     public void AssignTo(UMat m, MatType? type = null)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         NativeMethods.HandleException(
             NativeMethods.core_UMat_assignTo(Handle, m.CvPtr, type?.Value ?? -1));
@@ -817,8 +800,7 @@ public class UMat : CvObject
     /// <returns></returns>
     public UMat Reshape(int cn, params int[] newDims)
     {
-        if (newDims is null)
-            throw new ArgumentNullException(nameof(newDims));
+        ArgumentNullException.ThrowIfNull(newDims);
 
         ThrowIfDisposed();
 
@@ -924,8 +906,7 @@ public class UMat : CvObject
     /// <param name="type">New matrix type.</param>
     public void Create(MatType type, params int[] sizes)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         if (sizes.Length < 2)
             throw new ArgumentException("sizes.Length < 2");
         NativeMethods.HandleException(
@@ -1032,8 +1013,7 @@ public class UMat : CvObject
     /// <returns></returns>
     public UMat SubMat(params Range[] ranges)
     {
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ArgumentNullException.ThrowIfNull(ranges);
 
         ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/core/MatExpr.cs
+++ b/src/OpenCvSharp/Modules/core/MatExpr.cs
@@ -57,8 +57,7 @@ public sealed class MatExpr
     /// </summary>
     public static MatExpr From(Mat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         // Capturing 'mat' keeps it alive until the (possibly much later) materialization.
         return new MatExpr(() => new NativeMatExpr(mat));
     }
@@ -242,8 +241,7 @@ public sealed class MatExpr
     /// </summary>
     public MatExpr Min(Mat m) => new(() =>
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         using var l = ToMat();
         using var dst = new Mat();
         Cv2.Min(l, m, dst);
@@ -278,8 +276,7 @@ public sealed class MatExpr
     /// </summary>
     public MatExpr Max(Mat m) => new(() =>
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         using var l = ToMat();
         using var dst = new Mat();
         Cv2.Max(l, m, dst);
@@ -315,8 +312,7 @@ public sealed class MatExpr
     /// </summary>
     public MatExpr Mul(Mat m, double scale = 1.0)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         return new MatExpr(() => { using var a = Eval(); return a.Mul(m, scale); });
     }
 
@@ -424,8 +420,7 @@ public sealed class MatExpr
     private static MatExpr Combine(MatExpr a, Mat b, Func<NativeMatExpr, Mat, NativeMatExpr> op)
     {
         NotNull(a);
-        if (b is null)
-            throw new ArgumentNullException(nameof(b));
+        ArgumentNullException.ThrowIfNull(b);
         return new MatExpr(() => { using var l = a.Eval(); return op(l, b); });
     }
 
@@ -448,8 +443,7 @@ public sealed class MatExpr
     private static MatExpr CombineMat(MatExpr a, Mat b, Func<Mat, Mat, NativeMatExpr> op)
     {
         NotNull(a);
-        if (b is null)
-            throw new ArgumentNullException(nameof(b));
+        ArgumentNullException.ThrowIfNull(b);
         return new MatExpr(() => { using var l = a.ToMat(); return op(l, b); });
     }
 

--- a/src/OpenCvSharp/Modules/core/NativeMatExpr.cs
+++ b/src/OpenCvSharp/Modules/core/NativeMatExpr.cs
@@ -25,8 +25,7 @@ internal sealed partial class NativeMatExpr : CvObject
     /// <param name="mat"></param>
     internal NativeMatExpr(Mat mat)
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         NativeMethods.HandleException(
             NativeMethods.core_MatExpr_new2(mat.CvPtr, out var p));
         InitSafeHandle(p);
@@ -54,8 +53,7 @@ internal sealed partial class NativeMatExpr : CvObject
     public static implicit operator Mat(NativeMatExpr self)
     {
 #pragma warning disable CA1065 // TODO
-        if (self is null)
-            throw new ArgumentNullException(nameof(self));
+        ArgumentNullException.ThrowIfNull(self);
 #pragma warning restore CA1065 
         return self.ToMat();
     }
@@ -113,8 +111,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator -(NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -127,8 +124,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator ~(NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -141,10 +137,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator +(NativeMatExpr e, Mat m)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(e);
+        ArgumentNullException.ThrowIfNull(m);
         e.ThrowIfDisposed();
         m.ThrowIfDisposed();
 
@@ -157,10 +151,8 @@ internal sealed partial class NativeMatExpr : CvObject
         
     public static NativeMatExpr operator +(Mat m, NativeMatExpr e)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(e);
         m.ThrowIfDisposed();
         e.ThrowIfDisposed();
 
@@ -173,8 +165,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator +(NativeMatExpr e, Scalar s)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -185,8 +176,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator +(Scalar s, NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -197,10 +187,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator +(NativeMatExpr e1, NativeMatExpr e2)
     {
-        if (e1 is null)
-            throw new ArgumentNullException(nameof(e1));
-        if (e2 is null)
-            throw new ArgumentNullException(nameof(e2));
+        ArgumentNullException.ThrowIfNull(e1);
+        ArgumentNullException.ThrowIfNull(e2);
         e1.ThrowIfDisposed();
         e2.ThrowIfDisposed();
 
@@ -217,10 +205,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator -(NativeMatExpr e, Mat m)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(e);
+        ArgumentNullException.ThrowIfNull(m);
         e.ThrowIfDisposed();
         m.ThrowIfDisposed();
 
@@ -233,10 +219,8 @@ internal sealed partial class NativeMatExpr : CvObject
         
     public static NativeMatExpr operator -(Mat m, NativeMatExpr e)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(e);
         m.ThrowIfDisposed();
         e.ThrowIfDisposed();
 
@@ -249,8 +233,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator -(NativeMatExpr e, Scalar s)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -261,8 +244,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator -(Scalar s, NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -273,10 +255,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator -(NativeMatExpr e1, NativeMatExpr e2)
     {
-        if (e1 is null)
-            throw new ArgumentNullException(nameof(e1));
-        if (e2 is null)
-            throw new ArgumentNullException(nameof(e2));
+        ArgumentNullException.ThrowIfNull(e1);
+        ArgumentNullException.ThrowIfNull(e2);
         e1.ThrowIfDisposed();
         e2.ThrowIfDisposed();
 
@@ -293,10 +273,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator *(NativeMatExpr e, Mat m)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(e);
+        ArgumentNullException.ThrowIfNull(m);
         e.ThrowIfDisposed();
         m.ThrowIfDisposed();
 
@@ -309,10 +287,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator *(Mat m, NativeMatExpr e)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(e);
         m.ThrowIfDisposed();
         e.ThrowIfDisposed();
 
@@ -325,8 +301,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator *(NativeMatExpr e, double s)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -337,8 +312,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator *(double s, NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -349,10 +323,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator *(NativeMatExpr e1, NativeMatExpr e2)
     {
-        if (e1 is null)
-            throw new ArgumentNullException(nameof(e1));
-        if (e2 is null)
-            throw new ArgumentNullException(nameof(e2));
+        ArgumentNullException.ThrowIfNull(e1);
+        ArgumentNullException.ThrowIfNull(e2);
         e1.ThrowIfDisposed();
         e2.ThrowIfDisposed();
 
@@ -369,10 +341,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator /(NativeMatExpr e, Mat m)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(e);
+        ArgumentNullException.ThrowIfNull(m);
         e.ThrowIfDisposed();
         m.ThrowIfDisposed();
 
@@ -385,10 +355,8 @@ internal sealed partial class NativeMatExpr : CvObject
         
     public static NativeMatExpr operator /(Mat m, NativeMatExpr e)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(m);
+        ArgumentNullException.ThrowIfNull(e);
         m.ThrowIfDisposed();
         e.ThrowIfDisposed();
 
@@ -401,8 +369,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator /(NativeMatExpr e, double s)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -413,8 +380,7 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator /(double s, NativeMatExpr e)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         e.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -425,10 +391,8 @@ internal sealed partial class NativeMatExpr : CvObject
 
     public static NativeMatExpr operator /(NativeMatExpr e1, NativeMatExpr e2)
     {
-        if (e1 is null)
-            throw new ArgumentNullException(nameof(e1));
-        if (e2 is null)
-            throw new ArgumentNullException(nameof(e2));
+        ArgumentNullException.ThrowIfNull(e1);
+        ArgumentNullException.ThrowIfNull(e2);
         e1.ThrowIfDisposed();
         e2.ThrowIfDisposed();
 
@@ -616,8 +580,7 @@ internal sealed partial class NativeMatExpr : CvObject
     /// <returns></returns>
     public NativeMatExpr Mul(NativeMatExpr e, double scale = 1.0)
     {
-        if (e is null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
         ThrowIfDisposed();
         e.ThrowIfDisposed();
 
@@ -638,8 +601,7 @@ internal sealed partial class NativeMatExpr : CvObject
     /// <returns></returns>
     public NativeMatExpr Mul(Mat m, double scale = 1.0)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         ThrowIfDisposed();
         m.ThrowIfDisposed();
 
@@ -658,8 +620,7 @@ internal sealed partial class NativeMatExpr : CvObject
     /// <returns></returns>
     public Mat Cross(Mat m)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         ThrowIfDisposed();
         m.ThrowIfDisposed();
@@ -679,8 +640,7 @@ internal sealed partial class NativeMatExpr : CvObject
     /// <returns></returns>
     public double Dot(Mat m)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         ThrowIfDisposed();
         m.ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/core/PCA.cs
+++ b/src/OpenCvSharp/Modules/core/PCA.cs
@@ -263,8 +263,7 @@ public class PCA : CvObject
     /// <param name="fs"></param>
     public void Write(FileStorage fs)
     {
-        if (fs is null) 
-            throw new ArgumentNullException(nameof(fs));
+        ArgumentNullException.ThrowIfNull(fs);
         fs.ThrowIfDisposed();
             
         NativeMethods.HandleException(
@@ -280,8 +279,7 @@ public class PCA : CvObject
     /// <param name="fn"></param>
     public void Read(FileNode fn)
     {
-        if (fn is null) 
-            throw new ArgumentNullException(nameof(fn));
+        ArgumentNullException.ThrowIfNull(fn);
         fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/core/SparseMat.cs
+++ b/src/OpenCvSharp/Modules/core/SparseMat.cs
@@ -42,8 +42,7 @@ public class SparseMat : CvObject
     /// <param name="type">Array type.</param>
     public SparseMat(IEnumerable<int> sizes, MatType type)
     {
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
 
         var sizesArray = sizes as int[] ?? sizes.ToArray();
         NativeMethods.HandleException(
@@ -57,8 +56,7 @@ public class SparseMat : CvObject
     /// <param name="m">cv::Mat object</param>
     public SparseMat(Mat m)
     {
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         m.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -101,8 +99,7 @@ public class SparseMat : CvObject
     public SparseMat AssignFrom(SparseMat m)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_operatorAssign_SparseMat(Handle, m.CvPtr));
@@ -117,8 +114,7 @@ public class SparseMat : CvObject
     public SparseMat AssignFrom(Mat m)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
 
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_operatorAssign_Mat(Handle, m.CvPtr));
@@ -144,8 +140,7 @@ public class SparseMat : CvObject
     public void CopyTo(SparseMat m)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_copyTo_SparseMat(Handle, m.CvPtr));
         GC.KeepAlive(m);
@@ -158,8 +153,7 @@ public class SparseMat : CvObject
     public void CopyTo(Mat m)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_copyTo_Mat(Handle, m.CvPtr));
         GC.KeepAlive(m);
@@ -171,8 +165,7 @@ public class SparseMat : CvObject
     public void ConvertTo(SparseMat m, MatType rtype, double alpha = 1)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_convertTo_SparseMat(Handle, m.CvPtr, rtype, alpha));
         GC.KeepAlive(m);
@@ -184,8 +177,7 @@ public class SparseMat : CvObject
     public void ConvertTo(Mat m, MatType rtype, double alpha = 1, double beta = 0)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_convertTo_Mat(Handle, m.CvPtr, rtype, alpha, beta));
         GC.KeepAlive(m);
@@ -207,8 +199,7 @@ public class SparseMat : CvObject
     public void AssignTo(SparseMat m, MatType? type = null)
     {
         ThrowIfDisposed();
-        if (m is null)
-            throw new ArgumentNullException(nameof(m));
+        ArgumentNullException.ThrowIfNull(m);
         NativeMethods.HandleException(
             NativeMethods.core_SparseMat_assignTo(Handle, m.CvPtr, type?.Value ?? -1));
         GC.KeepAlive(m);
@@ -220,8 +211,7 @@ public class SparseMat : CvObject
     public void Create(MatType type, params int[] sizes)
     {
         ThrowIfDisposed();
-        if (sizes is null)
-            throw new ArgumentNullException(nameof(sizes));
+        ArgumentNullException.ThrowIfNull(sizes);
         if (sizes.Length == 1)
             throw new ArgumentException("sizes is empty");
         NativeMethods.HandleException(
@@ -471,8 +461,7 @@ public sealed class SparseMat<T> : SparseMat
     public static new SparseMat<T> FromMat(Mat mat)
 #pragma warning restore CA1000
     {
-        if (mat is null)
-            throw new ArgumentNullException(nameof(mat));
+        ArgumentNullException.ThrowIfNull(mat);
         var expected = MatTypeMap.Get<T>();
         if (mat.Type() != expected)
             throw new OpenCvSharpException(

--- a/src/OpenCvSharp/Modules/core/Struct/Scalar.cs
+++ b/src/OpenCvSharp/Modules/core/Struct/Scalar.cs
@@ -126,8 +126,7 @@ public record struct Scalar(double Val0, double Val1, double Val2, double Val3)
     /// <param name="rng">.NET random number generator. This method uses Random.NextBytes()</param>
     public static Scalar RandomColor(RandomNumberGenerator rng)
     {
-        if (rng is null) 
-            throw new ArgumentNullException(nameof(rng));
+        ArgumentNullException.ThrowIfNull(rng);
 
         var buf = new byte[3];
         rng.GetBytes(buf);

--- a/src/OpenCvSharp/Modules/dnn/ClassificationModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/ClassificationModel.cs
@@ -23,8 +23,7 @@ public class ClassificationModel : Model
     /// <param name="config">Text file contains network configuration.</param>
     public ClassificationModel(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_ClassificationModel_new_String(model, config, out var p));
@@ -37,8 +36,7 @@ public class ClassificationModel : Model
     /// <param name="network">Net object.</param>
     public ClassificationModel(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_ClassificationModel_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/Cv2.Dnn.cs
+++ b/src/OpenCvSharp/Modules/dnn/Cv2.Dnn.cs
@@ -52,8 +52,7 @@ public static partial class Cv2
         /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
         public static Net? ReadNetFromTensorflow(Stream bufferModel, Stream? bufferConfig = null, EngineType engine = EngineType.Auto)
         {
-            if (bufferModel is null)
-                throw new ArgumentNullException(nameof(bufferModel));
+            ArgumentNullException.ThrowIfNull(bufferModel);
             return Net.ReadNetFromTensorflow(
                 StreamToArray(bufferModel),
                 bufferConfig is null ? null : StreamToArray(bufferConfig),
@@ -129,8 +128,7 @@ public static partial class Cv2
         // ReSharper disable once InconsistentNaming
         public static Net? ReadNetFromONNX(Stream onnxFileStream, EngineType engine = EngineType.Auto)
         {
-            if (onnxFileStream is null)
-                throw new ArgumentNullException(nameof(onnxFileStream));
+            ArgumentNullException.ThrowIfNull(onnxFileStream);
             return ReadNetFromONNX(StreamToArray(onnxFileStream), engine);
         }
 
@@ -179,8 +177,7 @@ public static partial class Cv2
         // ReSharper disable once InconsistentNaming
         public static Net? ReadNetFromTFLite(Stream bufferModelStream, EngineType engine = EngineType.Auto)
         {
-            if (bufferModelStream is null)
-                throw new ArgumentNullException(nameof(bufferModelStream));
+            ArgumentNullException.ThrowIfNull(bufferModelStream);
             return Net.ReadNetFromTFLite(StreamToArray(bufferModelStream), engine);
         }
 
@@ -192,8 +189,7 @@ public static partial class Cv2
         // ReSharper disable once InconsistentNaming
         public static Mat? ReadTensorFromONNX(string path)
         {
-            if (path is null)
-                throw new ArgumentNullException(nameof(path));
+            ArgumentNullException.ThrowIfNull(path);
 
             NativeMethods.HandleException(
                 NativeMethods.dnn_readTensorFromONNX(path, out var ret));
@@ -219,8 +215,7 @@ public static partial class Cv2
             Mat image, double scaleFactor = 1.0, Size size = default,
             Scalar mean = default, bool swapRB = true, bool crop = true)
         {
-            if (image is null)
-                throw new ArgumentNullException(nameof(image));
+            ArgumentNullException.ThrowIfNull(image);
 
             NativeMethods.HandleException(
                 NativeMethods.dnn_blobFromImage(
@@ -247,8 +242,7 @@ public static partial class Cv2
             IEnumerable<Mat> images, double scaleFactor,
             Size size = default, Scalar mean = default, bool swapRB = true, bool crop = true)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
 
             var imagesPointers = images.Select(x => x.CvPtr).ToArray();
 
@@ -287,8 +281,7 @@ public static partial class Cv2
         /// <returns>4-dimensional Mat.</returns>
         public static Mat BlobFromImagesWithParams(IEnumerable<Mat> images, Image2BlobParams? param = null)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
             param ??= new Image2BlobParams();
 
             var imagesPointers = images.Select(x => x.CvPtr).ToArray();
@@ -309,8 +302,7 @@ public static partial class Cv2
         /// <returns>array of 2D Mat containing the images extracted from the blob in floating point precision (CV_32F).</returns>
         public static Mat[] ImagesFromBlob(Mat blob)
         {
-            if (blob is null)
-                throw new ArgumentNullException(nameof(blob));
+            ArgumentNullException.ThrowIfNull(blob);
             blob.ThrowIfDisposed();
 
             using var imagesVec = new Internal.Vectors.VectorOfMat();
@@ -327,10 +319,8 @@ public static partial class Cv2
         /// <param name="output">A path to output text file to be created.</param>
         public static void WriteTextGraph(string model, string output)
         {
-            if (model is null)
-                throw new ArgumentNullException(nameof(model));
-            if (output is null)
-                throw new ArgumentNullException(nameof(output));
+            ArgumentNullException.ThrowIfNull(model);
+            ArgumentNullException.ThrowIfNull(output);
 
             NativeMethods.HandleException(
                 NativeMethods.dnn_writeTextGraph(model, output));
@@ -352,10 +342,8 @@ public static partial class Cv2
             out int[] indices,
             float eta = 1.0f, int topK = 0)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<Rect>(bboxes);
@@ -384,10 +372,8 @@ public static partial class Cv2
             out int[] indices,
             float eta = 1.0f, int topK = 0)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<Rect2d>(bboxes);
@@ -416,10 +402,8 @@ public static partial class Cv2
             out int[] indices,
             float eta = 1.0f, int topK = 0)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<RotatedRect>(bboxes);
@@ -449,12 +433,9 @@ public static partial class Cv2
             out int[] indices,
             float eta = 1.0f, int topK = 0)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
-            if (classIds is null)
-                throw new ArgumentNullException(nameof(classIds));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
+            ArgumentNullException.ThrowIfNull(classIds);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<Rect>(bboxes);
@@ -485,12 +466,9 @@ public static partial class Cv2
             out int[] indices,
             float eta = 1.0f, int topK = 0)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
-            if (classIds is null)
-                throw new ArgumentNullException(nameof(classIds));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
+            ArgumentNullException.ThrowIfNull(classIds);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<Rect2d>(bboxes);
@@ -524,10 +502,8 @@ public static partial class Cv2
             out int[] indices,
             int topK = 0, float sigma = 0.5f, SoftNMSMethod method = SoftNMSMethod.SOFTNMS_GAUSSIAN)
         {
-            if (bboxes is null)
-                throw new ArgumentNullException(nameof(bboxes));
-            if (scores is null)
-                throw new ArgumentNullException(nameof(scores));
+            ArgumentNullException.ThrowIfNull(bboxes);
+            ArgumentNullException.ThrowIfNull(scores);
 
             // ReSharper disable once IdentifierTypo
             using var bboxesVec = new StdVector<Rect>(bboxes);

--- a/src/OpenCvSharp/Modules/dnn/DetectionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/DetectionModel.cs
@@ -24,8 +24,7 @@ public class DetectionModel : Model
     /// <param name="config">Text file contains network configuration.</param>
     public DetectionModel(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_DetectionModel_new_String(model, config, out var p));
@@ -38,8 +37,7 @@ public class DetectionModel : Model
     /// <param name="network">Net object.</param>
     public DetectionModel(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_DetectionModel_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/KeypointsModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/KeypointsModel.cs
@@ -24,8 +24,7 @@ public class KeypointsModel : Model
     /// <param name="config">Text file contains network configuration.</param>
     public KeypointsModel(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_KeypointsModel_new_String(model, config, out var p));
@@ -38,8 +37,7 @@ public class KeypointsModel : Model
     /// <param name="network">Net object.</param>
     public KeypointsModel(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_KeypointsModel_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/Model.cs
+++ b/src/OpenCvSharp/Modules/dnn/Model.cs
@@ -32,8 +32,7 @@ public class Model : CvObject
     /// <param name="config">Text file contains network configuration.</param>
     public Model(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Model_new_String(model, config, out var p));
@@ -46,8 +45,7 @@ public class Model : CvObject
     /// <param name="network">Net object.</param>
     public Model(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Model_new_Net(network.CvPtr, out var p));
@@ -62,8 +60,7 @@ public class Model : CvObject
     /// <param name="deleter">native destructor for the concrete model type</param>
     protected void SetHandle(IntPtr p, Func<IntPtr, ExceptionStatus> deleter)
     {
-        if (deleter is null)
-            throw new ArgumentNullException(nameof(deleter));
+        ArgumentNullException.ThrowIfNull(deleter);
         SetSafeHandle(new OpenCvPtrSafeHandle(p, true,
             h => NativeMethods.HandleException(deleter(h))));
     }
@@ -139,8 +136,7 @@ public class Model : CvObject
     /// <param name="outNames">Names for output layers.</param>
     public void SetOutputNames(IEnumerable<string> outNames)
     {
-        if (outNames is null)
-            throw new ArgumentNullException(nameof(outNames));
+        ArgumentNullException.ThrowIfNull(outNames);
         ThrowIfDisposed();
 
         var outNamesArray = outNames as string[] ?? outNames.ToArray();

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -64,10 +64,8 @@ public class Net : CvObject
     /// <returns></returns>
     public static Net? ReadFromModelOptimizer(string xml, string bin)
     {
-        if (xml is null) 
-            throw new ArgumentNullException(nameof(xml));
-        if (bin is null) 
-            throw new ArgumentNullException(nameof(bin));
+        ArgumentNullException.ThrowIfNull(xml);
+        ArgumentNullException.ThrowIfNull(bin);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_readFromModelOptimizer(xml, bin, out var p));
@@ -85,8 +83,7 @@ public class Net : CvObject
     /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     public static Net? ReadNetFromTensorflow(string model, string? config = null, EngineType engine = EngineType.Auto)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_readNetFromTensorflow(model, config, (int)engine, out var p));
@@ -103,8 +100,7 @@ public class Net : CvObject
     /// <param name="engine">DNN engine to use. <see cref="EngineType.Auto"/> tries the new engine first and falls back to the classic one.</param>
     public static Net? ReadNetFromTensorflow(byte[] bufferModel, byte[]? bufferConfig = null, EngineType engine = EngineType.Auto)
     {
-        if (bufferModel is null)
-            throw new ArgumentNullException(nameof(bufferModel));
+        ArgumentNullException.ThrowIfNull(bufferModel);
 
         var ret = ReadNetFromTensorflow(
             new ReadOnlySpan<byte>(bufferModel),
@@ -184,10 +180,8 @@ public class Net : CvObject
     /// <returns></returns>
     public static Net? ReadNetFromModelOptimizer(string xml, string bin)
     {
-        if (xml is null)
-            throw new ArgumentNullException(nameof(xml));
-        if (bin is null)
-            throw new ArgumentNullException(nameof(bin));
+        ArgumentNullException.ThrowIfNull(xml);
+        ArgumentNullException.ThrowIfNull(bin);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_readNetFromModelOptimizer(xml, bin, out var p));
@@ -203,8 +197,7 @@ public class Net : CvObject
     // ReSharper disable once InconsistentNaming
     public static Net? ReadNetFromONNX(string onnxFile, EngineType engine = EngineType.Auto)
     {
-        if (onnxFile is null)
-            throw new ArgumentNullException(nameof(onnxFile));
+        ArgumentNullException.ThrowIfNull(onnxFile);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_readNetFromONNX(onnxFile, (int)engine, out var p));
@@ -220,8 +213,7 @@ public class Net : CvObject
     // ReSharper disable once InconsistentNaming
     public static Net? ReadNetFromONNX(byte[] onnxFileData, EngineType engine = EngineType.Auto)
     {
-        if (onnxFileData is null)
-            throw new ArgumentNullException(nameof(onnxFileData));
+        ArgumentNullException.ThrowIfNull(onnxFileData);
 
         var ret = ReadNetFromONNX(
             new ReadOnlySpan<byte>(onnxFileData), engine);
@@ -261,8 +253,7 @@ public class Net : CvObject
     // ReSharper disable once InconsistentNaming
     public static Net? ReadNetFromTFLite(string model, EngineType engine = EngineType.Auto)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_readNetFromTFLite(model, (int)engine, out var p));
@@ -278,8 +269,7 @@ public class Net : CvObject
     // ReSharper disable once InconsistentNaming
     public static Net? ReadNetFromTFLite(byte[] bufferModel, EngineType engine = EngineType.Auto)
     {
-        if (bufferModel is null)
-            throw new ArgumentNullException(nameof(bufferModel));
+        ArgumentNullException.ThrowIfNull(bufferModel);
 
         var ret = ReadNetFromTFLite(new ReadOnlySpan<byte>(bufferModel), engine);
         GC.KeepAlive(bufferModel);
@@ -347,8 +337,7 @@ public class Net : CvObject
     /// <param name="path">path to output file with .dot extension</param>
     public void DumpToFile(string path)
     {
-        if (path is null) 
-            throw new ArgumentNullException(nameof(path));
+        ArgumentNullException.ThrowIfNull(path);
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_dumpToFile(Handle, path));
     }
@@ -360,8 +349,7 @@ public class Net : CvObject
     /// <returns>id of the layer, or -1 if the layer wasn't found.</returns>
     public int GetLayerId(string layer)
     {
-        if (layer is null)
-            throw new ArgumentNullException(nameof(layer));
+        ArgumentNullException.ThrowIfNull(layer);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -388,10 +376,8 @@ public class Net : CvObject
     /// <param name="inpPin">descriptor of the second layer input.</param>
     public void Connect(string outPin, string inpPin)
     {
-        if (outPin is null)
-            throw new ArgumentNullException(nameof(outPin));
-        if (inpPin is null)
-            throw new ArgumentNullException(nameof(inpPin));
+        ArgumentNullException.ThrowIfNull(outPin);
+        ArgumentNullException.ThrowIfNull(inpPin);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_connect1(Handle, outPin, inpPin));
@@ -422,8 +408,7 @@ public class Net : CvObject
     /// </remarks>
     public void SetInputsNames(IEnumerable<string> inputBlobNames)
     {
-        if (inputBlobNames is null)
-            throw new ArgumentNullException(nameof(inputBlobNames));
+        ArgumentNullException.ThrowIfNull(inputBlobNames);
 
         var inputBlobNamesArray = inputBlobNames.ToArray();
         NativeMethods.HandleException(
@@ -451,8 +436,7 @@ public class Net : CvObject
     /// If outputName is empty, runs forward pass for the whole network.</param>
     public void Forward(IEnumerable<Mat> outputBlobs, string? outputName = null)
     {
-        if (outputBlobs is null)
-            throw new ArgumentNullException(nameof(outputBlobs));
+        ArgumentNullException.ThrowIfNull(outputBlobs);
 
         var outputBlobsPtrs = outputBlobs.Select(x => x.CvPtr).ToArray();
         NativeMethods.HandleException(
@@ -468,10 +452,8 @@ public class Net : CvObject
     /// <param name="outBlobNames">names for layers which outputs are needed to get</param>
     public void Forward(IEnumerable<Mat> outputBlobs, IEnumerable<string> outBlobNames)
     {
-        if (outputBlobs is null)
-            throw new ArgumentNullException(nameof(outputBlobs));
-        if (outBlobNames is null)
-            throw new ArgumentNullException(nameof(outBlobNames));
+        ArgumentNullException.ThrowIfNull(outputBlobs);
+        ArgumentNullException.ThrowIfNull(outBlobNames);
 
         var outputBlobsPtrs = outputBlobs.Select(x => x.CvPtr).ToArray();
         var outBlobNamesArray = outBlobNames.ToArray();
@@ -516,8 +498,7 @@ public class Net : CvObject
     /// </remarks>
     public void SetInput(Mat blob, string name = "")
     {
-        if (blob is null)
-            throw new ArgumentNullException(nameof(blob));
+        ArgumentNullException.ThrowIfNull(blob);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_setInput(Handle, blob.CvPtr, name));
@@ -588,10 +569,8 @@ public class Net : CvObject
     /// <param name="shape">the shape of the input blob.</param>
     public void SetInputShape(string inputName, IEnumerable<int> shape)
     {
-        if (inputName is null)
-            throw new ArgumentNullException(nameof(inputName));
-        if (shape is null)
-            throw new ArgumentNullException(nameof(shape));
+        ArgumentNullException.ThrowIfNull(inputName);
+        ArgumentNullException.ThrowIfNull(shape);
         ThrowIfDisposed();
 
         var shapeArray = shape as int[] ?? shape.ToArray();
@@ -621,8 +600,7 @@ public class Net : CvObject
     /// <returns></returns>
     public Mat GetParam(string layerName, int numParam = 0)
     {
-        if (layerName is null)
-            throw new ArgumentNullException(nameof(layerName));
+        ArgumentNullException.ThrowIfNull(layerName);
         return GetParam(GetLayerId(layerName), numParam);
     }
 
@@ -634,8 +612,7 @@ public class Net : CvObject
     /// <param name="blob">the new value.</param>
     public void SetParam(int layer, int numParam, Mat blob)
     {
-        if (blob is null)
-            throw new ArgumentNullException(nameof(blob));
+        ArgumentNullException.ThrowIfNull(blob);
         ThrowIfDisposed();
         blob.ThrowIfDisposed();
         NativeMethods.HandleException(
@@ -651,8 +628,7 @@ public class Net : CvObject
     /// <param name="blob">the new value.</param>
     public void SetParam(string layerName, int numParam, Mat blob)
     {
-        if (layerName is null)
-            throw new ArgumentNullException(nameof(layerName));
+        ArgumentNullException.ThrowIfNull(layerName);
         SetParam(GetLayerId(layerName), numParam, blob);
     }
 
@@ -676,8 +652,7 @@ public class Net : CvObject
     /// <returns>count of layers</returns>
     public int GetLayersCount(string layerType)
     {
-        if (layerType is null)
-            throw new ArgumentNullException(nameof(layerType));
+        ArgumentNullException.ThrowIfNull(layerType);
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_getLayersCount(Handle, layerType, out var ret));
@@ -703,8 +678,7 @@ public class Net : CvObject
     /// <param name="path">path to output file with .pbtxt extension.</param>
     public void DumpToPbtxt(string path)
     {
-        if (path is null)
-            throw new ArgumentNullException(nameof(path));
+        ArgumentNullException.ThrowIfNull(path);
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_dumpToPbtxt(Handle, path));
@@ -823,8 +797,7 @@ public class Net : CvObject
     /// <returns>The index of the registered output.</returns>
     public int RegisterOutput(string outputName, int layerId, int outputPort)
     {
-        if (outputName is null)
-            throw new ArgumentNullException(nameof(outputName));
+        ArgumentNullException.ThrowIfNull(outputName);
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.dnn_Net_registerOutput(Handle, outputName, layerId, outputPort, out var ret));
@@ -989,10 +962,8 @@ public class Net : CvObject
     private static int[] EncodeShapes(
         IEnumerable<MatShape> netInputShapes, IEnumerable<MatType> netInputTypes, out int[] types)
     {
-        if (netInputShapes is null)
-            throw new ArgumentNullException(nameof(netInputShapes));
-        if (netInputTypes is null)
-            throw new ArgumentNullException(nameof(netInputTypes));
+        ArgumentNullException.ThrowIfNull(netInputShapes);
+        ArgumentNullException.ThrowIfNull(netInputTypes);
 
         var shapes = netInputShapes as IReadOnlyList<MatShape> ?? netInputShapes.ToArray();
         types = netInputTypes.Select(static t => t.Value).ToArray();

--- a/src/OpenCvSharp/Modules/dnn/SegmentationModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/SegmentationModel.cs
@@ -23,8 +23,7 @@ public class SegmentationModel : Model
     /// <param name="config">Text file contains network configuration.</param>
     public SegmentationModel(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_SegmentationModel_new_String(model, config, out var p));
@@ -37,8 +36,7 @@ public class SegmentationModel : Model
     /// <param name="network">Net object.</param>
     public SegmentationModel(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_SegmentationModel_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/TextDetectionModelDB.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextDetectionModelDB.cs
@@ -20,8 +20,7 @@ public class TextDetectionModelDB : TextDetectionModel
     /// <param name="config">Text file contains network configuration.</param>
     public TextDetectionModelDB(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextDetectionModel_DB_new_String(model, config, out var p));
@@ -34,8 +33,7 @@ public class TextDetectionModelDB : TextDetectionModel
     /// <param name="network">Net object.</param>
     public TextDetectionModelDB(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextDetectionModel_DB_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/TextDetectionModelEAST.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextDetectionModelEAST.cs
@@ -20,8 +20,7 @@ public class TextDetectionModelEAST : TextDetectionModel
     /// <param name="config">Text file contains network configuration.</param>
     public TextDetectionModelEAST(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextDetectionModel_EAST_new_String(model, config, out var p));
@@ -34,8 +33,7 @@ public class TextDetectionModelEAST : TextDetectionModel
     /// <param name="network">Net object.</param>
     public TextDetectionModelEAST(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextDetectionModel_EAST_new_Net(network.CvPtr, out var p));

--- a/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
@@ -25,8 +25,7 @@ public class TextRecognitionModel : Model
     /// <param name="config">Text file contains network configuration.</param>
     public TextRecognitionModel(string model, string? config = null)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
+        ArgumentNullException.ThrowIfNull(model);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextRecognitionModel_new_String(model, config, out var p));
@@ -39,8 +38,7 @@ public class TextRecognitionModel : Model
     /// <param name="network">Net object.</param>
     public TextRecognitionModel(Net network)
     {
-        if (network is null)
-            throw new ArgumentNullException(nameof(network));
+        ArgumentNullException.ThrowIfNull(network);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_TextRecognitionModel_new_Net(network.CvPtr, out var p));
@@ -56,8 +54,7 @@ public class TextRecognitionModel : Model
     /// - "CTC-prefix-beam-search" Prefix beam search decoding for the output of CTC-based methods</param>
     public void SetDecodeType(string decodeType)
     {
-        if (decodeType is null)
-            throw new ArgumentNullException(nameof(decodeType));
+        ArgumentNullException.ThrowIfNull(decodeType);
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.dnn_TextRecognitionModel_setDecodeType(Handle, decodeType));
@@ -95,8 +92,7 @@ public class TextRecognitionModel : Model
     /// <param name="vocabulary">the associated vocabulary of the network.</param>
     public void SetVocabulary(IEnumerable<string> vocabulary)
     {
-        if (vocabulary is null)
-            throw new ArgumentNullException(nameof(vocabulary));
+        ArgumentNullException.ThrowIfNull(vocabulary);
         ThrowIfDisposed();
 
         var vocabularyArray = vocabulary as string[] ?? vocabulary.ToArray();

--- a/src/OpenCvSharp/Modules/dnn/Tokenizer.cs
+++ b/src/OpenCvSharp/Modules/dnn/Tokenizer.cs
@@ -24,8 +24,7 @@ public class Tokenizer : CvObject
     /// <returns>A ready-to-use Tokenizer.</returns>
     public static Tokenizer Load(string modelConfig)
     {
-        if (modelConfig is null)
-            throw new ArgumentNullException(nameof(modelConfig));
+        ArgumentNullException.ThrowIfNull(modelConfig);
 
         NativeMethods.HandleException(
             NativeMethods.dnn_Tokenizer_load(modelConfig, out var ptr));
@@ -41,8 +40,7 @@ public class Tokenizer : CvObject
     /// <returns>The token ids.</returns>
     public int[] Encode(string text)
     {
-        if (text is null)
-            throw new ArgumentNullException(nameof(text));
+        ArgumentNullException.ThrowIfNull(text);
         ThrowIfDisposed();
 
         using var vec = new StdVector<int>();
@@ -58,8 +56,7 @@ public class Tokenizer : CvObject
     /// <returns>The decoded UTF-8 string.</returns>
     public string Decode(int[] tokens)
     {
-        if (tokens is null)
-            throw new ArgumentNullException(nameof(tokens));
+        ArgumentNullException.ThrowIfNull(tokens);
         ThrowIfDisposed();
 
         using var stdString = new StdString();

--- a/src/OpenCvSharp/Modules/dnn_superres/DnnSuperResImpl.cs
+++ b/src/OpenCvSharp/Modules/dnn_superres/DnnSuperResImpl.cs
@@ -157,10 +157,8 @@ public class DnnSuperResImpl : CvObject
         InputArray img, out Mat[] imgsNew, IEnumerable<int> scaleFactors, IEnumerable<string> nodeNames)
     {
         ThrowIfDisposed();
-        if (scaleFactors is null) 
-            throw new ArgumentNullException(nameof(scaleFactors));
-        if (nodeNames is null)
-            throw new ArgumentNullException(nameof(nodeNames));
+        ArgumentNullException.ThrowIfNull(scaleFactors);
+        ArgumentNullException.ThrowIfNull(nodeNames);
 
         using var imgsNewVec = new VectorOfMat();
         var scaleFactorsArray = scaleFactors as int[] ?? scaleFactors.ToArray();

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
@@ -24,10 +24,8 @@ public abstract class FaceRecognizer : Algorithm
     public virtual void Train(IEnumerable<Mat> src, IEnumerable<int> labels)
     {
         ThrowIfDisposed();
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (labels is null)
-            throw new ArgumentNullException(nameof(labels));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(labels);
 
         var srcArray = src.Select(x => x.CvPtr).ToArray();
         var labelsArray = labels.ToArray();
@@ -46,10 +44,8 @@ public abstract class FaceRecognizer : Algorithm
     public void Update(IEnumerable<Mat> src, IEnumerable<int> labels)
     {
         ThrowIfDisposed();
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (labels is null)
-            throw new ArgumentNullException(nameof(labels));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(labels);
 
         var srcArray = src.Select(x => x.CvPtr).ToArray();
         var labelsArray = labels.ToArray();
@@ -96,8 +92,7 @@ public abstract class FaceRecognizer : Algorithm
     public virtual void Write(string fileName)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_write1(Handle, fileName));
@@ -110,8 +105,7 @@ public abstract class FaceRecognizer : Algorithm
     public virtual void Read(string fileName)
     {
         ThrowIfDisposed();
-        if (fileName is null)
-            throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
 
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_read1(Handle, fileName));
@@ -121,8 +115,7 @@ public abstract class FaceRecognizer : Algorithm
     public override void Write(FileStorage fs)
     {
         ThrowIfDisposed();
-        if (fs is null)
-            throw new ArgumentNullException(nameof(fs));
+        ArgumentNullException.ThrowIfNull(fs);
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -134,8 +127,7 @@ public abstract class FaceRecognizer : Algorithm
     public override void Read(FileNode fn)
     {
         ThrowIfDisposed();
-        if (fn is null)
-            throw new ArgumentNullException(nameof(fn));
+        ArgumentNullException.ThrowIfNull(fn);
         fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -152,8 +144,7 @@ public abstract class FaceRecognizer : Algorithm
     public void SetLabelInfo(int label, string strInfo)
     {
         ThrowIfDisposed();
-        if (strInfo is null)
-            throw new ArgumentNullException(nameof(strInfo));
+        ArgumentNullException.ThrowIfNull(strInfo);
 
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_setLabelInfo(Handle, label, strInfo));
@@ -185,8 +176,7 @@ public abstract class FaceRecognizer : Algorithm
     public int[] GetLabelsByString(string str)
     {
         ThrowIfDisposed();
-        if (str is null)
-            throw new ArgumentNullException(nameof(str));
+        ArgumentNullException.ThrowIfNull(str);
         using var resultVector = new StdVector<int>();
         NativeMethods.HandleException(
             NativeMethods.face_FaceRecognizer_getLabelsByString(Handle, str, resultVector.CvPtr));

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -130,8 +130,7 @@ public sealed class FacemarkAAM : Facemark
         /// <param name="fn"></param>
         public void Read(FileNode fn)
         {
-            if (fn is null)
-                throw new ArgumentNullException(nameof(fn));
+            ArgumentNullException.ThrowIfNull(fn);
             var p = ToNative();
             try
             {
@@ -152,8 +151,7 @@ public sealed class FacemarkAAM : Facemark
         /// <param name="fs"></param>
         public void Write(FileStorage fs)
         {
-            if (fs is null)
-                throw new ArgumentNullException(nameof(fs));
+            ArgumentNullException.ThrowIfNull(fs);
             var p = ToNative();
             try
             {

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -166,8 +166,7 @@ public sealed class FacemarkLBF : Facemark
         /// <param name="fn"></param>
         public void Read(FileNode fn)
         {
-            if (fn is null)
-                throw new ArgumentNullException(nameof(fn));
+            ArgumentNullException.ThrowIfNull(fn);
             var p = ToNative();
             try
             {
@@ -188,8 +187,7 @@ public sealed class FacemarkLBF : Facemark
         /// <param name="fs"></param>
         public void Write(FileStorage fs)
         {
-            if (fs is null)
-                throw new ArgumentNullException(nameof(fs));
+            ArgumentNullException.ThrowIfNull(fs);
             var p = ToNative();
             try
             {

--- a/src/OpenCvSharp/Modules/features/ALIKED.cs
+++ b/src/OpenCvSharp/Modules/features/ALIKED.cs
@@ -30,8 +30,7 @@ public class ALIKED : Feature2D
         string modelPath, Size? inputSize = null, bool normalizeDescriptors = true,
         int engine = 2, int backend = 0, int target = 0)
     {
-        if (modelPath is null)
-            throw new ArgumentNullException(nameof(modelPath));
+        ArgumentNullException.ThrowIfNull(modelPath);
         var size = inputSize ?? new Size(640, 640);
 
         NativeMethods.HandleException(
@@ -55,8 +54,7 @@ public class ALIKED : Feature2D
         byte[] modelData, Size? inputSize = null, bool normalizeDescriptors = true,
         int engine = 2, int backend = 0, int target = 0)
     {
-        if (modelData is null)
-            throw new ArgumentNullException(nameof(modelData));
+        ArgumentNullException.ThrowIfNull(modelData);
         var size = inputSize ?? new Size(640, 640);
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/features/ANNIndex.cs
+++ b/src/OpenCvSharp/Modules/features/ANNIndex.cs
@@ -77,8 +77,7 @@ public class ANNIndex : CvPtrObject
     public void Save(string filename, bool prefault = false)
     {
         ThrowIfDisposed();
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         NativeMethods.HandleException(NativeMethods.features_ANNIndex_save(Handle, filename, prefault ? 1 : 0));
     }
@@ -91,8 +90,7 @@ public class ANNIndex : CvPtrObject
     public void Load(string filename, bool prefault = false)
     {
         ThrowIfDisposed();
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         NativeMethods.HandleException(NativeMethods.features_ANNIndex_load(Handle, filename, prefault ? 1 : 0));
     }
@@ -126,8 +124,7 @@ public class ANNIndex : CvPtrObject
     public bool SetOnDiskBuild(string filename)
     {
         ThrowIfDisposed();
-        if (filename is null)
-            throw new ArgumentNullException(nameof(filename));
+        ArgumentNullException.ThrowIfNull(filename);
 
         NativeMethods.HandleException(NativeMethods.features_ANNIndex_setOnDiskBuild(Handle, filename, out var ret));
         return ret != 0;

--- a/src/OpenCvSharp/Modules/features/AffineFeature.cs
+++ b/src/OpenCvSharp/Modules/features/AffineFeature.cs
@@ -30,8 +30,7 @@ public class AffineFeature : Feature2D
         Feature2D backend, int maxTilt = 5, int minTilt = 0,
         float tiltStep = 1.4142135623730951f, float rotateStepBase = 72)
     {
-        if (backend is null)
-            throw new ArgumentNullException(nameof(backend));
+        ArgumentNullException.ThrowIfNull(backend);
 
         NativeMethods.HandleException(
             NativeMethods.features_AffineFeature_create(
@@ -49,10 +48,8 @@ public class AffineFeature : Feature2D
     /// <param name="rolls">Roll (rotation) sampling values, in degrees.</param>
     public void SetViewParams(float[] tilts, float[] rolls)
     {
-        if (tilts is null)
-            throw new ArgumentNullException(nameof(tilts));
-        if (rolls is null)
-            throw new ArgumentNullException(nameof(rolls));
+        ArgumentNullException.ThrowIfNull(tilts);
+        ArgumentNullException.ThrowIfNull(rolls);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/features/DISK.cs
+++ b/src/OpenCvSharp/Modules/features/DISK.cs
@@ -31,8 +31,7 @@ public class DISK : Feature2D
         string modelPath, int maxKeypoints = -1, float scoreThreshold = 0.0f,
         Size imageSize = default, int backendId = 0, int targetId = 0)
     {
-        if (modelPath is null)
-            throw new ArgumentNullException(nameof(modelPath));
+        ArgumentNullException.ThrowIfNull(modelPath);
 
         NativeMethods.HandleException(
             NativeMethods.features_DISK_create(modelPath, maxKeypoints, scoreThreshold, imageSize, backendId, targetId, out var smartPtr));
@@ -55,8 +54,7 @@ public class DISK : Feature2D
         byte[] bufferModel, int maxKeypoints = -1, float scoreThreshold = 0.0f,
         Size imageSize = default, int backendId = 0, int targetId = 0)
     {
-        if (bufferModel is null)
-            throw new ArgumentNullException(nameof(bufferModel));
+        ArgumentNullException.ThrowIfNull(bufferModel);
 
         NativeMethods.HandleException(
             NativeMethods.features_DISK_create_buffer(

--- a/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
@@ -95,8 +95,7 @@ public class DescriptorMatcher : Algorithm
     public virtual void Add(IEnumerable<Mat> descriptors)
     {
         ThrowIfDisposed();
-        if (descriptors is null)
-            throw new ArgumentNullException(nameof(descriptors));
+        ArgumentNullException.ThrowIfNull(descriptors);
 
         var descriptorsArray = descriptors.ToArray();
         if (descriptorsArray.Length == 0)
@@ -184,10 +183,8 @@ public class DescriptorMatcher : Algorithm
     public DMatch[] Match(Mat queryDescriptors, Mat trainDescriptors, Mat? mask = null)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
-        if (trainDescriptors is null)
-            throw new ArgumentNullException(nameof(trainDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
+        ArgumentNullException.ThrowIfNull(trainDescriptors);
         using var matchesVec = new StdVector<DMatch>();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_match1(
@@ -215,10 +212,8 @@ public class DescriptorMatcher : Algorithm
         int k, Mat? mask = null, bool compactResult = false)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
-        if (trainDescriptors is null)
-            throw new ArgumentNullException(nameof(trainDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
+        ArgumentNullException.ThrowIfNull(trainDescriptors);
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
             NativeMethods.features_DescriptorMatcher_knnMatch1(
@@ -244,10 +239,8 @@ public class DescriptorMatcher : Algorithm
         float maxDistance, Mat? mask = null, bool compactResult = false)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
-        if (trainDescriptors is null)
-            throw new ArgumentNullException(nameof(trainDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
+        ArgumentNullException.ThrowIfNull(trainDescriptors);
 
         using var matchesVec = new VectorOfVectorDMatch();
         NativeMethods.HandleException(
@@ -269,8 +262,7 @@ public class DescriptorMatcher : Algorithm
     public DMatch[] Match(Mat queryDescriptors, Mat[]? masks = null)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
 
         var masksPtrs = Array.Empty<IntPtr>();
         if (masks is not null)
@@ -301,8 +293,7 @@ public class DescriptorMatcher : Algorithm
     public DMatch[][] KnnMatch(Mat queryDescriptors, int k, Mat[]? masks = null, bool compactResult = false)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
 
         var masksPtrs = Array.Empty<IntPtr>();
         if (masks is not null)
@@ -332,8 +323,7 @@ public class DescriptorMatcher : Algorithm
     public DMatch[][] RadiusMatch(Mat queryDescriptors, float maxDistance, Mat[]? masks = null, bool compactResult = false)
     {
         ThrowIfDisposed();
-        if (queryDescriptors is null)
-            throw new ArgumentNullException(nameof(queryDescriptors));
+        ArgumentNullException.ThrowIfNull(queryDescriptors);
 
         var masksPtrs = Array.Empty<IntPtr>();
         if (masks is not null)

--- a/src/OpenCvSharp/Modules/features/Feature2D.cs
+++ b/src/OpenCvSharp/Modules/features/Feature2D.cs
@@ -90,8 +90,7 @@ public class Feature2D : Algorithm
     /// <returns>The detected keypoints.</returns>
     public KeyPoint[] Detect(Mat image, Mat? mask = null)
     {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         ThrowIfDisposed();
 
         image.ThrowIfDisposed();
@@ -142,8 +141,7 @@ public class Feature2D : Algorithm
     /// <returns>Collection of keypoints detected in an input images. keypoints[i] is a set of keypoints detected in an images[i].</returns>
     public KeyPoint[][] Detect(IEnumerable<Mat> images, IEnumerable<Mat>? masks = null)
     {
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
+        ArgumentNullException.ThrowIfNull(images);
         ThrowIfDisposed();
 
         var imagesArray = images.ToArray();
@@ -198,10 +196,8 @@ public class Feature2D : Algorithm
     public virtual void Compute(IEnumerable<Mat> images, ref KeyPoint[][] keypoints, IEnumerable<Mat> descriptors)
     {
         ThrowIfDisposed();
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
-        if (descriptors is null)
-            throw new ArgumentNullException(nameof(descriptors));
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(descriptors);
 
         var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
         var descriptorsPtrs = descriptors.Select(x => x.CvPtr).ToArray();

--- a/src/OpenCvSharp/Modules/features/FlannBasedMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/FlannBasedMatcher.cs
@@ -82,8 +82,7 @@ public class FlannBasedMatcher : DescriptorMatcher
     public override void Add(IEnumerable<Mat> descriptors)
     {
         ThrowIfDisposed();
-        if (descriptors is null)
-            throw new ArgumentNullException(nameof(descriptors));
+        ArgumentNullException.ThrowIfNull(descriptors);
 
         var descriptorsArray = descriptors.ToArray();
         if (descriptorsArray.Length == 0)

--- a/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
+++ b/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
@@ -18,8 +18,7 @@ public static class KeyPointsFilter
     /// <returns></returns>
     public static KeyPoint[] RunByImageBorder(IEnumerable<KeyPoint> keypoints, Size imageSize, int borderSize)
     {
-        if (keypoints is null) 
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
@@ -38,8 +37,7 @@ public static class KeyPointsFilter
     public static KeyPoint[] RunByKeypointSize(IEnumerable<KeyPoint> keypoints, float minSize,
         float maxSize = float.MaxValue)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
@@ -56,10 +54,8 @@ public static class KeyPointsFilter
     /// <returns></returns>
     public static KeyPoint[] RunByPixelsMask(IEnumerable<KeyPoint> keypoints, Mat mask)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
-        if (mask is null) 
-            throw new ArgumentNullException(nameof(mask));
+        ArgumentNullException.ThrowIfNull(keypoints);
+        ArgumentNullException.ThrowIfNull(mask);
         mask.ThrowIfDisposed();
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
@@ -76,8 +72,7 @@ public static class KeyPointsFilter
     /// <returns></returns>
     public static KeyPoint[] RemoveDuplicated(IEnumerable<KeyPoint> keypoints)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
@@ -92,8 +87,7 @@ public static class KeyPointsFilter
     /// <returns></returns>
     public static KeyPoint[] RemoveDuplicatedSorted(IEnumerable<KeyPoint> keypoints)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
@@ -110,8 +104,7 @@ public static class KeyPointsFilter
     /// <returns></returns>
     public static KeyPoint[] RetainBest(IEnumerable<KeyPoint> keypoints, int nPoints)
     {
-        if (keypoints is null)
-            throw new ArgumentNullException(nameof(keypoints));
+        ArgumentNullException.ThrowIfNull(keypoints);
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/LightGlueMatcher.cs
@@ -23,8 +23,7 @@ public class LightGlueMatcher : DescriptorMatcher
     /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
     public static LightGlueMatcher Create(string modelPath, float scoreThreshold = 0.0f, int backend = 0, int target = 0)
     {
-        if (modelPath is null)
-            throw new ArgumentNullException(nameof(modelPath));
+        ArgumentNullException.ThrowIfNull(modelPath);
 
         NativeMethods.HandleException(
             NativeMethods.features_LightGlueMatcher_create(modelPath, scoreThreshold, backend, target, out var smartPtr));
@@ -42,8 +41,7 @@ public class LightGlueMatcher : DescriptorMatcher
     /// <param name="target">DNN target (see <see cref="Dnn.Target"/>). Default is 0 (CPU).</param>
     public static LightGlueMatcher CreateFromMemory(byte[] modelData, float scoreThreshold = 0.0f, int backend = 0, int target = 0)
     {
-        if (modelData is null)
-            throw new ArgumentNullException(nameof(modelData));
+        ArgumentNullException.ThrowIfNull(modelData);
 
         NativeMethods.HandleException(
             NativeMethods.features_LightGlueMatcher_create_buffer(

--- a/src/OpenCvSharp/Modules/flann/Index.cs
+++ b/src/OpenCvSharp/Modules/flann/Index.cs
@@ -15,8 +15,7 @@ public class Index : CvObject
     /// <param name="distType"></param>
     public Index(InputArray features, IndexParams @params, FlannDistance distType = FlannDistance.L2)
     {
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(@params);
 
         NativeMethods.HandleException(
             NativeMethods.flann_Index_new(features.Proxy, @params.CvPtr, (int)distType, out var p));
@@ -48,14 +47,11 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void KnnSearch(float[] queries, out int[] indices, out float[] dists, int knn, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(@params);
         if (queries.Length == 0)
             throw new ArgumentException("empty array", nameof(queries));
-        if (knn < 1)
-            throw new ArgumentOutOfRangeException(nameof(knn));
+        ArgumentOutOfRangeException.ThrowIfLessThan(knn, 1);
 
         indices = new int[knn];
         dists = new float[knn];
@@ -77,14 +73,10 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void KnnSearch(Mat queries, Mat indices, Mat dists, int knn, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (indices is null)
-            throw new ArgumentNullException(nameof(indices));
-        if (dists is null)
-            throw new ArgumentNullException(nameof(dists));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(indices);
+        ArgumentNullException.ThrowIfNull(dists);
+        ArgumentNullException.ThrowIfNull(@params);
 
         NativeMethods.HandleException(
             NativeMethods.flann_Index_knnSearch2(
@@ -106,12 +98,9 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void KnnSearch(Mat queries, out int[] indices, out float[] dists, int knn, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
-        if (knn < 1)
-            throw new ArgumentOutOfRangeException(nameof(knn));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(@params);
+        ArgumentOutOfRangeException.ThrowIfLessThan(knn, 1);
 
         indices = new int[knn];
         dists = new float[knn];
@@ -135,14 +124,10 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void RadiusSearch(float[] queries, int[] indices, float[] dists, double radius, int maxResults, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (indices is null)
-            throw new ArgumentNullException(nameof(indices));
-        if (dists is null)
-            throw new ArgumentNullException(nameof(dists));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(indices);
+        ArgumentNullException.ThrowIfNull(dists);
+        ArgumentNullException.ThrowIfNull(@params);
 
         NativeMethods.HandleException(
             NativeMethods.flann_Index_radiusSearch1(
@@ -162,14 +147,10 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void RadiusSearch(Mat queries, Mat indices, Mat dists, double radius, int maxResults, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (indices is null)
-            throw new ArgumentNullException(nameof(indices));
-        if (dists is null)
-            throw new ArgumentNullException(nameof(dists));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(indices);
+        ArgumentNullException.ThrowIfNull(dists);
+        ArgumentNullException.ThrowIfNull(@params);
 
         NativeMethods.HandleException(
             NativeMethods.flann_Index_radiusSearch2(
@@ -192,14 +173,10 @@ public class Index : CvObject
     /// <param name="params">Search parameters</param>
     public void RadiusSearch(Mat queries, int[] indices, float[] dists, double radius, int maxResults, SearchParams @params)
     {
-        if (queries is null)
-            throw new ArgumentNullException(nameof(queries));
-        if (indices is null)
-            throw new ArgumentNullException(nameof(indices));
-        if (dists is null)
-            throw new ArgumentNullException(nameof(dists));
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(queries);
+        ArgumentNullException.ThrowIfNull(indices);
+        ArgumentNullException.ThrowIfNull(dists);
+        ArgumentNullException.ThrowIfNull(@params);
 
         NativeMethods.HandleException(
             NativeMethods.flann_Index_radiusSearch3(

--- a/src/OpenCvSharp/Modules/highgui/CvTrackbar.cs
+++ b/src/OpenCvSharp/Modules/highgui/CvTrackbar.cs
@@ -50,7 +50,8 @@ public sealed class CvTrackbar
         if (string.IsNullOrEmpty(windowName))
             throw new ArgumentException("Null or empty window name.", nameof(windowName));
 
-        Callback = callback ?? throw new ArgumentNullException(nameof(callback));
+        ArgumentNullException.ThrowIfNull(callback);
+        Callback = callback;
         TrackbarName = trackbarName;
         WindowName = windowName;
 

--- a/src/OpenCvSharp/Modules/highgui/Window.cs
+++ b/src/OpenCvSharp/Modules/highgui/Window.cs
@@ -257,8 +257,7 @@ public sealed class Window : IDisposable
     /// <param name="images"></param>
     public static void ShowImages(params Mat[] images)
     {
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
+        ArgumentNullException.ThrowIfNull(images);
 
         ShowImagesAndWaitKey(images.Select(img => new Window { Image = img }));
     }
@@ -271,8 +270,7 @@ public sealed class Window : IDisposable
     /// <param name="images">Pairs of window title and image to display</param>
     public static void ShowImages(params (string Title, Mat Image)[] images)
     {
-        if (images is null)
-            throw new ArgumentNullException(nameof(images));
+        ArgumentNullException.ThrowIfNull(images);
 
         ShowImagesAndWaitKey(images.Select(t => new Window(t.Title, image: t.Image)));
     }

--- a/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
+++ b/src/OpenCvSharp/Modules/imgproc/ConnectedComponent.cs
@@ -56,12 +56,9 @@ public class ConnectedComponents
     /// <returns>Filtered image.</returns>
     public void FilterByLabels(Mat src, Mat dst, IEnumerable<int> labelValues)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (dst is null)
-            throw new ArgumentNullException(nameof(dst));
-        if (labelValues is null)
-            throw new ArgumentNullException(nameof(labelValues));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        ArgumentNullException.ThrowIfNull(labelValues);
         var labelArray = labelValues.ToArray();
         if (labelArray.Length == 0)
             throw new ArgumentException("empty labelValues");
@@ -93,8 +90,7 @@ public class ConnectedComponents
     /// <returns>Filtered image.</returns>
     public void FilterByBlob(Mat src, Mat dst, Blob blob)
     {
-        if (blob is null)
-            throw new ArgumentNullException(nameof(blob));
+        ArgumentNullException.ThrowIfNull(blob);
         FilterByLabels(src, dst, [blob.Label]);
     }
 
@@ -116,8 +112,7 @@ public class ConnectedComponents
     /// <param name="img">The target image to be drawn.</param>
     public void RenderBlobs(Mat img)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         if (Blobs is null || Blobs.Count == 0)
             throw new OpenCvSharpException("Blobs is empty");
         if (Labels is null)

--- a/src/OpenCvSharp/Modules/imgproc/CvExtensions.cs
+++ b/src/OpenCvSharp/Modules/imgproc/CvExtensions.cs
@@ -24,24 +24,17 @@ public static class CvExtensions
     public static LineSegmentPoint[] HoughLinesProbabilisticEx(this Mat img, double rho, double theta, int threshold, double minLineLength, double maxLineGap,
         double thetaMin = 0, double thetaMax = Math.PI)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         if (img.Type() != MatType.CV_8UC1)
             throw new ArgumentException("The source matrix must be 8-bit, single-channel image.");
-        if (rho <= 0)
-            throw new ArgumentOutOfRangeException(nameof(rho));
-        if (theta <= 0)
-            throw new ArgumentOutOfRangeException(nameof(theta));
-        if (threshold <= 0)
-            throw new ArgumentOutOfRangeException(nameof(threshold));
-        if (minLineLength <= 0)
-            throw new ArgumentOutOfRangeException(nameof(minLineLength));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(rho);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(theta);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(threshold);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(minLineLength);
         if (thetaMax < thetaMin)
             throw new ArgumentException("thetaMax < thetaMin");
-        if (thetaMax > Math.PI)
-            throw new ArgumentOutOfRangeException(nameof(thetaMax), "thetaMax <= pi");
-        if (thetaMin < 0)
-            throw new ArgumentOutOfRangeException(nameof(thetaMin), "thetaMin >= 0");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(thetaMax, Math.PI);
+        ArgumentOutOfRangeException.ThrowIfNegative(thetaMin);
 
         unsafe
         {

--- a/src/OpenCvSharp/Modules/imgproc/FontFace.cs
+++ b/src/OpenCvSharp/Modules/imgproc/FontFace.cs
@@ -28,8 +28,7 @@ public class FontFace : CvObject
     /// ("sans", "italic" or "uni"). An empty string means the default embedded font.</param>
     public FontFace(string fontPathOrName)
     {
-        if (fontPathOrName is null)
-            throw new ArgumentNullException(nameof(fontPathOrName));
+        ArgumentNullException.ThrowIfNull(fontPathOrName);
         NativeMethods.HandleException(
             NativeMethods.imgproc_FontFace_new2(fontPathOrName, out var p));
         if (p == IntPtr.Zero)
@@ -50,8 +49,7 @@ public class FontFace : CvObject
     /// <returns>True on success.</returns>
     public bool Set(string fontPathOrName)
     {
-        if (fontPathOrName is null)
-            throw new ArgumentNullException(nameof(fontPathOrName));
+        ArgumentNullException.ThrowIfNull(fontPathOrName);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -82,8 +80,7 @@ public class FontFace : CvObject
     /// <returns>True on success.</returns>
     public bool SetInstance(int[] @params)
     {
-        if (@params is null)
-            throw new ArgumentNullException(nameof(@params));
+        ArgumentNullException.ThrowIfNull(@params);
         ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/imgproc/LineIterator.cs
+++ b/src/OpenCvSharp/Modules/imgproc/LineIterator.cs
@@ -41,7 +41,8 @@ public sealed class LineIterator : CvObject, IEnumerable<LineIterator.Pixel>
         PixelConnectivity connectivity = PixelConnectivity.Connectivity8,
         bool leftToRight = false)
     {
-        this.img = img ?? throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
+        this.img = img;
         this.pt1 = pt1;
         this.pt2 = pt2;
         this.connectivity = connectivity;

--- a/src/OpenCvSharp/Modules/imgproc/Model/Line2D.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Model/Line2D.cs
@@ -52,8 +52,7 @@ public class Line2D
     /// <param name="line">The returned value from cvFitLine</param>param>
     public Line2D(float[] line)
     {
-        if (line is null)
-            throw new ArgumentNullException(nameof(line));
+        ArgumentNullException.ThrowIfNull(line);
 
         Vx = line[0];
         Vy = line[1];

--- a/src/OpenCvSharp/Modules/imgproc/Model/Line3D.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Model/Line3D.cs
@@ -60,8 +60,7 @@ public class Line3D
     /// <param name="line">The returned value from cvFitLine</param>param>
     public Line3D(float[] line)
     {
-        if (line is null)
-            throw new ArgumentNullException(nameof(line));
+        ArgumentNullException.ThrowIfNull(line);
         if (line.Length != 6)
             throw new ArgumentException("array.Length != 6", nameof(line));
 

--- a/src/OpenCvSharp/Modules/imgproc/Moments.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Moments.cs
@@ -79,8 +79,7 @@ public class Moments
     /// <returns></returns>
     public Moments(byte[,] array, bool binaryImage = false)
     {
-        if (array is null)
-            throw new ArgumentNullException(nameof(array));
+        ArgumentNullException.ThrowIfNull(array);
         var rows = array.GetLength(0);
         var cols = array.GetLength(1);
         using var arrayMat = Mat.FromPixelData(rows, cols, MatType.CV_8UC1, array);
@@ -96,8 +95,7 @@ public class Moments
     /// <returns></returns>
     public Moments(float[,] array, bool binaryImage = false)
     {
-        if (array is null)
-            throw new ArgumentNullException(nameof(array));
+        ArgumentNullException.ThrowIfNull(array);
         var rows = array.GetLength(0);
         var cols = array.GetLength(1);
         using var arrayMat = Mat.FromPixelData(rows, cols, MatType.CV_32FC1, array);
@@ -113,8 +111,7 @@ public class Moments
     /// <returns></returns>
     public Moments(IEnumerable<Point> array, bool binaryImage = false)
     {
-        if (array is null)
-            throw new ArgumentNullException(nameof(array));
+        ArgumentNullException.ThrowIfNull(array);
         var points = array.ToArray();
         using var pointsMat = Mat.FromPixelData(points.Length, 1, MatType.CV_32SC2, points);
         InitializeFromInputArray(pointsMat, binaryImage);
@@ -129,8 +126,7 @@ public class Moments
     /// <returns></returns>
     public Moments(IEnumerable<Point2f> array, bool binaryImage = false)
     {
-        if (array is null)
-            throw new ArgumentNullException(nameof(array));
+        ArgumentNullException.ThrowIfNull(array);
         var points = array.ToArray();
         using var pointsMat = Mat.FromPixelData(points.Length, 1, MatType.CV_32FC2, points);
         InitializeFromInputArray(pointsMat, binaryImage);

--- a/src/OpenCvSharp/Modules/imgproc/Subdiv2D.cs
+++ b/src/OpenCvSharp/Modules/imgproc/Subdiv2D.cs
@@ -139,8 +139,7 @@ public class Subdiv2D : CvObject
     public void Insert(IEnumerable<Point2f> ptVec)
     {
         ThrowIfDisposed();
-        if (ptVec is null)
-            throw new ArgumentNullException(nameof(ptVec));
+        ArgumentNullException.ThrowIfNull(ptVec);
 
         var ptVecArray = ptVec.CastOrToArray();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/LSDDetector.cs
@@ -74,8 +74,7 @@ namespace OpenCvSharp.LineDescriptor
         /// <returns>vector that will store extracted lines for one or more images</returns>
         public KeyLine[] Detect(Mat image, int scale, int numOctaves, Mat? mask = null)
         {
-            if (image is null)
-                throw new ArgumentNullException(nameof(image));
+            ArgumentNullException.ThrowIfNull(image);
             image.ThrowIfDisposed();
             mask?.ThrowIfDisposed();
 
@@ -99,8 +98,7 @@ namespace OpenCvSharp.LineDescriptor
         /// <returns>set of vectors that will store extracted lines for one or more images</returns>
         public KeyLine[][] Detect(IEnumerable<Mat> images, int scale, int numOctaves, IEnumerable<Mat>? masks = null)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
 
             var imagesPtrs = images.Select(i =>
             {

--- a/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
+++ b/src/OpenCvSharp/Modules/ml/ANN_MLP.cs
@@ -39,8 +39,7 @@ public class ANN_MLP : StatModel
     /// <returns></returns>
     public static ANN_MLP Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_ANN_MLP_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_ANN_MLP_get(smartPtr, out var rawPtr));
@@ -54,8 +53,7 @@ public class ANN_MLP : StatModel
     /// <returns></returns>
     public static ANN_MLP LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_ANN_MLP_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_ANN_MLP_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/Boost.cs
+++ b/src/OpenCvSharp/Modules/ml/Boost.cs
@@ -34,8 +34,7 @@ public class Boost : DTrees
     /// <returns></returns>
     public new static Boost Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_Boost_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_Boost_get(smartPtr, out var rawPtr));
@@ -49,8 +48,7 @@ public class Boost : DTrees
     /// <returns></returns>
     public new static Boost LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_Boost_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_Boost_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/DTrees.cs
+++ b/src/OpenCvSharp/Modules/ml/DTrees.cs
@@ -40,8 +40,7 @@ public class DTrees : StatModel
     /// <returns></returns>
     public static DTrees Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_DTrees_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_DTrees_get(smartPtr, out var rawPtr));
@@ -55,8 +54,7 @@ public class DTrees : StatModel
     /// <returns></returns>
     public static DTrees LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_DTrees_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_DTrees_get(smartPtr, out var rawPtr));
@@ -238,8 +236,7 @@ public class DTrees : StatModel
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
 
             NativeMethods.HandleException(
                 NativeMethods.ml_DTrees_setPriors(Handle, value.CvPtr));

--- a/src/OpenCvSharp/Modules/ml/EM.cs
+++ b/src/OpenCvSharp/Modules/ml/EM.cs
@@ -47,8 +47,7 @@ public class EM : Algorithm
     /// <returns></returns>
     public static EM Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_EM_load(filePath, out var ret));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_EM_get(ret, out var rawPtr));
@@ -62,8 +61,7 @@ public class EM : Algorithm
     /// <returns></returns>
     public static EM LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_EM_loadFromString(strModel, out var ret));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_EM_get(ret, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/KNearest.cs
+++ b/src/OpenCvSharp/Modules/ml/KNearest.cs
@@ -36,8 +36,7 @@ public class KNearest : StatModel
     /// <returns></returns>
     public static KNearest Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_KNearest_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_KNearest_get(smartPtr, out var rawPtr));
@@ -51,8 +50,7 @@ public class KNearest : StatModel
     /// <returns></returns>
     public static KNearest LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_KNearest_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_KNearest_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
+++ b/src/OpenCvSharp/Modules/ml/LogisticRegression.cs
@@ -34,8 +34,7 @@ public class LogisticRegression : StatModel
     /// <returns></returns>
     public static LogisticRegression Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_LogisticRegression_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_LogisticRegression_get(smartPtr, out var rawPtr));
@@ -49,8 +48,7 @@ public class LogisticRegression : StatModel
     /// <returns></returns>
     public static LogisticRegression LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_LogisticRegression_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_LogisticRegression_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
+++ b/src/OpenCvSharp/Modules/ml/NormalBayesClassifier.cs
@@ -33,8 +33,7 @@ public class NormalBayesClassifier : StatModel
     /// <returns></returns>
     public static NormalBayesClassifier Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_NormalBayesClassifier_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_NormalBayesClassifier_get(smartPtr, out var rawPtr));
@@ -48,8 +47,7 @@ public class NormalBayesClassifier : StatModel
     /// <returns></returns>
     public static NormalBayesClassifier LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_NormalBayesClassifier_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_NormalBayesClassifier_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/RTrees.cs
+++ b/src/OpenCvSharp/Modules/ml/RTrees.cs
@@ -34,8 +34,7 @@ public class RTrees : DTrees
     /// <returns></returns>
     public new static RTrees Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_RTrees_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_RTrees_get(smartPtr, out var rawPtr));
@@ -49,8 +48,7 @@ public class RTrees : DTrees
     /// <returns></returns>
     public new static RTrees LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_RTrees_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_RTrees_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/ml/SVM.cs
+++ b/src/OpenCvSharp/Modules/ml/SVM.cs
@@ -40,8 +40,7 @@ public class SVM : StatModel
     /// <returns></returns>
     public static SVM Load(string filePath)
     {
-        if (filePath is null)
-            throw new ArgumentNullException(nameof(filePath));
+        ArgumentNullException.ThrowIfNull(filePath);
         NativeMethods.HandleException(
             NativeMethods.ml_SVM_load(filePath, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_SVM_get(smartPtr, out var rawPtr));
@@ -55,8 +54,7 @@ public class SVM : StatModel
     /// <returns></returns>
     public static SVM LoadFromString(string strModel)
     {
-        if (strModel is null)
-            throw new ArgumentNullException(nameof(strModel));
+        ArgumentNullException.ThrowIfNull(strModel);
         NativeMethods.HandleException(
             NativeMethods.ml_SVM_loadFromString(strModel, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ml_Ptr_SVM_get(smartPtr, out var rawPtr));
@@ -219,8 +217,7 @@ public class SVM : StatModel
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
 
             NativeMethods.HandleException(
                 NativeMethods.ml_SVM_setClassWeights(Handle, value.CvPtr));

--- a/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
+++ b/src/OpenCvSharp/Modules/objdetect/CascadeClassifier.cs
@@ -90,10 +90,8 @@ public class CascadeClassifier : CvObject
     /// <param name="fn"></param>
     public virtual bool Read(FileNode fn)
     {
-        if (ptr == IntPtr.Zero)
-            throw new ObjectDisposedException(GetType().Name);
-        if (fn is null)
-            throw new ArgumentNullException(nameof(fn));
+        ObjectDisposedException.ThrowIf(ptr == IntPtr.Zero, this);
+        ArgumentNullException.ThrowIfNull(fn);
 
         NativeMethods.HandleException(
             NativeMethods.objdetect_CascadeClassifier_read(Handle, fn.CvPtr, out var ret));
@@ -122,8 +120,7 @@ public class CascadeClassifier : CvObject
         Size? maxSize = null)
     {
         ThrowIfDisposed();
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         var minSize0 = minSize.GetValueOrDefault(new Size());
@@ -165,8 +162,7 @@ public class CascadeClassifier : CvObject
         bool outputRejectLevels = false)
     {
         ThrowIfDisposed();
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         var minSize0 = minSize.GetValueOrDefault(new Size());

--- a/src/OpenCvSharp/Modules/objdetect/HOGDescriptor.cs
+++ b/src/OpenCvSharp/Modules/objdetect/HOGDescriptor.cs
@@ -1751,8 +1751,7 @@ public class HOGDescriptor : CvObject
     public virtual float[] Compute(Mat img, Size? winStride = null, Size? padding = null, Point[]? locations = null)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
         var padding0 = padding.GetValueOrDefault(new Size());
@@ -1781,8 +1780,7 @@ public class HOGDescriptor : CvObject
         double hitThreshold = 0, Size? winStride = null, Size? padding = null, Point[]? searchLocations = null)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
@@ -1815,8 +1813,7 @@ public class HOGDescriptor : CvObject
         double hitThreshold = 0, Size? winStride = null, Size? padding = null, Point[]? searchLocations = null)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
@@ -1851,8 +1848,7 @@ public class HOGDescriptor : CvObject
         double hitThreshold = 0, Size? winStride = null, Size? padding = null, double scale=1.05, int groupThreshold = 2)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
@@ -1884,8 +1880,7 @@ public class HOGDescriptor : CvObject
         double hitThreshold = 0, Size? winStride = null, Size? padding = null, double scale = 1.05, int groupThreshold = 2)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
@@ -1914,12 +1909,9 @@ public class HOGDescriptor : CvObject
     public virtual void ComputeGradient(Mat img, Mat grad, Mat angleOfs, Size? paddingTL = null, Size? paddingBR = null)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
-        if (grad is null)
-            throw new ArgumentNullException(nameof(grad));
-        if (angleOfs is null)
-            throw new ArgumentNullException(nameof(angleOfs));
+        ArgumentNullException.ThrowIfNull(img);
+        ArgumentNullException.ThrowIfNull(grad);
+        ArgumentNullException.ThrowIfNull(angleOfs);
         img.ThrowIfDisposed();
         grad.ThrowIfDisposed();
         angleOfs.ThrowIfDisposed();
@@ -1952,10 +1944,8 @@ public class HOGDescriptor : CvObject
         double hitThreshold = 0, Size? winStride = null, Size? padding = null)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
-        if (locations is null)
-            throw new ArgumentNullException(nameof(locations));
+        ArgumentNullException.ThrowIfNull(img);
+        ArgumentNullException.ThrowIfNull(locations);
         img.ThrowIfDisposed();
 
         var winStride0 = winStride.GetValueOrDefault(new Size());
@@ -1990,8 +1980,7 @@ public class HOGDescriptor : CvObject
         int groupThreshold = 0)
     {
         ThrowIfDisposed();
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
+        ArgumentNullException.ThrowIfNull(img);
         img.ThrowIfDisposed();
 
         using var flVec = new StdVector<Rect>();

--- a/src/OpenCvSharp/Modules/objdetect/QRCodeDetector.cs
+++ b/src/OpenCvSharp/Modules/objdetect/QRCodeDetector.cs
@@ -81,8 +81,7 @@ public class QRCodeDetector : CvObject
     /// <returns></returns>
     public string Decode(InputArray img, IEnumerable<Point2f> points, OutputArray straightQrCode = default)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
 
         using var pointsVec = new StdVector<Point2f>(points);
         using var resultString = new StdString();
@@ -178,8 +177,7 @@ public class QRCodeDetector : CvObject
     /// <returns></returns>
     protected bool DecodeMulti(InputArray img, IEnumerable<Point2f> points, out string?[] decodedInfo, out Mat[] straightQrCode, bool isOutputStraightQrCode)
     {
-        if (points is null)
-            throw new ArgumentNullException(nameof(points));
+        ArgumentNullException.ThrowIfNull(points);
 
         using var decodedInfoVec = new VectorOfString();
         using var pointsVec = new StdVector<Point2f>(points);

--- a/src/OpenCvSharp/Modules/photo/CalibrateCRF.cs
+++ b/src/OpenCvSharp/Modules/photo/CalibrateCRF.cs
@@ -20,10 +20,8 @@ public abstract class CalibrateCRF : Algorithm
     /// <param name="times">vector of exposure time values for each image</param>
     public virtual void Process(IEnumerable<Mat> src, OutputArray dst, IEnumerable<float> times)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (times is null)
-            throw new ArgumentNullException(nameof(times));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(times);
 
         var srcArray = src.Select(x => x.CvPtr).ToArray();
         var timesArray = times.ToArray();

--- a/src/OpenCvSharp/Modules/photo/MergeExposures.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeExposures.cs
@@ -20,10 +20,8 @@ public abstract class MergeExposures : Algorithm
     /// <param name="response"> 256x1 matrix with inverse camera response function for each pixel value, it should have the same number of channels as images.</param>
     public virtual void Process(IEnumerable<Mat> src, OutputArray dst, IEnumerable<float> times, InputArray response)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (times is null)
-            throw new ArgumentNullException(nameof(times));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(times);
 
         var srcArray = src.Select(s => s.CvPtr).ToArray();
         var timesArray = times as float[] ?? times.ToArray();

--- a/src/OpenCvSharp/Modules/photo/MergeMertens.cs
+++ b/src/OpenCvSharp/Modules/photo/MergeMertens.cs
@@ -39,8 +39,7 @@ public sealed class MergeMertens : MergeExposures
     /// <param name="dst">result image</param>
     public void Process(IEnumerable<Mat> src, OutputArray dst)
     {
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
+        ArgumentNullException.ThrowIfNull(src);
 
         var srcArray = src.Select(s => s.CvPtr).ToArray();
 

--- a/src/OpenCvSharp/Modules/ptcloud/Odometry.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/Odometry.cs
@@ -45,8 +45,7 @@ public class Odometry : CvObject
     /// <param name="algtype">odometry algorithm type.</param>
     public Odometry(OdometryType otype, OdometrySettings settings, OdometryAlgoType algtype)
     {
-        if (settings is null)
-            throw new ArgumentNullException(nameof(settings));
+        ArgumentNullException.ThrowIfNull(settings);
         settings.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ptcloud_Odometry_new3((int)otype, settings.CvPtr, (int)algtype, out var p));
@@ -81,8 +80,7 @@ public class Odometry : CvObject
     public void PrepareFrame(OdometryFrame frame)
     {
         ThrowIfDisposed();
-        if (frame is null)
-            throw new ArgumentNullException(nameof(frame));
+        ArgumentNullException.ThrowIfNull(frame);
         frame.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ptcloud_Odometry_prepareFrame(Handle, frame.CvPtr));
@@ -97,10 +95,8 @@ public class Odometry : CvObject
     public void PrepareFrames(OdometryFrame srcFrame, OdometryFrame dstFrame)
     {
         ThrowIfDisposed();
-        if (srcFrame is null)
-            throw new ArgumentNullException(nameof(srcFrame));
-        if (dstFrame is null)
-            throw new ArgumentNullException(nameof(dstFrame));
+        ArgumentNullException.ThrowIfNull(srcFrame);
+        ArgumentNullException.ThrowIfNull(dstFrame);
         srcFrame.ThrowIfDisposed();
         dstFrame.ThrowIfDisposed();
         NativeMethods.HandleException(
@@ -119,10 +115,8 @@ public class Odometry : CvObject
     public bool Compute(OdometryFrame srcFrame, OdometryFrame dstFrame, OutputArray Rt)
     {
         ThrowIfDisposed();
-        if (srcFrame is null)
-            throw new ArgumentNullException(nameof(srcFrame));
-        if (dstFrame is null)
-            throw new ArgumentNullException(nameof(dstFrame));
+        ArgumentNullException.ThrowIfNull(srcFrame);
+        ArgumentNullException.ThrowIfNull(dstFrame);
         srcFrame.ThrowIfDisposed();
         dstFrame.ThrowIfDisposed();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/ptcloud/Volume.cs
+++ b/src/OpenCvSharp/Modules/ptcloud/Volume.cs
@@ -69,8 +69,7 @@ public class Volume : CvObject
     public void IntegrateFrame(OdometryFrame frame, InputArray pose)
     {
         ThrowIfDisposed();
-        if (frame is null)
-            throw new ArgumentNullException(nameof(frame));
+        ArgumentNullException.ThrowIfNull(frame);
         frame.ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.ptcloud_Volume_integrateFrame(Handle, frame.CvPtr, pose.Proxy));

--- a/src/OpenCvSharp/Modules/quality/QualityBRISQUE.cs
+++ b/src/OpenCvSharp/Modules/quality/QualityBRISQUE.cs
@@ -50,10 +50,8 @@ public class QualityBRISQUE : QualityBase
     /// <returns></returns>
     public static QualityBRISQUE Create(SVM model, Mat range)
     {
-        if (model is null)
-            throw new ArgumentNullException(nameof(model));
-        if (range is null)
-            throw new ArgumentNullException(nameof(range));
+        ArgumentNullException.ThrowIfNull(model);
+        ArgumentNullException.ThrowIfNull(range);
         model.ThrowIfDisposed();
         range.ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
+++ b/src/OpenCvSharp/Modules/saliency/ObjectnessBING.cs
@@ -69,8 +69,7 @@ public class ObjectnessBING : Algorithm
     public void SetTrainingPath(string trainingPath)
     {
         ThrowIfDisposed();
-        if (trainingPath is null)
-            throw new ArgumentNullException(nameof(trainingPath));
+        ArgumentNullException.ThrowIfNull(trainingPath);
         NativeMethods.HandleException(
             NativeMethods.saliency_ObjectnessBING_setTrainingPath(Handle, trainingPath));
     }
@@ -81,8 +80,7 @@ public class ObjectnessBING : Algorithm
     public void SetBBResDir(string resultsDir)
     {
         ThrowIfDisposed();
-        if (resultsDir is null)
-            throw new ArgumentNullException(nameof(resultsDir));
+        ArgumentNullException.ThrowIfNull(resultsDir);
         NativeMethods.HandleException(
             NativeMethods.saliency_ObjectnessBING_setBBResDir(Handle, resultsDir));
     }

--- a/src/OpenCvSharp/Modules/shape/ShapeContextDistanceExtractor.cs
+++ b/src/OpenCvSharp/Modules/shape/ShapeContextDistanceExtractor.cs
@@ -294,8 +294,7 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
     public void SetCostExtractor(HistogramCostExtractor comparer)
     {
         ThrowIfDisposed();
-        if (comparer is null)
-            throw new ArgumentNullException(nameof(comparer));
+        ArgumentNullException.ThrowIfNull(comparer);
         comparer.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -312,8 +311,7 @@ public class ShapeContextDistanceExtractor : ShapeDistanceExtractor
     public void SetTransformAlgorithm(ShapeTransformer transformer)
     {
         ThrowIfDisposed();
-        if (transformer is null)
-            throw new ArgumentNullException(nameof(transformer));
+        ArgumentNullException.ThrowIfNull(transformer);
         transformer.ThrowIfDisposed();
 
         var basePtr = transformer.CreateBaseSmartPtr();

--- a/src/OpenCvSharp/Modules/shape/ShapeTransformer.cs
+++ b/src/OpenCvSharp/Modules/shape/ShapeTransformer.cs
@@ -32,8 +32,7 @@ public abstract class ShapeTransformer : Algorithm
         IEnumerable<DMatch> matches)
     {
         ThrowIfDisposed();
-        if (matches is null)
-            throw new ArgumentNullException(nameof(matches));
+        ArgumentNullException.ThrowIfNull(matches);
 
         using var matchesVec = new StdVector<DMatch>(matches);
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
+++ b/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
@@ -24,10 +24,8 @@ public static partial class Cv2
             IEnumerable<Mat> images,
             IEnumerable<Mat>? masks = null)
         {
-            if (featuresFinder is null)
-                throw new ArgumentNullException(nameof(featuresFinder));
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(featuresFinder);
+            ArgumentNullException.ThrowIfNull(images);
             featuresFinder.ThrowIfDisposed();
 
             var imagesArray = images as Mat[] ?? images.ToArray();
@@ -67,8 +65,7 @@ public static partial class Cv2
             InputArray image,
             InputArray mask = default)
         {
-            if (featuresFinder is null)
-                throw new ArgumentNullException(nameof(featuresFinder));
+            ArgumentNullException.ThrowIfNull(featuresFinder);
             featuresFinder.ThrowIfDisposed();
 
             var descriptorsMat = new Mat();

--- a/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
@@ -29,10 +29,8 @@ public abstract class FeaturesMatcher : CvObject
     {
         ThrowIfDisposed();
 
-        if (features1 is null)
-            throw new ArgumentNullException(nameof(features1));
-        if (features2 is null) 
-            throw new ArgumentNullException(nameof(features2));
+        ArgumentNullException.ThrowIfNull(features1);
+        ArgumentNullException.ThrowIfNull(features2);
         if (features1.Descriptors is null)
             throw new ArgumentException($"{nameof(features1)}.Descriptors is null", nameof(features1));
         if (features2.Descriptors is null)
@@ -87,8 +85,7 @@ public abstract class FeaturesMatcher : CvObject
     public virtual MatchesInfo[] Apply(
         IEnumerable<ImageFeatures> features, Mat? mask = null)
     {
-        if (features is null) 
-            throw new ArgumentNullException(nameof(features));
+        ArgumentNullException.ThrowIfNull(features);
         ThrowIfDisposed();
 
         var featuresArray = features.CastOrToArray();

--- a/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
@@ -85,8 +85,8 @@ public abstract class FeaturesMatcher : CvObject
     public virtual MatchesInfo[] Apply(
         IEnumerable<ImageFeatures> features, Mat? mask = null)
     {
-        ArgumentNullException.ThrowIfNull(features);
         ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(features);
 
         var featuresArray = features.CastOrToArray();
         if (featuresArray.Length == 0)

--- a/src/OpenCvSharp/Modules/stitching/MatchesInfo.cs
+++ b/src/OpenCvSharp/Modules/stitching/MatchesInfo.cs
@@ -77,8 +77,7 @@ public sealed class MatchesInfo : IDisposable
     /// <param name="other"></param>
     public MatchesInfo(MatchesInfo other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
+        ArgumentNullException.ThrowIfNull(other);
         SrcImgIdx = other.SrcImgIdx;
         DstImgIdx = other.DstImgIdx;
         Matches = other.Matches;

--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -280,8 +280,7 @@ namespace OpenCvSharp
 
         public Status EstimateTransform(InputArray images, Rect[][] rois)
         {
-            if (rois is null)
-                throw new ArgumentNullException(nameof(rois));
+            ArgumentNullException.ThrowIfNull(rois);
 
             using var roisPointer = new ArrayAddress2<Rect>(rois);
             NativeMethods.HandleException(
@@ -293,8 +292,7 @@ namespace OpenCvSharp
 
         public Status EstimateTransform(IEnumerable<Mat> images)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
 
@@ -308,10 +306,8 @@ namespace OpenCvSharp
 
         public Status EstimateTransform(IEnumerable<Mat> images, Rect[][] rois)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
-            if (rois is null)
-                throw new ArgumentNullException(nameof(rois));
+            ArgumentNullException.ThrowIfNull(images);
+            ArgumentNullException.ThrowIfNull(rois);
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
             using var roisPointer = new ArrayAddress2<Rect>(rois);
@@ -346,8 +342,7 @@ namespace OpenCvSharp
 
         public Status ComposePanorama(IEnumerable<Mat> images, OutputArray pano)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
             NativeMethods.HandleException(
@@ -383,8 +378,7 @@ namespace OpenCvSharp
         /// <returns>Status code.</returns>
         public Status Stitch(IEnumerable<Mat> images, OutputArray pano)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
+            ArgumentNullException.ThrowIfNull(images);
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
 
@@ -406,8 +400,7 @@ namespace OpenCvSharp
         /// <returns>Status code.</returns>
         public Status Stitch(InputArray images, Rect[][] rois, OutputArray pano)
         {
-            if (rois is null)
-                throw new ArgumentNullException(nameof(rois));
+            ArgumentNullException.ThrowIfNull(rois);
 
             using var roisPointer = new ArrayAddress2<Rect>(rois);
             NativeMethods.HandleException(
@@ -427,10 +420,8 @@ namespace OpenCvSharp
         /// <returns>Status code.</returns>
         public Status Stitch(IEnumerable<Mat> images, Rect[][] rois, OutputArray pano)
         {
-            if (images is null)
-                throw new ArgumentNullException(nameof(images));
-            if (rois is null)
-                throw new ArgumentNullException(nameof(rois));
+            ArgumentNullException.ThrowIfNull(images);
+            ArgumentNullException.ThrowIfNull(rois);
 
             var imagesPtrs = images.Select(x => x.CvPtr).ToArray();
 

--- a/src/OpenCvSharp/Modules/superres/SuperResolution.cs
+++ b/src/OpenCvSharp/Modules/superres/SuperResolution.cs
@@ -64,8 +64,7 @@ public class SuperResolution : Algorithm
     public virtual void SetInput(FrameSource fs)
     {
         ThrowIfDisposed();
-        if (fs is null)
-            throw new ArgumentNullException(nameof(fs));
+        ArgumentNullException.ThrowIfNull(fs);
         fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/text/OCRTesseract.cs
+++ b/src/OpenCvSharp/Modules/text/OCRTesseract.cs
@@ -67,8 +67,7 @@ public sealed class OCRTesseract : BaseOCR
         out float[] componentConfidences,
         ComponentLevels componentLevel = ComponentLevels.Word)
     {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         using var outputTextString = new StdString();
@@ -117,10 +116,8 @@ public sealed class OCRTesseract : BaseOCR
         out float[] componentConfidences,
         ComponentLevels componentLevel = ComponentLevels.Word)
     {
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-        if (mask is null)
-            throw new ArgumentNullException(nameof(mask));
+        ArgumentNullException.ThrowIfNull(image);
+        ArgumentNullException.ThrowIfNull(mask);
         image.ThrowIfDisposed();
         mask.ThrowIfDisposed();
 
@@ -152,8 +149,7 @@ public sealed class OCRTesseract : BaseOCR
     /// <param name="charWhitelist"></param>
     public void SetWhiteList(string charWhitelist)
     {
-        if (charWhitelist is null) 
-            throw new ArgumentNullException(nameof(charWhitelist));
+        ArgumentNullException.ThrowIfNull(charWhitelist);
 
         NativeMethods.HandleException(
             NativeMethods.text_OCRTesseract_setWhiteList(Handle, charWhitelist));

--- a/src/OpenCvSharp/Modules/text/TextDetectorCNN.cs
+++ b/src/OpenCvSharp/Modules/text/TextDetectorCNN.cs
@@ -31,8 +31,7 @@ public class TextDetectorCNN : TextDetector
             throw new ArgumentException("empty string", nameof(detectionSizes));
         if (string.IsNullOrEmpty(modelWeightsFilename))
             throw new ArgumentException("empty string", nameof(modelWeightsFilename));
-        if (detectionSizes is null)
-            throw new ArgumentNullException(nameof(detectionSizes));
+        ArgumentNullException.ThrowIfNull(detectionSizes);
 
         var detectionSizesArray = detectionSizes.ToArray();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/video/KalmanFilter.cs
+++ b/src/OpenCvSharp/Modules/video/KalmanFilter.cs
@@ -65,8 +65,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = StatePre; 
@@ -88,8 +87,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = StatePost;
@@ -111,8 +109,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = TransitionMatrix;
@@ -134,8 +131,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = ControlMatrix;
@@ -157,8 +153,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = MeasurementMatrix;
@@ -180,8 +175,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = ProcessNoiseCov;
@@ -203,8 +197,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = MeasurementNoiseCov;
@@ -226,8 +219,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = ErrorCovPre;
@@ -249,8 +241,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = Gain;
@@ -272,8 +263,7 @@ public class KalmanFilter : CvObject
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             value.ThrowIfDisposed();
 
             using var get = ErrorCovPost;
@@ -322,8 +312,7 @@ public class KalmanFilter : CvObject
     public Mat Correct(Mat measurement)
     {
         ThrowIfDisposed();
-        if (measurement is null)
-            throw new ArgumentNullException(nameof(measurement));
+        ArgumentNullException.ThrowIfNull(measurement);
         measurement.ThrowIfDisposed();
 
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/video/Tracker.cs
+++ b/src/OpenCvSharp/Modules/video/Tracker.cs
@@ -21,8 +21,7 @@ public abstract class Tracker : Algorithm
     {
         ThrowIfDisposed();
 
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
 
         image.ThrowIfDisposed();
         NativeMethods.HandleException(
@@ -42,8 +41,7 @@ public abstract class Tracker : Algorithm
     {
         ThrowIfDisposed();
 
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
 
         image.ThrowIfDisposed();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/videoio/FourCC.cs
+++ b/src/OpenCvSharp/Modules/videoio/FourCC.cs
@@ -103,8 +103,7 @@ public readonly struct FourCC : IEquatable<FourCC>
     /// <returns></returns>
     public static FourCC FromString(string code)
     {
-        if (code is null)
-            throw new ArgumentNullException(nameof(code));
+        ArgumentNullException.ThrowIfNull(code);
         if (code.Length == 0)
             throw new ArgumentException("code.Length == 0", nameof(code));
         if (code.Length > 4)

--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -65,8 +65,7 @@ public class VideoCapture : CvObject
     /// <returns></returns>
     public VideoCapture(int index, VideoCaptureAPIs apiPreference, int[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
 
         NativeMethods.HandleException(
             NativeMethods.videoio_VideoCapture_new5(index, (int)apiPreference, prms, prms.Length, out var p));
@@ -89,8 +88,7 @@ public class VideoCapture : CvObject
     /// <returns></returns>
     public VideoCapture(int index, VideoCaptureAPIs apiPreference, VideoCapturePara prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
         var prmsArray = prms.GetParameters();
 
         NativeMethods.HandleException(
@@ -161,8 +159,7 @@ public class VideoCapture : CvObject
     {
         if (string.IsNullOrEmpty(fileName))
             throw new ArgumentNullException(nameof(fileName));
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
 
         NativeMethods.HandleException(
             NativeMethods.videoio_VideoCapture_new4(fileName, (int)apiPreference, prms, prms.Length, out var p));
@@ -191,8 +188,7 @@ public class VideoCapture : CvObject
     {
         if (string.IsNullOrEmpty(fileName))
             throw new ArgumentNullException(nameof(fileName));
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
+        ArgumentNullException.ThrowIfNull(prms);
         var prmsArray = prms.GetParameters();
 
         NativeMethods.HandleException(
@@ -1189,8 +1185,7 @@ public class VideoCapture : CvObject
     public bool Retrieve(Mat image, int flag = 0)
     {
         ThrowIfDisposed();
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1213,8 +1208,7 @@ public class VideoCapture : CvObject
     public bool Retrieve(Mat image, CameraChannels streamIdx)
     {
         ThrowIfDisposed();
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1273,8 +1267,7 @@ public class VideoCapture : CvObject
     public bool Read(Mat image)
     {
         ThrowIfDisposed();
-        if(image is null)
-            throw new ArgumentNullException(nameof(image));
+        ArgumentNullException.ThrowIfNull(image);
         image.ThrowIfDisposed();
 
         NativeMethods.HandleException(
@@ -1396,8 +1389,7 @@ public class VideoCapture : CvObject
         out int[] readyIndex, 
         long timeoutNs = 0)
     {
-        if (streams is null) 
-            throw new ArgumentNullException(nameof(streams));
+        ArgumentNullException.ThrowIfNull(streams);
 
         var streamPtrs = streams.Select(s =>
         {

--- a/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoWriter.cs
@@ -37,7 +37,8 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, bool isColor = true)
     {
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         IsColor = isColor;
@@ -62,7 +63,8 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, bool isColor = true)
     {
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         IsColor = isColor;
@@ -86,9 +88,9 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, int[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(prms);
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         NativeMethods.HandleException(
@@ -110,9 +112,9 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, FourCC fourcc, double fps, Size frameSize, VideoWriterPara prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(prms);
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         var prmsArr = prms.GetParameters();
@@ -138,9 +140,9 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, int[] prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(prms);
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         NativeMethods.HandleException(
@@ -164,9 +166,9 @@ public class VideoWriter : CvObject
     /// <returns></returns>
     public VideoWriter(string fileName, VideoCaptureAPIs apiPreference, FourCC fourcc, double fps, Size frameSize, VideoWriterPara prms)
     {
-        if (prms is null)
-            throw new ArgumentNullException(nameof(prms));
-        FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        ArgumentNullException.ThrowIfNull(prms);
+        ArgumentNullException.ThrowIfNull(fileName);
+        FileName = fileName;
         Fps = fps;
         FrameSize = frameSize;
         var prmsArr = prms.GetParameters();
@@ -372,8 +374,7 @@ public class VideoWriter : CvObject
     // ReSharper disable once InconsistentNaming
     public static int FourCC(string code)
     {
-        if (code is null)
-            throw new ArgumentNullException(nameof(code));
+        ArgumentNullException.ThrowIfNull(code);
         if (code.Length != 4)
             throw new ArgumentException("code.Length != 4", nameof(code));
 

--- a/src/OpenCvSharp/Modules/wechat_qrcode/WeChatQRCode.cs
+++ b/src/OpenCvSharp/Modules/wechat_qrcode/WeChatQRCode.cs
@@ -22,10 +22,8 @@ public class WeChatQRCode : CvObject
         string detectorModelPath = "",
         string superResolutionModelPath = "")
     {
-        if (detectorModelPath is null)
-            throw new ArgumentNullException(nameof(detectorModelPath));
-        if (superResolutionModelPath is null)
-            throw new ArgumentNullException(nameof(superResolutionModelPath));
+        ArgumentNullException.ThrowIfNull(detectorModelPath);
+        ArgumentNullException.ThrowIfNull(superResolutionModelPath);
 
         NativeMethods.HandleException(
             NativeMethods.wechat_qrcode_create1(

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWImgDescriptorExtractor.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWImgDescriptorExtractor.cs
@@ -17,10 +17,8 @@ public class BOWImgDescriptorExtractor : CvObject
     /// <param name="dmatcher">Descriptor matcher that is used to find the nearest word of the trained vocabulary for each keypoint descriptor of the image.</param>
     public BOWImgDescriptorExtractor(Feature2D dextractor, DescriptorMatcher dmatcher)
     {
-        if (dextractor is null)
-            throw new ArgumentNullException(nameof(dextractor));
-        if (dmatcher is null)
-            throw new ArgumentNullException(nameof(dmatcher));
+        ArgumentNullException.ThrowIfNull(dextractor);
+        ArgumentNullException.ThrowIfNull(dmatcher);
 
         NativeMethods.HandleException(
             NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_new1_RawPtr(dextractor.RawPtr, dmatcher.RawPtr, out var p));
@@ -36,8 +34,7 @@ public class BOWImgDescriptorExtractor : CvObject
     /// <param name="dmatcher">Descriptor matcher that is used to find the nearest word of the trained vocabulary for each keypoint descriptor of the image.</param>
     public BOWImgDescriptorExtractor(DescriptorMatcher dmatcher)
     {
-        if (dmatcher is null)
-            throw new ArgumentNullException(nameof(dmatcher));
+        ArgumentNullException.ThrowIfNull(dmatcher);
 
         NativeMethods.HandleException(
             NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_new2_RawPtr(dmatcher.RawPtr, out var p));
@@ -63,8 +60,7 @@ public class BOWImgDescriptorExtractor : CvObject
     public void SetVocabulary(Mat vocabulary)
     {
         ThrowIfDisposed();
-        if (vocabulary is null)
-            throw new ArgumentNullException(nameof(vocabulary));
+        ArgumentNullException.ThrowIfNull(vocabulary);
         NativeMethods.HandleException(
             NativeMethods.xfeatures2d_BOWImgDescriptorExtractor_setVocabulary(Handle, vocabulary.CvPtr));
         GC.KeepAlive(vocabulary);
@@ -141,10 +137,8 @@ public class BOWImgDescriptorExtractor : CvObject
     public void Compute2(Mat image, ref KeyPoint[] keypoints, Mat imgDescriptor)
     {
         ThrowIfDisposed();
-        if (image is null)
-            throw new ArgumentNullException(nameof(image));
-        if (imgDescriptor is null)
-            throw new ArgumentNullException(nameof(imgDescriptor));
+        ArgumentNullException.ThrowIfNull(image);
+        ArgumentNullException.ThrowIfNull(imgDescriptor);
 
         using (var keypointsVec = new StdVector<KeyPoint>(keypoints))
         {

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWKMeansTrainer.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWKMeansTrainer.cs
@@ -56,8 +56,7 @@ public class BOWKMeansTrainer : BOWTrainer
     /// <returns></returns>
     public override Mat Cluster(Mat descriptors)
     {
-        if (descriptors is null) 
-            throw new ArgumentNullException(nameof(descriptors));
+        ArgumentNullException.ThrowIfNull(descriptors);
         ThrowIfDisposed();
         descriptors.ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/xfeatures2d/BOWTrainer.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BOWTrainer.cs
@@ -17,8 +17,7 @@ public abstract class BOWTrainer : CvObject
     /// The training set is clustered using clustermethod to construct the vocabulary.</param>
     public void Add(Mat descriptors)
     {
-        if (descriptors is null)
-            throw new ArgumentNullException(nameof(descriptors));
+        ArgumentNullException.ThrowIfNull(descriptors);
         NativeMethods.HandleException(
             NativeMethods.xfeatures2d_BOWTrainer_add(Handle, descriptors.CvPtr));
         GC.KeepAlive(descriptors);

--- a/src/OpenCvSharp/Modules/xfeatures2d/BRISK.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BRISK.cs
@@ -47,10 +47,8 @@ public class BRISK : Feature2D
         float dMin = 8.2f,
         IEnumerable<int>? indexChange = null)
     {
-        if (radiusList is null)
-            throw new ArgumentNullException(nameof(radiusList));
-        if (numberList is null)
-            throw new ArgumentNullException(nameof(numberList));
+        ArgumentNullException.ThrowIfNull(radiusList);
+        ArgumentNullException.ThrowIfNull(numberList);
 
         var radiusListArray = radiusList.ToArray();
         var numberListArray = numberList.ToArray();
@@ -88,10 +86,8 @@ public class BRISK : Feature2D
         float dMin = 8.2f,
         IEnumerable<int>? indexChange = null)
     {
-        if (radiusList is null)
-            throw new ArgumentNullException(nameof(radiusList));
-        if (numberList is null)
-            throw new ArgumentNullException(nameof(numberList));
+        ArgumentNullException.ThrowIfNull(radiusList);
+        ArgumentNullException.ThrowIfNull(numberList);
 
         var radiusListArray = radiusList.ToArray();
         var numberListArray = numberList.ToArray();

--- a/src/OpenCvSharp/Modules/ximgproc/Cv2.XImgProc.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Cv2.XImgProc.cs
@@ -355,10 +355,8 @@ public static partial class Cv2
         /// <param name="longRange"></param>
         public static void BrightEdges(Mat original, Mat edgeView, int contrast = 1, int shortRange = 3, int longRange = 9)
         {
-            if (original is null)
-                throw new ArgumentNullException(nameof(original));
-            if (edgeView is null)
-                throw new ArgumentNullException(nameof(edgeView));
+            ArgumentNullException.ThrowIfNull(original);
+            ArgumentNullException.ThrowIfNull(edgeView);
             original.ThrowIfDisposed();
             edgeView.ThrowIfDisposed();
 

--- a/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/EdgeDrawing.cs
@@ -270,8 +270,7 @@ public class EdgeDrawing : Algorithm
     public virtual void SetParams(EdgeDrawingParams parameters)
     {
         ThrowIfDisposed();
-        if (parameters is null)
-            throw new ArgumentNullException(nameof(parameters));
+        ArgumentNullException.ThrowIfNull(parameters);
 
         var native = parameters.ToNative();
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/FastLineDetector.cs
@@ -106,8 +106,7 @@ public class FastLineDetector : Algorithm
     public virtual void DrawSegments(InputOutputArray image, IEnumerable<Vec4f> lines, bool drawArrow = false)
     {
         ThrowIfDisposed();
-        if (lines is null)
-            throw new ArgumentNullException(nameof(lines));
+        ArgumentNullException.ThrowIfNull(lines);
 
         using var linesVec = new StdVector<Vec4f>(lines);
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/ximgproc/RFFeatureGetter.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/RFFeatureGetter.cs
@@ -55,10 +55,8 @@ public class RFFeatureGetter : Algorithm
         int gradNum)
     {
         ThrowIfDisposed();
-        if (src is null)
-            throw new ArgumentNullException(nameof(src));
-        if (features is null)
-            throw new ArgumentNullException(nameof(features));
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(features);
         src.ThrowIfDisposed();
         features.ThrowIfDisposed();
             

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentation.cs
@@ -112,8 +112,7 @@ public class SelectiveSearchSegmentation : Algorithm
     public virtual void AddGraphSegmentation(GraphSegmentation g)
     {
         ThrowIfDisposed();
-        if (g is null)
-            throw new ArgumentNullException(nameof(g));
+        ArgumentNullException.ThrowIfNull(g);
         g.ThrowIfDisposed();
 
         if (g.PtrObj == IntPtr.Zero)
@@ -142,8 +141,7 @@ public class SelectiveSearchSegmentation : Algorithm
     public virtual void AddStrategy(SelectiveSearchSegmentationStrategy s)
     {
         ThrowIfDisposed();
-        if (s is null)
-            throw new ArgumentNullException(nameof(s));
+        ArgumentNullException.ThrowIfNull(s);
         s.ThrowIfDisposed();
         if (s.PtrObj == IntPtr.Zero)
             throw new ArgumentException("s.PtrObj is zero");

--- a/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Segmentation/SelectiveSearchSegmentationStrategyMultiple.cs
@@ -82,8 +82,7 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     public static SelectiveSearchSegmentationStrategyMultiple Create(
         SelectiveSearchSegmentationStrategy s1)
     {
-        if (s1 is null)
-            throw new ArgumentNullException(nameof(s1));
+        ArgumentNullException.ThrowIfNull(s1);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple1(s1.PtrObj, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(smartPtr, out var rawPtr));
@@ -99,10 +98,8 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     public static SelectiveSearchSegmentationStrategyMultiple Create(
         SelectiveSearchSegmentationStrategy s1, SelectiveSearchSegmentationStrategy s2)
     {
-        if (s1 is null)
-            throw new ArgumentNullException(nameof(s1));
-        if (s2 is null)
-            throw new ArgumentNullException(nameof(s2));
+        ArgumentNullException.ThrowIfNull(s1);
+        ArgumentNullException.ThrowIfNull(s2);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple2(s1.PtrObj, s2.PtrObj, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(smartPtr, out var rawPtr));
@@ -119,12 +116,9 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     public static SelectiveSearchSegmentationStrategyMultiple Create(
         SelectiveSearchSegmentationStrategy s1, SelectiveSearchSegmentationStrategy s2, SelectiveSearchSegmentationStrategy s3)
     {
-        if (s1 is null)
-            throw new ArgumentNullException(nameof(s1));
-        if (s2 is null)
-            throw new ArgumentNullException(nameof(s2));
-        if (s3 is null)
-            throw new ArgumentNullException(nameof(s3));
+        ArgumentNullException.ThrowIfNull(s1);
+        ArgumentNullException.ThrowIfNull(s2);
+        ArgumentNullException.ThrowIfNull(s3);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple3(s1.PtrObj, s2.PtrObj, s3.PtrObj, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(smartPtr, out var rawPtr));
@@ -142,14 +136,10 @@ public class SelectiveSearchSegmentationStrategyMultiple : SelectiveSearchSegmen
     public static SelectiveSearchSegmentationStrategyMultiple Create(
         SelectiveSearchSegmentationStrategy s1, SelectiveSearchSegmentationStrategy s2, SelectiveSearchSegmentationStrategy s3, SelectiveSearchSegmentationStrategy s4)
     {
-        if (s1 is null)
-            throw new ArgumentNullException(nameof(s1));
-        if (s2 is null)
-            throw new ArgumentNullException(nameof(s2));
-        if (s3 is null)
-            throw new ArgumentNullException(nameof(s3));
-        if (s4 is null)
-            throw new ArgumentNullException(nameof(s4));
+        ArgumentNullException.ThrowIfNull(s1);
+        ArgumentNullException.ThrowIfNull(s2);
+        ArgumentNullException.ThrowIfNull(s3);
+        ArgumentNullException.ThrowIfNull(s4);
         NativeMethods.HandleException(
             NativeMethods.ximgproc_segmentation_createSelectiveSearchSegmentationStrategyMultiple4(s1.PtrObj, s2.PtrObj, s3.PtrObj, s4.PtrObj, out var smartPtr));
         NativeMethods.HandleException(NativeMethods.ximgproc_segmentation_Ptr_SelectiveSearchSegmentationStrategyMultiple_get(smartPtr, out var rawPtr));

--- a/src/OpenCvSharp/Modules/xphoto/Cv2.XPhoto.cs
+++ b/src/OpenCvSharp/Modules/xphoto/Cv2.XPhoto.cs
@@ -124,10 +124,8 @@ public static partial class Cv2
         /// <param name="psize">size of block side where dct is computed</param>
         public static void DctDenoising(Mat src, Mat dst, double sigma, int psize = 16)
         {
-            if (src is null)
-                throw new ArgumentNullException(nameof(src));
-            if (dst is null)
-                throw new ArgumentNullException(nameof(dst));
+            ArgumentNullException.ThrowIfNull(src);
+            ArgumentNullException.ThrowIfNull(dst);
             src.ThrowIfDisposed();
             dst.ThrowIfDisposed();
             
@@ -151,12 +149,9 @@ public static partial class Cv2
         /// <param name="algorithm">see OpenCvSharp.XPhoto.InpaintTypes</param>
         public static void Inpaint(Mat src, Mat mask, Mat dst, OpenCvSharp.XPhoto.InpaintTypes algorithm)
         {
-            if (src is null)
-                throw new ArgumentNullException(nameof(src));
-            if (mask is null)
-                throw new ArgumentNullException(nameof(mask));
-            if (dst is null)
-                throw new ArgumentNullException(nameof(dst));
+            ArgumentNullException.ThrowIfNull(src);
+            ArgumentNullException.ThrowIfNull(mask);
+            ArgumentNullException.ThrowIfNull(dst);
             src.ThrowIfDisposed();
             mask.ThrowIfDisposed();
             dst.ThrowIfDisposed();

--- a/test/OpenCvSharp.Tests/dnn/EastTextDetectionTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/EastTextDetectionTest.cs
@@ -29,7 +29,8 @@ public class EastTextDetectionTest : TestBase
     /// <param name="testOutputHelper"></param>
     public EastTextDetectionTest(ITestOutputHelper testOutputHelper)
     {
-        this.testOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+        ArgumentNullException.ThrowIfNull(testOutputHelper);
+        this.testOutputHelper = testOutputHelper;
             
         testOutputHelper.WriteLine("Downloading EAST Model...");
         PrepareModel(new Uri(ModelUrl), LocalRawModelPath);

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -534,10 +534,8 @@ public class ImgProcTest : TestBase
 
     private static void TestImage(Mat img, Vec3b[,] expected)
     {
-        if (img is null)
-            throw new ArgumentNullException(nameof(img));
-        if (expected is null)
-            throw new ArgumentNullException(nameof(expected));
+        ArgumentNullException.ThrowIfNull(img);
+        ArgumentNullException.ThrowIfNull(expected);
 
         if (img.Type() != MatType.CV_8UC3)
             throw new ArgumentException("Mat.Type() != 8UC3", nameof(img));

--- a/test/OpenCvSharp.Tests/tracking/TrackerTestBase.cs
+++ b/test/OpenCvSharp.Tests/tracking/TrackerTestBase.cs
@@ -6,8 +6,7 @@ public abstract class TrackerTestBase : TestBase
 {
     protected static void InitBase(Tracker tracker)
     {
-        if (tracker is null) 
-            throw new ArgumentNullException(nameof(tracker));
+        ArgumentNullException.ThrowIfNull(tracker);
 
         using var vc = LoadImage("lenna.png");
         tracker.Init(vc, new Rect(220, 60, 200, 220));
@@ -15,8 +14,7 @@ public abstract class TrackerTestBase : TestBase
 
     protected static void UpdateBase(Tracker tracker)
     {
-        if (tracker is null)            
-            throw new ArgumentNullException(nameof(tracker));
+        ArgumentNullException.ThrowIfNull(tracker);
             
         // ETHZ dataset
         // ETHZ is Eidgenössische Technische Hochschule Zürich, in Deutsch


### PR DESCRIPTION
## Summary
- Replace the hand-written `if (x is null) throw new ArgumentNullException(nameof(x));` guard clause (including `field = x ?? throw ...;` in constructor bodies) with `ArgumentNullException.ThrowIfNull(x);` across `src/` and `test/`, and update the sample in `.github/copilot-instructions.md` to match.
- Do the same for the .NET 8 `ArgumentOutOfRangeException.ThrowIfNegative`/`ThrowIfNegativeOrZero`/`ThrowIfLessThan`/`ThrowIfGreaterThan`/`ThrowIfGreaterThanOrEqual` and `ObjectDisposedException.ThrowIf` helpers, which were entirely unused in the codebase.
- Left untouched: `?? throw` inside constructor initializer chains (`: this(...)`, `: base(...)`) and expression-bodied members (can't be split since the helpers return `void`), `string.IsNullOrEmpty(...)` guards (changing to `ArgumentException.ThrowIfNullOrEmpty` would change the thrown exception type for the empty-string case), `IntPtr == IntPtr.Zero` checks, and switch-expression/statement `default` fallbacks in indexers (`Vec2b`..`Vec6w`, `Scalar`).
- Found and fixed two latent bugs along the way:
  - `Cv2_imgproc.cs` `PutText`/`GetTextSize` threw `new ArgumentNullException(text)`, passing the string value itself as `paramName` instead of `nameof(text)`.
  - `VectorOfString`/`VectorOfVectorPoint` took an `nuint size` constructor parameter, so their "negative size" guard could never fire (unsigned type). Changed the parameter to `int` to match `VectorOfMat` and make the guard meaningful; neither constructor has any call site in the repo, so this is a safe signature change.

## Test plan
- [x] `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release`
- [x] `dotnet build src/OpenCvSharp.GdipExtensions/OpenCvSharp.GdipExtensions.csproj -c Release`
- [x] `dotnet build src/OpenCvSharp.WpfExtensions/OpenCvSharp.WpfExtensions.csproj -c Release`
- [x] `dotnet build test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized argument validation across the library by using .NET guard helpers (e.g., `ThrowIfNull`), replacing scattered manual null-check/throw patterns.
  * Added/clarified bounds checks using built-in range guards.
  * Updated `GetOptimalNewCameraMatrix` to accept nullable distortion coefficients (`distCoeffs`).
  * Updated a couple vector constructors to use signed sizes (`VectorOfString`, `VectorOfVectorPoint`).

* **Tests**
  * Updated test helpers to follow the same validation pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->