### PR TITLE
DEBUG ONLY: do not merge - blame-crash repro

### DIFF
--- a/.github/workflows/docker-test-ubuntu.yml
+++ b/.github/workflows/docker-test-ubuntu.yml
@@ -45,16 +45,23 @@ jobs:
         with:
           context: .
           file: ${{ env.DOCKER_BUILD_CONTEXT_FULL }}/Dockerfile
-          target: test-dotnet
+          target: test-output-export
           build-args: |
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
-          outputs: type=cacheonly
+          outputs: type=local,dest=./test-dotnet-output
           cache-from: |
             type=gha,scope=full-test-dotnet-${{ github.ref_name }}
             type=gha,scope=full-test-dotnet-main
             type=gha,scope=full-${{ github.ref_name }}
             type=gha,scope=full-main
           cache-to: type=gha,mode=min,scope=full-test-dotnet-${{ github.ref_name }}
+
+      - name: Upload test output (debug)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-dotnet-output-debug
+          path: ./test-dotnet-output
 
       - name: Build with Docker (full)
         uses: docker/build-push-action@v7

--- a/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
+++ b/packaging/docker/ubuntu24-dotnet10-opencv5.0.0/Dockerfile
@@ -139,7 +139,13 @@ RUN cd /opencvsharp/src/OpenCvSharp && \
     dotnet build -c Release -f net8.0 && \
     cd /opencvsharp/src/OpenCvSharp.GdipExtensions && \
     dotnet build -c Release -f net8.0
-RUN dotnet test /opencvsharp/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-x64 --logger "trx;LogFileName=test-results.trx" < /dev/null
+RUN dotnet test /opencvsharp/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-x64 --blame-crash --logger "console;verbosity=detailed" --logger "trx;LogFileName=test-results.trx" < /dev/null; \
+    mkdir -p /testoutput; \
+    cp -r /opencvsharp/test/OpenCvSharp.Tests/TestResults /testoutput/ 2>/dev/null || true
+
+########## DEBUG ONLY: export test output (temporary, not for merge) ##########
+FROM scratch AS test-output-export
+COPY --from=test-dotnet /testoutput /
 
 ########## Final images ##########
 FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS final-sdk


### PR DESCRIPTION
Temporary diagnostic PR to capture --blame-crash output from CI. Will be closed without merging.