### PR TITLE
Fill OpenCV 5.x API gaps in calib/stereo/flann/imgproc/core

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -216,7 +216,7 @@ static partial class Cv2
         NativeMethods.HandleException(
             NativeMethods.calib_calibrateCamera_InputArray(
                 objectPointsPtrs, objectPointsPtrs.Length,
-                imagePointsPtrs, objectPointsPtrs.Length,
+                imagePointsPtrs, imagePointsPtrs.Length,
                 imageSize, cameraMatrix.Proxy, distCoeffs.Proxy,
                 rvecsVec.CvPtr, tvecsVec.CvPtr, (int) flags, criteria0, out var ret));
         GC.KeepAlive(cameraMatrix.Source);
@@ -341,7 +341,7 @@ static partial class Cv2
         NativeMethods.HandleException(
             NativeMethods.calib_calibrateCameraRO_InputArray(
                 objectPointsPtrs, objectPointsPtrs.Length,
-                imagePointsPtrs, objectPointsPtrs.Length,
+                imagePointsPtrs, imagePointsPtrs.Length,
                 imageSize, iFixedPoint, cameraMatrix.Proxy, distCoeffs.Proxy,
                 rvecsVec.CvPtr, tvecsVec.CvPtr, newObjPoints.Proxy, (int) flags, criteria0, out var ret));
         GC.KeepAlive(cameraMatrix.Source);

--- a/src/OpenCvSharp/Cv2/Cv2_calib.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_calib.cs
@@ -296,6 +296,66 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Finds intrinsic and extrinsic camera parameters, additionally allowing one point of the
+    /// calibration pattern object to be optimized ("releasing object" method). Useful when the
+    /// calibration pattern is not perfectly rigid/planar.
+    /// </summary>
+    /// <param name="objectPoints">Vector of vectors of calibration pattern points, as in CalibrateCamera.</param>
+    /// <param name="imagePoints">Vector of vectors of the projections of calibration pattern points.</param>
+    /// <param name="imageSize">Size of the image used only to initialize the intrinsic camera matrix.</param>
+    /// <param name="iFixedPoint">The index of the object point to be fixed. It must be within [1, objectPoints[0].Count - 2].
+    /// It is ignored with <see cref="CalibrationFlags.FixK3"/> or if the calibration pattern is a non-planar rig.</param>
+    /// <param name="cameraMatrix">Output 3x3 floating-point camera matrix.</param>
+    /// <param name="distCoeffs">Output vector of distortion coefficients.</param>
+    /// <param name="rvecs">Output vector of rotation vectors estimated for each pattern view.</param>
+    /// <param name="tvecs">Output vector of translation vectors estimated for each pattern view.</param>
+    /// <param name="newObjPoints">The updated output vector of calibration pattern points, where the coordinates
+    /// of the fixed point (index iFixedPoint) are unchanged.</param>
+    /// <param name="flags">Different flags that may be zero or a combination of the CalibrationFlag values</param>
+    /// <param name="criteria">Termination criteria for the iterative optimization algorithm.</param>
+    /// <returns>Root mean square (RMS) re-projection error.</returns>
+    public static double CalibrateCameraRO(
+        IEnumerable<Mat> objectPoints,
+        IEnumerable<Mat> imagePoints,
+        Size imageSize,
+        int iFixedPoint,
+        InputOutputArray cameraMatrix,
+        InputOutputArray distCoeffs,
+        out Mat[] rvecs,
+        out Mat[] tvecs,
+        OutputArray newObjPoints,
+        CalibrationFlags flags = CalibrationFlags.None,
+        TermCriteria? criteria = null)
+    {
+        ArgumentNullException.ThrowIfNull(objectPoints);
+        ArgumentNullException.ThrowIfNull(imagePoints);
+
+        var criteria0 = criteria.GetValueOrDefault(
+            new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 30, Double.Epsilon));
+
+        var objectPointsPtrs = objectPoints.Select(x => x.CvPtr).ToArray();
+        var imagePointsPtrs = imagePoints.Select(x => x.CvPtr).ToArray();
+
+        using var rvecsVec = new VectorOfMat();
+        using var tvecsVec = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.calib_calibrateCameraRO_InputArray(
+                objectPointsPtrs, objectPointsPtrs.Length,
+                imagePointsPtrs, objectPointsPtrs.Length,
+                imageSize, iFixedPoint, cameraMatrix.Proxy, distCoeffs.Proxy,
+                rvecsVec.CvPtr, tvecsVec.CvPtr, newObjPoints.Proxy, (int) flags, criteria0, out var ret));
+        GC.KeepAlive(cameraMatrix.Source);
+        GC.KeepAlive(distCoeffs.Source);
+        GC.KeepAlive(newObjPoints.Source);
+        GC.KeepAlive(objectPoints);
+        GC.KeepAlive(imagePoints);
+        rvecs = rvecsVec.ToArray();
+        tvecs = tvecsVec.ToArray();
+
+        return ret;
+    }
+
+    /// <summary>
     /// Registers a pair of cameras (OpenCV 5), estimating the relative pose (R, T) between them.
     /// The two cameras may use different camera models (pinhole / fisheye).
     /// </summary>

--- a/src/OpenCvSharp/Cv2/Cv2_core.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_core.cs
@@ -307,6 +307,21 @@ public static partial class Cv2
     }
 
     /// <summary>
+    /// Checks whether the array contains at least one non-zero element. Faster than
+    /// <see cref="CountNonZero"/> when only the presence of non-zero elements matters.
+    /// </summary>
+    /// <param name="src">Single-channel array</param>
+    /// <returns>true if src has at least one non-zero element</returns>
+    public static bool HasNonZero(InputArray src)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_hasNonZero(src.Proxy, out var ret));
+
+        GC.KeepAlive(src.Source);
+        return ret != 0;
+    }
+
+    /// <summary>
     /// computes the number of nonzero array elements
     /// </summary>
     /// <param name="mtx">Single-channel array</param>
@@ -803,6 +818,37 @@ public static partial class Cv2
             NativeMethods.core_flip(src.Proxy, dst.Proxy, (int) flipCode));
 
         GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
+    /// Flips an n-dimensional array along the given axis.
+    /// </summary>
+    /// <param name="src">The source array</param>
+    /// <param name="dst">The destination array; will have the same size and same type as src</param>
+    /// <param name="axis">Axis to flip along.</param>
+    public static void FlipND(InputArray src, OutputArray dst, int axis)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_flipND(src.Proxy, dst.Proxy, axis));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
+    /// Broadcasts the given array to the given shape.
+    /// </summary>
+    /// <param name="src">input array</param>
+    /// <param name="shape">target shape. Should be a list of CV_32S numbers. Negative values are not supported.</param>
+    /// <param name="dst">output array that has the given shape</param>
+    public static void Broadcast(InputArray src, InputArray shape, OutputArray dst)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_broadcast(src.Proxy, shape.Proxy, dst.Proxy));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(shape.Source);
         GC.KeepAlive(dst.Source);
     }
 
@@ -1399,6 +1445,20 @@ public static partial class Cv2
     }
 
     /// <summary>
+    /// Computes a mask of finite (non-NaN, non-Inf) elements, a companion to <see cref="PatchNaNs"/>.
+    /// </summary>
+    /// <param name="src">input array.</param>
+    /// <param name="mask">output mask array of the same size as src, CV_8U type.</param>
+    public static void FiniteMask(InputArray src, OutputArray mask)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_finiteMask(src.Proxy, mask.Proxy));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(mask.Source);
+    }
+
+    /// <summary>
     /// implements generalized matrix product algorithm GEMM from BLAS
     /// </summary>
     /// <param name="src1"></param>
@@ -1461,7 +1521,24 @@ public static partial class Cv2
         GC.KeepAlive(src.Source);
         GC.KeepAlive(dst.Source);
     }
-        
+
+    /// <summary>
+    /// Transposes an n-dimensional array by permuting its axes according to the given order.
+    /// </summary>
+    /// <param name="src">The source array</param>
+    /// <param name="order">Permutation of axes, e.g. { 1, 0, 2 } to swap the first two axes.</param>
+    /// <param name="dst">The destination array</param>
+    public static void TransposeND(InputArray src, int[] order, OutputArray dst)
+    {
+        ArgumentNullException.ThrowIfNull(order);
+
+        NativeMethods.HandleException(
+            NativeMethods.core_transposeND(src.Proxy, order, order.Length, dst.Proxy));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
     /// <summary>
     /// performs affine transformation of each element of multi-channel input matrix
     /// </summary>
@@ -2644,6 +2721,61 @@ public static partial class Cv2
         NativeMethods.HandleException(
             NativeMethods.core_useOptimized(out var ret));
         return ret != 0;
+    }
+
+    /// <summary>
+    /// Returns whether IPP is used for acceleration.
+    /// </summary>
+    /// <returns></returns>
+    public static bool UseIPP()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_useIPP(out var ret));
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Turns on/off IPP-based acceleration.
+    /// </summary>
+    /// <param name="flag"></param>
+    public static void SetUseIPP(bool flag)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_setUseIPP(flag ? 1 : 0));
+    }
+
+    /// <summary>
+    /// Returns the current IPP library version.
+    /// </summary>
+    /// <returns></returns>
+    public static string GetIppVersion()
+    {
+        using var buf = new StdString();
+        NativeMethods.HandleException(
+            NativeMethods.core_getIppVersion(buf.CvPtr));
+        return buf.ToString();
+    }
+
+    /// <summary>
+    /// Returns whether IPP is used in "not exact" mode. In this mode IPP may be used even where
+    /// it and OpenCV have internal accuracy differences that impact accuracy tests.
+    /// </summary>
+    /// <returns></returns>
+    public static bool UseIppNotExact()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_useIPP_NotExact(out var ret));
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Turns on/off IPP "not exact" mode.
+    /// </summary>
+    /// <param name="flag"></param>
+    public static void SetUseIppNotExact(bool flag)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_setUseIPP_NotExact(flag ? 1 : 0));
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -248,6 +248,21 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Blurs an image using the stackBlur algorithm, a fast approximation of a Gaussian blur.
+    /// </summary>
+    /// <param name="src">The source image</param>
+    /// <param name="dst">The destination image; will have the same size and the same type as src</param>
+    /// <param name="ksize">The smoothing kernel size (must be positive and odd)</param>
+    public static void StackBlur(InputArray src, OutputArray dst, Size ksize)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_stackBlur(src.Proxy, dst.Proxy, ksize));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
     /// Convolves an image with the kernel
     /// </summary>
     /// <param name="src">The source image</param>
@@ -1140,6 +1155,25 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Iterative variant of <see cref="PhaseCorrelate"/> that refines the detected shift over
+    /// multiple iterations for improved sub-pixel accuracy.
+    /// </summary>
+    /// <param name="src1">Source floating point array (CV_32FC1 or CV_64FC1)</param>
+    /// <param name="src2">Source floating point array (CV_32FC1 or CV_64FC1)</param>
+    /// <param name="l2size">Size of the neighborhood used at each iteration.</param>
+    /// <param name="maxIters">Maximum number of iterations.</param>
+    /// <returns>detected phase shift(sub-pixel) between the two arrays.</returns>
+    public static Point2d PhaseCorrelateIterative(InputArray src1, InputArray src2, int l2size = 7, int maxIters = 10)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_phaseCorrelateIterative(src1.Proxy, src2.Proxy, l2size, maxIters, out var ret));
+
+        GC.KeepAlive(src1.Source);
+        GC.KeepAlive(src2.Source);
+        return ret;
+    }
+
+    /// <summary>
     /// Computes a Hanning window coefficients in two dimensions.
     /// </summary>
     /// <param name="dst">Destination array to place Hann coefficients in</param>
@@ -1169,6 +1203,28 @@ static partial class Cv2
 
         GC.KeepAlive(src.Source);
         GC.KeepAlive(dst.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Applies a fixed-level threshold to each array element, restricted to the pixels selected by mask.
+    /// </summary>
+    /// <param name="src">input array (single-channel, 8-bit or 32-bit floating point).</param>
+    /// <param name="dst">input/output array of the same size and type as src.</param>
+    /// <param name="mask">optional mask; pixels outside the mask keep their original value in dst.</param>
+    /// <param name="thresh">threshold value.</param>
+    /// <param name="maxval">maximum value to use with the THRESH_BINARY and THRESH_BINARY_INV thresholding types.</param>
+    /// <param name="type">thresholding type (see the details below).</param>
+    /// <returns>the computed threshold value when type == OTSU</returns>
+    public static double ThresholdWithMask(
+        InputArray src, InputOutputArray dst, InputArray mask, double thresh, double maxval, ThresholdTypes type)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_thresholdWithMask(src.Proxy, dst.Proxy, mask.Proxy, thresh, maxval, (int)type, out var ret));
+
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(dst.Source);
+        GC.KeepAlive(mask.Source);
         return ret;
     }
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_flann.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_flann.cs
@@ -20,6 +20,26 @@ static partial class NativeMethods
     public static partial ExceptionStatus flann_Index_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Index_new0(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus flann_Index_build(
+        OpenCvSafeHandle obj, in InputArrayProxy features, IntPtr @params, int distType);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus flann_Index_load(
+        OpenCvSafeHandle obj, in InputArrayProxy features, [MarshalAs(UnmanagedType.LPStr)] string filename, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Index_release(OpenCvSafeHandle obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Index_getDistance(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Index_getAlgorithm(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus flann_Index_knnSearch1(
         OpenCvSafeHandle obj, [In] float[] queries, int queriesLength, [Out] int[] indices, [Out] float[] dists, int knn, IntPtr @params);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -119,6 +139,20 @@ static partial class NativeMethods
 
     #endregion
 
+    #region HierarchicalClusteringIndexParams
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Ptr_HierarchicalClusteringIndexParams_new(
+        int branching, FlannCentersInit centersInit, int trees, int leafSize, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Ptr_HierarchicalClusteringIndexParams_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Ptr_HierarchicalClusteringIndexParams_delete(IntPtr obj);
+
+    #endregion
+
     #region LshIndexParams
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -179,6 +213,9 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus flann_Ptr_SearchParams_new(int checks, float eps, int sorted, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus flann_Ptr_SearchParams_new2(int checks, float eps, int sorted, int exploreAllTrees, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus flann_Ptr_SearchParams_get(IntPtr ptr, out IntPtr returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/calib/NativeMethods_calib.cs
@@ -52,6 +52,17 @@ static partial class NativeMethods
         int flags, TermCriteria criteria,
         out double returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus calib_calibrateCameraRO_InputArray(
+        IntPtr[] objectPoints, int objectPointsSize,
+        IntPtr[] imagePoints, int imagePointsSize,
+        Size imageSize, int iFixedPoint,
+        in InputOutputArrayProxy cameraMatrix, in InputOutputArrayProxy distCoeffs,
+        IntPtr rvecs, IntPtr tvecs,
+        in OutputArrayProxy newObjPoints,
+        int flags, TermCriteria criteria,
+        out double returnValue);
+
     // OpenCV 5 multi-view calibration
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus calib_registerCameras(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -81,8 +81,22 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_useOptimized(out int returnValue);
-        
-        
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_useIPP(out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_setUseIPP(int flag);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_getIppVersion(IntPtr buf);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_useIPP_NotExact(out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_setUseIPP_NotExact(int flag);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_format(in InputArrayProxy mtx, int fmt, IntPtr buf);
 
@@ -142,6 +156,9 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_sum(in InputArrayProxy src, out Scalar returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_hasNonZero(in InputArrayProxy src, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_countNonZero(in InputArrayProxy src, out int returnValue);
@@ -218,6 +235,12 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_flip(in InputArrayProxy src, in OutputArrayProxy dst, int flipCode);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_flipND(in InputArrayProxy src, in OutputArrayProxy dst, int axis);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_broadcast(in InputArrayProxy src, in InputArrayProxy shape, in OutputArrayProxy dst);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_rotate(in InputArrayProxy src, in OutputArrayProxy dst, int rotateCode);
@@ -309,6 +332,9 @@ static partial class NativeMethods
     internal static partial ExceptionStatus core_patchNaNs(in InputOutputArrayProxy a, double val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_finiteMask(in InputArrayProxy src, in OutputArrayProxy mask);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_gemm(in InputArrayProxy src1, in InputArrayProxy src2, double alpha, in InputArrayProxy src3, double gamma, in OutputArrayProxy dst, int flags);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -319,6 +345,10 @@ static partial class NativeMethods
     // path (optimized kinds) and the still-class path (Raw kinds wrapping an existing cv::_InputArray*).
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus core_transpose(in InputArrayProxy src, in OutputArrayProxy dst);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus core_transposeND(
+        in InputArrayProxy src, [In] int[] order, int orderLength, in OutputArrayProxy dst);
 
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -50,6 +50,9 @@ static partial class NativeMethods
     internal static partial ExceptionStatus imgproc_blur(in InputArrayProxy src, in OutputArrayProxy dst, Size ksize, Point anchor, int borderType);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus imgproc_stackBlur(in InputArrayProxy src, in OutputArrayProxy dst, Size ksize);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_filter2D(in InputArrayProxy src, in OutputArrayProxy dst, MatType ddepth, in InputArrayProxy kernel, Point anchor,
         double delta, int borderType);
 
@@ -196,14 +199,22 @@ static partial class NativeMethods
     internal static partial ExceptionStatus imgproc_accumulateWeighted(in InputArrayProxy src, in InputOutputArrayProxy dst, double alpha, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus imgproc_phaseCorrelate(in InputArrayProxy src1, in InputArrayProxy src2, in InputArrayProxy window, 
+    internal static partial ExceptionStatus imgproc_phaseCorrelate(in InputArrayProxy src1, in InputArrayProxy src2, in InputArrayProxy window,
         out double response, out Point2d returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus imgproc_phaseCorrelateIterative(in InputArrayProxy src1, in InputArrayProxy src2,
+        int l2size, int maxIters, out Point2d returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_createHanningWindow(in OutputArrayProxy dst, Size winSize, MatType type);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_threshold(in InputArrayProxy src, in OutputArrayProxy dst, double thresh, double maxval, int type, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus imgproc_thresholdWithMask(in InputArrayProxy src, in InputOutputArrayProxy dst, in InputArrayProxy mask,
+        double thresh, double maxval, int type, out double returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_adaptiveThreshold(in InputArrayProxy src, in OutputArrayProxy dst,

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_CLAHE.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_CLAHE.cs
@@ -42,4 +42,10 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_CLAHE_collectGarbage(OpenCvSafeHandle obj);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_CLAHE_setBitShift(OpenCvSafeHandle obj, int bitShift);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus imgproc_CLAHE_getBitShift(OpenCvSafeHandle obj, out int returnValue);
+
 }

--- a/src/OpenCvSharp/Modules/flann/FlannAlgorithm.cs
+++ b/src/OpenCvSharp/Modules/flann/FlannAlgorithm.cs
@@ -1,0 +1,55 @@
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Flann;
+
+/// <summary>
+/// Nearest neighbour index algorithm.
+/// [cvflann::flann_algorithm_t]
+/// </summary>
+public enum FlannAlgorithm
+{
+    /// <summary>
+    /// [FLANN_INDEX_LINEAR]
+    /// </summary>
+    Linear = 0,
+
+    /// <summary>
+    /// [FLANN_INDEX_KDTREE]
+    /// </summary>
+    KDTree = 1,
+
+    /// <summary>
+    /// [FLANN_INDEX_KMEANS]
+    /// </summary>
+    KMeans = 2,
+
+    /// <summary>
+    /// [FLANN_INDEX_COMPOSITE]
+    /// </summary>
+    Composite = 3,
+
+    /// <summary>
+    /// [FLANN_INDEX_KDTREE_SINGLE]
+    /// </summary>
+    KDTreeSingle = 4,
+
+    /// <summary>
+    /// [FLANN_INDEX_HIERARCHICAL]
+    /// </summary>
+    Hierarchical = 5,
+
+    /// <summary>
+    /// [FLANN_INDEX_LSH]
+    /// </summary>
+    Lsh = 6,
+
+    /// <summary>
+    /// [FLANN_INDEX_SAVED]
+    /// </summary>
+    Saved = 254,
+
+    /// <summary>
+    /// [FLANN_INDEX_AUTOTUNED]
+    /// </summary>
+    Autotuned = 255,
+}

--- a/src/OpenCvSharp/Modules/flann/Index.cs
+++ b/src/OpenCvSharp/Modules/flann/Index.cs
@@ -8,6 +8,18 @@ namespace OpenCvSharp.Flann;
 public class Index : CvObject
 {
     /// <summary>
+    /// Constructs an empty index. Call <see cref="Build"/> or <see cref="Load"/> before searching.
+    /// </summary>
+    public Index()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_new0(out var p));
+        if (p == IntPtr.Zero)
+            throw new OpenCvSharpException("Failed to create Index");
+        InitSafeHandle(p);
+    }
+
+    /// <summary>
     /// Constructs a nearest neighbor search index for a given dataset.
     /// </summary>
     /// <param name="features">features – Matrix of type CV _ 32F containing the features(points) to index. The size of the matrix is num _ features x feature _ dimensionality.</param>
@@ -35,6 +47,70 @@ public class Index : CvObject
     {
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
             static h => NativeMethods.HandleException(NativeMethods.flann_Index_delete(h))));
+    }
+
+    /// <summary>
+    /// Builds the index using the specified dataset and parameters.
+    /// </summary>
+    /// <param name="features">Matrix of type CV_32F containing the features(points) to index.</param>
+    /// <param name="params">Structure containing the index parameters.</param>
+    /// <param name="distType"></param>
+    public void Build(InputArray features, IndexParams @params, FlannDistance distType = FlannDistance.L2)
+    {
+        ArgumentNullException.ThrowIfNull(@params);
+
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_build(Handle, features.Proxy, @params.CvPtr, (int)distType));
+
+        GC.KeepAlive(features.Source);
+        GC.KeepAlive(@params);
+    }
+
+    /// <summary>
+    /// Loads a previously saved index from a file.
+    /// </summary>
+    /// <param name="features">The dataset that was used to build the saved index.</param>
+    /// <param name="filename">The file to load the index from.</param>
+    /// <returns>true if the load succeeded.</returns>
+    public bool Load(InputArray features, string filename)
+    {
+        if (string.IsNullOrEmpty(filename))
+            throw new ArgumentNullException(nameof(filename));
+
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_load(Handle, features.Proxy, filename, out var ret));
+
+        GC.KeepAlive(features.Source);
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Releases the inner search structures. Reserved for future use.
+    /// </summary>
+    public void Release()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_release(Handle));
+    }
+
+    /// <summary>
+    /// The distance metric used by the index.
+    /// </summary>
+    public FlannDistance GetDistance()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_getDistance(Handle, out var ret));
+        return (FlannDistance)ret;
+    }
+
+    /// <summary>
+    /// The algorithm used by the index.
+    /// </summary>
+    public FlannAlgorithm GetAlgorithm()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Index_getAlgorithm(Handle, out var ret));
+        return (FlannAlgorithm)ret;
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/flann/IndexParams/HierarchicalClusteringIndexParams.cs
+++ b/src/OpenCvSharp/Modules/flann/IndexParams/HierarchicalClusteringIndexParams.cs
@@ -1,0 +1,39 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Flann;
+
+/// <summary>
+///
+/// </summary>
+public class HierarchicalClusteringIndexParams : IndexParams
+{
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="branching"></param>
+    /// <param name="centersInit"></param>
+    /// <param name="trees"></param>
+    /// <param name="leafSize"></param>
+    public HierarchicalClusteringIndexParams(
+        int branching = 32, FlannCentersInit centersInit = FlannCentersInit.Random, int trees = 4, int leafSize = 100)
+        : this(Create(branching, centersInit, trees, leafSize))
+    {
+    }
+
+    private HierarchicalClusteringIndexParams((IntPtr smartPtr, IntPtr rawPtr) ptrs)
+        : base(ptrs.smartPtr, ptrs.rawPtr,
+            static h => NativeMethods.HandleException(NativeMethods.flann_Ptr_HierarchicalClusteringIndexParams_delete(h)))
+    {
+    }
+
+    private static (IntPtr smartPtr, IntPtr rawPtr) Create(int branching, FlannCentersInit centersInit, int trees, int leafSize)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Ptr_HierarchicalClusteringIndexParams_new(branching, centersInit, trees, leafSize, out var smartPtr));
+        if (smartPtr == IntPtr.Zero)
+            throw new OpenCvSharpException($"Failed to create {nameof(HierarchicalClusteringIndexParams)}");
+        NativeMethods.HandleException(
+            NativeMethods.flann_Ptr_HierarchicalClusteringIndexParams_get(smartPtr, out var rawPtr));
+        return (smartPtr, rawPtr);
+    }
+}

--- a/src/OpenCvSharp/Modules/flann/IndexParams/SearchParams.cs
+++ b/src/OpenCvSharp/Modules/flann/IndexParams/SearchParams.cs
@@ -8,13 +8,25 @@ namespace OpenCvSharp.Flann;
 public class SearchParams : IndexParams
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="checks"></param>
     /// <param name="eps"></param>
     /// <param name="sorted"></param>
     public SearchParams(int checks = 32, float eps = 0.0f, bool sorted = true)
         : this(Create(checks, eps, sorted))
+    {
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="checks"></param>
+    /// <param name="eps"></param>
+    /// <param name="sorted"></param>
+    /// <param name="exploreAllTrees"></param>
+    public SearchParams(int checks, float eps, bool sorted, bool exploreAllTrees)
+        : this(Create(checks, eps, sorted, exploreAllTrees))
     {
     }
 
@@ -28,6 +40,17 @@ public class SearchParams : IndexParams
     {
         NativeMethods.HandleException(
             NativeMethods.flann_Ptr_SearchParams_new(checks, eps, sorted ? 1 : 0, out var smartPtr));
+        if (smartPtr == IntPtr.Zero)
+            throw new OpenCvSharpException($"Failed to create {nameof(SearchParams)}");
+        NativeMethods.HandleException(
+            NativeMethods.flann_Ptr_SearchParams_get(smartPtr, out var rawPtr));
+        return (smartPtr, rawPtr);
+    }
+
+    private static (IntPtr smartPtr, IntPtr rawPtr) Create(int checks, float eps, bool sorted, bool exploreAllTrees)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.flann_Ptr_SearchParams_new2(checks, eps, sorted ? 1 : 0, exploreAllTrees ? 1 : 0, out var smartPtr));
         if (smartPtr == IntPtr.Zero)
             throw new OpenCvSharpException($"Failed to create {nameof(SearchParams)}");
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/imgproc/CLAHE.cs
+++ b/src/OpenCvSharp/Modules/imgproc/CLAHE.cs
@@ -95,7 +95,27 @@ public sealed class CLAHE : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// Gets or sets the bit shift parameter for histogram bins (default is 0).
+    /// </summary>
+    public int BitShift
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.imgproc_CLAHE_getBitShift(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.imgproc_CLAHE_setBitShift(Handle, value));
+        }
+    }
+
+    /// <summary>
+    ///
     /// </summary>
     public void CollectGarbage()
     {

--- a/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
@@ -12,6 +12,8 @@ public enum StereoSGBMMode
 {
     SGBM = 0,
     HH   = 1,
+    SGBM3Way = 2,
+    HH4 = 3,
 }
 
 /// <summary>

--- a/src/OpenCvSharpExtern/calib.h
+++ b/src/OpenCvSharpExtern/calib.h
@@ -154,6 +154,35 @@ CVAPI(ExceptionStatus) calib_calibrateCamera_InputArray(
     });
 }
 
+CVAPI(ExceptionStatus) calib_calibrateCameraRO_InputArray(
+    cv::Mat **objectPoints,
+    int objectPointsSize,
+    cv::Mat **imagePoints,
+    int imagePointsSize,
+    interop::Size imageSize,
+    int iFixedPoint,
+    const interop::InputOutputArrayProxy* cameraMatrix,
+    const interop::InputOutputArrayProxy* distCoeffs,
+    std::vector<cv::Mat> *rvecs,
+    std::vector<cv::Mat> *tvecs,
+    const interop::OutputArrayProxy* newObjPoints,
+    int flags,
+    interop::TermCriteria criteria,
+    double *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> objectPointsVec(objectPointsSize);
+        for (auto i = 0; i < objectPointsSize; i++)
+            objectPointsVec[i] = *objectPoints[i];
+        std::vector<cv::Mat> imagePointsVec(imagePointsSize);
+        for (auto i = 0; i < imagePointsSize; i++)
+            imagePointsVec[i] = *imagePoints[i];
+
+        *returnValue = cv::calibrateCameraRO(objectPointsVec, imagePointsVec, cpp(imageSize), iFixedPoint,
+            IoProxy(*cameraMatrix), IoProxy(*distCoeffs), *rvecs, *tvecs, OutProxy(*newObjPoints), flags, cpp(criteria));
+    });
+}
+
 CVAPI(ExceptionStatus) calib_calibrateCamera_vector(
     cv::Point3f **objectPoints,
     int opSize1,

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -166,6 +166,13 @@ CVAPI(ExceptionStatus) core_sum(const interop::InputArrayProxy* src, interop::Sc
     });
 }
 
+CVAPI(ExceptionStatus) core_hasNonZero(const interop::InputArrayProxy* src, int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::hasNonZero(InProxy(*src)) ? 1 : 0;
+    });
+}
+
 CVAPI(ExceptionStatus) core_countNonZero(const interop::InputArrayProxy* src, int* returnValue)
 {
     return cvTry([&] {
@@ -404,6 +411,21 @@ CVAPI(ExceptionStatus) core_flip(const interop::InputArrayProxy* src, const inte
 {
     return cvTry([&] {
         cv::flip(InProxy(*src), OutProxy(*dst), flipCode);
+    });
+}
+
+CVAPI(ExceptionStatus) core_flipND(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* dst, int axis)
+{
+    return cvTry([&] {
+        cv::flipND(InProxy(*src), OutProxy(*dst), axis);
+    });
+}
+
+CVAPI(ExceptionStatus) core_broadcast(
+    const interop::InputArrayProxy* src, const interop::InputArrayProxy* shape, const interop::OutputArrayProxy* dst)
+{
+    return cvTry([&] {
+        cv::broadcast(InProxy(*src), InProxy(*shape), OutProxy(*dst));
     });
 }
 
@@ -709,6 +731,13 @@ CVAPI(ExceptionStatus) core_patchNaNs(const interop::InputOutputArrayProxy* a, d
     });
 }
 
+CVAPI(ExceptionStatus) core_finiteMask(const interop::InputArrayProxy* src, const interop::OutputArrayProxy* mask)
+{
+    return cvTry([&] {
+        cv::finiteMask(InProxy(*src), OutProxy(*mask));
+    });
+}
+
 CVAPI(ExceptionStatus) core_gemm(
     const interop::InputArrayProxy* src1,
     const interop::InputArrayProxy* src2,
@@ -745,6 +774,15 @@ CVAPI(ExceptionStatus) core_transpose(const interop::InputArrayProxy* src, const
 {
     return cvTry([&] {
         cv::transpose(InProxy(*src), OutProxy(*dst));
+    });
+}
+
+CVAPI(ExceptionStatus) core_transposeND(
+    const interop::InputArrayProxy* src, const int* order, int orderLength, const interop::OutputArrayProxy* dst)
+{
+    return cvTry([&] {
+        const std::vector<int> orderVec(order, order + orderLength);
+        cv::transposeND(InProxy(*src), orderVec, OutProxy(*dst));
     });
 }
 
@@ -1342,6 +1380,37 @@ CVAPI(ExceptionStatus) core_useOptimized(int *returnValue)
 {
     return cvTry([&] {
         *returnValue = cv::useOptimized() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) core_useIPP(int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::ipp::useIPP() ? 1 : 0;
+    });
+}
+CVAPI(ExceptionStatus) core_setUseIPP(int flag)
+{
+    return cvTry([&] {
+        cv::ipp::setUseIPP(flag != 0);
+    });
+}
+CVAPI(ExceptionStatus) core_getIppVersion(std::string *buf)
+{
+    return cvTry([&] {
+        buf->assign(cv::ipp::getIppVersion());
+    });
+}
+CVAPI(ExceptionStatus) core_useIPP_NotExact(int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::ipp::useIPP_NotExact() ? 1 : 0;
+    });
+}
+CVAPI(ExceptionStatus) core_setUseIPP_NotExact(int flag)
+{
+    return cvTry([&] {
+        cv::ipp::setUseIPP_NotExact(flag != 0);
     });
 }
 

--- a/src/OpenCvSharpExtern/flann.h
+++ b/src/OpenCvSharpExtern/flann.h
@@ -28,6 +28,56 @@ CVAPI(ExceptionStatus) flann_Index_delete(cv::flann::Index* obj)
     });
 }
 
+CVAPI(ExceptionStatus) flann_Index_new0(cv::flann::Index **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::flann::Index();
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Index_build(
+    cv::flann::Index* obj,
+    const interop::InputArrayProxy* features,
+    cv::flann::IndexParams* params,
+    cvflann::flann_distance_t distType)
+{
+    return cvTry([&] {
+        obj->build(InProxy(*features), *params, distType);
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Index_load(
+    cv::flann::Index* obj,
+    const interop::InputArrayProxy* features,
+    const char* filename,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->load(InProxy(*features), filename) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Index_release(cv::flann::Index* obj)
+{
+    return cvTry([&] {
+        obj->release();
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Index_getDistance(cv::flann::Index* obj, cvflann::flann_distance_t *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getDistance();
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Index_getAlgorithm(cv::flann::Index* obj, cvflann::flann_algorithm_t *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getAlgorithm();
+    });
+}
+
 CVAPI(ExceptionStatus) flann_Index_knnSearch1(
     cv::flann::Index* obj,
     float* queries,

--- a/src/OpenCvSharpExtern/flann_IndexParams.h
+++ b/src/OpenCvSharpExtern/flann_IndexParams.h
@@ -167,6 +167,34 @@ CVAPI(ExceptionStatus) flann_Ptr_KMeansIndexParams_delete(cv::Ptr<cv::flann::KMe
 }
 
 
+// cv::flann::HierarchicalClusteringIndexParams
+
+CVAPI(ExceptionStatus) flann_Ptr_HierarchicalClusteringIndexParams_new(
+    int branching, cvflann::flann_centers_init_t centers_init, int trees, int leaf_size,
+    cv::Ptr<cv::flann::HierarchicalClusteringIndexParams> **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Ptr<cv::flann::HierarchicalClusteringIndexParams>(
+            new cv::flann::HierarchicalClusteringIndexParams(branching, centers_init, trees, leaf_size));
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Ptr_HierarchicalClusteringIndexParams_get(
+    cv::Ptr<cv::flann::HierarchicalClusteringIndexParams> *ptr, cv::flann::HierarchicalClusteringIndexParams **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Ptr_HierarchicalClusteringIndexParams_delete(cv::Ptr<cv::flann::HierarchicalClusteringIndexParams> *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
 // cv::flann::LshIndexParams
 
 CVAPI(ExceptionStatus) flann_Ptr_LshIndexParams_new(
@@ -276,6 +304,15 @@ CVAPI(ExceptionStatus) flann_Ptr_SearchParams_new(int checks, float eps, int sor
 {
     return cvTry([&] {
         *returnValue = new cv::Ptr<cv::flann::SearchParams>(new cv::flann::SearchParams(checks, eps, (sorted != 0)));
+    });
+}
+
+CVAPI(ExceptionStatus) flann_Ptr_SearchParams_new2(
+    int checks, float eps, int sorted, int explore_all_trees, cv::Ptr<cv::flann::SearchParams> **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Ptr<cv::flann::SearchParams>(
+            new cv::flann::SearchParams(checks, eps, (sorted != 0), (explore_all_trees != 0)));
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -137,6 +137,16 @@ CVAPI(ExceptionStatus) imgproc_blur(
     });
 }
 
+CVAPI(ExceptionStatus) imgproc_stackBlur(
+    const interop::InputArrayProxy* src,
+    const interop::OutputArrayProxy* dst,
+    interop::Size ksize)
+{
+    return cvTry([&] {
+        cv::stackBlur(InProxy(*src), OutProxy(*dst), cpp(ksize));
+    });
+}
+
 CVAPI(ExceptionStatus) imgproc_filter2D(
     const interop::InputArrayProxy* src,
     const interop::OutputArrayProxy* dst,
@@ -658,6 +668,19 @@ CVAPI(ExceptionStatus) imgproc_phaseCorrelate(
     });
 }
 
+CVAPI(ExceptionStatus) imgproc_phaseCorrelateIterative(
+    const interop::InputArrayProxy* src1,
+    const interop::InputArrayProxy* src2,
+    int l2size,
+    int maxIters,
+    interop::Point2d* returnValue)
+{
+    return cvTry([&] {
+        const auto p = cv::phaseCorrelateIterative(InProxy(*src1), InProxy(*src2), l2size, maxIters);
+        *returnValue = { p.x, p.y };
+    });
+}
+
 CVAPI(ExceptionStatus) imgproc_createHanningWindow(
     const interop::OutputArrayProxy* dst,
     interop::Size winSize,
@@ -678,6 +701,20 @@ CVAPI(ExceptionStatus) imgproc_threshold(
 {
     return cvTry([&] {
         *returnValue = cv::threshold(InProxy(*src), OutProxy(*dst), thresh, maxVal, type);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_thresholdWithMask(
+    const interop::InputArrayProxy* src,
+    const interop::InputOutputArrayProxy* dst,
+    const interop::InputArrayProxy* mask,
+    double thresh,
+    double maxVal,
+    int type,
+    double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::thresholdWithMask(InProxy(*src), IoProxy(*dst), InProxy(*mask), thresh, maxVal, type);
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc_CLAHE.h
+++ b/src/OpenCvSharpExtern/imgproc_CLAHE.h
@@ -77,3 +77,17 @@ CVAPI(ExceptionStatus) imgproc_CLAHE_collectGarbage(cv::CLAHE *obj)
         obj->collectGarbage();
     });
 }
+
+CVAPI(ExceptionStatus) imgproc_CLAHE_setBitShift(cv::CLAHE *obj, int bitShift)
+{
+    return cvTry([&] {
+        obj->setBitShift(bitShift);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_CLAHE_getBitShift(cv::CLAHE *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getBitShift();
+    });
+}

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -228,6 +228,65 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Assert.Contains(distCoeffValues, d => Math.Abs(d) > 1e-20);
     }
 
+    // The "releasing object" method (calibrateCameraRO) needs multiple independent views to
+    // usefully solve for per-point corrections, so this uses synthetic multi-view data
+    // (projected from a known camera) rather than the single real calibration photo in the
+    // fixture set, following the same Rodrigues/ProjectPoints-based synthesis as CalibrateHandEye.
+    [Fact]
+    public void CalibrateCameraRO()
+    {
+        var patternSize = new Size(10, 7);
+        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
+
+        var trueCameraMatrix = new double[,]
+        {
+            { 800, 0, 320 },
+            { 0, 800, 240 },
+            { 0, 0, 1 }
+        };
+        var trueDistCoeffs = new double[] { 0, 0, 0, 0, 0 };
+
+        var views = new (double[] rvec, double[] tvec)[]
+        {
+            (new double[] { 0.10, 0.05, 0.00 }, new double[] { 0.0, 0.0, 8.0 }),
+            (new double[] { 0.15, -0.05, 0.05 }, new double[] { 0.5, 0.2, 8.5 }),
+            (new double[] { -0.10, 0.10, -0.05 }, new double[] { -0.3, -0.2, 9.0 }),
+        };
+
+        var objectPoints = new List<Mat>();
+        var imagePoints = new List<Mat>();
+        try
+        {
+            foreach (var (rvec, tvec) in views)
+            {
+                Cv2.ProjectPoints(objectPointsArray, rvec, tvec, trueCameraMatrix, trueDistCoeffs, out var imagePointsArray, out _);
+                objectPoints.Add(Mat<Point3f>.FromArray(objectPointsArray));
+                imagePoints.Add(Mat<Point2f>.FromArray(imagePointsArray));
+            }
+
+            using var cameraMatrix = Mat.EyeMat(3, 3, MatType.CV_64FC1);
+            using var distCoeffs = new Mat<double>();
+            using var newObjPoints = new Mat();
+
+            var iFixedPoint = patternSize.Width - 1;
+            var rms = Cv2.CalibrateCameraRO(
+                objectPoints, imagePoints, new Size(640, 480), iFixedPoint,
+                cameraMatrix, distCoeffs, out var rvecs, out var tvecs, newObjPoints);
+
+            Assert.False(double.IsNaN(rms));
+            Assert.False(double.IsInfinity(rms));
+            Assert.Equal(views.Length, rvecs.Length);
+            Assert.Equal(views.Length, tvecs.Length);
+            Assert.False(newObjPoints.Empty());
+            Assert.Equal(objectPointsArray.Length, (int)newObjPoints.Total());
+        }
+        finally
+        {
+            foreach (var m in objectPoints) m.Dispose();
+            foreach (var m in imagePoints) m.Dispose();
+        }
+    }
+
     [Fact]
     public void FishEyeCalibrate()
     {

--- a/test/OpenCvSharp.Tests/calib3d/StereoSGBMTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/StereoSGBMTest.cs
@@ -24,4 +24,13 @@ public class StereoSGBMTest : TestBase
             Window.ShowImages(disparityU8);
         }
     }
+
+    [Fact]
+    public void ModeValues()
+    {
+        Assert.Equal(0, (int)StereoSGBMMode.SGBM);
+        Assert.Equal(1, (int)StereoSGBMMode.HH);
+        Assert.Equal(2, (int)StereoSGBMMode.SGBM3Way);
+        Assert.Equal(3, (int)StereoSGBMMode.HH4);
+    }
 }

--- a/test/OpenCvSharp.Tests/core/CoreTest.cs
+++ b/test/OpenCvSharp.Tests/core/CoreTest.cs
@@ -619,6 +619,16 @@ public class CoreTest : TestBase
     }
 
     [Fact]
+    public void HasNonZero()
+    {
+        using var zeros = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 0, 0, 0, 0 });
+        Assert.False(Cv2.HasNonZero(zeros));
+
+        using var withNonZero = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 0, 1, 0, 0 });
+        Assert.True(Cv2.HasNonZero(withNonZero));
+    }
+
+    [Fact]
     public void FindNonZero()
     {
         using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 0, 1, 0, 1 });
@@ -639,6 +649,33 @@ public class CoreTest : TestBase
         Assert.Equal(4, dst.At<byte>(0, 1));
         Assert.Equal(1, dst.At<byte>(1, 0));
         Assert.Equal(2, dst.At<byte>(1, 1));
+    }
+
+    [Fact]
+    public void FlipND()
+    {
+        using var src = Mat.FromPixelData(2, 2, MatType.CV_8UC1, new byte[] { 1, 2, 3, 4 });
+        using var dst = new Mat();
+        Cv2.FlipND(src, dst, 0);
+
+        Assert.Equal(3, dst.At<byte>(0, 0));
+        Assert.Equal(4, dst.At<byte>(0, 1));
+        Assert.Equal(1, dst.At<byte>(1, 0));
+        Assert.Equal(2, dst.At<byte>(1, 1));
+    }
+
+    [Fact]
+    public void Broadcast()
+    {
+        using var src = Mat.FromPixelData(1, 3, MatType.CV_32FC1, new float[] { 1, 2, 3 });
+        int[] shapeData = [3, 3];
+        using var shape = Mat.FromPixelData(1, 2, MatType.CV_32SC1, shapeData);
+        using var dst = new Mat();
+        Cv2.Broadcast(src, shape, dst);
+
+        Assert.Equal(new Size(3, 3), dst.Size());
+        Assert.Equal(1.0f, dst.At<float>(2, 0), 3);
+        Assert.Equal(3.0f, dst.At<float>(2, 2), 3);
     }
 
     [Fact]
@@ -815,6 +852,68 @@ public class CoreTest : TestBase
 
         Assert.Equal(0.0, a.At<float>(0, 1), 3);
         Assert.Equal(1.0, a.At<float>(0, 0), 3);
+    }
+
+    [Fact]
+    public void FiniteMask()
+    {
+        using var src = Mat.FromPixelData(1, 3, MatType.CV_32FC1, new[] { 1.0f, float.NaN, float.PositiveInfinity });
+        using var mask = new Mat();
+        Cv2.FiniteMask(src, mask);
+
+        Assert.Equal(255, mask.At<byte>(0, 0));
+        Assert.Equal(0, mask.At<byte>(0, 1));
+        Assert.Equal(0, mask.At<byte>(0, 2));
+    }
+
+    [Fact]
+    public void TransposeND()
+    {
+        using var src = Mat.FromPixelData(2, 3, MatType.CV_32FC1, new float[] { 1, 2, 3, 4, 5, 6 });
+        using var dst = new Mat();
+        Cv2.TransposeND(src, [1, 0], dst);
+
+        Assert.Equal(new Size(2, 3), dst.Size());
+        Assert.Equal(1.0f, dst.At<float>(0, 0), 3);
+        Assert.Equal(4.0f, dst.At<float>(0, 1), 3);
+    }
+
+    [Fact]
+    public void UseIPP()
+    {
+        var original = Cv2.UseIPP();
+        try
+        {
+            Cv2.SetUseIPP(false);
+            Assert.False(Cv2.UseIPP());
+            Cv2.SetUseIPP(true);
+            Assert.True(Cv2.UseIPP());
+        }
+        finally
+        {
+            Cv2.SetUseIPP(original);
+        }
+    }
+
+    [Fact]
+    public void GetIppVersion()
+    {
+        Assert.NotNull(Cv2.GetIppVersion());
+    }
+
+    [Fact]
+    public void UseIppNotExact()
+    {
+        var original = Cv2.UseIppNotExact();
+        try
+        {
+            Cv2.SetUseIppNotExact(!original);
+            Assert.Equal(!original, Cv2.UseIppNotExact());
+        }
+        finally
+        {
+            Cv2.SetUseIppNotExact(original);
+        }
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/core/CoreTest.cs
+++ b/test/OpenCvSharp.Tests/core/CoreTest.cs
@@ -884,6 +884,13 @@ public class CoreTest : TestBase
         var original = Cv2.UseIPP();
         try
         {
+            Cv2.SetUseIPP(true);
+            if (!Cv2.UseIPP())
+            {
+                // IPP is not compiled into this OpenCV build (e.g. arm64), so the flag is a no-op.
+                Assert.Skip("IPP is not available in this OpenCV build.");
+            }
+
             Cv2.SetUseIPP(false);
             Assert.False(Cv2.UseIPP());
             Cv2.SetUseIPP(true);
@@ -908,6 +915,12 @@ public class CoreTest : TestBase
         try
         {
             Cv2.SetUseIppNotExact(!original);
+            if (Cv2.UseIppNotExact() == original)
+            {
+                // IPP is not compiled into this OpenCV build (e.g. arm64), so the flag is a no-op.
+                Assert.Skip("IPP is not available in this OpenCV build.");
+            }
+
             Assert.Equal(!original, Cv2.UseIppNotExact());
         }
         finally

--- a/test/OpenCvSharp.Tests/flann/IndexParamsTest.cs
+++ b/test/OpenCvSharp.Tests/flann/IndexParamsTest.cs
@@ -1,0 +1,38 @@
+using OpenCvSharp.Flann;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Flann;
+
+// Coverage for issue #2008 gaps: HierarchicalClusteringIndexParams (previously unwrapped)
+// and the SearchParams overload with explore_all_trees.
+public class IndexParamsTest : TestBase
+{
+    [Fact]
+    public void HierarchicalClusteringIndexParamsConstructAndSearch()
+    {
+        var features = new float[,]
+        {
+            { 0, 0 },
+            { 10, 0 },
+            { 0, 10 },
+            { 10, 10 },
+        };
+        using var featuresMat = Mat.FromPixelData(4, 2, MatType.CV_32FC1, features);
+        using var indexParams = new HierarchicalClusteringIndexParams();
+
+        using var index = new global::OpenCvSharp.Flann.Index(featuresMat, indexParams);
+
+        using var searchParams = new SearchParams();
+        index.KnnSearch([1f, 1f], out var indices, out var dists, 1, searchParams);
+
+        Assert.Equal(0, indices[0]);
+        Assert.True(dists[0] > 0);
+    }
+
+    [Fact]
+    public void SearchParamsExploreAllTreesConstructs()
+    {
+        using var searchParams = new SearchParams(32, 0.0f, true, true);
+        Assert.False(searchParams.IsDisposed);
+    }
+}

--- a/test/OpenCvSharp.Tests/flann/IndexTest.cs
+++ b/test/OpenCvSharp.Tests/flann/IndexTest.cs
@@ -28,4 +28,58 @@ public class IndexTest : TestBase
         Assert.Equal(0, indices[0]);
         Assert.True(dists[0] > 0);
     }
+
+    [Fact]
+    public void DefaultConstructorThenBuild()
+    {
+        var features = new float[,]
+        {
+            { 0, 0 },
+            { 10, 0 },
+            { 0, 10 },
+            { 10, 10 },
+        };
+        using var featuresMat = Mat.FromPixelData(4, 2, MatType.CV_32FC1, features);
+        using var indexParams = new KDTreeIndexParams();
+
+        using var index = new global::OpenCvSharp.Flann.Index();
+        index.Build(featuresMat, indexParams);
+
+        Assert.Equal(FlannAlgorithm.KDTree, index.GetAlgorithm());
+        Assert.Equal(FlannDistance.L2, index.GetDistance());
+
+        using var searchParams = new SearchParams();
+        index.KnnSearch([1f, 1f], out var indices, out var dists, 1, searchParams);
+        Assert.Equal(0, indices[0]);
+    }
+
+    [Fact]
+    public void SaveLoadRoundTrip()
+    {
+        const string fileName = "flann_index.dat";
+        var features = new float[,]
+        {
+            { 0, 0 },
+            { 10, 0 },
+            { 0, 10 },
+            { 10, 10 },
+        };
+        using var featuresMat = Mat.FromPixelData(4, 2, MatType.CV_32FC1, features);
+        using var indexParams = new LinearIndexParams();
+
+        using (var index = new global::OpenCvSharp.Flann.Index(featuresMat, indexParams))
+        {
+            index.Save(fileName);
+        }
+
+        using var loaded = new global::OpenCvSharp.Flann.Index();
+        var loadedOk = loaded.Load(featuresMat, fileName);
+        Assert.True(loadedOk);
+
+        using var searchParams = new SearchParams();
+        loaded.KnnSearch([1f, 1f], out var indices, out _, 1, searchParams);
+        Assert.Equal(0, indices[0]);
+
+        loaded.Release();
+    }
 }

--- a/test/OpenCvSharp.Tests/imgproc/CLAHETest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/CLAHETest.cs
@@ -33,4 +33,14 @@ public class CLAHETest : TestBase
         clahe.TilesGridSize = value;
         Assert.Equal(value, clahe.TilesGridSize);
     }
+
+    [Fact]
+    public void BitShift()
+    {
+        using var clahe = Cv2.CreateCLAHE();
+        Assert.Equal(0, clahe.BitShift);
+
+        clahe.BitShift = 2;
+        Assert.Equal(2, clahe.BitShift);
+    }
 }

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -873,6 +873,33 @@ public class ImgProcTest : TestBase
     }
 
     [Fact]
+    public void StackBlur()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var dst = new Mat();
+        Cv2.StackBlur(src, dst, new Size(3, 3));
+
+        Assert.Equal(src.Size(), dst.Size());
+        Assert.Equal(src.Type(), dst.Type());
+    }
+
+    [Fact]
+    public void ThresholdWithMask()
+    {
+        using var src = Mat.FromPixelData(1, 4, MatType.CV_8UC1, new byte[] { 10, 200, 10, 200 });
+        using var dst = src.Clone();
+        using var mask = Mat.FromPixelData(1, 4, MatType.CV_8UC1, new byte[] { 1, 1, 1, 0 }); // last element excluded
+
+        var ret = Cv2.ThresholdWithMask(src, dst, mask, 128, 255, ThresholdTypes.Binary);
+
+        Assert.Equal(128, ret);
+        Assert.Equal(0, dst.At<byte>(0, 0));
+        Assert.Equal(255, dst.At<byte>(0, 1));
+        Assert.Equal(0, dst.At<byte>(0, 2));
+        Assert.Equal(200, dst.At<byte>(0, 3)); // masked-out pixel left as-is
+    }
+
+    [Fact]
     public void BoxFilter()
     {
         using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
@@ -1474,6 +1501,20 @@ public class ImgProcTest : TestBase
         Cv2.CreateHanningWindow(window, new Size(64, 64), MatType.CV_32F);
 
         var shift = Cv2.PhaseCorrelate(src, src, window, out var response);
+
+        Assert.True(Math.Abs(shift.X) < 1.0 && Math.Abs(shift.Y) < 1.0); // identical inputs -> no shift
+    }
+
+    [Fact]
+    public void PhaseCorrelateIterative()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var small = new Mat();
+        Cv2.Resize(gray, small, new Size(64, 64));
+        using var src = new Mat();
+        small.ConvertTo(src, MatType.CV_32F);
+
+        var shift = Cv2.PhaseCorrelateIterative(src, src);
 
         Assert.True(Math.Abs(shift.X) < 1.0 && Math.Abs(shift.Y) < 1.0); // identical inputs -> no shift
     }


### PR DESCRIPTION
## Summary
- Adds `Cv2.CalibrateCameraRO`, `StereoSGBMMode.SGBM3Way`/`HH4`, and a handful of small `core`/`imgproc` free functions (`HasNonZero`, `FiniteMask`, `Broadcast`, `FlipND`, `TransposeND`, the `useIPP` family) that were missing relative to OpenCV 5.x's public C++ surface.
- Fills out FLANN coverage: `HierarchicalClusteringIndexParams`, `Index.Build`/`Load`/`Release`/`GetDistance`/`GetAlgorithm` (plus a parameterless constructor), and a `SearchParams` overload with `exploreAllTrees`.
- Adds `CLAHE.BitShift` and imgproc's `ThresholdWithMask`/`StackBlur`/`PhaseCorrelateIterative`.
- Identified via an API coverage audit (#2019); `AsyncArray` and the `cv::samples` facade were investigated and deliberately left out of scope (no real producer/consumer for the former, low value for the latter — see issue discussion).

## Test plan
- [x] `dotnet build` on `src/OpenCvSharp` and the native `OpenCvSharpExtern` CMake target
- [x] New xUnit tests added per API (`calib3d`, `flann`, `imgproc`, `core`) and run against a locally built native DLL — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Cv2.CalibrateCameraRO` for releasing object points during multi-view calibration.
  * Added core utilities: `HasNonZero`, `FlipND`, `TransposeND`, `Broadcast`, `FiniteMask`, and IPP toggles/version info.
  * Added imgproc APIs: `StackBlur`, `PhaseCorrelateIterative`, `ThresholdWithMask`.
  * Expanded FLANN: `Index` constructor plus `Build/Load/Release/GetDistance/GetAlgorithm`, new `FlannAlgorithm`, and new index/search parameter options.
  * Added `CLAHE.BitShift` and new `StereoSGBMMode` values (`SGBM3Way`, `HH4`).
* **Bug Fixes**
  * Corrected a calibration interop pointer-length issue.
* **Tests**
  * Added coverage for the new calibration, core, FLANN, CLAHE, stereo, and imgproc features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->