### PR TITLE
Close FileNode/FileStorage gaps vs. the native CV_WRAP surface

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
@@ -450,6 +450,9 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void vector_string_delete(IntPtr vector);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_string_pushBack(OpenCvSafeHandle vector, [MarshalAs(UnmanagedType.LPStr)] string value);
     #endregion
     #region vector<cv::line_descriptor::KeyLine>
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileNode.cs
@@ -48,9 +48,16 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_FileNode_name(OpenCvSafeHandle obj, IntPtr buf);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_size(OpenCvSafeHandle obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileNode_rawSize(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileNode_keys(OpenCvSafeHandle obj, IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_toInt(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileNode_toInt64(OpenCvSafeHandle obj, out long returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_toFloat(OpenCvSafeHandle obj, out float returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -73,6 +80,8 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_read_int(OpenCvSafeHandle node, out int value, int defaultValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileNode_read_int64(OpenCvSafeHandle node, out long value, long defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileNode_read_float(OpenCvSafeHandle node, out float value, float defaultValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
@@ -79,8 +79,20 @@ static partial class NativeMethods
     public static partial ExceptionStatus core_FileStorage_state(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileStorage_getFormat(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_int(
         OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, int value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileStorage_write_bool(
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, int value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileStorage_write_int64(
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, long value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_FileStorage_write_vectorOfString(
+        OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr value);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_write_float(
         OpenCvSafeHandle fs, [MarshalAs(UnmanagedType.LPStr)] string name, float value);

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
@@ -37,6 +37,8 @@ public class VectorOfString : CvObject, IStdVector<string?>
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
         foreach (var s in data)
         {
+            if (s is null)
+                throw new ArgumentException("Collection must not contain null elements.", nameof(data));
             NativeMethods.vector_string_pushBack(Handle, s);
         }
     }

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfString.cs
@@ -27,6 +27,21 @@ public class VectorOfString : CvObject, IStdVector<string?>
     }
 
     /// <summary>
+    /// Creates a vector populated from <paramref name="data"/>.
+    /// </summary>
+    /// <param name="data"></param>
+    public VectorOfString(IEnumerable<string> data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var p = NativeMethods.vector_string_new1();
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
+        foreach (var s in data)
+        {
+            NativeMethods.vector_string_pushBack(Handle, s);
+        }
+    }
+
+    /// <summary>
     /// Releases unmanaged resources
     /// </summary>
     protected override void DisposeUnmanaged()

--- a/src/OpenCvSharp/Modules/core/FileNode.cs
+++ b/src/OpenCvSharp/Modules/core/FileNode.cs
@@ -316,6 +316,50 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     }
 
     /// <summary>
+    /// Navigates a chain of mapping keys (<see cref="string"/>) and/or sequence indices
+    /// (<see cref="int"/>), disposing every intermediate <see cref="FileNode"/> along the way.
+    /// Equivalent to repeated indexer chaining (e.g. <c>node["a"][2]["b"]</c>), except that the
+    /// indexer chain leaves every intermediate node unreferenced - each one is still a real
+    /// native allocation that would otherwise sit around until the GC finalizes it.
+    /// </summary>
+    /// <param name="path">One or more mapping keys / sequence indices to follow, in order.</param>
+    /// <returns>The node at the end of the path, or null if any segment along the way is missing.</returns>
+    public FileNode? GetPath(params object[] path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        if (path.Length == 0)
+            throw new ArgumentException("Path must contain at least one key or index.", nameof(path));
+
+        ThrowIfDisposed();
+
+        var current = this;
+        var ownsCurrent = false;
+
+        foreach (var segment in path)
+        {
+            var next = segment switch
+            {
+                string key => current[key],
+                int index => current[index],
+                _ => throw new ArgumentException(
+                    $"Path segments must be string (mapping key) or int (sequence index), got '{segment?.GetType()}'.",
+                    nameof(path)),
+            };
+
+            if (ownsCurrent)
+                current.Dispose();
+
+            if (next is null)
+                return null;
+
+            current = next;
+            ownsCurrent = true;
+        }
+
+        return current;
+    }
+
+    /// <summary>
     /// Returns true if the node is empty
     /// </summary>
     /// <returns></returns>

--- a/src/OpenCvSharp/Modules/core/FileNode.cs
+++ b/src/OpenCvSharp/Modules/core/FileNode.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
@@ -45,6 +46,28 @@ public class FileNode : CvObject, IEnumerable<FileNode>
             static h => NativeMethods.HandleException(NativeMethods.core_FileNode_delete(h))));
     }
 
+    /// <summary>
+    /// Wraps a native cv::FileNode* as a nullable FileNode, normalizing the "not found" case.
+    /// Native FileNode lookups (FileStorage/FileNode indexers) never return a null pointer -
+    /// a missing key comes back as a non-null, heap-allocated node whose Type is None. That
+    /// sentinel is indistinguishable from a key that is present but explicitly stores a "none"
+    /// value (e.g. YAML's <c>~</c>), so this treats both as "not found" and returns null,
+    /// which is what a C# caller chaining with <c>?.</c> actually expects.
+    /// </summary>
+    internal static FileNode? FromRawPtrOrNull(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero)
+            return null;
+
+        var node = new FileNode(ptr);
+        if (node.IsNone)
+        {
+            node.Dispose();
+            return null;
+        }
+        return node;
+    }
+
     #endregion
 
     #region Cast
@@ -70,6 +93,31 @@ public class FileNode : CvObject, IEnumerable<FileNode>
 
         NativeMethods.HandleException(
             NativeMethods.core_FileNode_toInt(Handle, out var ret));
+
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the node content as a signed 64-bit integer. If the node stores a floating-point number, it is rounded.
+    /// </summary>
+    /// <param name="node"></param>
+    /// <returns></returns>
+    public static explicit operator long(FileNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        return node.ToInt64();
+    }
+
+    /// <summary>
+    /// Returns the node content as a signed 64-bit integer. If the node stores a floating-point number, it is rounded.
+    /// </summary>
+    /// <returns></returns>
+    public long ToInt64()
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.core_FileNode_toInt64(Handle, out var ret));
 
         return ret;
     }
@@ -176,12 +224,65 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         return matrix;
     }
 
+    /// <summary>
+    /// Converts this node (and, recursively, its children) into a <see cref="JsonNode"/> tree,
+    /// regardless of whether the underlying <see cref="FileStorage"/> was opened as XML, YAML or
+    /// JSON. This is a generic structural conversion (scalars, sequences, mappings) - it does not
+    /// give special treatment to OpenCV-specific encodings such as <c>Mat</c>/<c>KeyPoint</c>/
+    /// <c>DMatch</c>, which come through as their raw mapping/sequence shape (e.g. a Mat becomes a
+    /// JSON object with "rows"/"cols"/"dt"/"data" members, not an <see cref="OpenCvSharp.Mat"/>).
+    /// The result can be fed to <see cref="System.Text.Json.JsonSerializer"/> or queried directly.
+    /// </summary>
+    /// <returns>
+    /// The converted node, or null for a <see cref="Types.None"/> node (mirroring JSON <c>null</c>).
+    /// </returns>
+    public JsonNode? ToJsonNode()
+    {
+        ThrowIfDisposed();
+
+        return Type switch
+        {
+            Types.None => null,
+            Types.Int => JsonValue.Create(ToInt64()),
+            Types.Real => JsonValue.Create(ToDouble()),
+            Types.Str => JsonValue.Create(ToString()),
+            Types.Seq => SeqToJsonArray(),
+            Types.Map => MapToJsonObject(),
+            _ => throw new NotSupportedException($"Cannot convert a FileNode of type {Type} to a JsonNode."),
+        };
+    }
+
+    private JsonArray SeqToJsonArray()
+    {
+        var array = new JsonArray();
+        foreach (var child in this)
+        {
+            using (child)
+            {
+                array.Add(child.ToJsonNode());
+            }
+        }
+        return array;
+    }
+
+    private JsonObject MapToJsonObject()
+    {
+        var obj = new JsonObject();
+        foreach (var key in Keys)
+        {
+            using var child = this[key];
+            obj[key] = child?.ToJsonNode();
+        }
+        return obj;
+    }
+
     #endregion
 
     #region Properties
 
     /// <summary>
-    /// returns element of a mapping node
+    /// Returns the element of a mapping node with the given key, or null if the key is not
+    /// present (or is explicitly stored as a "none" value).
     /// </summary>
     public FileNode? this[string nodeName]
     {
@@ -193,14 +294,13 @@ public class FileNode : CvObject, IEnumerable<FileNode>
             NativeMethods.HandleException(
                 NativeMethods.core_FileNode_operatorThis_byString(Handle, nodeName, out var node));
 
-            if (node == IntPtr.Zero)
-                return null;
-            return new FileNode(node);
+            return FromRawPtrOrNull(node);
         }
     }
 
     /// <summary>
-    /// returns element of a sequence node
+    /// Returns the element of a sequence node at the given index, or null if the index is out
+    /// of range (or the element is explicitly stored as a "none" value).
     /// </summary>
     public FileNode? this[int i]
     {
@@ -208,12 +308,10 @@ public class FileNode : CvObject, IEnumerable<FileNode>
         {
             ThrowIfDisposed();
 
-            NativeMethods.HandleException( 
+            NativeMethods.HandleException(
                 NativeMethods.core_FileNode_operatorThis_byInt(Handle, i, out var node));
 
-            if (node == IntPtr.Zero)
-                return null;
-            return new FileNode(node);
+            return FromRawPtrOrNull(node);
         }
     }
 
@@ -369,6 +467,35 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     }
 
     /// <summary>
+    /// Returns the keys of a mapping node.
+    /// </summary>
+    public string[] Keys
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var buf = new VectorOfString();
+            NativeMethods.HandleException(
+                NativeMethods.core_FileNode_keys(Handle, buf.CvPtr));
+            return buf.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Returns the raw size of the node in bytes.
+    /// </summary>
+    public long RawSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.core_FileNode_rawSize(Handle, out var ret));
+            return ret.ToInt64();
+        }
+    }
+
+    /// <summary>
     /// Returns type of the node.
     /// </summary>
     /// <returns>Type of the node.</returns>
@@ -433,14 +560,17 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     /// Reads node elements to the buffer with the specified format
     /// </summary>
     /// <param name="fmt"></param>
-    /// <param name="vec"></param>
-    /// <param name="len"></param>
-    public void ReadRaw(string fmt, IntPtr vec, long len)
+    /// <param name="vec">The buffer to read into.</param>
+    public unsafe void ReadRaw(string fmt, Span<byte> vec)
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fmt);
-        NativeMethods.HandleException(
-            NativeMethods.core_FileNode_readRaw(Handle, fmt, vec, new IntPtr(len)));
+
+        fixed (byte* p = vec)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_FileNode_readRaw(Handle, fmt, (IntPtr)p, new IntPtr(vec.Length)));
+        }
     }
 
     #region Read
@@ -454,6 +584,18 @@ public class FileNode : CvObject, IEnumerable<FileNode>
     {
         NativeMethods.HandleException(
             NativeMethods.core_FileNode_read_int(Handle, out var value, defaultValue));
+        return value;
+    }
+
+    /// <summary>
+    /// Reads the node element as Int64 (long)
+    /// </summary>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public long ReadInt64(long defaultValue = default)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.core_FileNode_read_int64(Handle, out var value, defaultValue));
         return value;
     }
 

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -306,7 +306,16 @@ public class FileStorage : CvObject
     /// Disposable scope returned by <see cref="WriteStruct"/>. Disposing it calls
     /// <see cref="EndWriteStruct"/> on the owning <see cref="FileStorage"/>.
     /// </summary>
-    public struct StructScope : IDisposable
+    /// <remarks>
+    /// This is deliberately a class, not a struct: EndWriteStruct() has an ordered, one-shot
+    /// unmanaged side effect (it closes the innermost open structure in the underlying
+    /// cv::FileStorage), so calling it twice corrupts whatever is written afterwards. A struct
+    /// can't guarantee that - copying it (e.g. `var b = a;`) produces an independent instance
+    /// with its own disposed flag, so guarding with a field only protects the single-variable
+    /// case, not a copy disposed separately. As a class, every reference shares the same
+    /// disposed flag, so Dispose() is idempotent no matter how many variables point to it.
+    /// </remarks>
+    public sealed class StructScope : IDisposable
     {
         private readonly FileStorage fileStorage;
         private bool disposed;
@@ -314,12 +323,11 @@ public class FileStorage : CvObject
         internal StructScope(FileStorage fileStorage)
         {
             this.fileStorage = fileStorage;
-            disposed = false;
         }
 
         /// <summary>
         /// Ends the structure (calls <see cref="FileStorage.EndWriteStruct"/>). Idempotent:
-        /// calling this more than once on the same scope only ends the structure once.
+        /// calling this more than once only ends the structure once.
         /// </summary>
         public void Dispose()
         {

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 using OpenCvSharp.Internal;
 using OpenCvSharp.Internal.Vectors;
 
@@ -76,6 +77,41 @@ public class FileStorage : CvObject
                 NativeMethods.core_FileStorage_indexer(Handle, nodeName, out var node));
 
             return FileNode.FromRawPtrOrNull(node);
+        }
+    }
+
+    /// <summary>
+    /// Navigates a chain of mapping keys (<see cref="string"/>) and/or sequence indices
+    /// (<see cref="int"/>) starting from the top-level mapping, disposing every intermediate
+    /// <see cref="FileNode"/> along the way. Equivalent to repeated indexer chaining (e.g.
+    /// <c>fs["a"][2]["b"]</c>), except that the indexer chain leaves every intermediate node
+    /// unreferenced - each one is still a real native allocation that would otherwise sit
+    /// around until the GC finalizes it.
+    /// </summary>
+    /// <param name="path">One or more mapping keys / sequence indices to follow, in order.
+    /// The first segment must be a string (a key of the top-level mapping).</param>
+    /// <returns>The node at the end of the path, or null if any segment along the way is missing.</returns>
+    public FileNode? GetPath(params object[] path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        if (path.Length == 0)
+            throw new ArgumentException("Path must contain at least one key or index.", nameof(path));
+        if (path[0] is not string firstKey)
+            throw new ArgumentException("The first path segment must be a string (top-level mapping key).", nameof(path));
+
+        ThrowIfDisposed();
+
+        var first = this[firstKey];
+        if (first is null || path.Length == 1)
+            return first;
+
+        try
+        {
+            return first.GetPath(path[1..]);
+        }
+        finally
+        {
+            first.Dispose();
         }
     }
 
@@ -521,7 +557,63 @@ public class FileStorage : CvObject
     }
 
     /// <summary>
-    /// 
+    /// Writes a <see cref="JsonNode"/> tree (scalars, arrays, objects) under the given key,
+    /// recursively, via the ordinary <see cref="Write(string,int)"/>/<see cref="WriteStruct"/>
+    /// calls - the counterpart to <see cref="FileNode.ToJsonNode"/>. Native FileStorage remains
+    /// the actual XML/YAML/JSON engine; this only lets callers build the data to write using
+    /// <see cref="System.Text.Json"/> types instead of one-call-per-value/struct-scope calls.
+    /// </summary>
+    /// <param name="name">Key to write the value under (top level or inside an open mapping).
+    /// Pass an empty string for an anonymous element inside an open sequence.</param>
+    /// <param name="value">The value to write. A JSON null throws, since FileStorage has no
+    /// native representation for an explicit null scalar.</param>
+    public void Write(string name, JsonNode? value)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(name);
+
+        switch (value)
+        {
+            case null:
+                throw new NotSupportedException(
+                    $"Cannot write a JSON null for key '{name}': FileStorage has no representation for an explicit null value.");
+
+            case JsonObject obj:
+                using (WriteStruct(name, FileNode.Types.Map))
+                {
+                    foreach (var (key, child) in obj)
+                        Write(key, child);
+                }
+                break;
+
+            case JsonArray array:
+                using (WriteStruct(name, FileNode.Types.Seq))
+                {
+                    foreach (var item in array)
+                        Write(string.Empty, item);
+                }
+                break;
+
+            case JsonValue scalar:
+                WriteJsonScalar(name, scalar);
+                break;
+
+            default:
+                throw new NotSupportedException($"Unsupported JsonNode type '{value.GetType()}' for key '{name}'.");
+        }
+    }
+
+    private void WriteJsonScalar(string name, JsonValue value)
+    {
+        if (value.TryGetValue(out bool b)) { Write(name, b); return; }
+        if (value.TryGetValue(out long l)) { Write(name, l); return; }
+        if (value.TryGetValue(out double d)) { Write(name, d); return; }
+        if (value.TryGetValue(out string? s)) { Write(name, s!); return; }
+        throw new NotSupportedException($"Unsupported JsonValue underlying type for key '{name}'.");
+    }
+
+    /// <summary>
+    ///
     /// </summary>
     /// <param name="value"></param>
     public void WriteScalar(int value)

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -606,8 +606,25 @@ public class FileStorage : CvObject
     private void WriteJsonScalar(string name, JsonValue value)
     {
         if (value.TryGetValue(out bool b)) { Write(name, b); return; }
+
+        // JsonValue.Create(T) preserves the exact CLR type it was created from - TryGetValue<T>
+        // does a strict type match for it, unlike a JsonNode.Parse()-produced JsonValue (backed by
+        // JsonElement, which freely widens across numeric types). So a value created via e.g.
+        // JsonValue.Create(3) (int) or a plain `new JsonObject { ["x"] = 3 }` assignment fails
+        // TryGetValue<long>/<double> and must be probed by its exact CLR type instead.
         if (value.TryGetValue(out long l)) { Write(name, l); return; }
+        if (value.TryGetValue(out int i)) { Write(name, (long)i); return; }
+        if (value.TryGetValue(out short sh)) { Write(name, (long)sh); return; }
+        if (value.TryGetValue(out sbyte sb)) { Write(name, (long)sb); return; }
+        if (value.TryGetValue(out byte by)) { Write(name, (long)by); return; }
+        if (value.TryGetValue(out ushort us)) { Write(name, (long)us); return; }
+        if (value.TryGetValue(out uint ui)) { Write(name, (long)ui); return; }
+        if (value.TryGetValue(out ulong ul)) { Write(name, unchecked((long)ul)); return; }
+
         if (value.TryGetValue(out double d)) { Write(name, d); return; }
+        if (value.TryGetValue(out float f)) { Write(name, (double)f); return; }
+        if (value.TryGetValue(out decimal dec)) { Write(name, (double)dec); return; }
+
         if (value.TryGetValue(out string? s)) { Write(name, s!); return; }
         throw new NotSupportedException($"Unsupported JsonValue underlying type for key '{name}'.");
     }

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -1236,6 +1236,16 @@ public class FileStorage : CvObject
         FormatYaml = (2 << 3),
 
         /// <summary>
+        /// flag, JSON format
+        /// </summary>
+        FormatJson = (3 << 3),
+
+        /// <summary>
+        /// flag, legacy YAML 1.0 format (strict headers, booleans as ints)
+        /// </summary>
+        FormatYaml10 = (4 << 3),
+
+        /// <summary>
         /// flag, write rawdata in Base64 by default. (consider using WRITE_BASE64)
         /// </summary>
         Base64 = 64, 

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -306,20 +306,26 @@ public class FileStorage : CvObject
     /// Disposable scope returned by <see cref="WriteStruct"/>. Disposing it calls
     /// <see cref="EndWriteStruct"/> on the owning <see cref="FileStorage"/>.
     /// </summary>
-    public readonly struct StructScope : IDisposable
+    public struct StructScope : IDisposable
     {
         private readonly FileStorage fileStorage;
+        private bool disposed;
 
         internal StructScope(FileStorage fileStorage)
         {
             this.fileStorage = fileStorage;
+            disposed = false;
         }
 
         /// <summary>
-        /// Ends the structure (calls <see cref="FileStorage.EndWriteStruct"/>).
+        /// Ends the structure (calls <see cref="FileStorage.EndWriteStruct"/>). Idempotent:
+        /// calling this more than once on the same scope only ends the structure once.
         /// </summary>
         public void Dispose()
         {
+            if (disposed)
+                return;
+            disposed = true;
             fileStorage.EndWriteStruct();
         }
     }

--- a/src/OpenCvSharp/Modules/core/FileStorage.cs
+++ b/src/OpenCvSharp/Modules/core/FileStorage.cs
@@ -60,7 +60,8 @@ public class FileStorage : CvObject
     #region Properties
 
     /// <summary>
-    /// Returns the specified element of the top-level mapping
+    /// Returns the specified element of the top-level mapping, or null if the key is not
+    /// present (or is explicitly stored as a "none" value).
     /// </summary>
     /// <param name="nodeName"></param>
     /// <returns></returns>
@@ -74,9 +75,7 @@ public class FileStorage : CvObject
             NativeMethods.HandleException(
                 NativeMethods.core_FileStorage_indexer(Handle, nodeName, out var node));
 
-            if (node == IntPtr.Zero)
-                return null;
-            return new FileNode(node);
+            return FileNode.FromRawPtrOrNull(node);
         }
     }
 
@@ -148,6 +147,18 @@ public class FileStorage : CvObject
     }
 
     /// <summary>
+    /// Returns the current format (one of the Modes.Format* flags).
+    /// </summary>
+    /// <returns></returns>
+    public virtual Modes GetFormat()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.core_FileStorage_getFormat(Handle, out var ret));
+        return (Modes)ret;
+    }
+
+    /// <summary>
     /// Closes the file and releases all the memory buffers
     /// </summary>
     public virtual void Release()
@@ -188,9 +199,7 @@ public class FileStorage : CvObject
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_getFirstTopLevelNode(Handle, out var node));
 
-        if (node == IntPtr.Zero)
-            return null;
-        return new FileNode(node);
+        return FileNode.FromRawPtrOrNull(node);
     }
 
     /// <summary>
@@ -206,27 +215,24 @@ public class FileStorage : CvObject
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_root(Handle, streamIdx, out var node));
 
-        if (node == IntPtr.Zero)
-            return null;
-        return new FileNode(node);
+        return FileNode.FromRawPtrOrNull(node);
     }
 
     /// <summary>
     /// Writes one or more numbers of the specified format to the currently written structure
     /// </summary>
     /// <param name="fmt">Specification of each array element, see @ref format_spec "format specification"</param>
-    /// <param name="vec">Pointer to the written array.</param>
-    /// <param name="len">Number of the uchar elements to write.</param>
-    public void WriteRaw(string fmt, IntPtr vec, int len)
+    /// <param name="vec">The bytes to write.</param>
+    public unsafe void WriteRaw(string fmt, ReadOnlySpan<byte> vec)
     {
         ArgumentNullException.ThrowIfNull(fmt);
-        if (vec == IntPtr.Zero) 
-            throw new ArgumentException("vec == IntPtr.Zero", nameof(vec));
         ThrowIfDisposed();
-            
-        NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_writeRaw(Handle, fmt, vec, new IntPtr(len)));
 
+        fixed (byte* p = vec)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_FileStorage_writeRaw(Handle, fmt, (IntPtr)p, new IntPtr(vec.Length)));
+        }
     }
 
     /// <summary>
@@ -247,16 +253,18 @@ public class FileStorage : CvObject
     }
 
     /// <summary>
-    /// 
+    /// Starts to write a nested structure (sequence or a mapping).
     /// </summary>
-    /// <param name="name"></param>
-    /// <param name="flags"></param>
-    /// <param name="typeName"></param>
-    public void StartWriteStruct(string name, int flags, string typeName)
+    /// <param name="name">name of the structure. When writing to sequences (a.k.a. "arrays"), pass an empty string.</param>
+    /// <param name="flags">structure type, one of <see cref="FileNode.Types.Map"/>/<see cref="FileNode.Types.Seq"/>,
+    /// optionally combined with <see cref="FileNode.Types.Flow"/> for a compact YAML representation.</param>
+    /// <param name="typeName">optional name of an object class this structure stores.</param>
+    public void StartWriteStruct(string name, FileNode.Types flags, string? typeName = null)
     {
         ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(name);
         NativeMethods.HandleException(
-            NativeMethods.core_FileStorage_startWriteStruct(Handle, name, flags, typeName));
+            NativeMethods.core_FileStorage_startWriteStruct(Handle, name, (int)flags, typeName ?? string.Empty));
     }
 
     /// <summary>
@@ -267,6 +275,53 @@ public class FileStorage : CvObject
         ThrowIfDisposed();
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_endWriteStruct(Handle));
+    }
+
+    /// <summary>
+    /// Starts writing a nested structure (sequence or mapping) and returns a disposable scope
+    /// that calls <see cref="EndWriteStruct"/> automatically, so the structure can be written
+    /// inside a <c>using</c> block instead of manually pairing
+    /// <see cref="StartWriteStruct"/>/<see cref="EndWriteStruct"/> calls.
+    /// </summary>
+    /// <param name="name">name of the structure. When writing to sequences (a.k.a. "arrays"), pass an empty string.</param>
+    /// <param name="flags">structure type, one of <see cref="FileNode.Types.Map"/>/<see cref="FileNode.Types.Seq"/>,
+    /// optionally combined with <see cref="FileNode.Types.Flow"/> for a compact YAML representation.</param>
+    /// <param name="typeName">optional name of an object class this structure stores.</param>
+    /// <example>
+    /// <code>
+    /// using (fs.WriteStruct("camera", FileNode.Types.Map))
+    /// {
+    ///     fs.Write("fx", 800.0);
+    ///     fs.Write("fy", 800.0);
+    /// }
+    /// </code>
+    /// </example>
+    public StructScope WriteStruct(string name, FileNode.Types flags, string? typeName = null)
+    {
+        StartWriteStruct(name, flags, typeName);
+        return new StructScope(this);
+    }
+
+    /// <summary>
+    /// Disposable scope returned by <see cref="WriteStruct"/>. Disposing it calls
+    /// <see cref="EndWriteStruct"/> on the owning <see cref="FileStorage"/>.
+    /// </summary>
+    public readonly struct StructScope : IDisposable
+    {
+        private readonly FileStorage fileStorage;
+
+        internal StructScope(FileStorage fileStorage)
+        {
+            this.fileStorage = fileStorage;
+        }
+
+        /// <summary>
+        /// Ends the structure (calls <see cref="FileStorage.EndWriteStruct"/>).
+        /// </summary>
+        public void Dispose()
+        {
+            fileStorage.EndWriteStruct();
+        }
     }
 
     /// <summary>
@@ -301,7 +356,35 @@ public class FileStorage : CvObject
     }
 
     /// <summary>
-    /// 
+    ///
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
+    public void Write(string name, bool value)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(name);
+
+        NativeMethods.HandleException(
+            NativeMethods.core_FileStorage_write_bool(Handle, name, value ? 1 : 0));
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
+    public void Write(string name, long value)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(name);
+
+        NativeMethods.HandleException(
+            NativeMethods.core_FileStorage_write_int64(Handle, name, value));
+    }
+
+    /// <summary>
+    ///
     /// </summary>
     /// <param name="name"></param>
     /// <param name="value"></param>
@@ -392,7 +475,7 @@ public class FileStorage : CvObject
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="name"></param>
     /// <param name="value"></param>
@@ -405,6 +488,22 @@ public class FileStorage : CvObject
         using var valueVector = new StdVector<DMatch>(value);
         NativeMethods.HandleException(
             NativeMethods.core_FileStorage_write_vectorOfDMatch(Handle, name, valueVector.CvPtr));
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
+    public void Write(string name, IEnumerable<string> value)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
+
+        using var valueVector = new VectorOfString(value);
+        NativeMethods.HandleException(
+            NativeMethods.core_FileStorage_write_vectorOfString(Handle, name, valueVector.CvPtr));
     }
 
     /// <summary>

--- a/src/OpenCvSharpExtern/core_FileNode.h
+++ b/src/OpenCvSharpExtern/core_FileNode.h
@@ -98,10 +98,29 @@ CVAPI(ExceptionStatus) core_FileNode_name(cv::FileNode *obj, std::string *buf)
         buf->assign(obj->name());
     });
 }
+CVAPI(ExceptionStatus) core_FileNode_keys(cv::FileNode *obj, std::vector<std::string> *returnValue)
+{
+    return cvTry([&] {
+        const auto v = obj->keys();
+        returnValue->clear();
+        returnValue->resize(v.size());
+        for (size_t i = 0; i < v.size(); i++)
+        {
+            returnValue->at(i) = v[i];
+        }
+    });
+}
+
 CVAPI(ExceptionStatus) core_FileNode_size(cv::FileNode *obj, size_t *returnValue)
 {
     return cvTry([&] {
         *returnValue = obj->size();
+    });
+}
+CVAPI(ExceptionStatus) core_FileNode_rawSize(cv::FileNode *obj, size_t *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->rawSize();
     });
 }
 
@@ -109,6 +128,12 @@ CVAPI(ExceptionStatus) core_FileNode_toInt(cv::FileNode *obj, int *returnValue)
 {
     return cvTry([&] {
         *returnValue = static_cast<int>(*obj);
+    });
+}
+CVAPI(ExceptionStatus) core_FileNode_toInt64(cv::FileNode *obj, int64_t *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = static_cast<int64_t>(*obj);
     });
 }
 CVAPI(ExceptionStatus) core_FileNode_toFloat(cv::FileNode *obj, float *returnValue)
@@ -160,6 +185,14 @@ CVAPI(ExceptionStatus) core_FileNode_read_int(cv::FileNode *node, int *value, in
 {
     return cvTry([&] {
         int temp;
+        cv::read(*node, temp, default_value);
+        *value = temp;
+    });
+}
+CVAPI(ExceptionStatus) core_FileNode_read_int64(cv::FileNode *node, int64_t *value, int64_t default_value)
+{
+    return cvTry([&] {
+        int64_t temp;
         cv::read(*node, temp, default_value);
         *value = temp;
     });

--- a/src/OpenCvSharpExtern/core_FileStorage.h
+++ b/src/OpenCvSharpExtern/core_FileStorage.h
@@ -136,10 +136,37 @@ CVAPI(ExceptionStatus) core_FileStorage_state(cv::FileStorage *obj, int *returnV
     });
 }
 
+CVAPI(ExceptionStatus) core_FileStorage_getFormat(cv::FileStorage *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getFormat();
+    });
+}
+
 CVAPI(ExceptionStatus) core_FileStorage_write_int(cv::FileStorage *fs, const char *name, int value)
 {
     return cvTry([&] {
         cv::write(*fs, cv::String(name), value);
+    });
+}
+CVAPI(ExceptionStatus) core_FileStorage_write_bool(cv::FileStorage *fs, const char *name, int value)
+{
+    return cvTry([&] {
+        cv::write(*fs, cv::String(name), value != 0);
+    });
+}
+CVAPI(ExceptionStatus) core_FileStorage_write_int64(cv::FileStorage *fs, const char *name, int64_t value)
+{
+    return cvTry([&] {
+        cv::write(*fs, cv::String(name), value);
+    });
+}
+CVAPI(ExceptionStatus) core_FileStorage_write_vectorOfString(cv::FileStorage *fs, const char *name, const std::vector<std::string> *value)
+{
+    return cvTry([&] {
+        // No free-function cv::write(FileStorage&, name, vector<String>) overload exists;
+        // this is the member function form (matches CV_WRAP'd FileStorage::write).
+        fs->write(cv::String(name), *value);
     });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_float(cv::FileStorage *fs, const char *name, float value)
@@ -157,7 +184,12 @@ CVAPI(ExceptionStatus) core_FileStorage_write_double(cv::FileStorage *fs, const 
 CVAPI(ExceptionStatus) core_FileStorage_write_String(cv::FileStorage *fs, const char *name, const char *value)
 {
     return cvTry([&] {
-        cv::write(*fs, cv::String(name), value);
+        // Must wrap as cv::String explicitly: passing the raw const char* lets C++ overload
+        // resolution prefer the standard pointer-to-bool conversion (matching
+        // cv::write(FileStorage&, const String&, bool)) over the user-defined const char* ->
+        // String conversion needed for cv::write(FileStorage&, const String&, const String&),
+        // silently writing "true"/"false" instead of the string content for any value.
+        cv::write(*fs, cv::String(name), cv::String(value));
     });
 }
 CVAPI(ExceptionStatus) core_FileStorage_write_Mat(cv::FileStorage *fs, const char *name, const cv::Mat *value)

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -31,6 +31,10 @@ CVAPI(void) vector_string_delete(std::vector<std::string>* vector)
 {
     delete vector;
 }
+CVAPI(void) vector_string_pushBack(std::vector<std::string>* vector, const char* value)
+{
+    vector->emplace_back(value);
+}
 #pragma endregion
 
 #pragma region Generated blittable std::vector<T> wrappers

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -494,6 +494,39 @@ public class FileStorageTest : TestBase
     }
 
     [Fact]
+    public void WriteStructScopeDisposeIsIdempotentAcrossAliases()
+    {
+        // StructScope is a class specifically so that two variables referencing the same scope
+        // (not just the same variable disposed twice) share one "disposed" flag. If it were a
+        // struct, this alias would be an independent copy with its own flag, and disposing both
+        // would end the structure twice.
+        const string fileName = "fs_write_struct_scope_alias_dispose.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("before", 1);
+
+            var scope = fs.WriteStruct("camera", FileNode.Types.Map);
+            var alias = scope;
+            fs.Write("fx", 800.0);
+            scope.Dispose();
+            alias.Dispose();
+
+            fs.Write("after", 2);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.Equal(1, fs["before"]!.ReadInt());
+            Assert.Equal(2, fs["after"]!.ReadInt());
+
+            using var camera = fs["camera"];
+            Assert.NotNull(camera);
+            Assert.Equal(800.0, camera["fx"]!.ReadDouble());
+        }
+    }
+
+    [Fact]
     public void ToJsonNodeConvertsScalarsSequencesAndMappings()
     {
         const string fileName = "fs_to_json_node.yml";

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -375,6 +375,31 @@ public class FileStorageTest : TestBase
     }
 
     [Fact]
+    public void WriteStringArrayRejectsNullElement()
+    {
+        const string fileName = "fs_string_array_null_element.yml";
+        using var fs = new FileStorage(fileName, FileStorage.Modes.Write);
+
+        Assert.Throws<ArgumentException>(() => fs.Write("labels", new[] { "cat", null!, "bird" }));
+    }
+
+    [Fact]
+    public void GetFormatRecognizesJson()
+    {
+        const string fileName = "fs_format.json";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("x", 1);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.Equal(FileStorage.Modes.FormatJson, fs.GetFormat());
+        }
+    }
+
+    [Fact]
     public void KeysReturnsMappingKeys()
     {
         const string fileName = "fs_keys.yml";

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -463,6 +463,37 @@ public class FileStorageTest : TestBase
     }
 
     [Fact]
+    public void WriteStructScopeDisposeIsIdempotent()
+    {
+        const string fileName = "fs_write_struct_scope_double_dispose.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("before", 1);
+
+            // A double Dispose() (e.g. an explicit call inside a using block) must not end the
+            // structure twice - otherwise it would unbalance FileStorage's write-struct nesting
+            // and corrupt whatever comes after it, such as "after" below.
+            var scope = fs.WriteStruct("camera", FileNode.Types.Map);
+            fs.Write("fx", 800.0);
+            scope.Dispose();
+            scope.Dispose();
+
+            fs.Write("after", 2);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.Equal(1, fs["before"]!.ReadInt());
+            Assert.Equal(2, fs["after"]!.ReadInt());
+
+            using var camera = fs["camera"];
+            Assert.NotNull(camera);
+            Assert.Equal(800.0, camera["fx"]!.ReadDouble());
+        }
+    }
+
+    [Fact]
     public void ToJsonNodeConvertsScalarsSequencesAndMappings()
     {
         const string fileName = "fs_to_json_node.yml";

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -593,4 +593,118 @@ public class FileStorageTest : TestBase
             Assert.Contains("widget", roundTripped, StringComparison.Ordinal);
         }
     }
+
+    [Fact]
+    public void WriteJsonNodeRoundTripsThroughToJsonNode()
+    {
+        const string fileName = "fs_write_json_node.yml";
+
+        var source = JsonNode.Parse("""
+            {
+                "name": "widget",
+                "count": 3,
+                "ratio": 1.5,
+                "enabled": true,
+                "tags": ["red", "green", "blue"],
+                "nested": { "x": 1, "y": 2 },
+                "matrix": [[1, 2], [3, 4]]
+            }
+            """)!;
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            foreach (var (key, value) in source.AsObject())
+                fs.Write(key, value);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            var json = root.ToJsonNode();
+            Assert.NotNull(json);
+
+            Assert.Equal("widget", json!["name"]!.GetValue<string>());
+            Assert.Equal(3L, json["count"]!.GetValue<long>());
+            Assert.Equal(1.5, json["ratio"]!.GetValue<double>());
+            Assert.Equal(1L, json["enabled"]!.GetValue<long>()); // bool round-trips as int (0/1) in FileStorage
+
+            var tags = Assert.IsType<JsonArray>(json["tags"]);
+            Assert.Equal(["red", "green", "blue"], tags.Select(n => n!.GetValue<string>()));
+
+            var nested = Assert.IsType<JsonObject>(json["nested"]);
+            Assert.Equal(1L, nested["x"]!.GetValue<long>());
+            Assert.Equal(2L, nested["y"]!.GetValue<long>());
+
+            var matrix = Assert.IsType<JsonArray>(json["matrix"]);
+            Assert.Equal(2, matrix.Count);
+            var row0 = Assert.IsType<JsonArray>(matrix[0]);
+            Assert.Equal([1L, 2L], row0.Select(n => n!.GetValue<long>()));
+            var row1 = Assert.IsType<JsonArray>(matrix[1]);
+            Assert.Equal([3L, 4L], row1.Select(n => n!.GetValue<long>()));
+        }
+    }
+
+    [Fact]
+    public void WriteJsonNodeNullThrows()
+    {
+        const string fileName = "fs_write_json_node_null.yml";
+        using var fs = new FileStorage(fileName, FileStorage.Modes.Write);
+
+        Assert.Throws<NotSupportedException>(() => fs.Write("x", (JsonNode?)null));
+    }
+
+    [Fact]
+    public void GetPathNavigatesNestedStructure()
+    {
+        const string fileName = "fs_get_path.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            using (fs.WriteStruct("a", FileNode.Types.Map))
+            {
+                using (fs.WriteStruct("b", FileNode.Types.Seq))
+                {
+                    fs.Add(10).Add(20).Add(30);
+                }
+            }
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var value = fs.GetPath("a", "b", 1);
+            Assert.NotNull(value);
+            Assert.Equal(20, value.ReadInt());
+
+            Assert.Null(fs.GetPath("a", "missing"));
+            Assert.Null(fs.GetPath("missing"));
+
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            using var viaFileNode = root.GetPath("a", "b", 2);
+            Assert.NotNull(viaFileNode);
+            Assert.Equal(30, viaFileNode.ReadInt());
+        }
+    }
+
+    [Fact]
+    public void GetPathRejectsEmptyOrInvalidSegments()
+    {
+        const string fileName = "fs_get_path_invalid.yml";
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("a", 1);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.Throws<ArgumentException>(() => fs.GetPath());
+            Assert.Throws<ArgumentException>(() => fs.GetPath(42)); // first segment must be a string
+
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            Assert.Throws<ArgumentException>(() => root.GetPath());
+            Assert.Throws<ArgumentException>(() => root.GetPath(3.14)); // unsupported segment type
+        }
+    }
 }

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace OpenCvSharp.Tests.Core;
@@ -73,6 +74,7 @@ public class FileStorageTest : TestBase
         using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
         {
             Assert.True(fs.IsOpened());
+            Assert.Equal(FileStorage.Modes.FormatYaml, fs.GetFormat());
 
             // sequence
             using (var node = fs["sequence"])
@@ -120,6 +122,7 @@ public class FileStorageTest : TestBase
                 Assert.Equal(map.@int, node["int"].ReadInt());
                 Assert.Equal(map.@double, node["double"].ReadDouble());
                 Assert.Equal(map.@string, node["string"].ReadString());
+                Assert.True(node.RawSize > 0);
             }
                 
             // map_sequence
@@ -341,5 +344,164 @@ public class FileStorageTest : TestBase
         }
 #pragma warning restore CS8602
 #pragma warning restore CS8604
+    }
+
+    [Fact]
+    public void WriteBoolInt64AndStringArray()
+    {
+        const string fileName = "fs_bool_int64_strings.yml";
+        string[] labels = ["cat", "dog", "bird"];
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("flagTrue", true);
+            fs.Write("flagFalse", false);
+            fs.Write("bigNumber", 9_000_000_000_000L);
+            fs.Write("labels", labels);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.True(fs["flagTrue"]!.ReadInt() != 0);
+            Assert.True(fs["flagFalse"]!.ReadInt() == 0);
+            Assert.Equal(9_000_000_000_000L, fs["bigNumber"]!.ToInt64());
+            Assert.Equal(9_000_000_000_000L, fs["bigNumber"]!.ReadInt64());
+
+            using var labelsNode = fs["labels"];
+            Assert.NotNull(labelsNode);
+            Assert.Equal(FileNode.Types.Seq, labelsNode.Type);
+            Assert.Equal(labels, labelsNode.Select(n => n.ReadString()));
+        }
+    }
+
+    [Fact]
+    public void KeysReturnsMappingKeys()
+    {
+        const string fileName = "fs_keys.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("alpha", 1);
+            fs.Write("beta", 2);
+            fs.Write("gamma", 3);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            Assert.Equal(["alpha", "beta", "gamma"], root.Keys);
+        }
+    }
+
+    [Fact]
+    public void MissingKeyIndexerReturnsNull()
+    {
+        const string fileName = "fs_missing_key.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("present", 1);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.NotNull(fs["present"]);
+            Assert.Null(fs["definitely_not_present"]);
+
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            Assert.Null(root["definitely_not_present"]);
+        }
+    }
+
+    [Fact]
+    public void WriteRawAndReadRawRoundTrip()
+    {
+        const string fileName = "fs_raw.yml";
+        byte[] source = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.StartWriteStruct("raw", FileNode.Types.Seq | FileNode.Types.Flow);
+            fs.WriteRaw("u", source.AsSpan());
+            fs.EndWriteStruct();
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var node = fs["raw"];
+            Assert.NotNull(node);
+            var buffer = new byte[source.Length];
+            node.ReadRaw("u", buffer);
+            Assert.Equal(source, buffer);
+        }
+    }
+
+    [Fact]
+    public void WriteStructScopeMatchesManualStartEnd()
+    {
+        const string fileName = "fs_write_struct_scope.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            using (fs.WriteStruct("camera", FileNode.Types.Map))
+            {
+                fs.Write("fx", 800.0);
+                fs.Write("fy", 800.0);
+            }
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var camera = fs["camera"];
+            Assert.NotNull(camera);
+            Assert.Equal(FileNode.Types.Map, camera.Type);
+            Assert.Equal(800.0, camera["fx"]!.ReadDouble());
+            Assert.Equal(800.0, camera["fy"]!.ReadDouble());
+        }
+    }
+
+    [Fact]
+    public void ToJsonNodeConvertsScalarsSequencesAndMappings()
+    {
+        const string fileName = "fs_to_json_node.yml";
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            fs.Write("name", "widget");
+            fs.Write("count", 3);
+            fs.Write("ratio", 1.5);
+            using (fs.WriteStruct("tags", FileNode.Types.Seq))
+            {
+                fs.Add("red").Add("green").Add("blue");
+            }
+            using (fs.WriteStruct("nested", FileNode.Types.Map))
+            {
+                fs.Write("enabled", true);
+            }
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            using var root = fs.Root();
+            Assert.NotNull(root);
+            var json = root.ToJsonNode();
+            Assert.NotNull(json);
+
+            Assert.Equal("widget", json!["name"]!.GetValue<string>());
+            Assert.Equal(3L, json["count"]!.GetValue<long>());
+            Assert.Equal(1.5, json["ratio"]!.GetValue<double>());
+
+            var tags = Assert.IsType<JsonArray>(json["tags"]);
+            Assert.Equal(["red", "green", "blue"], tags.Select(n => n!.GetValue<string>()));
+
+            var nested = Assert.IsType<JsonObject>(json["nested"]);
+            Assert.Equal(1L, nested["enabled"]!.GetValue<long>()); // bool round-trips as int (0/1) in FileStorage
+
+            // The resulting tree is a plain JsonNode graph, usable with System.Text.Json as normal.
+            var roundTripped = json.ToJsonString();
+            Assert.Contains("widget", roundTripped, StringComparison.Ordinal);
+        }
     }
 }

--- a/test/OpenCvSharp.Tests/core/FileStorageTest.cs
+++ b/test/OpenCvSharp.Tests/core/FileStorageTest.cs
@@ -655,6 +655,46 @@ public class FileStorageTest : TestBase
     }
 
     [Fact]
+    public void WriteJsonNodeHandlesProgrammaticNumericJsonValueTypes()
+    {
+        // Unlike a JsonNode.Parse()-produced value (backed by a flexible JsonElement),
+        // JsonValue.Create(T) - what a plain `new JsonObject { ["x"] = 3 }` assignment does under
+        // the hood - preserves the exact CLR type it was created from, so this must be covered
+        // independently of the JsonNode.Parse-based round-trip test above.
+        const string fileName = "fs_write_json_node_numeric_types.yml";
+
+        var obj = new JsonObject
+        {
+            ["intValue"] = 3,
+            ["longValue"] = 9_000_000_000L,
+            ["shortValue"] = (short)7,
+            ["byteValue"] = (byte)8,
+            ["floatValue"] = 1.5f,
+            ["doubleValue"] = 2.5,
+            ["boolValue"] = true,
+            ["stringValue"] = "text",
+        };
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+        {
+            foreach (var (key, value) in obj)
+                fs.Write(key, value);
+        }
+
+        using (var fs = new FileStorage(fileName, FileStorage.Modes.Read))
+        {
+            Assert.Equal(3, fs["intValue"]!.ReadInt());
+            Assert.Equal(9_000_000_000L, fs["longValue"]!.ReadInt64());
+            Assert.Equal(7, fs["shortValue"]!.ReadInt());
+            Assert.Equal(8, fs["byteValue"]!.ReadInt());
+            Assert.Equal(1.5, fs["floatValue"]!.ReadDouble(), 3);
+            Assert.Equal(2.5, fs["doubleValue"]!.ReadDouble(), 3);
+            Assert.True(fs["boolValue"]!.ReadInt() != 0);
+            Assert.Equal("text", fs["stringValue"]!.ReadString());
+        }
+    }
+
+    [Fact]
     public void GetPathNavigatesNestedStructure()
     {
         const string fileName = "fs_get_path.yml";


### PR DESCRIPTION
## Summary
A focused review of `FileNode`/`FileStorage` against OpenCV 5.x's native `CV_WRAP`'d (i.e. Python-visible) surface turned up a few concrete gaps and one API-design issue, all fixed here:

- **Missing write/read overloads**: `FileStorage.Write(bool)`, `Write(long)`, `Write(IEnumerable<string>)`, and the matching `FileNode.ToInt64()`/`ReadInt64()` — these exist natively (and in Python) but had no C# equivalent.
- **`FileNode.Keys()`**: wraps `cv::FileNode::keys()`; previously you had to manually iterate a mapping node and read each child's `Name`.
- **Nullable indexer fix**: `FileStorage`/`FileNode`'s `[]` indexers are typed `FileNode?`, but the native bridge always heap-allocates a wrapper — even for a missing key — so a C# `null` was never actually produced and `fs["missing"]?.ReadInt()` silently ran on a "none" node. `FileNode.FromRawPtrOrNull()` now treats a "none" result as `null`, so `?.` behaves as its signature promises.
- **`WriteRaw`/`ReadRaw` modernized**: took a caller-managed `IntPtr` before (manual pinning required); now take `Span<byte>`/`ReadOnlySpan<byte>`.
- **`StartWriteStruct` strongly typed**: took a raw `int flags` instead of `FileNode.Types`. Also added `FileStorage.WriteStruct(...)`, returning an `IDisposable` scope, so a struct's start/end pairing can be written as a `using` block instead of manual `StartWriteStruct`/`EndWriteStruct` calls.
- **`FileNode.ToJsonNode()`**: a direct structural walk into `System.Text.Json`'s `JsonNode` (no intermediate text serialize/parse round-trip), so a parsed `FileStorage` tree — XML, YAML, or JSON on disk — can interoperate with the rest of the `System.Text.Json` ecosystem. Native OpenCV-specific encodings (e.g. `Mat`'s `rows`/`cols`/`dt`/`data` shape) come through as their raw structure rather than being reconstructed into typed objects.

`VectorOfString` gained an `IEnumerable<string>` constructor (backed by a new `vector_string_pushBack` native entry point) to support `Write(IEnumerable<string>)` and `Keys()`.

## Test plan
- [x] `dotnet build` on `src/OpenCvSharp` and the native `OpenCvSharpExtern` CMake target (built and run standalone on this branch, independent of #2027)
- [x] Extended `FileStorageTest.cs`: bool/int64/string-array write+read round trip, `Keys()`, missing-key indexer returns `null`, `WriteRaw`/`ReadRaw` round trip, `WriteStruct` scope vs. manual Start/EndWriteStruct, `ToJsonNode()` over scalars/sequences/mappings — all pass against a locally built native DLL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended file storage read/write to support booleans, 64-bit integers, and string arrays, plus added `GetFormat()`.
  * Enhanced `FileNode` with `ToJsonNode()`, `Keys`, `RawSize`, and 64-bit numeric access via `ToInt64()`/`ReadInt64()`.
  * Introduced span-based `ReadRaw`/`WriteRaw` and added scoped `WriteStruct` support.
* **Bug Fixes**
  * Improved “missing”/`none` handling so indexers consistently return `null`.
* **Tests**
  * Expanded coverage for format detection, keys/raw size, JSON conversion, raw byte round-trips, and `WriteStruct` scope + idempotent disposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->