### PR TITLE
dnn/ml: close API coverage gaps from issue #2010

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn.cs
@@ -153,6 +153,20 @@ static partial class NativeMethods
         IntPtr[] images, int imagesLength, Scalar scalefactor, Size size, Scalar mean,
         int swapRB, int ddepth, int datalayout, int paddingmode, Scalar borderValue, out IntPtr returnValue);
 
+    // Image2BlobParams.BlobRectToImageRect / BlobRectsToImageRects
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Image2BlobParams_blobRectToImageRect(
+        Scalar scalefactor, Size paramSize, Scalar mean,
+        int swapRB, int ddepth, int datalayout, int paddingmode, Scalar borderValue,
+        Rect rBlob, Size size, out Rect returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Image2BlobParams_blobRectsToImageRects(
+        Scalar scalefactor, Size paramSize, Scalar mean,
+        int swapRB, int ddepth, int datalayout, int paddingmode, Scalar borderValue,
+        [In] Rect[] rBlob, int rBlobLength, Size size, IntPtr outVec);
+
     // imagesFromBlob
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Layer.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Layer.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+// ReSharper disable InconsistentNaming
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_getBlobs(OpenCvSafeHandle obj, IntPtr outVec);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_setBlobs(OpenCvSafeHandle obj, IntPtr blobs);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_getName(OpenCvSafeHandle obj, IntPtr outString);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_getType(OpenCvSafeHandle obj, IntPtr outString);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_getPreferableTarget(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Layer_outputNameToIndex(
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPStr)] string outputName, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Ptr_Layer_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Ptr_Layer_get(IntPtr obj, out IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_Net.cs
@@ -34,6 +34,9 @@ static partial class NativeMethods
     public static partial ExceptionStatus dnn_Net_getLayerId(OpenCvSafeHandle net, [MarshalAs(UnmanagedType.LPStr)] string layer, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Net_getLayer(OpenCvSafeHandle net, int layerId, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_Net_getLayerNames(OpenCvSafeHandle net, IntPtr outVec);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -57,6 +60,12 @@ static partial class NativeMethods
     public static partial ExceptionStatus dnn_Net_forward3(
         OpenCvSafeHandle net, IntPtr[] outputBlobs, int outputBlobsLength, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] string[] outBlobNames, int outBlobNamesLength);
         
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus dnn_Net_forwardAndRetrieve(
+        OpenCvSafeHandle net,
+        [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] string[] outBlobNames, int outBlobNamesLength,
+        IntPtr outFlatBlobs, IntPtr outCounts);
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus dnn_Net_setPreferableBackend(OpenCvSafeHandle net, int backendId);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/dnn/NativeMethods_dnn_TextModel.cs
@@ -48,6 +48,10 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus dnn_TextRecognitionModel_recognize(OpenCvSafeHandle model, in InputArrayProxy frame, IntPtr outString);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus dnn_TextRecognitionModel_recognize_batch(
+        OpenCvSafeHandle model, in InputArrayProxy frame, in InputArrayProxy roiRects, IntPtr outVec);
+
     // ------------------------------------------------------------------------
     // TextDetectionModel (base; shared by EAST and DB)
     // ------------------------------------------------------------------------

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_RTrees.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_RTrees.cs
@@ -29,6 +29,10 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_RTrees_getVarImportance(OpenCvSafeHandle obj, out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus ml_RTrees_getVotes(
+        OpenCvSafeHandle obj, in InputArrayProxy samples, in OutputArrayProxy results, int flags);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus ml_RTrees_create(out IntPtr returnValue);
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVM.cs
@@ -68,6 +68,12 @@ static partial class NativeMethods
     internal static partial ExceptionStatus ml_SVM_getDecisionFunction(
         OpenCvSafeHandle obj, int i, in OutputArrayProxy alpha, in OutputArrayProxy svidx, out double returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVM_trainAuto(
+        OpenCvSafeHandle obj, IntPtr data, int kFold,
+        ParamGrid cGrid, ParamGrid gammaGrid, ParamGrid pGrid, ParamGrid nuGrid, ParamGrid coeffGrid, ParamGrid degreeGrid,
+        [MarshalAs(UnmanagedType.Bool)] bool balanced, out int returnValue);
+
     // static
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVMSGD.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_SVMSGD.cs
@@ -1,0 +1,68 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getWeights(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getShift(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setOptimalParameters(OpenCvSafeHandle obj, int svmsgdType, int marginType);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getSvmsgdType(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setSvmsgdType(OpenCvSafeHandle obj, int val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getMarginType(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setMarginType(OpenCvSafeHandle obj, int val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getMarginRegularization(OpenCvSafeHandle obj, out float returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setMarginRegularization(OpenCvSafeHandle obj, float val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getInitialStepSize(OpenCvSafeHandle obj, out float returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setInitialStepSize(OpenCvSafeHandle obj, float val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getStepDecreasingPower(OpenCvSafeHandle obj, out float returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setStepDecreasingPower(OpenCvSafeHandle obj, float val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_getTermCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_setTermCriteria(OpenCvSafeHandle obj, TermCriteria val);
+
+    // static
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_create(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_Ptr_SVMSGD_get(IntPtr obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_Ptr_SVMSGD_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_load([MarshalAs(UnmanagedType.LPStr)] string filePath, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_SVMSGD_loadFromString([MarshalAs(UnmanagedType.LPStr)] string strModel, out IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_StatModel.cs
@@ -25,8 +25,16 @@ static partial class NativeMethods
     public static partial ExceptionStatus ml_StatModel_isClassifier(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_StatModel_train1(
+        OpenCvSafeHandle obj, IntPtr trainData, int flags, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus ml_StatModel_train2(
         OpenCvSafeHandle obj, in InputArrayProxy samples, int layout, in InputArrayProxy responses, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus ml_StatModel_calcError(
+        OpenCvSafeHandle obj, IntPtr data, [MarshalAs(UnmanagedType.Bool)] bool test, in OutputArrayProxy resp, out float returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus ml_StatModel_predict(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_TrainData.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/ml/NativeMethods_ml_TrainData.cs
@@ -1,0 +1,101 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getLayout(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getNSamples(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getNTrainSamples(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getNTestSamples(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getNVars(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getNAllVars(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getSamples(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getMissing(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTrainSamples(
+        OpenCvSafeHandle obj, int layout, int compressSamples, int compressVars, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTrainResponses(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTestSamples(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTestResponses(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getResponses(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getVarIdx(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getVarType(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getClassLabels(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTrainSampleIdx(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_getTestSampleIdx(OpenCvSafeHandle obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_setTrainTestSplit(OpenCvSafeHandle obj, int count, [MarshalAs(UnmanagedType.Bool)] bool shuffle);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_setTrainTestSplitRatio(OpenCvSafeHandle obj, double ratio, [MarshalAs(UnmanagedType.Bool)] bool shuffle);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_shuffleTrainTest(OpenCvSafeHandle obj);
+
+    // static
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus ml_TrainData_create(
+        in InputArrayProxy samples, int layout, in InputArrayProxy responses,
+        in InputArrayProxy varIdx, in InputArrayProxy sampleIdx, in InputArrayProxy sampleWeights, in InputArrayProxy varType,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_TrainData_loadFromCSV(
+        [MarshalAs(UnmanagedType.LPStr)] string filename,
+        int headerLineCount,
+        int responseStartIdx,
+        int responseEndIdx,
+        [MarshalAs(UnmanagedType.LPStr)] string varTypeSpec,
+        byte delimiter,
+        byte missch,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_Ptr_TrainData_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus ml_Ptr_TrainData_get(IntPtr obj, out IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Modules/dnn/Image2BlobParams.cs
+++ b/src/OpenCvSharp/Modules/dnn/Image2BlobParams.cs
@@ -1,3 +1,6 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
 // ReSharper disable IdentifierTypo
 // ReSharper disable InconsistentNaming
 // ReSharper disable CommentTypo
@@ -82,5 +85,39 @@ public class Image2BlobParams
         DataLayout = dataLayout;
         PaddingMode = paddingMode;
         BorderValue = borderValue;
+    }
+
+    /// <summary>
+    /// Get rectangle coordinates in original image system from rectangle in blob coordinates.
+    /// </summary>
+    /// <param name="rBlob">rect in blob coordinates.</param>
+    /// <param name="size">original input image size.</param>
+    /// <returns>rectangle in original image coordinates.</returns>
+    public Rect BlobRectToImageRect(Rect rBlob, Size size)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Image2BlobParams_blobRectToImageRect(
+                ScaleFactor, Size, Mean, SwapRB ? 1 : 0, (int)Depth, (int)DataLayout, (int)PaddingMode, BorderValue,
+                rBlob, size, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Get rectangle coordinates in original image system from rectangles in blob coordinates.
+    /// </summary>
+    /// <param name="rBlob">rect in blob coordinates.</param>
+    /// <param name="size">original input image size.</param>
+    /// <returns>rectangles in original image coordinates.</returns>
+    public Rect[] BlobRectsToImageRects(IEnumerable<Rect> rBlob, Size size)
+    {
+        ArgumentNullException.ThrowIfNull(rBlob);
+
+        var rBlobArray = rBlob.ToArray();
+        using var outVec = new StdVector<Rect>();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Image2BlobParams_blobRectsToImageRects(
+                ScaleFactor, Size, Mean, SwapRB ? 1 : 0, (int)Depth, (int)DataLayout, (int)PaddingMode, BorderValue,
+                rBlobArray, rBlobArray.Length, size, outVec.CvPtr));
+        return outVec.ToArray();
     }
 }

--- a/src/OpenCvSharp/Modules/dnn/Layer.cs
+++ b/src/OpenCvSharp/Modules/dnn/Layer.cs
@@ -1,0 +1,107 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Dnn;
+
+/// <summary>
+/// This interface class allows to build new Layers - are building blocks of networks.
+/// </summary>
+/// <remarks>
+/// Each class, derived from Layer, must implement forward() method to compute outputs.
+/// Also before using the new layer into networks you must register your layer by using one of
+/// LayerFactory macros.
+/// </remarks>
+public class Layer : Algorithm
+{
+    /// <summary>
+    /// Creates instance by raw pointer cv::dnn::Layer*
+    /// </summary>
+    internal Layer(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.dnn_Ptr_Layer_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// List of learned parameters must be stored here to allow read them by using Net::getParam().
+    /// </summary>
+    public Mat[] Blobs
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var blobsVec = new VectorOfMat();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Layer_getBlobs(Handle, blobsVec.CvPtr));
+            return blobsVec.ToArray();
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentNullException.ThrowIfNull(value);
+
+            using var blobsVec = new VectorOfMat(value);
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Layer_setBlobs(Handle, blobsVec.CvPtr));
+            GC.KeepAlive(value);
+        }
+    }
+
+    /// <summary>
+    /// Name of the layer instance, can be used for logging or other internal purposes.
+    /// </summary>
+    public string Name
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var str = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Layer_getName(Handle, str.CvPtr));
+            return str.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Type name which was used for creating layer by layer factory.
+    /// </summary>
+    public string Type
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var str = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Layer_getType(Handle, str.CvPtr));
+            return str.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Preferred target for layer forwarding.
+    /// </summary>
+    public Target PreferableTarget
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.dnn_Layer_getPreferableTarget(Handle, out var ret));
+            return (Target)ret;
+        }
+    }
+
+    /// <summary>
+    /// Returns index of output blob in output array.
+    /// </summary>
+    /// <param name="outputName">label of output blob</param>
+    /// <returns></returns>
+    public int OutputNameToIndex(string outputName)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(outputName);
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Layer_outputNameToIndex(Handle, outputName, out var ret));
+        return ret;
+    }
+}

--- a/src/OpenCvSharp/Modules/dnn/Net.cs
+++ b/src/OpenCvSharp/Modules/dnn/Net.cs
@@ -358,7 +358,33 @@ public class Net : CvObject
     }
 
     /// <summary>
-    /// 
+    /// Returns pointer to layer with specified id which the network use.
+    /// </summary>
+    /// <param name="layerId"></param>
+    /// <returns></returns>
+    public Layer GetLayer(int layerId)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_getLayer(Handle, layerId, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.dnn_Ptr_Layer_get(smartPtr, out var rawPtr));
+        return new Layer(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Returns pointer to layer with specified name which the network use.
+    /// </summary>
+    /// <param name="layerName"></param>
+    /// <returns></returns>
+    public Layer GetLayer(string layerName)
+    {
+        ArgumentNullException.ThrowIfNull(layerName);
+        return GetLayer(GetLayerId(layerName));
+    }
+
+    /// <summary>
+    ///
     /// </summary>
     /// <returns></returns>
     public string?[] GetLayerNames()
@@ -462,6 +488,37 @@ public class Net : CvObject
                 Handle, outputBlobsPtrs, outputBlobsPtrs.Length, outBlobNamesArray, outBlobNamesArray.Length));
 
         GC.KeepAlive(outputBlobs);
+    }
+
+    /// <summary>
+    /// Runs forward pass to compute outputs of layers listed in @p outBlobNames, retrieving
+    /// all output blobs for each layer specified in @p outBlobNames.
+    /// </summary>
+    /// <param name="outBlobNames">names for layers which outputs are needed to get</param>
+    /// <returns>for each requested layer, an array containing all of that layer's output blobs.</returns>
+    public Mat[][] ForwardAndRetrieve(IEnumerable<string> outBlobNames)
+    {
+        ArgumentNullException.ThrowIfNull(outBlobNames);
+
+        var outBlobNamesArray = outBlobNames.ToArray();
+        using var flatBlobs = new VectorOfMat();
+        using var counts = new StdVector<int>();
+
+        NativeMethods.HandleException(
+            NativeMethods.dnn_Net_forwardAndRetrieve(
+                Handle, outBlobNamesArray, outBlobNamesArray.Length, flatBlobs.CvPtr, counts.CvPtr));
+
+        var flat = flatBlobs.ToArray();
+        var countsArray = counts.ToArray();
+        var result = new Mat[countsArray.Length][];
+        var offset = 0;
+        for (var i = 0; i < countsArray.Length; i++)
+        {
+            result[i] = new Mat[countsArray[i]];
+            Array.Copy(flat, offset, result[i], 0, countsArray[i]);
+            offset += countsArray[i];
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
+++ b/src/OpenCvSharp/Modules/dnn/TextRecognitionModel.cs
@@ -128,4 +128,24 @@ public class TextRecognitionModel : Model
         GC.KeepAlive(frame.Source);
         return result.ToString();
     }
+
+    /// <summary>
+    /// Given the @p input frame, create input blob, run net and return recognition result for each ROI.
+    /// </summary>
+    /// <param name="frame">The input image.</param>
+    /// <param name="roiRects">List of text detection regions of interest. ROIs are cropped as the network inputs.</param>
+    /// <returns>A set of text recognition results, one per ROI.</returns>
+    public string?[] Recognize(InputArray frame, IEnumerable<Rect> roiRects)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(roiRects);
+
+        var roiRectsMat = InputArray.Create(roiRects.ToArray());
+        using var resultVec = new VectorOfString();
+        NativeMethods.HandleException(
+            NativeMethods.dnn_TextRecognitionModel_recognize_batch(Handle, frame.Proxy, roiRectsMat.Proxy, resultVec.CvPtr));
+        GC.KeepAlive(frame.Source);
+        GC.KeepAlive(roiRectsMat.Source);
+        return resultVec.ToArray();
+    }
 }

--- a/src/OpenCvSharp/Modules/ml/RTrees.cs
+++ b/src/OpenCvSharp/Modules/ml/RTrees.cs
@@ -126,9 +126,9 @@ public class RTrees : DTrees
     #region Methods
 
     /// <summary>
-    /// Returns the variable importance array. 
-    /// The method returns the variable importance vector, computed at the training 
-    /// stage when CalculateVarImportance is set to true. If this flag was set to false, 
+    /// Returns the variable importance array.
+    /// The method returns the variable importance vector, computed at the training
+    /// stage when CalculateVarImportance is set to true. If this flag was set to false,
     /// the empty matrix is returned.
     /// </summary>
     /// <returns></returns>
@@ -138,6 +138,22 @@ public class RTrees : DTrees
         NativeMethods.HandleException(
             NativeMethods.ml_RTrees_getVarImportance(Handle, out var ret));
         return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the class probabilities for each sample, as voted by each of the trees.
+    /// </summary>
+    /// <param name="samples">Array containing the samples for which votes will be calculated.</param>
+    /// <param name="results">Array where the result of the calculation will be written.</param>
+    /// <param name="flags">Flags for defining the type of RTrees.</param>
+    public void GetVotes(InputArray samples, OutputArray results, int flags)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.ml_RTrees_getVotes(Handle, samples.Proxy, results.Proxy, flags));
+        GC.KeepAlive(samples.Source);
+        GC.KeepAlive(results.Source);
     }
 
     #endregion

--- a/src/OpenCvSharp/Modules/ml/SVM.cs
+++ b/src/OpenCvSharp/Modules/ml/SVM.cs
@@ -289,7 +289,7 @@ public class SVM : StatModel
     /// to such proportion in the whole train dataset.</param>
     /// <returns></returns>
     public bool TrainAuto(
-        TrainData data, 
+        TrainData data,
         int kFold = 10,
         ParamGrid? cGrid = null,
         ParamGrid? gammaGrid = null,
@@ -299,14 +299,23 @@ public class SVM : StatModel
         ParamGrid? degreeGrid = null,
         bool balanced = false)
     {
-        throw new NotImplementedException();
-        /*
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(data);
+
         var cGridValue = cGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.C));
         var gammaGridValue = gammaGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.Gamma));
         var pGridValue = pGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.P));
         var nuGridValue = nuGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.Nu));
         var coeffGridValue = coeffGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.Coef));
-        var degreeGridValue = degreeGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.Degree));*/
+        var degreeGridValue = degreeGrid.GetValueOrDefault(GetDefaultGrid(ParamTypes.Degree));
+
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVM_trainAuto(
+                Handle, data.SmartPtr, kFold,
+                cGridValue, gammaGridValue, pGridValue, nuGridValue, coeffGridValue, degreeGridValue,
+                balanced, out var ret));
+        GC.KeepAlive(data);
+        return ret != 0;
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/ml/SVMSGD.cs
+++ b/src/OpenCvSharp/Modules/ml/SVMSGD.cs
@@ -1,0 +1,273 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.ML;
+
+// ReSharper disable InconsistentNaming
+/// <summary>
+/// Stochastic Gradient Descent SVM classifier
+/// </summary>
+public class SVMSGD : StatModel
+{
+    #region Init and Disposal
+
+    /// <summary>
+    /// Creates instance by raw pointer cv::ml::SVMSGD*
+    /// </summary>
+    private SVMSGD(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.ml_Ptr_SVMSGD_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates empty model.
+    /// Use StatModel::Train to train the model.
+    /// Since %SVMSGD has several parameters, you may want to find the best
+    /// parameters for your problem or use SetOptimalParameters to set some default parameters.
+    /// </summary>
+    /// <returns></returns>
+    public static SVMSGD Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_create(out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.ml_Ptr_SVMSGD_get(smartPtr, out var rawPtr));
+        return new SVMSGD(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Loads and creates a serialized SVMSGD from a file.
+    /// Use SVMSGD::save to serialize and store an SVMSGD to disk.
+    /// Load the SVMSGD from this file again, by calling this function with the path to the file.
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns></returns>
+    public static SVMSGD Load(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_load(filePath, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.ml_Ptr_SVMSGD_get(smartPtr, out var rawPtr));
+        return new SVMSGD(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Loads algorithm from a String.
+    /// </summary>
+    /// <param name="strModel">The string variable containing the model you want to load.</param>
+    /// <returns></returns>
+    public static SVMSGD LoadFromString(string strModel)
+    {
+        ArgumentNullException.ThrowIfNull(strModel);
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_loadFromString(strModel, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.ml_Ptr_SVMSGD_get(smartPtr, out var rawPtr));
+        return new SVMSGD(smartPtr, rawPtr);
+    }
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// Algorithm type, one of SVMSGD::SvmsgdType.
+    /// </summary>
+    public SvmsgdTypes SvmsgdType
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getSvmsgdType(Handle, out var ret));
+            return (SvmsgdTypes)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setSvmsgdType(Handle, (int)value));
+        }
+    }
+
+    /// <summary>
+    /// Margin type, one of SVMSGD::MarginType.
+    /// </summary>
+    public MarginTypes MarginType
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getMarginType(Handle, out var ret));
+            return (MarginTypes)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setMarginType(Handle, (int)value));
+        }
+    }
+
+    /// <summary>
+    /// Parameter marginRegularization of a %SVMSGD optimization problem.
+    /// </summary>
+    public float MarginRegularization
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getMarginRegularization(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setMarginRegularization(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Parameter initialStepSize of a %SVMSGD optimization problem.
+    /// </summary>
+    public float InitialStepSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getInitialStepSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setInitialStepSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Parameter stepDecreasingPower of a %SVMSGD optimization problem.
+    /// </summary>
+    public float StepDecreasingPower
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getStepDecreasingPower(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setStepDecreasingPower(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Termination criteria of the training algorithm.
+    /// You can specify the maximum number of iterations (maxCount) and/or how much the error could
+    /// change between the iterations to make the algorithm continue (epsilon).
+    /// </summary>
+    public TermCriteria TermCriteria
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_getTermCriteria(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.ml_SVMSGD_setTermCriteria(Handle, value));
+        }
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Returns the weights of the trained model (decision function f(x) = weights * x + shift).
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetWeights()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_getWeights(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the shift of the trained model (decision function f(x) = weights * x + shift).
+    /// </summary>
+    /// <returns></returns>
+    public float GetShift()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_getShift(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Function sets optimal parameters values for chosen SVM SGD model.
+    /// </summary>
+    /// <param name="svmsgdType">is the type of SVMSGD classifier.</param>
+    /// <param name="marginType">is the type of margin constraint.</param>
+    public void SetOptimalParameters(
+        SvmsgdTypes svmsgdType = SvmsgdTypes.Asgd, MarginTypes marginType = MarginTypes.SoftMargin)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_SVMSGD_setOptimalParameters(Handle, (int)svmsgdType, (int)marginType));
+    }
+
+    #endregion
+
+    #region Types
+
+#pragma warning disable CA1008
+
+    /// <summary>
+    /// SVMSGD type. ASGD is often the preferable choice.
+    /// </summary>
+    public enum SvmsgdTypes
+    {
+        /// <summary>
+        /// Stochastic Gradient Descent
+        /// </summary>
+        Sgd,
+
+        /// <summary>
+        /// Average Stochastic Gradient Descent
+        /// </summary>
+        Asgd
+    }
+
+    /// <summary>
+    /// Margin type
+    /// </summary>
+    public enum MarginTypes
+    {
+        /// <summary>
+        /// General case, suits to the case of non-linearly separable sets, allows outliers.
+        /// </summary>
+        SoftMargin,
+
+        /// <summary>
+        /// More accurate for the case of linearly separable sets.
+        /// </summary>
+        HardMargin
+    }
+
+#pragma warning restore CA1008
+
+    #endregion
+}

--- a/src/OpenCvSharp/Modules/ml/StatModel.cs
+++ b/src/OpenCvSharp/Modules/ml/StatModel.cs
@@ -70,7 +70,13 @@ public abstract class StatModel : Algorithm
     /// <returns></returns>
     public virtual bool Train(TrainData trainData, int flags = 0)
     {
-        throw new NotImplementedException();
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(trainData);
+
+        NativeMethods.HandleException(
+            NativeMethods.ml_StatModel_train1(Handle, trainData.SmartPtr, flags, out var ret));
+        GC.KeepAlive(trainData);
+        return ret != 0;
     }
 
     /// <summary>
@@ -105,7 +111,14 @@ public abstract class StatModel : Algorithm
     /// <returns></returns>
     public virtual float CalcError(TrainData data, bool test, OutputArray resp)
     {
-        throw new NotImplementedException();
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(data);
+
+        NativeMethods.HandleException(
+            NativeMethods.ml_StatModel_calcError(Handle, data.SmartPtr, test, resp.Proxy, out var ret));
+        GC.KeepAlive(data);
+        GC.KeepAlive(resp.Source);
+        return ret;
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/ml/TrainData.cs
+++ b/src/OpenCvSharp/Modules/ml/TrainData.cs
@@ -1,15 +1,350 @@
+using OpenCvSharp.Internal;
+
 namespace OpenCvSharp.ML;
 
 /// <summary>
-/// 
+/// Training data used by the ml algorithms
 /// </summary>
-public class TrainData
+public class TrainData : CvPtrObject
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    public TrainData()
+    private TrainData(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, static p => NativeMethods.HandleException(NativeMethods.ml_Ptr_TrainData_delete(p)))
     {
-        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Creates training data from in-memory arrays.
+    /// </summary>
+    /// <param name="samples">matrix of samples. It should have CV_32F type.</param>
+    /// <param name="layout">see ml::SampleTypes.</param>
+    /// <param name="responses">matrix of responses. If the responses are scalar, they should be stored as a
+    /// single row or as a single column. The matrix should have type CV_32F or CV_32S (in the
+    /// former case the responses are considered as ordered by default; in the latter case - as categorical)</param>
+    /// <param name="varIdx">vector specifying which variables to use for training. It can be an integer vector
+    /// (CV_32S) containing 0-based variable indices or byte vector (CV_8U) containing a mask of active variables.</param>
+    /// <param name="sampleIdx">vector specifying which samples to use for training. It can be an integer
+    /// vector (CV_32S) containing 0-based sample indices or byte vector (CV_8U) containing a mask
+    /// of training samples.</param>
+    /// <param name="sampleWeights">optional vector with weights for each sample. It should have CV_32F type.</param>
+    /// <param name="varType">optional vector of type CV_8U and size &lt;number_of_variables_in_samples&gt; +
+    /// &lt;number_of_variables_in_responses&gt;, containing types of each input and output variable.
+    /// See ml::VariableTypes.</param>
+    /// <returns></returns>
+    public static TrainData Create(
+        InputArray samples,
+        SampleTypes layout,
+        InputArray responses,
+        InputArray varIdx = default,
+        InputArray sampleIdx = default,
+        InputArray sampleWeights = default,
+        InputArray varType = default)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_create(
+                samples.Proxy, (int)layout, responses.Proxy,
+                varIdx.Proxy, sampleIdx.Proxy, sampleWeights.Proxy, varType.Proxy,
+                out var smartPtr));
+        GC.KeepAlive(samples.Source);
+        GC.KeepAlive(responses.Source);
+        GC.KeepAlive(varIdx.Source);
+        GC.KeepAlive(sampleIdx.Source);
+        GC.KeepAlive(sampleWeights.Source);
+        GC.KeepAlive(varType.Source);
+
+        NativeMethods.HandleException(NativeMethods.ml_Ptr_TrainData_get(smartPtr, out var rawPtr));
+        return new TrainData(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Reads the dataset from a .csv file and returns the ready-to-use training data.
+    /// </summary>
+    /// <param name="filename">The input file name</param>
+    /// <param name="headerLineCount">The number of lines in the beginning to skip; besides the header, the
+    /// function also skips empty lines and lines starting with '#'</param>
+    /// <param name="responseStartIdx">Index of the first output variable. If -1, the function considers the
+    /// last variable as the response</param>
+    /// <param name="responseEndIdx">Index of the last output variable + 1. If -1, then there is single
+    /// response variable at responseStartIdx.</param>
+    /// <param name="varTypeSpec">The optional text string that specifies the variables' types. It has the
+    /// format `ord[n1-n2,n3,n4-n5,...]cat[n6,n7-n8,...]`.</param>
+    /// <param name="delimiter">The character used to separate values in each line.</param>
+    /// <param name="missch">The character used to specify missing measurements. It should not be a digit.</param>
+    /// <returns></returns>
+    public static TrainData LoadFromCSV(
+        string filename,
+        int headerLineCount,
+        int responseStartIdx = -1,
+        int responseEndIdx = -1,
+        string varTypeSpec = "",
+        char delimiter = ',',
+        char missch = '?')
+    {
+        ArgumentNullException.ThrowIfNull(filename);
+        ArgumentNullException.ThrowIfNull(varTypeSpec);
+
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_loadFromCSV(
+                filename, headerLineCount, responseStartIdx, responseEndIdx, varTypeSpec,
+                (byte)delimiter, (byte)missch, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.ml_Ptr_TrainData_get(smartPtr, out var rawPtr));
+        return new TrainData(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Returns the layout (ml::SampleTypes) used by this training data.
+    /// </summary>
+    /// <returns></returns>
+    public SampleTypes GetLayout()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getLayout(Handle, out var ret));
+        return (SampleTypes)ret;
+    }
+
+    /// <summary>
+    /// Returns the total number of samples
+    /// </summary>
+    /// <returns></returns>
+    public int GetNSamples()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getNSamples(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the number of training samples
+    /// </summary>
+    /// <returns></returns>
+    public int GetNTrainSamples()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getNTrainSamples(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the number of test samples
+    /// </summary>
+    /// <returns></returns>
+    public int GetNTestSamples()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getNTestSamples(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the number of variables
+    /// </summary>
+    /// <returns></returns>
+    public int GetNVars()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getNVars(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the number of variables including the responses
+    /// </summary>
+    /// <returns></returns>
+    public int GetNAllVars()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getNAllVars(Handle, out var ret));
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the matrix of all the samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetSamples()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getSamples(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the mask of missing values in the samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetMissing()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getMissing(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns matrix of train samples
+    /// </summary>
+    /// <param name="layout">The requested layout. If it's different from the initial one, the matrix is
+    /// transposed. See ml::SampleTypes.</param>
+    /// <param name="compressSamples">if true, the function returns only the training samples (specified by
+    /// sampleIdx)</param>
+    /// <param name="compressVars">if true, the function returns the shorter training samples, containing only
+    /// the active variables.</param>
+    /// <returns></returns>
+    public Mat GetTrainSamples(
+        SampleTypes layout = SampleTypes.RowSample, bool compressSamples = true, bool compressVars = true)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTrainSamples(
+                Handle, (int)layout, compressSamples ? 1 : 0, compressVars ? 1 : 0, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the vector of responses for the training samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetTrainResponses()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTrainResponses(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns matrix of test samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetTestSamples()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTestSamples(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the vector of responses for the test samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetTestResponses()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTestResponses(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the vector of responses
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetResponses()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getResponses(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the vector of variable indices used for training
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetVarIdx()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getVarIdx(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the type of each input and output variable
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetVarType()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getVarType(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the vector of class labels
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetClassLabels()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getClassLabels(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the indices of the training samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetTrainSampleIdx()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTrainSampleIdx(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Returns the indices of the test samples
+    /// </summary>
+    /// <returns></returns>
+    public Mat GetTestSampleIdx()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_getTestSampleIdx(Handle, out var ret));
+        return new Mat(ret);
+    }
+
+    /// <summary>
+    /// Splits the training data into the training and test parts
+    /// </summary>
+    /// <param name="count"></param>
+    /// <param name="shuffle"></param>
+    public void SetTrainTestSplit(int count, bool shuffle = true)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_setTrainTestSplit(Handle, count, shuffle));
+    }
+
+    /// <summary>
+    /// Splits the training data into the training and test parts
+    /// </summary>
+    /// <param name="ratio"></param>
+    /// <param name="shuffle"></param>
+    public void SetTrainTestSplitRatio(double ratio, bool shuffle = true)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_setTrainTestSplitRatio(Handle, ratio, shuffle));
+    }
+
+    /// <summary>
+    /// Shuffles the training and test sample indices
+    /// </summary>
+    public void ShuffleTrainTest()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.ml_TrainData_shuffleTrainTest(Handle));
     }
 }

--- a/src/OpenCvSharpExtern/dnn.cpp
+++ b/src/OpenCvSharpExtern/dnn.cpp
@@ -1,6 +1,7 @@
 // ReSharper disable CppUnusedIncludeDirective
 #include "dnn.h"
 #include "dnn_Net.h"
+#include "dnn_Layer.h"
 #include "dnn_Model.h"
 #include "dnn_TextModel.h"
 #include "dnn_Tokenizer.h"

--- a/src/OpenCvSharpExtern/dnn.h
+++ b/src/OpenCvSharpExtern/dnn.h
@@ -405,6 +405,58 @@ CVAPI(ExceptionStatus) dnn_blobFromImagesWithParams(
     });
 }
 
+CVAPI(ExceptionStatus) dnn_Image2BlobParams_blobRectToImageRect(
+    const interop::Scalar scalefactor,
+    const interop::Size paramSize,
+    const interop::Scalar mean,
+    const int swapRB,
+    const int ddepth,
+    const int datalayout,
+    const int paddingmode,
+    const interop::Scalar borderValue,
+    const interop::Rect rBlob,
+    const interop::Size size,
+    interop::Rect *returnValue)
+{
+    return cvTry([&] {
+        cv::dnn::Image2BlobParams param(
+            cpp(scalefactor), cpp(paramSize), cpp(mean), swapRB != 0, ddepth,
+            static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
+        *returnValue = c(param.blobRectToImageRect(cpp(rBlob), cpp(size)));
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Image2BlobParams_blobRectsToImageRects(
+    const interop::Scalar scalefactor,
+    const interop::Size paramSize,
+    const interop::Scalar mean,
+    const int swapRB,
+    const int ddepth,
+    const int datalayout,
+    const int paddingmode,
+    const interop::Scalar borderValue,
+    const interop::Rect *rBlob,
+    const int rBlobLength,
+    const interop::Size size,
+    std::vector<cv::Rect> *outVec)
+{
+    return cvTry([&] {
+        cv::dnn::Image2BlobParams param(
+            cpp(scalefactor), cpp(paramSize), cpp(mean), swapRB != 0, ddepth,
+            static_cast<cv::DataLayout>(datalayout), static_cast<cv::dnn::ImagePaddingMode>(paddingmode), cpp(borderValue));
+
+        std::vector<cv::Rect> rBlobVec(rBlobLength);
+        for (auto i = 0; i < rBlobLength; i++)
+        {
+            rBlobVec[i] = cpp(rBlob[i]);
+        }
+
+        std::vector<cv::Rect> rImgVec;
+        param.blobRectsToImageRects(rBlobVec, rImgVec, cpp(size));
+        outVec->assign(rImgVec.begin(), rImgVec.end());
+    });
+}
+
 CVAPI(ExceptionStatus) dnn_imagesFromBlob(cv::Mat *blob, std::vector<cv::Mat> *images)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/dnn_Layer.h
+++ b/src/OpenCvSharpExtern/dnn_Layer.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#ifndef NO_DNN
+
+#ifndef _WINRT_DLL
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+CVAPI(ExceptionStatus) dnn_Layer_getBlobs(cv::dnn::Layer *obj, std::vector<cv::Mat> *outVec)
+{
+    return cvTry([&] {
+        outVec->assign(obj->blobs.begin(), obj->blobs.end());
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Layer_setBlobs(cv::dnn::Layer *obj, std::vector<cv::Mat> *blobs)
+{
+    return cvTry([&] {
+        obj->blobs.assign(blobs->begin(), blobs->end());
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Layer_getName(cv::dnn::Layer *obj, std::string *outString)
+{
+    return cvTry([&] {
+        outString->assign(obj->name);
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Layer_getType(cv::dnn::Layer *obj, std::string *outString)
+{
+    return cvTry([&] {
+        outString->assign(obj->type);
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Layer_getPreferableTarget(cv::dnn::Layer *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->preferableTarget;
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Layer_outputNameToIndex(cv::dnn::Layer *obj, const char *outputName, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->outputNameToIndex(outputName);
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Ptr_Layer_delete(cv::Ptr<cv::dnn::Layer> *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Ptr_Layer_get(cv::Ptr<cv::dnn::Layer>* obj, cv::dnn::Layer **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+#endif // _WINRT_DLL
+
+#endif // NO_DNN

--- a/src/OpenCvSharpExtern/dnn_Net.h
+++ b/src/OpenCvSharpExtern/dnn_Net.h
@@ -60,6 +60,14 @@ CVAPI(ExceptionStatus) dnn_Net_getLayerId(cv::dnn::Net* net, const char *layer, 
     });
 }
 
+CVAPI(ExceptionStatus) dnn_Net_getLayer(cv::dnn::Net* net, int layerId, cv::Ptr<cv::dnn::Layer> **returnValue)
+{
+    return cvTry([&] {
+        const auto layer = net->getLayer(layerId);
+        *returnValue = new cv::Ptr<cv::dnn::Layer>(layer);
+    });
+}
+
 CVAPI(ExceptionStatus) dnn_Net_getLayerNames(cv::dnn::Net* net, std::vector<cv::String> *outVec)
 {
     return cvTry([&] {
@@ -138,6 +146,31 @@ CVAPI(ExceptionStatus) dnn_Net_forward3(
         for (auto i = 0; i < outputBlobsLength; i++)
         {
             *outputBlobs[i] = outputBlobsVec[i];
+        }
+    });
+}
+
+CVAPI(ExceptionStatus) dnn_Net_forwardAndRetrieve(
+    cv::dnn::Net* net, const char **outBlobNames, int outBlobNamesLength,
+    std::vector<cv::Mat> *outFlatBlobs, std::vector<int> *outCounts)
+{
+    return cvTry([&] {
+        std::vector<cv::String> outBlobNamesVec(outBlobNamesLength);
+        for (auto i = 0; i < outBlobNamesLength; i++)
+        {
+            outBlobNamesVec[i] = outBlobNames[i];
+        }
+
+        std::vector<std::vector<cv::Mat>> outputBlobs;
+        net->forward(outputBlobs, outBlobNamesVec);
+
+        for (const auto& layerBlobs : outputBlobs)
+        {
+            outCounts->push_back(static_cast<int>(layerBlobs.size()));
+            for (const auto& m : layerBlobs)
+            {
+                outFlatBlobs->push_back(m);
+            }
         }
     });
 }

--- a/src/OpenCvSharpExtern/dnn_TextModel.h
+++ b/src/OpenCvSharpExtern/dnn_TextModel.h
@@ -101,6 +101,17 @@ CVAPI(ExceptionStatus) dnn_TextRecognitionModel_recognize(
     });
 }
 
+CVAPI(ExceptionStatus) dnn_TextRecognitionModel_recognize_batch(
+    cv::dnn::TextRecognitionModel *model,
+    const interop::InputArrayProxy* frame,
+    const interop::InputArrayProxy* roiRects,
+    std::vector<std::string> *outVec)
+{
+    return cvTry([&] {
+        model->recognize(InProxy(*frame), InProxy(*roiRects), *outVec);
+    });
+}
+
 // ----------------------------------------------------------------------------
 // TextDetectionModel (base; methods are shared by EAST and DB via upcast)
 // ----------------------------------------------------------------------------

--- a/src/OpenCvSharpExtern/ml.cpp
+++ b/src/OpenCvSharpExtern/ml.cpp
@@ -10,3 +10,5 @@
 #include "ml_NormalBayesClassifier.h"
 #include "ml_RTrees.h"
 #include "ml_SVM.h"
+#include "ml_SVMSGD.h"
+#include "ml_TrainData.h"

--- a/src/OpenCvSharpExtern/ml_RTrees.h
+++ b/src/OpenCvSharpExtern/ml_RTrees.h
@@ -55,6 +55,14 @@ CVAPI(ExceptionStatus) ml_RTrees_getVarImportance(cv::ml::RTrees *obj, cv::Mat *
     });
 }
 
+CVAPI(ExceptionStatus) ml_RTrees_getVotes(
+    cv::ml::RTrees *obj, const interop::InputArrayProxy *samples, const interop::OutputArrayProxy *results, int flags)
+{
+    return cvTry([&] {
+        obj->getVotes(InProxy(*samples), OutProxy(*results), flags);
+    });
+}
+
 CVAPI(ExceptionStatus) ml_RTrees_create(cv::Ptr<cv::ml::RTrees> **returnValue)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/ml_SVM.h
+++ b/src/OpenCvSharpExtern/ml_SVM.h
@@ -159,6 +159,27 @@ CVAPI(ExceptionStatus) ml_SVM_getDecisionFunction(
 }
 
 
+CVAPI(ExceptionStatus) ml_SVM_trainAuto(
+    cv::ml::SVM *obj,
+    cv::Ptr<cv::ml::TrainData> *data,
+    int kFold,
+    ParamGridStruct cGrid,
+    ParamGridStruct gammaGrid,
+    ParamGridStruct pGrid,
+    ParamGridStruct nuGrid,
+    ParamGridStruct coeffGrid,
+    ParamGridStruct degreeGrid,
+    int balanced,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->trainAuto(
+            *data, kFold,
+            cpp(cGrid), cpp(gammaGrid), cpp(pGrid), cpp(nuGrid), cpp(coeffGrid), cpp(degreeGrid),
+            balanced != 0) ? 1 : 0;
+    });
+}
+
 // static
 
 CVAPI(ExceptionStatus) ml_SVM_getDefaultGrid(int param_id, ParamGridStruct *returnValue)

--- a/src/OpenCvSharpExtern/ml_SVMSGD.h
+++ b/src/OpenCvSharpExtern/ml_SVMSGD.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#ifndef NO_ML
+
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+// ReSharper disable once CppInconsistentNaming
+
+#include "include_opencv.h"
+#include "ml.h"
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getWeights(cv::ml::SVMSGD *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getWeights());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getShift(cv::ml::SVMSGD *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getShift();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_setOptimalParameters(cv::ml::SVMSGD *obj, int svmsgdType, int marginType)
+{
+    return cvTry([&] {
+        obj->setOptimalParameters(svmsgdType, marginType);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getSvmsgdType(cv::ml::SVMSGD *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSvmsgdType();
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setSvmsgdType(cv::ml::SVMSGD *obj, int val)
+{
+    return cvTry([&] {
+        obj->setSvmsgdType(val);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getMarginType(cv::ml::SVMSGD *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getMarginType();
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setMarginType(cv::ml::SVMSGD *obj, int val)
+{
+    return cvTry([&] {
+        obj->setMarginType(val);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getMarginRegularization(cv::ml::SVMSGD *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getMarginRegularization();
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setMarginRegularization(cv::ml::SVMSGD *obj, float val)
+{
+    return cvTry([&] {
+        obj->setMarginRegularization(val);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getInitialStepSize(cv::ml::SVMSGD *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getInitialStepSize();
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setInitialStepSize(cv::ml::SVMSGD *obj, float val)
+{
+    return cvTry([&] {
+        obj->setInitialStepSize(val);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getStepDecreasingPower(cv::ml::SVMSGD *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getStepDecreasingPower();
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setStepDecreasingPower(cv::ml::SVMSGD *obj, float val)
+{
+    return cvTry([&] {
+        obj->setStepDecreasingPower(val);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_getTermCriteria(cv::ml::SVMSGD *obj, interop::TermCriteria *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->getTermCriteria());
+    });
+}
+CVAPI(ExceptionStatus) ml_SVMSGD_setTermCriteria(cv::ml::SVMSGD *obj, interop::TermCriteria val)
+{
+    return cvTry([&] {
+        obj->setTermCriteria(cpp(val));
+    });
+}
+
+// static
+
+CVAPI(ExceptionStatus) ml_SVMSGD_create(cv::Ptr<cv::ml::SVMSGD> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::ml::SVMSGD::create();
+        *returnValue = new cv::Ptr<cv::ml::SVMSGD>(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_Ptr_SVMSGD_delete(cv::Ptr<cv::ml::SVMSGD> *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) ml_Ptr_SVMSGD_get(cv::Ptr<cv::ml::SVMSGD>* obj, cv::ml::SVMSGD **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_load(const char *filePath, cv::Ptr<cv::ml::SVMSGD> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::Algorithm::load<cv::ml::SVMSGD>(filePath);
+        *returnValue = new cv::Ptr<cv::ml::SVMSGD>(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_SVMSGD_loadFromString(const char *strModel, cv::Ptr<cv::ml::SVMSGD> **returnValue)
+{
+    return cvTry([&] {
+        const auto objName = cv::ml::SVMSGD::create()->getDefaultName();
+        const auto ptr = cv::Algorithm::loadFromString<cv::ml::SVMSGD>(strModel, objName);
+        *returnValue = new cv::Ptr<cv::ml::SVMSGD>(ptr);
+    });
+}
+
+#endif // NO_ML

--- a/src/OpenCvSharpExtern/ml_SVMSGD.h
+++ b/src/OpenCvSharpExtern/ml_SVMSGD.h
@@ -135,6 +135,8 @@ CVAPI(ExceptionStatus) ml_SVMSGD_load(const char *filePath, cv::Ptr<cv::ml::SVMS
 {
     return cvTry([&] {
         const auto ptr = cv::Algorithm::load<cv::ml::SVMSGD>(filePath);
+        if (ptr.empty())
+            CV_Error(cv::Error::StsError, cv::format("Failed to load SVMSGD model from: %s", filePath));
         *returnValue = new cv::Ptr<cv::ml::SVMSGD>(ptr);
     });
 }
@@ -142,8 +144,9 @@ CVAPI(ExceptionStatus) ml_SVMSGD_load(const char *filePath, cv::Ptr<cv::ml::SVMS
 CVAPI(ExceptionStatus) ml_SVMSGD_loadFromString(const char *strModel, cv::Ptr<cv::ml::SVMSGD> **returnValue)
 {
     return cvTry([&] {
-        const auto objName = cv::ml::SVMSGD::create()->getDefaultName();
-        const auto ptr = cv::Algorithm::loadFromString<cv::ml::SVMSGD>(strModel, objName);
+        const auto ptr = cv::Algorithm::loadFromString<cv::ml::SVMSGD>(strModel);
+        if (ptr.empty())
+            CV_Error(cv::Error::StsError, "Failed to load SVMSGD model from string");
         *returnValue = new cv::Ptr<cv::ml::SVMSGD>(ptr);
     });
 }

--- a/src/OpenCvSharpExtern/ml_StatModel.h
+++ b/src/OpenCvSharpExtern/ml_StatModel.h
@@ -42,7 +42,7 @@ CVAPI(ExceptionStatus) ml_StatModel_isClassifier(cv::ml::StatModel *obj, int *re
     });
 }
 
-/*CVAPI(ExceptionStatus) ml_StatModel_train1(
+CVAPI(ExceptionStatus) ml_StatModel_train1(
     cv::ml::StatModel *obj,
     cv::Ptr<cv::ml::TrainData> *trainData,
     int flags,
@@ -51,7 +51,7 @@ CVAPI(ExceptionStatus) ml_StatModel_isClassifier(cv::ml::StatModel *obj, int *re
     return cvTry([&] {
         *returnValue = obj->train(*trainData, flags) ? 1 : 0;
     });
-}*/
+}
 
 CVAPI(ExceptionStatus) ml_StatModel_train2(
     cv::ml::StatModel *obj,
@@ -65,7 +65,7 @@ CVAPI(ExceptionStatus) ml_StatModel_train2(
     });
 }
 
-/*CVAPI(ExceptionStatus) ml_StatModel_calcError(
+CVAPI(ExceptionStatus) ml_StatModel_calcError(
     cv::ml::StatModel *obj,
     cv::Ptr<cv::ml::TrainData> *data,
     int test,
@@ -75,7 +75,7 @@ CVAPI(ExceptionStatus) ml_StatModel_train2(
     return cvTry([&] {
         *returnValue = obj->calcError(*data, test != 0, OutProxy(*resp));
     });
-}*/
+}
 
 CVAPI(ExceptionStatus) ml_StatModel_predict(
     cv::ml::StatModel *obj,

--- a/src/OpenCvSharpExtern/ml_TrainData.h
+++ b/src/OpenCvSharpExtern/ml_TrainData.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#ifndef NO_ML
+
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+// ReSharper disable once CppInconsistentNaming
+
+#include "include_opencv.h"
+#include "ml.h"
+
+CVAPI(ExceptionStatus) ml_TrainData_getLayout(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getLayout();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getNSamples(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNSamples();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getNTrainSamples(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNTrainSamples();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getNTestSamples(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNTestSamples();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getNVars(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNVars();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getNAllVars(cv::ml::TrainData *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNAllVars();
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getSamples(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getSamples());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getMissing(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getMissing());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTrainSamples(
+    cv::ml::TrainData *obj, int layout, int compressSamples, int compressVars, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTrainSamples(layout, compressSamples != 0, compressVars != 0));
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTrainResponses(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTrainResponses());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTestSamples(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTestSamples());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTestResponses(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTestResponses());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getResponses(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getResponses());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getVarIdx(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getVarIdx());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getVarType(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getVarType());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getClassLabels(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getClassLabels());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTrainSampleIdx(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTrainSampleIdx());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_getTestSampleIdx(cv::ml::TrainData *obj, cv::Mat **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::Mat(obj->getTestSampleIdx());
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_setTrainTestSplit(cv::ml::TrainData *obj, int count, int shuffle)
+{
+    return cvTry([&] {
+        obj->setTrainTestSplit(count, shuffle != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_setTrainTestSplitRatio(cv::ml::TrainData *obj, double ratio, int shuffle)
+{
+    return cvTry([&] {
+        obj->setTrainTestSplitRatio(ratio, shuffle != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_shuffleTrainTest(cv::ml::TrainData *obj)
+{
+    return cvTry([&] {
+        obj->shuffleTrainTest();
+    });
+}
+
+// static
+
+CVAPI(ExceptionStatus) ml_TrainData_create(
+    const interop::InputArrayProxy *samples,
+    int layout,
+    const interop::InputArrayProxy *responses,
+    const interop::InputArrayProxy *varIdx,
+    const interop::InputArrayProxy *sampleIdx,
+    const interop::InputArrayProxy *sampleWeights,
+    const interop::InputArrayProxy *varType,
+    cv::Ptr<cv::ml::TrainData> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::ml::TrainData::create(
+            InProxy(*samples), layout, InProxy(*responses),
+            InProxy(*varIdx), InProxy(*sampleIdx), InProxy(*sampleWeights), InProxy(*varType));
+        *returnValue = new cv::Ptr<cv::ml::TrainData>(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_TrainData_loadFromCSV(
+    const char *filename,
+    int headerLineCount,
+    int responseStartIdx,
+    int responseEndIdx,
+    const char *varTypeSpec,
+    char delimiter,
+    char missch,
+    cv::Ptr<cv::ml::TrainData> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::ml::TrainData::loadFromCSV(
+            filename, headerLineCount, responseStartIdx, responseEndIdx, varTypeSpec, delimiter, missch);
+        *returnValue = new cv::Ptr<cv::ml::TrainData>(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) ml_Ptr_TrainData_delete(cv::Ptr<cv::ml::TrainData> *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) ml_Ptr_TrainData_get(cv::Ptr<cv::ml::TrainData>* obj, cv::ml::TrainData **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+#endif // NO_ML

--- a/test/OpenCvSharp.Tests/dnn/Image2BlobParamsTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/Image2BlobParamsTest.cs
@@ -1,0 +1,43 @@
+using OpenCvSharp.Dnn;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Dnn;
+
+public class Image2BlobParamsTest : TestBase
+{
+    // Note: when param.Size == the image size passed to BlobRectToImageRect/BlobRectsToImageRects,
+    // OpenCV's blobRectsToImageRects leaves the output untouched (all-zero Rects) rather than
+    // treating it as an identity mapping - see opencv/modules/dnn/src/dnn_utils.cpp. So these
+    // tests deliberately use a blob size different from the image size to exercise the real
+    // (PMODE_NULL) scaling path.
+    [Fact]
+    public void BlobRectToImageRectScalesByRatio()
+    {
+        var param = new Image2BlobParams(new Scalar(1.0, 1.0, 1.0, 1.0), new Size(208, 208));
+
+        var imageSize = new Size(416, 416);
+        var rBlob = new Rect(10, 20, 100, 200);
+
+        var rImg = param.BlobRectToImageRect(rBlob, imageSize);
+
+        // PaddingMode.NULL: image coordinates are blob coordinates scaled by imageSize/paramSize (here x2).
+        Assert.Equal(new Rect(20, 40, 200, 400), rImg);
+    }
+
+    [Fact]
+    public void BlobRectsToImageRectsMatchesSingleOverload()
+    {
+        var param = new Image2BlobParams(new Scalar(1.0, 1.0, 1.0, 1.0), new Size(208, 208));
+        var imageSize = new Size(416, 416);
+
+        Rect[] rBlobs = [new(0, 0, 50, 50), new(10, 20, 100, 200)];
+
+        var rImgs = param.BlobRectsToImageRects(rBlobs, imageSize);
+
+        Assert.Equal(rBlobs.Length, rImgs.Length);
+        for (var i = 0; i < rBlobs.Length; i++)
+        {
+            Assert.Equal(param.BlobRectToImageRect(rBlobs[i], imageSize), rImgs[i]);
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/dnn/NetIntrospectionTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/NetIntrospectionTest.cs
@@ -190,6 +190,45 @@ public class NetIntrospectionTest : TestBase
     }
 
     [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void GetLayerByIdAndName()
+    {
+        using var net = Cv2.Dnn.ReadNetFromTensorflow(MnistModelPath);
+        Assert.NotNull(net);
+
+        var names = net!.GetLayerNames();
+        Assert.NotEmpty(names);
+        var name = names.First(n => !string.IsNullOrEmpty(n))!;
+
+        var id = net.GetLayerId(name);
+        using var layerById = net.GetLayer(id);
+        Assert.Equal(name, layerById.Name);
+
+        using var layerByName = net.GetLayer(name);
+        Assert.Equal(name, layerByName.Name);
+        Assert.Equal(layerById.Type, layerByName.Type);
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
+    public void ForwardAndRetrieveReturnsOutputsPerLayer()
+    {
+        // OpenCV 5's new dnn engine (the default/Auto engine) rejects forward() calls that name
+        // a specific output layer ("doesn't support inference until a specified layer"); only the
+        // classic engine supports it, matching EngineSelectionTest's precedent for classic-only features.
+        using var net = Cv2.Dnn.ReadNetFromTensorflow(MnistModelPath, engine: EngineType.Classic);
+        Assert.NotNull(net);
+
+        using var input = new Mat(MnistInputShape, MatType.CV_32F, Scalar.All(0));
+        net!.SetInput(input);
+
+        var names = net.GetUnconnectedOutLayersNames().Where(n => !string.IsNullOrEmpty(n)).Cast<string>().ToArray();
+        Assert.NotEmpty(names);
+
+        var results = net.ForwardAndRetrieve(names);
+        Assert.Equal(names.Length, results.Length);
+        Assert.All(results, layerOutputs => Assert.NotEmpty(layerOutputs));
+    }
+
+    [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]
     public void GetLayersShapesIsConsistentAcrossLayers()
     {
         using var net = Cv2.Dnn.ReadNetFromTensorflow(MnistModelPath);

--- a/test/OpenCvSharp.Tests/dnn/TextModelTest.cs
+++ b/test/OpenCvSharp.Tests/dnn/TextModelTest.cs
@@ -72,6 +72,12 @@ public class TextModelTest : TestBase
         // proves the InputArray (frame) param is marshalled correctly.
         using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
         Assert.ThrowsAny<Exception>(() => model.Recognize(image));
+
+        // Same smoke test for the batch-ROI overload: verifies the roiRects InputArrayOfArrays
+        // and the vector<string> results are marshalled correctly, even though the empty Net
+        // still has no forward pass to run.
+        var roiRects = new[] { new Rect(0, 0, 10, 10) };
+        Assert.ThrowsAny<Exception>(() => model.Recognize(image, roiRects));
     }
 
     [Fact(Skip = "Only runs on Windows or Linux", SkipUnless = nameof(IsWindowsOrLinux))]

--- a/test/OpenCvSharp.Tests/ml/RTreesTest.cs
+++ b/test/OpenCvSharp.Tests/ml/RTreesTest.cs
@@ -32,6 +32,36 @@ public class RTreesTest : TestBase
     }
 
     [Fact]
+    public void GetVotes()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {0, 100},
+            {100, 0},
+            {100, 100},
+        };
+        using var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+
+        int[] trainLabelsData = [1, -1, 1, -1];
+        using var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32S, trainLabelsData);
+
+        using var model = RTrees.Create();
+        model.Train(trainFeatures, SampleTypes.RowSample, trainLabels);
+
+        float[,] testFeatureData = { { 99, 99 }, { 1, 1 } };
+        using var testFeatures = Mat.FromPixelData(2, 2, MatType.CV_32F, testFeatureData);
+
+        using var votes = new Mat();
+        model.GetVotes(testFeatures, votes, 0);
+
+        Assert.False(votes.Empty());
+        // Classification output is (nsamples + 1) rows (first row = class labels) x nclasses columns.
+        Assert.Equal(3, votes.Rows);
+        Assert.Equal(2, votes.Cols);
+    }
+
+    [Fact]
     public void SaveLoadTest()
     {
         float[,] trainFeaturesData =

--- a/test/OpenCvSharp.Tests/ml/SVMSGDTest.cs
+++ b/test/OpenCvSharp.Tests/ml/SVMSGDTest.cs
@@ -1,0 +1,73 @@
+using OpenCvSharp.ML;
+using Xunit;
+
+namespace OpenCvSharp.Tests.ML;
+
+// ReSharper disable once InconsistentNaming
+public class SVMSGDTest : TestBase
+{
+    [Fact]
+    public void RunTest()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {0, 100},
+            {100, 0},
+            {100, 100},
+        };
+        using var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+
+        // SVMSGD requires float (CV_32FC1) responses, unlike SVM/RTrees which accept CV_32S labels.
+        float[] trainLabelsData = [1, -1, 1, -1];
+        using var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32F, trainLabelsData);
+
+        using var model = SVMSGD.Create();
+        model.SetOptimalParameters();
+        model.Train(trainFeatures, SampleTypes.RowSample, trainLabels);
+
+        Assert.True(model.IsTrained());
+        Assert.False(model.GetWeights().Empty());
+    }
+
+    [Fact]
+    public void SaveLoadTest()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {0, 100},
+            {100, 0},
+            {100, 100},
+        };
+        using var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+
+        // SVMSGD requires float (CV_32FC1) responses, unlike SVM/RTrees which accept CV_32S labels.
+        float[] trainLabelsData = [1, -1, 1, -1];
+        using var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32F, trainLabelsData);
+
+        const string fileName = "svmsgd.yml";
+        if (File.Exists(fileName))
+            File.Delete(fileName);
+
+        using (var model = SVMSGD.Create())
+        {
+            model.SetOptimalParameters();
+            model.Train(trainFeatures, SampleTypes.RowSample, trainLabels);
+            model.Save(fileName);
+        }
+
+        Assert.True(File.Exists(fileName));
+
+        var content = File.ReadAllText(fileName);
+
+        using (var model2 = SVMSGD.Load(fileName))
+        {
+            GC.KeepAlive(model2);
+        }
+        using (var model2 = SVMSGD.LoadFromString(content))
+        {
+            GC.KeepAlive(model2);
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/ml/TrainDataTest.cs
+++ b/test/OpenCvSharp.Tests/ml/TrainDataTest.cs
@@ -1,0 +1,72 @@
+using OpenCvSharp.ML;
+using Xunit;
+
+namespace OpenCvSharp.Tests.ML;
+
+public class TrainDataTest : TestBase
+{
+    private static (Mat samples, Mat responses) MakeSampleSet()
+    {
+        float[,] trainFeaturesData =
+        {
+            {0, 0},
+            {0, 100},
+            {100, 0},
+            {100, 100},
+        };
+        var trainFeatures = Mat.FromPixelData(4, 2, MatType.CV_32F, trainFeaturesData);
+
+        int[] trainLabelsData = [+1, -1, +1, -1];
+        var trainLabels = Mat.FromPixelData(4, 1, MatType.CV_32S, trainLabelsData);
+
+        return (trainFeatures, trainLabels);
+    }
+
+    [Fact]
+    public void CreateAndBasicAccessors()
+    {
+        var (samples, responses) = MakeSampleSet();
+
+        using var data = TrainData.Create(samples, SampleTypes.RowSample, responses);
+
+        Assert.Equal(SampleTypes.RowSample, data.GetLayout());
+        Assert.Equal(4, data.GetNSamples());
+        Assert.Equal(2, data.GetNVars());
+        Assert.False(data.GetSamples().Empty());
+        Assert.False(data.GetResponses().Empty());
+        Assert.False(data.GetTrainSamples().Empty());
+    }
+
+    [Fact]
+    public void TrainTestSplit()
+    {
+        var (samples, responses) = MakeSampleSet();
+
+        using var data = TrainData.Create(samples, SampleTypes.RowSample, responses);
+        data.SetTrainTestSplit(2, shuffle: false);
+
+        Assert.Equal(2, data.GetNTrainSamples());
+        Assert.Equal(2, data.GetNTestSamples());
+        Assert.False(data.GetTestSamples().Empty());
+    }
+
+    [Fact]
+    public void TrainViaStatModel()
+    {
+        var (samples, responses) = MakeSampleSet();
+
+        using var data = TrainData.Create(samples, SampleTypes.RowSample, responses);
+        using var model = SVM.Create();
+        model.Type = SVM.Types.CSvc;
+        model.KernelType = SVM.KernelTypes.Linear;
+        model.TermCriteria = new TermCriteria(CriteriaTypes.MaxIter, 100, 1e-6);
+
+        var trained = model.Train(data);
+        Assert.True(trained);
+        Assert.True(model.IsTrained());
+
+        using var resp = new Mat();
+        var error = model.CalcError(data, test: false, resp);
+        Assert.False(double.IsNaN(error));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2010 (dnn/ml gaps from the OpenCV 5.x API coverage sweep, itself part of the broader #2019 audit).

- `ml::TrainData` is implemented (`Create`, `LoadFromCSV`, and the commonly-needed accessors), which unblocks `StatModel.Train(TrainData,...)` / `CalcError(TrainData,...)` and `SVM.TrainAuto(TrainData,...)` - all three were previously stubbed with `NotImplementedException`.
- `ml::SVMSGD` is added as a new StatModel-derived classifier, following the `SVM` wrapper pattern.
- `ml::RTrees.GetVotes` is added.
- `dnn::Layer` is added as a new Algorithm-derived wrapper (`Blobs`, `Name`, `Type`, `PreferableTarget`, `OutputNameToIndex`), plus `Net.GetLayer(int)` / `GetLayer(string)` to retrieve it from a `Net`.
- `dnn::Net.ForwardAndRetrieve` is added (retrieves all outputs for each named layer, as opposed to the existing `Forward` overloads which retrieve a single Mat per layer).
- `dnn::TextRecognitionModel.Recognize` gets a batch-ROI overload.
- `dnn::Image2BlobParams.BlobRectToImageRect` / `BlobRectsToImageRects` are added.

### Deliberately left unwrapped (see issue discussion)

- `Net.AddLayer` / `AddLayerToPrev`, and the underlying `Dict` / `DictValue` / `LayerParams` - `Dict` isn't even `CV_EXPORTS_W` upstream (no Python binding either), and programmatic graph-building is off the beaten path for a .NET consumer that mainly loads pretrained nets.
- `Net.ForwardAsync` + `AsyncArray` - the issue itself flags this as relevant only to OpenVINO/Inference Engine backends the official runtime doesn't ship.
- `ml::randMVNormal` / `ml::createConcentricSpheresTestSet` - upstream demo/tutorial-only synthetic-data generators; not worth standing up a new `Cv2.Ml` facade for.

## Test plan

- [x] `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release`
- [x] Native `OpenCvSharpExtern` rebuilt via MSBuild (Release/x64)
- [x] Added/extended unit tests: `TrainDataTest`, `SVMSGDTest`, `RTreesTest.GetVotes`, `NetIntrospectionTest.GetLayerByIdAndName` / `ForwardAndRetrieveReturnsOutputsPerLayer`, `TextModelTest` batch-ROI smoke test, `Image2BlobParamsTest`
- [x] Full `dotnet test` run: 1348 passed, 26 skipped (pre-existing network-download-dependent tests), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DNN `Layer` wrapper with metadata access and output-name index lookup, plus `Net` layer retrieval and multi-output `ForwardAndRetrieve`.
  - Added `Image2BlobParams` helpers to convert blob-space rectangles to image-space coordinates (single and batch).
  - Added batch ROI text recognition for `TextRecognitionModel`.
  - Implemented ML: `TrainData` creation/CSV loading and dataset operations; `StatModel` training/error; `SVM.TrainAuto`; new `SVMSGD` classifier; `RTrees.GetVotes`.
- **Tests**
  - Added/expanded coverage for DNN introspection, rectangle conversions, batch text recognition, and ML workflows (RTrees, SVM, SVMSGD, TrainData).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
