### PR TITLE
highgui: add pollKey and currentUIFramework wrappers (#2009)

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_highgui.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_highgui.cs
@@ -93,6 +93,19 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// Returns the HighGUI backend name in use: could be COCOA, GTK2/3, QT, WAYLAND or WIN32.
+    /// Returns an empty string if there is no available UI backend.
+    /// </summary>
+    /// <returns></returns>
+    public static string CurrentUIFramework()
+    {
+        using var returnString = new StdString();
+        NativeMethods.HandleException(
+            NativeMethods.highgui_currentUIFramework(returnString.CvPtr));
+        return returnString.ToString();
+    }
+
+    /// <summary>
     /// 
     /// </summary>
     /// <returns></returns>
@@ -118,7 +131,7 @@ static partial class Cv2
     }
 
     /// <summary>
-    /// Waits for a pressed key. 
+    /// Waits for a pressed key.
     /// </summary>
     /// <param name="delay">Delay in milliseconds. 0 is the special value that means ”forever”</param>
     /// <returns>Returns the code of the pressed key or -1 if no key was pressed before the specified time had elapsed.</returns>
@@ -126,6 +139,17 @@ static partial class Cv2
     {
         NativeMethods.HandleException(
             NativeMethods.highgui_waitKey(delay, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Polls for a pressed key without waiting. To wait until a key is pressed, use WaitKey instead.
+    /// </summary>
+    /// <returns>Returns the code of the pressed key or -1 if no key was pressed since the last invocation.</returns>
+    public static int PollKey()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.highgui_pollKey(out var ret));
         return ret;
     }
 

--- a/src/OpenCvSharp/Cv2/Cv2_highgui.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_highgui.cs
@@ -144,6 +144,7 @@ static partial class Cv2
 
     /// <summary>
     /// Polls for a pressed key without waiting. To wait until a key is pressed, use WaitKey instead.
+    /// Only works if there is at least one HighGUI window created and active.
     /// </summary>
     /// <returns>Returns the code of the pressed key or -1 if no key was pressed since the last invocation.</returns>
     public static int PollKey()

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_highgui.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_highgui.cs
@@ -18,7 +18,10 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus highgui_destroyAllWindows();
-        
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus highgui_currentUIFramework(IntPtr returnValue);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus highgui_startWindowThread(out int returnValue);
 
@@ -33,6 +36,9 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus highgui_waitKeyEx(int delay, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus highgui_pollKey(out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus highgui_resizeWindow([MarshalAs(UnmanagedType.LPStr)] string winName, int width, int height);

--- a/src/OpenCvSharpExtern/highgui.h
+++ b/src/OpenCvSharpExtern/highgui.h
@@ -29,6 +29,13 @@ CVAPI(ExceptionStatus) highgui_destroyAllWindows()
     });
 }
 
+CVAPI(ExceptionStatus) highgui_currentUIFramework(std::string *returnValue)
+{
+    return cvTry([&] {
+        returnValue->assign(cv::currentUIFramework());
+    });
+}
+
 CVAPI(ExceptionStatus) highgui_startWindowThread(int *returnValue)
 {
     return cvTry([&] {
@@ -49,7 +56,14 @@ CVAPI(ExceptionStatus) highgui_waitKey(int delay, int *returnValue)
         *returnValue = cv::waitKey(delay);
     });
 }
-  
+
+CVAPI(ExceptionStatus) highgui_pollKey(int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::pollKey();
+    });
+}
+
 
 CVAPI(ExceptionStatus) highgui_imshow(const char *winname, cv::Mat *mat)
 {

--- a/test/OpenCvSharp.Tests/highgui/HighGuiTest.cs
+++ b/test/OpenCvSharp.Tests/highgui/HighGuiTest.cs
@@ -18,6 +18,20 @@ public class HighGuiTest : TestBase
         Assert.Equal(-1, val);
     }
 
+    [Fact]
+    public void PollKey()
+    {
+        int val = Cv2.PollKey();
+        Assert.Equal(-1, val);
+    }
+
+    [Fact]
+    public void CurrentUIFramework()
+    {
+        string framework = Cv2.CurrentUIFramework();
+        Assert.NotNull(framework);
+    }
+
     [ExplicitFact]
     public void Window()
     {


### PR DESCRIPTION
Fix #2009 

## Summary

Part of issue #2009 (imgcodecs and videoio are already done via #2030 and #2031). This covers the two small non-Qt gaps remaining in highgui:

- `Cv2.PollKey()` — non-blocking key poll, companion to `WaitKey`.
- `Cv2.CurrentUIFramework()` — returns the highgui backend name in use (COCOA/GTK/QT/WAYLAND/WIN32/empty).

## Scope notes

- Qt-only APIs (`createButton`, `fontQt`/`addText`, `displayOverlay`/`displayStatusBar`, `saveWindowParameters`/`loadWindowParameters`, `startLoop`/`stopLoop`) remain out of scope — our native builds have no Qt (`WITH_QT=OFF`, GTK3 used on Linux instead).
- The OpenGL family (`setOpenGlDrawCallback`/`setOpenGlContext`/`updateWindow`, `imshow(winname, ogl::Texture2D)`) is also intentionally excluded. Upstream OpenCV's own docs (`opencv2/core/opengl.hpp`) state OpenGL support is only available on Windows/Linux WIN32+GTK+Qt backends — **macOS and Android are not supported at all**. Our prebuilt binaries additionally build with `WITH_OPENGL=OFF` on every platform, so wrapping this would only produce runtime `OpenGlNotSupported` exceptions with no way to test it. `cv::ogl` itself is a narrow CUDA/OpenCL-GL interop helper, not a general visualization API.

With this PR, issue #2009 is fully addressed (imgcodecs, videoio, highgui).

## Test plan

- [x] `dotnet build` (managed) succeeds
- [x] Native `OpenCvSharpExtern` rebuild succeeds
- [x] `dotnet test --no-build -c Release --filter "FullyQualifiedName~HighGuiTest"` — 4 passed, 3 skipped (window-creation tests are `[ExplicitFact]`, manual-only)
- [x] Full `dotnet test --no-build -c Release` — 1340 passed, 26 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve the active OpenCV UI framework name.
  * Added non-blocking keyboard polling that returns the pending key code, or `-1` when none is available.
* **Tests**
  * Added test coverage for UI framework detection and keyboard polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->