### PR TITLE
features/xfeatures2d: close all API coverage gaps from issue #2011

### DIFF
--- a/src/OpenCvSharp/Cv2/Cv2_features.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_features.cs
@@ -67,6 +67,67 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// GMS (Grid-based Motion Statistics) feature matching strategy.
+    /// </summary>
+    /// <param name="size1">Input size of image1.</param>
+    /// <param name="size2">Input size of image2.</param>
+    /// <param name="keypoints1">Input keypoints of image1.</param>
+    /// <param name="keypoints2">Input keypoints of image2.</param>
+    /// <param name="matches1To2">Input 1-nearest neighbor matches.</param>
+    /// <param name="withRotation">Take rotation transformation into account.</param>
+    /// <param name="withScale">Take scale transformation into account.</param>
+    /// <param name="thresholdFactor">The higher, the less matches.</param>
+    /// <returns>Matches returned by the GMS matching strategy.</returns>
+    public static DMatch[] MatchGMS(
+        Size size1, Size size2,
+        IEnumerable<KeyPoint> keypoints1, IEnumerable<KeyPoint> keypoints2,
+        IEnumerable<DMatch> matches1To2,
+        bool withRotation = false, bool withScale = false, double thresholdFactor = 6.0)
+    {
+        ArgumentNullException.ThrowIfNull(keypoints1);
+        ArgumentNullException.ThrowIfNull(keypoints2);
+        ArgumentNullException.ThrowIfNull(matches1To2);
+
+        using var keypoints1Vec = new StdVector<KeyPoint>(keypoints1);
+        using var keypoints2Vec = new StdVector<KeyPoint>(keypoints2);
+        using var matches1To2Vec = new StdVector<DMatch>(matches1To2);
+        using var matchesGMSVec = new StdVector<DMatch>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_matchGMS(
+                size1, size2, keypoints1Vec.CvPtr, keypoints2Vec.CvPtr, matches1To2Vec.CvPtr, matchesGMSVec.CvPtr,
+                withRotation ? 1 : 0, withScale ? 1 : 0, thresholdFactor));
+        return matchesGMSVec.ToArray();
+    }
+
+    /// <summary>
+    /// LOGOS (Local geometric support for high-outlier spatial verification) feature matching strategy.
+    /// </summary>
+    /// <param name="keypoints1">Input keypoints of image1.</param>
+    /// <param name="keypoints2">Input keypoints of image2.</param>
+    /// <param name="nn1">Index to the closest BoW centroid for each descriptors of image1.</param>
+    /// <param name="nn2">Index to the closest BoW centroid for each descriptors of image2.</param>
+    /// <returns>Matches returned by the LOGOS matching strategy.</returns>
+    public static DMatch[] MatchLOGOS(
+        IEnumerable<KeyPoint> keypoints1, IEnumerable<KeyPoint> keypoints2,
+        IEnumerable<int> nn1, IEnumerable<int> nn2)
+    {
+        ArgumentNullException.ThrowIfNull(keypoints1);
+        ArgumentNullException.ThrowIfNull(keypoints2);
+        ArgumentNullException.ThrowIfNull(nn1);
+        ArgumentNullException.ThrowIfNull(nn2);
+
+        using var keypoints1Vec = new StdVector<KeyPoint>(keypoints1);
+        using var keypoints2Vec = new StdVector<KeyPoint>(keypoints2);
+        using var nn1Vec = new StdVector<int>(nn1);
+        using var nn2Vec = new StdVector<int>(nn2);
+        using var matches1To2Vec = new StdVector<DMatch>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_matchLOGOS(
+                keypoints1Vec.CvPtr, keypoints2Vec.CvPtr, nn1Vec.CvPtr, nn2Vec.CvPtr, matches1To2Vec.CvPtr));
+        return matches1To2Vec.ToArray();
+    }
+
+    /// <summary>
     /// Draw keypoints.
     /// </summary>
     /// <param name="image">Source image.</param>

--- a/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
+++ b/src/OpenCvSharp/Cv2/Cv2_imgproc.cs
@@ -611,6 +611,67 @@ static partial class Cv2
     }
 
     /// <summary>
+    /// finds the strong enough corners where the cornerMinEigenVal() or cornerHarris() report the local maxima
+    /// </summary>
+    /// <param name="src">Input 8-bit or floating-point 32-bit, single-channel image.</param>
+    /// <param name="maxCorners">Maximum number of corners to return. If there are more corners than are found,
+    /// the strongest of them is returned.</param>
+    /// <param name="qualityLevel">Parameter characterizing the minimal accepted quality of image corners.</param>
+    /// <param name="minDistance">Minimum possible Euclidean distance between the returned corners.</param>
+    /// <param name="mask">Optional region of interest. If the image is not empty
+    ///  (it needs to have the type CV_8UC1 and the same size as image ), it specifies the region
+    /// in which the corners are detected.</param>
+    /// <param name="blockSize">Size of an average block for computing a derivative covariation matrix over each pixel neighborhood.</param>
+    /// <param name="gradientSize">Aperture parameter for the Sobel operator used for derivatives computation.</param>
+    /// <param name="useHarrisDetector">Parameter indicating whether to use a Harris detector</param>
+    /// <param name="k">Free parameter of the Harris detector.</param>
+    /// <returns>Output vector of detected corners.</returns>
+    public static Point2f[] GoodFeaturesToTrack(InputArray src,
+        int maxCorners, double qualityLevel, double minDistance,
+        InputArray mask, int blockSize, int gradientSize, bool useHarrisDetector, double k)
+    {
+        using var vector = new StdVector<Point2f>();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_goodFeaturesToTrack_gradientSize(src.Proxy, vector.CvPtr, maxCorners, qualityLevel,
+                minDistance, mask.Proxy, blockSize, gradientSize, useHarrisDetector ? 1 : 0, k));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(mask.Source);
+        return vector.ToArray();
+    }
+
+    /// <summary>
+    /// Same as GoodFeaturesToTrack, but returns also quality measure of the detected corners.
+    /// </summary>
+    /// <param name="src">Input 8-bit or floating-point 32-bit, single-channel image.</param>
+    /// <param name="maxCorners">Maximum number of corners to return. If there are more corners than are found,
+    /// the strongest of them is returned.</param>
+    /// <param name="qualityLevel">Parameter characterizing the minimal accepted quality of image corners.</param>
+    /// <param name="minDistance">Minimum possible Euclidean distance between the returned corners.</param>
+    /// <param name="mask">Region of interest. If the image is not empty
+    ///  (it needs to have the type CV_8UC1 and the same size as image ), it specifies the region
+    /// in which the corners are detected.</param>
+    /// <param name="cornersQuality">Output vector of quality measure of the detected corners.</param>
+    /// <param name="blockSize">Size of an average block for computing a derivative covariation matrix over each pixel neighborhood.</param>
+    /// <param name="gradientSize">Aperture parameter for the Sobel operator used for derivatives computation.</param>
+    /// <param name="useHarrisDetector">Parameter indicating whether to use a Harris detector</param>
+    /// <param name="k">Free parameter of the Harris detector.</param>
+    /// <returns>Output vector of detected corners.</returns>
+    public static Point2f[] GoodFeaturesToTrackWithQuality(InputArray src,
+        int maxCorners, double qualityLevel, double minDistance,
+        InputArray mask, OutputArray cornersQuality, int blockSize = 3, int gradientSize = 3,
+        bool useHarrisDetector = false, double k = 0.04)
+    {
+        using var vector = new StdVector<Point2f>();
+        NativeMethods.HandleException(
+            NativeMethods.imgproc_goodFeaturesToTrackWithQuality(src.Proxy, vector.CvPtr, maxCorners, qualityLevel,
+                minDistance, mask.Proxy, cornersQuality.Proxy, blockSize, gradientSize, useHarrisDetector ? 1 : 0, k));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(mask.Source);
+        GC.KeepAlive(cornersQuality.Source);
+        return vector.ToArray();
+    }
+
+    /// <summary>
     /// Finds lines in a binary image using standard Hough transform.
     /// </summary>
     /// <param name="image">The 8-bit, single-channel, binary source image. The image may be modified by the function</param>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
@@ -272,6 +272,18 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void vector_DMatch_delete(IntPtr vector);
     #endregion
+    #region interop::EllipticKeyPoint
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_EllipticKeyPoint_new1();
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_EllipticKeyPoint_new3([In] XFeatures2D.EllipticKeyPoint[] data, nuint dataLength);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial nuint vector_EllipticKeyPoint_getSize(OpenCvSafeHandle vector);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial IntPtr vector_EllipticKeyPoint_getPointer(OpenCvSafeHandle vector);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void vector_EllipticKeyPoint_delete(IntPtr vector);
+    #endregion
     #region cv::Mat
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial IntPtr vector_Mat_new1();

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
@@ -13,7 +13,7 @@ static partial class NativeMethods
     // BriefDescriptorExtractor
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_create(int bytes, out IntPtr returnValue);
+    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_create(int bytes, int useOrientation, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_BriefDescriptorExtractor_delete(IntPtr obj);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d.cs
@@ -33,6 +33,16 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_BriefDescriptorExtractor_get(IntPtr ptr, out IntPtr returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_setDescriptorSize(OpenCvSafeHandle obj, int bytes);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_getDescriptorSize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_setUseOrientation(OpenCvSafeHandle obj, int useOrientation);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BriefDescriptorExtractor_getUseOrientation(OpenCvSafeHandle obj, out int returnValue);
+
 
     // FREAK
 
@@ -47,17 +57,62 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_FREAK_get(IntPtr ptr, out IntPtr returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_setOrientationNormalized(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_getOrientationNormalized(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_setScaleNormalized(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_getScaleNormalized(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_setPatternScale(OpenCvSafeHandle obj, double val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_getPatternScale(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_setNOctaves(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_FREAK_getNOctaves(OpenCvSafeHandle obj, out int returnValue);
+
     // StarDetector
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_StarDetector_create(
         int maxSize, int responseThreshold,
-        int lineThresholdProjected, int lineThresholdBinarized, int suppressNonmaxSize, 
+        int lineThresholdProjected, int lineThresholdBinarized, int suppressNonmaxSize,
         out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_StarDetector_delete(IntPtr ptr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_StarDetector_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_setMaxSize(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_getMaxSize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_setResponseThreshold(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_getResponseThreshold(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_setLineThresholdProjected(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_getLineThresholdProjected(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_setLineThresholdBinarized(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_getLineThresholdBinarized(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_setSuppressNonmaxSize(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_StarDetector_getSuppressNonmaxSize(OpenCvSafeHandle obj, out int returnValue);
 
 
     // LUCID
@@ -71,6 +126,16 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_LUCID_get(IntPtr ptr, out IntPtr returnValue);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LUCID_setLucidKernel(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LUCID_getLucidKernel(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LUCID_setBlurKernel(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LUCID_getBlurKernel(OpenCvSafeHandle obj, out int returnValue);
+
 
     // LATCH
 
@@ -83,6 +148,26 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus xfeatures2d_Ptr_LATCH_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_setBytes(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_getBytes(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_setRotationInvariance(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_getRotationInvariance(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_setHalfSSDsize(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_getHalfSSDsize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_setSigma(OpenCvSafeHandle obj, double val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_LATCH_getSigma(OpenCvSafeHandle obj, out double returnValue);
 
 
     // SURF

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_AffineFeature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_AffineFeature2D.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_AffineFeature2D_create1(
+        IntPtr keypointDetector, IntPtr descriptorExtractor, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_AffineFeature2D_create2(
+        IntPtr keypointDetector, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_AffineFeature2D_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_AffineFeature2D_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_AffineFeature2D_detect(
+        OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr keypoints, in InputArrayProxy mask);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_AffineFeature2D_detectAndCompute(
+        OpenCvSafeHandle obj, in InputArrayProxy image, in InputArrayProxy mask,
+        IntPtr keypoints, in OutputArrayProxy descriptors, int useProvidedKeypoints);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_BEBLID.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_BEBLID.cs
@@ -1,0 +1,39 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // BEBLID
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BEBLID_create(float scaleFactor, int nBits, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_BEBLID_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_BEBLID_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BEBLID_setScaleFactor(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BEBLID_getScaleFactor(OpenCvSafeHandle obj, out float returnValue);
+
+    // TEBLID
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TEBLID_create(float scaleFactor, int nBits, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_TEBLID_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_TEBLID_get(IntPtr ptr, out IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_DAISY.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_DAISY.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_DAISY_create(
+        float radius, int qRadius, int qTheta, int qHist, int norm, in InputArrayProxy h,
+        int interpolation, int useOrientation, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_DAISY_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_DAISY_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setRadius(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getRadius(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setQRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getQRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setQTheta(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getQTheta(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setQHist(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getQHist(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setNorm(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getNorm(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_DAISY_setH(OpenCvSafeHandle obj, in InputArrayProxy h);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getH(OpenCvSafeHandle obj, IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setInterpolation(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getInterpolation(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_setUseOrientation(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_getUseOrientation(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_DAISY_compute_roi(
+        OpenCvSafeHandle obj, in InputArrayProxy image, Rect roi, in OutputArrayProxy descriptors);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_DAISY_compute_dense(
+        OpenCvSafeHandle obj, in InputArrayProxy image, in OutputArrayProxy descriptors);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_GetDescriptor1(
+        OpenCvSafeHandle obj, double y, double x, int orientation, [Out] float[] descriptor);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_GetDescriptor2(
+        OpenCvSafeHandle obj, double y, double x, int orientation, [Out] float[] descriptor, double[] h, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_GetUnnormalizedDescriptor1(
+        OpenCvSafeHandle obj, double y, double x, int orientation, [Out] float[] descriptor);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_DAISY_GetUnnormalizedDescriptor2(
+        OpenCvSafeHandle obj, double y, double x, int orientation, [Out] float[] descriptor, double[] h, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_DAISY.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_DAISY.cs
@@ -62,6 +62,9 @@ static partial class NativeMethods
     public static partial ExceptionStatus xfeatures2d_DAISY_getUseOrientation(OpenCvSafeHandle obj, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_DAISY_getImageSize(in InputArrayProxy image, out Size returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus xfeatures2d_DAISY_compute_roi(
         OpenCvSafeHandle obj, in InputArrayProxy image, Rect roi, in OutputArrayProxy descriptors);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_HarrisLaplace.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_HarrisLaplace.cs
@@ -1,0 +1,81 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // HarrisLaplaceFeatureDetector
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_create(
+        int numOctaves, float cornThresh, float dogThresh, int maxCorners, int numLayers, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_setNumOctaves(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_getNumOctaves(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_setCornThresh(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_getCornThresh(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_setDOGThresh(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_getDOGThresh(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_setMaxCorners(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_getMaxCorners(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_setNumLayers(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_HarrisLaplaceFeatureDetector_getNumLayers(OpenCvSafeHandle obj, out int returnValue);
+
+    // TBMR
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_create(
+        int minArea, float maxAreaRelative, float scaleFactor, int nScales, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_TBMR_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_TBMR_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_setMinArea(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_getMinArea(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_setMaxAreaRelative(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_getMaxAreaRelative(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_setScaleFactor(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_getScaleFactor(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_setNScales(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_TBMR_getNScales(OpenCvSafeHandle obj, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_MSDDetector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_MSDDetector.cs
@@ -1,0 +1,68 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_create(
+        int patchRadius, int searchAreaRadius, int nmsRadius, int nmsScaleRadius, float thSaliency,
+        int kNN, float scaleFactor, int nScales, int computeOrientation, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_MSDDetector_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_MSDDetector_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setPatchRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getPatchRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setSearchAreaRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getSearchAreaRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setNmsRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getNmsRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setNmsScaleRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getNmsScaleRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setThSaliency(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getThSaliency(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setKNN(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getKNN(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setScaleFactor(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getScaleFactor(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setNScales(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getNScales(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_setComputeOrientation(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_MSDDetector_getComputeOrientation(OpenCvSafeHandle obj, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_Match.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_Match.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_matchGMS(
+        Size size1, Size size2, IntPtr keypoints1, IntPtr keypoints2,
+        IntPtr matches1to2, IntPtr matchesGMS,
+        int withRotation, int withScale, double thresholdFactor);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_matchLOGOS(
+        IntPtr keypoints1, IntPtr keypoints2, IntPtr nn1, IntPtr nn2, IntPtr matches1to2);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_PCTSignatures.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_PCTSignatures.cs
@@ -1,0 +1,175 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // PCTSignatures
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_create1(
+        int initSampleCount, int initSeedCount, int pointDistribution, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_create2(
+        Point2f[] initSamplingPoints, int initSamplingPointsLength, int initSeedCount, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_create3(
+        Point2f[] initSamplingPoints, int initSamplingPointsLength,
+        int[] initClusterSeedIndexes, int initClusterSeedIndexesLength, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_PCTSignatures_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_PCTSignatures_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_PCTSignatures_computeSignature(
+        OpenCvSafeHandle obj, in InputArrayProxy image, in OutputArrayProxy signature);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_computeSignatures(
+        OpenCvSafeHandle obj, IntPtr[] images, int imagesLength, IntPtr signatures);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_PCTSignatures_drawSignature(
+        in InputArrayProxy source, in InputArrayProxy signature, in OutputArrayProxy result,
+        float radiusToShorterSideRatio, int borderThickness);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_generateInitPoints(
+        IntPtr initPoints, int count, int pointDistribution);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getSampleCount(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setGrayscaleBits(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getGrayscaleBits(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWindowRadius(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWindowRadius(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightX(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightX(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightY(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightY(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightL(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightL(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightA(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightA(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightB(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightB(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightContrast(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightContrast(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeightEntropy(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getWeightEntropy(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getSamplingPoints(OpenCvSafeHandle obj, IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeight(OpenCvSafeHandle obj, int idx, float value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setWeights(OpenCvSafeHandle obj, float[] weights, int weightsLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setTranslation(OpenCvSafeHandle obj, int idx, float value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setTranslations(OpenCvSafeHandle obj, float[] translations, int translationsLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setSamplingPoints(OpenCvSafeHandle obj, Point2f[] samplingPoints, int samplingPointsLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getInitSeedIndexes(OpenCvSafeHandle obj, IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setInitSeedIndexes(OpenCvSafeHandle obj, int[] initSeedIndexes, int initSeedIndexesLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getInitSeedCount(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setIterationCount(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getIterationCount(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setMaxClustersCount(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getMaxClustersCount(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setClusterMinSize(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getClusterMinSize(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setJoiningDistance(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getJoiningDistance(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setDropThreshold(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getDropThreshold(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_setDistanceFunction(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignatures_getDistanceFunction(OpenCvSafeHandle obj, out int returnValue);
+
+    // PCTSignaturesSQFD
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignaturesSQFD_create(
+        int distanceFunction, int similarityFunction, float similarityParameter, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_PCTSignaturesSQFD_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_PCTSignaturesSQFD_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistance(
+        OpenCvSafeHandle obj, in InputArrayProxy signature0, in InputArrayProxy signature1, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistances(
+        OpenCvSafeHandle obj, IntPtr sourceSignature, IntPtr[] imageSignatures, int imageSignaturesLength, IntPtr distances);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_VGG.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_xfeatures2d_VGG.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // VGG
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_create(
+        int desc, float isigma, int imgNormalize, int useScaleOrientation, float scaleFactor, int dscNormalize,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_VGG_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_VGG_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_setSigma(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_getSigma(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_setUseNormalizeImage(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_getUseNormalizeImage(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_setUseScaleOrientation(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_getUseScaleOrientation(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_setScaleFactor(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_getScaleFactor(OpenCvSafeHandle obj, out float returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_setUseNormalizeDescriptor(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_VGG_getUseNormalizeDescriptor(OpenCvSafeHandle obj, out int returnValue);
+
+    // BoostDesc
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BoostDesc_create(
+        int desc, int useScaleOrientation, float scaleFactor, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_BoostDesc_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_Ptr_BoostDesc_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BoostDesc_setUseScaleOrientation(OpenCvSafeHandle obj, int val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BoostDesc_getUseScaleOrientation(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BoostDesc_setScaleFactor(OpenCvSafeHandle obj, float val);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus xfeatures2d_BoostDesc_getScaleFactor(OpenCvSafeHandle obj, out float returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
@@ -62,13 +62,13 @@ static partial class NativeMethods
         IntPtr keypoints, float minSize, float maxSize);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_KeyPointsFilter_runByPixelsMask(
-        IntPtr keypoints, IntPtr mask);
+    internal static partial ExceptionStatus features_KeyPointsFilter_runByPixelsMask(
+        IntPtr keypoints, in InputArrayProxy mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus features_KeyPointsFilter_runByPixelsMask2VectorPoint(
+    internal static partial ExceptionStatus features_KeyPointsFilter_runByPixelsMask2VectorPoint(
         IntPtr keypoints, IntPtr[] removeFrom, int removeFromSize1, int[] removeFromSize2,
-        IntPtr mask, IntPtr removeFromResult);
+        in InputArrayProxy mask, IntPtr removeFromResult);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_KeyPointsFilter_removeDuplicated(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features.cs
@@ -66,6 +66,11 @@ static partial class NativeMethods
         IntPtr keypoints, IntPtr mask);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus features_KeyPointsFilter_runByPixelsMask2VectorPoint(
+        IntPtr keypoints, IntPtr[] removeFrom, int removeFromSize1, int[] removeFromSize2,
+        IntPtr mask, IntPtr removeFromResult);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_KeyPointsFilter_removeDuplicated(
         IntPtr keypoints);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_DescriptorMatcher.cs
@@ -66,6 +66,10 @@ static partial class NativeMethods
         [MarshalAs(UnmanagedType.LPStr)] string descriptorMatcherType, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus features_DescriptorMatcher_create_MatcherType(
+        int matcherType, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_DescriptorMatcher_get(IntPtr ptr, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/features/NativeMethods_features_Feature2D.cs
@@ -242,6 +242,10 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus features_Ptr_SimpleBlobDetector_delete(IntPtr ptr);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus features_SimpleBlobDetector_getBlobContours(
+        OpenCvSafeHandle obj, IntPtr returnValue);
+
     #endregion
 
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -113,6 +113,16 @@ static partial class NativeMethods
         double k);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus imgproc_goodFeaturesToTrack_gradientSize(in InputArrayProxy src, IntPtr corners,
+        int maxCorners, double qualityLevel, double minDistance, in InputArrayProxy mask, int blockSize, int gradientSize,
+        int useHarrisDetector, double k);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus imgproc_goodFeaturesToTrackWithQuality(in InputArrayProxy src, IntPtr corners,
+        int maxCorners, double qualityLevel, double minDistance, in InputArrayProxy mask, in OutputArrayProxy cornersQuality,
+        int blockSize, int gradientSize, int useHarrisDetector, double k);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_HoughLines(in InputArrayProxy src, IntPtr lines,
         double rho, double theta, int threshold, double srn, double stn);
 

--- a/src/OpenCvSharp/Internal/Vectors/StdVector.cs
+++ b/src/OpenCvSharp/Internal/Vectors/StdVector.cs
@@ -136,6 +136,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
         if (typeof(T) == typeof(Vec4i)) return NativeMethods.vector_Vec4i_new1();
         if (typeof(T) == typeof(Vec6f)) return NativeMethods.vector_Vec6f_new1();
         if (typeof(T) == typeof(Vec6d)) return NativeMethods.vector_Vec6d_new1();
+        if (typeof(T) == typeof(XFeatures2D.EllipticKeyPoint)) return NativeMethods.vector_EllipticKeyPoint_new1();
         throw Unsupported();
     }
 
@@ -174,6 +175,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
         if (typeof(T) == typeof(DMatch)) return NativeMethods.vector_DMatch_new3((DMatch[])(object)data, length);
         if (typeof(T) == typeof(Vec4f)) return NativeMethods.vector_Vec4f_new3((Vec4f[])(object)data, length);
         if (typeof(T) == typeof(Vec4i)) return NativeMethods.vector_Vec4i_new3((Vec4i[])(object)data, length);
+        if (typeof(T) == typeof(XFeatures2D.EllipticKeyPoint)) return NativeMethods.vector_EllipticKeyPoint_new3((XFeatures2D.EllipticKeyPoint[])(object)data, length);
         throw new NotSupportedException($"std::vector<{typeof(T)}> cannot be constructed from data.");
     }
 
@@ -199,6 +201,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
         if (typeof(T) == typeof(Vec4i)) return NativeMethods.vector_Vec4i_getSize(ptr);
         if (typeof(T) == typeof(Vec6f)) return NativeMethods.vector_Vec6f_getSize(ptr);
         if (typeof(T) == typeof(Vec6d)) return NativeMethods.vector_Vec6d_getSize(ptr);
+        if (typeof(T) == typeof(XFeatures2D.EllipticKeyPoint)) return NativeMethods.vector_EllipticKeyPoint_getSize(ptr);
         throw Unsupported();
     }
 
@@ -224,6 +227,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
         if (typeof(T) == typeof(Vec4i)) return NativeMethods.vector_Vec4i_getPointer(ptr);
         if (typeof(T) == typeof(Vec6f)) return NativeMethods.vector_Vec6f_getPointer(ptr);
         if (typeof(T) == typeof(Vec6d)) return NativeMethods.vector_Vec6d_getPointer(ptr);
+        if (typeof(T) == typeof(XFeatures2D.EllipticKeyPoint)) return NativeMethods.vector_EllipticKeyPoint_getPointer(ptr);
         throw Unsupported();
     }
 
@@ -249,6 +253,7 @@ public class StdVector<T> : CvObject, IStdVector<T>
         if (typeof(T) == typeof(Vec4i)) { NativeMethods.vector_Vec4i_delete(ptr); return; }
         if (typeof(T) == typeof(Vec6f)) { NativeMethods.vector_Vec6f_delete(ptr); return; }
         if (typeof(T) == typeof(Vec6d)) { NativeMethods.vector_Vec6d_delete(ptr); return; }
+        if (typeof(T) == typeof(XFeatures2D.EllipticKeyPoint)) { NativeMethods.vector_EllipticKeyPoint_delete(ptr); return; }
         throw Unsupported();
     }
 }

--- a/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
@@ -34,7 +34,7 @@ public class DescriptorMatcher : Algorithm
         BruteForceHamming = 4,
 
         /// <summary>
-        /// BFMatcher with NormTypes.Hamming2
+        /// BFMatcher with NormTypes.Hamming
         /// </summary>
         BruteForceHammingLut = 5,
 

--- a/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
+++ b/src/OpenCvSharp/Modules/features/DescriptorMatcher.cs
@@ -8,9 +8,44 @@ namespace OpenCvSharp;
 /// </summary>
 public class DescriptorMatcher : Algorithm
 {
+    /// <summary>
+    /// Descriptor matcher type, mirroring cv::DescriptorMatcher::MatcherType.
+    /// </summary>
+    public enum MatcherType
+    {
+        /// <summary>
+        /// FlannBasedMatcher
+        /// </summary>
+        FlannBased = 1,
+
+        /// <summary>
+        /// BFMatcher with NormTypes.L2
+        /// </summary>
+        BruteForce = 2,
+
+        /// <summary>
+        /// BFMatcher with NormTypes.L1
+        /// </summary>
+        BruteForceL1 = 3,
+
+        /// <summary>
+        /// BFMatcher with NormTypes.Hamming
+        /// </summary>
+        BruteForceHamming = 4,
+
+        /// <summary>
+        /// BFMatcher with NormTypes.Hamming2
+        /// </summary>
+        BruteForceHammingLut = 5,
+
+        /// <summary>
+        /// BFMatcher with NormTypes.L2SQR
+        /// </summary>
+        BruteForceSL2 = 6
+    }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     protected DescriptorMatcher(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> release)
         : base(smartPtr, rawPtr, release) { }
@@ -60,6 +95,18 @@ public class DescriptorMatcher : Algorithm
             default:
                 throw new OpenCvSharpException($"Unknown matcher name '{descriptorMatcherType}'");
         }
+    }
+
+    /// <summary>
+    /// Creates a descriptor matcher of a given type with the default parameters (using default constructor).
+    /// </summary>
+    /// <param name="matcherType"></param>
+    /// <returns></returns>
+    public static DescriptorMatcher Create(MatcherType matcherType)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.features_DescriptorMatcher_create_MatcherType((int)matcherType, out var ptr));
+        return FromPtr(ptr);
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
+++ b/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
@@ -1,4 +1,5 @@
 using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
 using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp;
@@ -63,6 +64,32 @@ public static class KeyPointsFilter
             NativeMethods.features_KeyPointsFilter_runByPixelsMask(keypointsVec.CvPtr, mask.CvPtr));
         GC.KeepAlive(mask);
         return keypointsVec.ToArray();
+    }
+
+    /// <summary>
+    /// Remove objects from some image and a vector of points by mask for pixels of this image.
+    /// </summary>
+    /// <param name="keypoints"></param>
+    /// <param name="removeFrom"></param>
+    /// <param name="mask"></param>
+    /// <returns></returns>
+    public static (KeyPoint[] Keypoints, Point[][] RemoveFrom) RunByPixelsMask2VectorPoint(
+        IEnumerable<KeyPoint> keypoints, IEnumerable<IEnumerable<Point>> removeFrom, Mat mask)
+    {
+        ArgumentNullException.ThrowIfNull(keypoints);
+        ArgumentNullException.ThrowIfNull(removeFrom);
+        ArgumentNullException.ThrowIfNull(mask);
+        mask.ThrowIfDisposed();
+
+        using var keypointsVec = new StdVector<KeyPoint>(keypoints);
+        using var removeFromPtr = new ArrayAddress2<Point>(removeFrom);
+        using var removeFromResultVec = new VectorOfVectorPoint();
+        NativeMethods.HandleException(
+            NativeMethods.features_KeyPointsFilter_runByPixelsMask2VectorPoint(
+                keypointsVec.CvPtr, removeFromPtr.GetPointer(), removeFromPtr.GetDim1Length(), removeFromPtr.GetDim2Lengths(),
+                mask.CvPtr, removeFromResultVec.CvPtr));
+        GC.KeepAlive(mask);
+        return (keypointsVec.ToArray(), removeFromResultVec.ToArray());
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
+++ b/src/OpenCvSharp/Modules/features/KeyPointsFilter.cs
@@ -53,16 +53,14 @@ public static class KeyPointsFilter
     /// <param name="keypoints"></param>
     /// <param name="mask"></param>
     /// <returns></returns>
-    public static KeyPoint[] RunByPixelsMask(IEnumerable<KeyPoint> keypoints, Mat mask)
+    public static KeyPoint[] RunByPixelsMask(IEnumerable<KeyPoint> keypoints, InputArray mask)
     {
         ArgumentNullException.ThrowIfNull(keypoints);
-        ArgumentNullException.ThrowIfNull(mask);
-        mask.ThrowIfDisposed();
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         NativeMethods.HandleException(
-            NativeMethods.features_KeyPointsFilter_runByPixelsMask(keypointsVec.CvPtr, mask.CvPtr));
-        GC.KeepAlive(mask);
+            NativeMethods.features_KeyPointsFilter_runByPixelsMask(keypointsVec.CvPtr, mask.Proxy));
+        GC.KeepAlive(mask.Source);
         return keypointsVec.ToArray();
     }
 
@@ -74,12 +72,10 @@ public static class KeyPointsFilter
     /// <param name="mask"></param>
     /// <returns></returns>
     public static (KeyPoint[] Keypoints, Point[][] RemoveFrom) RunByPixelsMask2VectorPoint(
-        IEnumerable<KeyPoint> keypoints, IEnumerable<IEnumerable<Point>> removeFrom, Mat mask)
+        IEnumerable<KeyPoint> keypoints, IEnumerable<IEnumerable<Point>> removeFrom, InputArray mask)
     {
         ArgumentNullException.ThrowIfNull(keypoints);
         ArgumentNullException.ThrowIfNull(removeFrom);
-        ArgumentNullException.ThrowIfNull(mask);
-        mask.ThrowIfDisposed();
 
         using var keypointsVec = new StdVector<KeyPoint>(keypoints);
         using var removeFromPtr = new ArrayAddress2<Point>(removeFrom);
@@ -87,8 +83,8 @@ public static class KeyPointsFilter
         NativeMethods.HandleException(
             NativeMethods.features_KeyPointsFilter_runByPixelsMask2VectorPoint(
                 keypointsVec.CvPtr, removeFromPtr.GetPointer(), removeFromPtr.GetDim1Length(), removeFromPtr.GetDim2Lengths(),
-                mask.CvPtr, removeFromResultVec.CvPtr));
-        GC.KeepAlive(mask);
+                mask.Proxy, removeFromResultVec.CvPtr));
+        GC.KeepAlive(mask.Source);
         return (keypointsVec.ToArray(), removeFromResultVec.ToArray());
     }
 

--- a/src/OpenCvSharp/Modules/features/SimpleBlobDetector.cs
+++ b/src/OpenCvSharp/Modules/features/SimpleBlobDetector.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
 
 namespace OpenCvSharp;
 
@@ -43,7 +44,8 @@ public class SimpleBlobDetector : Feature2D
                 maxInertiaRatio = float.MaxValue,
                 filterByConvexity = 1,
                 minConvexity = 0.95f,
-                maxConvexity = float.MaxValue
+                maxConvexity = float.MaxValue,
+                collectContours = 0
             };
         }
 
@@ -161,6 +163,17 @@ public class SimpleBlobDetector : Feature2D
             get => Data.maxConvexity;
             set => Data.maxConvexity = value;
         }
+
+        /// <summary>
+        /// Flag to enable contour collection. If set to true, the detector will store the contours
+        /// of the detected blobs in memory, which can be retrieved after the Detect() call using
+        /// GetBlobContours(). Default value is false.
+        /// </summary>
+        public bool CollectContours
+        {
+            get => Data.collectContours != 0;
+            set => Data.collectContours = (value ? 1 : 0);
+        }
     }
 
 #pragma warning disable CA1051
@@ -188,6 +201,8 @@ public class SimpleBlobDetector : Feature2D
 
         public int filterByConvexity;
         public float minConvexity, maxConvexity;
+
+        public int collectContours;
 #pragma warning restore CA1051
 #pragma warning restore 1591
     }
@@ -212,5 +227,21 @@ public class SimpleBlobDetector : Feature2D
         NativeMethods.HandleException(
             NativeMethods.features_Ptr_Feature2D_get(smartPtr, out var rawPtr));
         return new SimpleBlobDetector(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Returns the contours of the blobs detected during the last call to Detect().
+    /// The <see cref="Params.CollectContours"/> parameter must be set to true before calling
+    /// Detect() for this method to return any data.
+    /// </summary>
+    /// <returns></returns>
+    public virtual Point[][] GetBlobContours()
+    {
+        ThrowIfDisposed();
+        using var contours = new VectorOfVectorPoint();
+        NativeMethods.HandleException(
+            NativeMethods.features_SimpleBlobDetector_getBlobContours(Handle, contours.CvPtr));
+        GC.KeepAlive(this);
+        return contours.ToArray();
     }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/AffineFeature2D.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/AffineFeature2D.cs
@@ -1,0 +1,112 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing affine adaptation for keypoints. A Feature2D detector and a Feature2D
+/// descriptor extractor are wrapped to augment the detected points with their affine invariant
+/// elliptic region, and to compute the feature descriptors on the regions after warping them into
+/// circles.
+/// </summary>
+public class AffineFeature2D : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private AffineFeature2D(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_AffineFeature2D_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates an instance wrapping the given keypoint detector and descriptor extractor.
+    /// </summary>
+    /// <param name="keypointDetector">The keypoint detector to wrap.</param>
+    /// <param name="descriptorExtractor">The descriptor extractor to wrap.</param>
+    public static AffineFeature2D Create(Feature2D keypointDetector, Feature2D descriptorExtractor)
+    {
+        ArgumentNullException.ThrowIfNull(keypointDetector);
+        ArgumentNullException.ThrowIfNull(descriptorExtractor);
+        keypointDetector.ThrowIfDisposed();
+        descriptorExtractor.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_AffineFeature2D_create1(keypointDetector.SmartPtr, descriptorExtractor.SmartPtr, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_AffineFeature2D_get(ptr, out var rawPtr));
+        GC.KeepAlive(keypointDetector);
+        GC.KeepAlive(descriptorExtractor);
+        return new AffineFeature2D(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates an instance where the keypoint detector and descriptor extractor are identical.
+    /// </summary>
+    /// <param name="keypointDetector">The keypoint detector/descriptor extractor to wrap.</param>
+    public static AffineFeature2D Create(Feature2D keypointDetector)
+    {
+        ArgumentNullException.ThrowIfNull(keypointDetector);
+        keypointDetector.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_AffineFeature2D_create2(keypointDetector.SmartPtr, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_AffineFeature2D_get(ptr, out var rawPtr));
+        GC.KeepAlive(keypointDetector);
+        return new AffineFeature2D(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Detects keypoints in the image using the wrapped detector and performs affine adaptation
+    /// to augment them with their elliptic regions.
+    /// </summary>
+    /// <param name="image">Image.</param>
+    /// <param name="mask">Mask specifying where to look for keypoints (optional).</param>
+    /// <returns>The detected elliptic keypoints.</returns>
+    public EllipticKeyPoint[] DetectElliptic(InputArray image, InputArray mask = default)
+    {
+        ThrowIfDisposed();
+
+        using var keypoints = new StdVector<EllipticKeyPoint>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_AffineFeature2D_detect(Handle, image.Proxy, keypoints.CvPtr, mask.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(mask.Source);
+        return keypoints.ToArray();
+    }
+
+    /// <summary>
+    /// Detects keypoints and computes descriptors for their surrounding regions, after warping
+    /// them into circles.
+    /// </summary>
+    /// <remarks>
+    /// OpenCV's native calcAffineCovariantDescriptors (opencv_contrib
+    /// xfeatures2d/src/affine_feature2d.cpp) has been observed to throw an assertion failure
+    /// when the wrapped descriptor extractor is ORB (a binary/CV_8U descriptor); SIFT-family
+    /// extractors work correctly.
+    /// </remarks>
+    /// <param name="image">Image.</param>
+    /// <param name="mask">Mask specifying where to look for keypoints (optional).</param>
+    /// <param name="descriptors">Computed descriptors.</param>
+    /// <param name="useProvidedKeypoints">If true, <paramref name="providedKeypoints"/> is used
+    /// as input instead of running detection.</param>
+    /// <param name="providedKeypoints">Keypoints to use when <paramref name="useProvidedKeypoints"/>
+    /// is true.</param>
+    /// <returns>The elliptic keypoints (either newly detected, or the augmented input keypoints
+    /// when <paramref name="useProvidedKeypoints"/> is true).</returns>
+    public EllipticKeyPoint[] DetectAndComputeElliptic(
+        InputArray image, InputArray mask, OutputArray descriptors,
+        bool useProvidedKeypoints = false, IEnumerable<EllipticKeyPoint>? providedKeypoints = null)
+    {
+        ThrowIfDisposed();
+
+        using var keypoints = useProvidedKeypoints
+            ? new StdVector<EllipticKeyPoint>(providedKeypoints ?? throw new ArgumentNullException(nameof(providedKeypoints)))
+            : new StdVector<EllipticKeyPoint>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_AffineFeature2D_detectAndCompute(
+                Handle, image.Proxy, mask.Proxy, keypoints.CvPtr, descriptors.Proxy, useProvidedKeypoints ? 1 : 0));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(mask.Source);
+        GC.KeepAlive(descriptors.Source);
+        return keypoints.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/AffineFeature2D.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/AffineFeature2D.cs
@@ -12,8 +12,14 @@ namespace OpenCvSharp.XFeatures2D;
 public class AffineFeature2D : Feature2D
 {
     /// <summary>
-    ///
+    /// Used by subclasses of the native cv::xfeatures2d::AffineFeature2D hierarchy (e.g. TBMR),
+    /// which need the elliptic detect/detectAndCompute methods below but are constructed through
+    /// their own native create()/delete() pair rather than AffineFeature2D::create().
     /// </summary>
+    protected AffineFeature2D(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> releaseSmartPtr)
+        : base(smartPtr, rawPtr, releaseSmartPtr)
+    { }
+
     private AffineFeature2D(IntPtr smartPtr, IntPtr rawPtr)
         : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_AffineFeature2D_delete(p)))
     { }

--- a/src/OpenCvSharp/Modules/xfeatures2d/BEBLID.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BEBLID.cs
@@ -1,0 +1,53 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing BEBLID (Boosted Efficient Binary Local Image Descriptor),
+/// a binary descriptor learned with boosting.
+/// </summary>
+public class BEBLID : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private BEBLID(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BEBLID_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the BEBLID descriptor.
+    /// </summary>
+    /// <param name="scaleFactor">Adjust the sampling window around detected keypoints:
+    /// 1.00f should be the scale for ORB keypoints, 6.75f for SIFT detected keypoints,
+    /// 6.25f (default) fits for KAZE/SURF detected keypoints,
+    /// 5.00f should be the scale for AKAZE, MSD, AGAST, FAST, BRISK keypoints.</param>
+    /// <param name="nBits">Determine the number of bits in the descriptor.</param>
+    public static BEBLID Create(float scaleFactor, BeblidSize nBits = BeblidSize.Size512Bits)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_BEBLID_create(scaleFactor, (int)nBits, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BEBLID_get(ptr, out var rawPtr));
+        return new BEBLID(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Adjust the sampling window around detected keypoints.
+    /// </summary>
+    public float ScaleFactor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BEBLID_getScaleFactor(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BEBLID_setScaleFactor(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/BoostDesc.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BoostDesc.cs
@@ -1,0 +1,68 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing BoostDesc (Learning Image Descriptors with Boosting).
+/// </summary>
+public class BoostDesc : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private BoostDesc(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BoostDesc_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the BoostDesc descriptor.
+    /// </summary>
+    /// <param name="desc">Type of descriptor to use.</param>
+    /// <param name="useScaleOrientation">Sample patterns using keypoints orientation.</param>
+    /// <param name="scaleFactor">Adjust the sampling window of detected keypoints.</param>
+    public static BoostDesc Create(
+        BoostDescType desc = BoostDescType.Binboost256,
+        bool useScaleOrientation = true, float scaleFactor = 6.25f)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_BoostDesc_create((int)desc, useScaleOrientation ? 1 : 0, scaleFactor, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BoostDesc_get(ptr, out var rawPtr));
+        return new BoostDesc(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Sample patterns using keypoints orientation.
+    /// </summary>
+    public bool UseScaleOrientation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_BoostDesc_getUseScaleOrientation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_BoostDesc_setUseScaleOrientation(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Adjust the sampling window of detected keypoints.
+    /// </summary>
+    public float ScaleFactor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_BoostDesc_getScaleFactor(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_BoostDesc_setScaleFactor(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/BriefDescriptorExtractor.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BriefDescriptorExtractor.cs
@@ -34,4 +34,44 @@ public class BriefDescriptorExtractor : DescriptorExtractor
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BriefDescriptorExtractor_get(ptr, out var rawPtr));
         return new BriefDescriptorExtractor(ptr, rawPtr);
     }
+
+    /// <summary>
+    /// Length of the descriptor in bytes. Valid values are: 16, 32 (default) or 64.
+    /// </summary>
+    public new int DescriptorSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BriefDescriptorExtractor_getDescriptorSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BriefDescriptorExtractor_setDescriptorSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Sample patterns using keypoints orientation. Disabled by default.
+    /// </summary>
+    public bool UseOrientation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BriefDescriptorExtractor_getUseOrientation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_BriefDescriptorExtractor_setUseOrientation(Handle, value ? 1 : 0));
+        }
+    }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/BriefDescriptorExtractor.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/BriefDescriptorExtractor.cs
@@ -27,10 +27,11 @@ public class BriefDescriptorExtractor : DescriptorExtractor
     /// bytes is a length of descriptor in bytes. It can be equal 16, 32 or 64 bytes.
     /// </summary>
     /// <param name="bytes"></param>
-    public static BriefDescriptorExtractor Create(int bytes = 32)
+    /// <param name="useOrientation">Sample patterns using keypoints orientation, disabled by default.</param>
+    public static BriefDescriptorExtractor Create(int bytes = 32, bool useOrientation = false)
     {
         NativeMethods.HandleException(
-            NativeMethods.xfeatures2d_BriefDescriptorExtractor_create(bytes, out var ptr));
+            NativeMethods.xfeatures2d_BriefDescriptorExtractor_create(bytes, useOrientation ? 1 : 0, out var ptr));
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_BriefDescriptorExtractor_get(ptr, out var rawPtr));
         return new BriefDescriptorExtractor(ptr, rawPtr);
     }

--- a/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
@@ -199,9 +199,11 @@ public class DAISY : Feature2D
     /// coordinates even though the buffer is only sized <c>roi.Width * roi.Height</c> rows,
     /// so it overflows unless <paramref name="roi"/> covers the entire image
     /// (<c>roi.X == 0 &amp;&amp; roi.Y == 0 &amp;&amp; roi.Width == image.Cols &amp;&amp; roi.Height == image.Rows</c>).
+    /// The native bridge guards against this and throws <see cref="OpenCVException"/> instead of
+    /// letting a partial ROI corrupt memory.
     /// </remarks>
     /// <param name="image">Image to extract descriptors from.</param>
-    /// <param name="roi">Region of interest within the image.</param>
+    /// <param name="roi">Region of interest within the image. Must cover the entire image (see remarks).</param>
     /// <param name="descriptors">Resulted descriptors array for the roi image pixels.</param>
     public void Compute(InputArray image, Rect roi, OutputArray descriptors)
     {

--- a/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
@@ -199,8 +199,8 @@ public class DAISY : Feature2D
     /// coordinates even though the buffer is only sized <c>roi.Width * roi.Height</c> rows,
     /// so it overflows unless <paramref name="roi"/> covers the entire image
     /// (<c>roi.X == 0 &amp;&amp; roi.Y == 0 &amp;&amp; roi.Width == image.Cols &amp;&amp; roi.Height == image.Rows</c>).
-    /// The native bridge guards against this and throws <see cref="OpenCVException"/> instead of
-    /// letting a partial ROI corrupt memory.
+    /// This is validated up front and throws <see cref="ArgumentException"/> instead of letting a
+    /// partial ROI corrupt memory.
     /// </remarks>
     /// <param name="image">Image to extract descriptors from.</param>
     /// <param name="roi">Region of interest within the image. Must cover the entire image (see remarks).</param>
@@ -208,6 +208,14 @@ public class DAISY : Feature2D
     public void Compute(InputArray image, Rect roi, OutputArray descriptors)
     {
         ThrowIfDisposed();
+
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getImageSize(image.Proxy, out var imageSize));
+        if (roi.X != 0 || roi.Y != 0 || roi.Width != imageSize.Width || roi.Height != imageSize.Height)
+        {
+            throw new ArgumentException(
+                "Due to an upstream OpenCV bug, roi must cover the entire image " +
+                "(X=0, Y=0, Width=image.Cols, Height=image.Rows).", nameof(roi));
+        }
 
         NativeMethods.HandleException(
             NativeMethods.xfeatures2d_DAISY_compute_roi(Handle, image.Proxy, roi, descriptors.Proxy));

--- a/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/DAISY.cs
@@ -1,0 +1,308 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Class implementing the DAISY descriptor.
+/// </summary>
+public class DAISY : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private DAISY(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_DAISY_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the DAISY descriptor.
+    /// </summary>
+    /// <param name="radius">Radius of the descriptor at the initial scale.</param>
+    /// <param name="qRadius">Amount of radial range division quantity.</param>
+    /// <param name="qTheta">Amount of angular range division quantity.</param>
+    /// <param name="qHist">Amount of gradient orientations range division quantity.</param>
+    /// <param name="norm">Descriptors normalization type.</param>
+    /// <param name="h">Optional 3x3 homography matrix used to warp the grid of daisy but sampling
+    /// keypoints remains unwarped on image.</param>
+    /// <param name="interpolation">Switch to disable interpolation for speed improvement at minor
+    /// quality loss.</param>
+    /// <param name="useOrientation">Sample patterns using keypoints orientation, disabled by default.</param>
+    public static DAISY Create(
+        float radius = 15, int qRadius = 3, int qTheta = 8, int qHist = 8,
+        DAISYNormalizationType norm = DAISYNormalizationType.None, InputArray h = default,
+        bool interpolation = true, bool useOrientation = false)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_create(
+                radius, qRadius, qTheta, qHist, (int)norm, h.Proxy,
+                interpolation ? 1 : 0, useOrientation ? 1 : 0, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_DAISY_get(ptr, out var rawPtr));
+        GC.KeepAlive(h.Source);
+        return new DAISY(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Radius of the descriptor at the initial scale.
+    /// </summary>
+    public float Radius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Amount of radial range division quantity.
+    /// </summary>
+    public int QRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getQRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setQRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Amount of angular range division quantity.
+    /// </summary>
+    public int QTheta
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getQTheta(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setQTheta(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Amount of gradient orientations range division quantity.
+    /// </summary>
+    public int QHist
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getQHist(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setQHist(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Descriptors normalization type.
+    /// </summary>
+    public DAISYNormalizationType Norm
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getNorm(Handle, out var ret));
+            return (DAISYNormalizationType)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setNorm(Handle, (int)value));
+        }
+    }
+
+    /// <summary>
+    /// Optional 3x3 homography matrix used to warp the grid of daisy but sampling keypoints
+    /// remains unwarped on image.
+    /// </summary>
+    public Mat H
+    {
+        get
+        {
+            ThrowIfDisposed();
+            var ret = new Mat();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getH(Handle, ret.CvPtr));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentNullException.ThrowIfNull(value);
+            InputArray h = value;
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setH(Handle, h.Proxy));
+            GC.KeepAlive(value);
+        }
+    }
+
+    /// <summary>
+    /// Switch to disable interpolation for speed improvement at minor quality loss.
+    /// </summary>
+    public bool Interpolation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getInterpolation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setInterpolation(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Sample patterns using keypoints orientation, disabled by default.
+    /// </summary>
+    public bool UseOrientation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_getUseOrientation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_DAISY_setUseOrientation(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Computes the descriptor for every pixel within the given region of interest.
+    /// </summary>
+    /// <remarks>
+    /// OpenCV's native implementation indexes the output buffer using absolute image
+    /// coordinates even though the buffer is only sized <c>roi.Width * roi.Height</c> rows,
+    /// so it overflows unless <paramref name="roi"/> covers the entire image
+    /// (<c>roi.X == 0 &amp;&amp; roi.Y == 0 &amp;&amp; roi.Width == image.Cols &amp;&amp; roi.Height == image.Rows</c>).
+    /// </remarks>
+    /// <param name="image">Image to extract descriptors from.</param>
+    /// <param name="roi">Region of interest within the image.</param>
+    /// <param name="descriptors">Resulted descriptors array for the roi image pixels.</param>
+    public void Compute(InputArray image, Rect roi, OutputArray descriptors)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_compute_roi(Handle, image.Proxy, roi, descriptors.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(descriptors.Source);
+    }
+
+    /// <summary>
+    /// Computes the descriptor for every pixel in the image.
+    /// </summary>
+    /// <param name="image">Image to extract descriptors from.</param>
+    /// <param name="descriptors">Resulted descriptors array for all image pixels.</param>
+    public void Compute(InputArray image, OutputArray descriptors)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_compute_dense(Handle, image.Proxy, descriptors.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(descriptors.Source);
+    }
+
+    /// <summary>
+    /// Retrieves the descriptor at the given position and orientation.
+    /// </summary>
+    /// <param name="y">Position y on image.</param>
+    /// <param name="x">Position x on image.</param>
+    /// <param name="orientation">Orientation on image (0-360).</param>
+    /// <returns>The computed descriptor.</returns>
+    public float[] GetDescriptor(double y, double x, int orientation)
+    {
+        ThrowIfDisposed();
+        var descriptor = new float[DescriptorSize];
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_GetDescriptor1(Handle, y, x, orientation, descriptor));
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Retrieves the descriptor at the given position and orientation, using a homography matrix
+    /// for the warped grid.
+    /// </summary>
+    /// <param name="y">Position y on image.</param>
+    /// <param name="x">Position x on image.</param>
+    /// <param name="orientation">Orientation on image (0-360).</param>
+    /// <param name="h">Homography matrix for warped grid (row-major, 9 elements).</param>
+    /// <param name="descriptor">The computed descriptor.</param>
+    /// <returns>false if the descriptor could not be computed (e.g. it falls outside the image), true otherwise.</returns>
+    public bool GetDescriptor(double y, double x, int orientation, double[] h, out float[] descriptor)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(h);
+        if (h.Length != 9)
+            throw new ArgumentException("h must have 9 elements (a 3x3 homography matrix).", nameof(h));
+
+        descriptor = new float[DescriptorSize];
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_GetDescriptor2(Handle, y, x, orientation, descriptor, h, out var ret));
+        return ret != 0;
+    }
+
+    /// <summary>
+    /// Retrieves the unnormalized descriptor at the given position and orientation.
+    /// </summary>
+    /// <param name="y">Position y on image.</param>
+    /// <param name="x">Position x on image.</param>
+    /// <param name="orientation">Orientation on image (0-360).</param>
+    /// <returns>The computed descriptor.</returns>
+    public float[] GetUnnormalizedDescriptor(double y, double x, int orientation)
+    {
+        ThrowIfDisposed();
+        var descriptor = new float[DescriptorSize];
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_GetUnnormalizedDescriptor1(Handle, y, x, orientation, descriptor));
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Retrieves the unnormalized descriptor at the given position and orientation, using a
+    /// homography matrix for the warped grid.
+    /// </summary>
+    /// <param name="y">Position y on image.</param>
+    /// <param name="x">Position x on image.</param>
+    /// <param name="orientation">Orientation on image (0-360).</param>
+    /// <param name="h">Homography matrix for warped grid (row-major, 9 elements).</param>
+    /// <param name="descriptor">The computed descriptor.</param>
+    /// <returns>false if the descriptor could not be computed (e.g. it falls outside the image), true otherwise.</returns>
+    public bool GetUnnormalizedDescriptor(double y, double x, int orientation, double[] h, out float[] descriptor)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(h);
+        if (h.Length != 9)
+            throw new ArgumentException("h must have 9 elements (a 3x3 homography matrix).", nameof(h));
+
+        descriptor = new float[DescriptorSize];
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_DAISY_GetUnnormalizedDescriptor2(Handle, y, x, orientation, descriptor, h, out var ret));
+        return ret != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/EllipticKeyPoint.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/EllipticKeyPoint.cs
@@ -1,0 +1,64 @@
+using System.Runtime.InteropServices;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Elliptic region around an interest point, as produced by AffineFeature2D. Mirrors
+/// cv::xfeatures2d::Elliptic_KeyPoint.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct EllipticKeyPoint
+{
+    /// <summary>
+    /// Coordinates of the keypoint.
+    /// </summary>
+    public Point2f Pt;
+
+    /// <summary>
+    /// Diameter of the meaningful keypoint neighborhood.
+    /// </summary>
+    public float Size;
+
+    /// <summary>
+    /// Computed orientation of the keypoint (-1 if not applicable). Its possible values are in a
+    /// range [0,360) degrees, measured relative to the image coordinate system (y-axis is
+    /// directed downward), i.e in clockwise direction.
+    /// </summary>
+    public float Angle;
+
+    /// <summary>
+    /// The response, by which the strongest keypoints have been selected. Can be used for the
+    /// further sorting or subsampling.
+    /// </summary>
+    public float Response;
+
+    /// <summary>
+    /// Octave (pyramid layer), from which the keypoint has been extracted.
+    /// </summary>
+    public int Octave;
+
+    /// <summary>
+    /// Object class (if the keypoints need to be clustered by an object they belong to).
+    /// </summary>
+    public int ClassId;
+
+    /// <summary>
+    /// The lengths of the major and minor ellipse axes.
+    /// </summary>
+    public Size2f Axes;
+
+    /// <summary>
+    /// The integration scale at which the parameters were estimated.
+    /// </summary>
+    public float Si;
+
+    /// <summary>
+    /// The transformation between image space and local patch space, row 0 (m00, m01, m02).
+    /// </summary>
+    public float Transf00, Transf01, Transf02;
+
+    /// <summary>
+    /// The transformation between image space and local patch space, row 1 (m10, m11, m12).
+    /// </summary>
+    public float Transf10, Transf11, Transf12;
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/BeblidSize.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/BeblidSize.cs
@@ -1,0 +1,17 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Descriptor number of bits, each bit is a boosting weak-learner. cv::xfeatures2d::BEBLID::BeblidSize
+/// </summary>
+public enum BeblidSize
+{
+    /// <summary>
+    /// 512 bits
+    /// </summary>
+    Size512Bits = 100,
+
+    /// <summary>
+    /// 256 bits
+    /// </summary>
+    Size256Bits = 101
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/BoostDescType.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/BoostDescType.cs
@@ -1,0 +1,42 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Descriptor type for cv::xfeatures2d::BoostDesc.
+/// </summary>
+public enum BoostDescType
+{
+    /// <summary>
+    /// Base descriptor where each binary dimension is computed as the output of a single weak learner
+    /// </summary>
+    Bgm = 100,
+
+    /// <summary>
+    /// BGM using ASSIGN_HARD gradient binning
+    /// </summary>
+    BgmHard = 101,
+
+    /// <summary>
+    /// BGM using ASSIGN_BILINEAR gradient binning
+    /// </summary>
+    BgmBilinear = 102,
+
+    /// <summary>
+    /// Floating point extension (alias FP-Boost)
+    /// </summary>
+    Lbgm = 200,
+
+    /// <summary>
+    /// 64-bit binary extension of LBGM
+    /// </summary>
+    Binboost64 = 300,
+
+    /// <summary>
+    /// 128-bit binary extension of LBGM
+    /// </summary>
+    Binboost128 = 301,
+
+    /// <summary>
+    /// 256-bit binary extension of LBGM
+    /// </summary>
+    Binboost256 = 302
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/DAISYNormalizationType.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/DAISYNormalizationType.cs
@@ -1,0 +1,30 @@
+// ReSharper disable InconsistentNaming
+#pragma warning disable CA1008 // Enums should have zero value
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Descriptor normalization type for cv::xfeatures2d::DAISY.
+/// </summary>
+public enum DAISYNormalizationType
+{
+    /// <summary>
+    /// No normalization is applied (default)
+    /// </summary>
+    None = 100,
+
+    /// <summary>
+    /// Histograms are normalized independently for L2 norm equal to 1.0
+    /// </summary>
+    Partial = 101,
+
+    /// <summary>
+    /// Descriptors are normalized for L2 norm equal to 1.0
+    /// </summary>
+    Full = 102,
+
+    /// <summary>
+    /// Descriptors are normalized for L2 norm equal to 1.0, but no individual value is bigger than 0.154 (as in SIFT)
+    /// </summary>
+    Sift = 103
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesDistanceFunction.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesDistanceFunction.cs
@@ -1,0 +1,37 @@
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Lp distance function selector for cv::xfeatures2d::PCTSignatures.
+/// </summary>
+public enum PCTSignaturesDistanceFunction
+{
+    /// <summary>
+    /// </summary>
+    L0_25,
+
+    /// <summary>
+    /// </summary>
+    L0_5,
+
+    /// <summary>
+    /// </summary>
+    L1,
+
+    /// <summary>
+    /// </summary>
+    L2,
+
+    /// <summary>
+    /// </summary>
+    L2Squared,
+
+    /// <summary>
+    /// </summary>
+    L5,
+
+    /// <summary>
+    /// </summary>
+    LInfinity
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesPointDistribution.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesPointDistribution.cs
@@ -1,0 +1,22 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Point distributions supported by the random point generator of cv::xfeatures2d::PCTSignatures.
+/// </summary>
+public enum PCTSignaturesPointDistribution
+{
+    /// <summary>
+    /// Generate numbers uniformly.
+    /// </summary>
+    Uniform,
+
+    /// <summary>
+    /// Generate points in a regular grid.
+    /// </summary>
+    Regular,
+
+    /// <summary>
+    /// Generate points with normal (gaussian) distribution.
+    /// </summary>
+    Normal
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesSimilarityFunction.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/PCTSignaturesSimilarityFunction.cs
@@ -1,0 +1,22 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Similarity function selector for cv::xfeatures2d::PCTSignatures.
+/// </summary>
+public enum PCTSignaturesSimilarityFunction
+{
+    /// <summary>
+    /// -d(c_i, c_j)
+    /// </summary>
+    Minus,
+
+    /// <summary>
+    /// e^(-alpha * d^2(c_i, c_j))
+    /// </summary>
+    Gaussian,
+
+    /// <summary>
+    /// 1 / (alpha + d(c_i, c_j))
+    /// </summary>
+    Heuristic
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/TeblidSize.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/TeblidSize.cs
@@ -1,0 +1,17 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Descriptor number of bits, each bit is a box average difference. cv::xfeatures2d::TEBLID::TeblidSize
+/// </summary>
+public enum TeblidSize
+{
+    /// <summary>
+    /// 256 bits
+    /// </summary>
+    Size256Bits = 102,
+
+    /// <summary>
+    /// 512 bits
+    /// </summary>
+    Size512Bits = 103
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/Enum/VGGDescriptorType.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/Enum/VGGDescriptorType.cs
@@ -1,0 +1,29 @@
+// ReSharper disable InconsistentNaming
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Descriptor type for cv::xfeatures2d::VGG.
+/// </summary>
+public enum VGGDescriptorType
+{
+    /// <summary>
+    /// 120-dimensional float descriptor
+    /// </summary>
+    Vgg120 = 100,
+
+    /// <summary>
+    /// 80-dimensional float descriptor
+    /// </summary>
+    Vgg80 = 101,
+
+    /// <summary>
+    /// 64-dimensional float descriptor
+    /// </summary>
+    Vgg64 = 102,
+
+    /// <summary>
+    /// 48-dimensional float descriptor
+    /// </summary>
+    Vgg48 = 103
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/FREAK.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/FREAK.cs
@@ -41,4 +41,84 @@ public class FREAK : Feature2D
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_FREAK_get(ptr, out var rawPtr));
         return new FREAK(ptr, rawPtr);
     }
+
+    /// <summary>
+    /// Enable orientation normalization.
+    /// </summary>
+    public bool OrientationNormalized
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_getOrientationNormalized(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_setOrientationNormalized(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Enable scale normalization.
+    /// </summary>
+    public bool ScaleNormalized
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_getScaleNormalized(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_setScaleNormalized(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Scaling of the description pattern.
+    /// </summary>
+    public double PatternScale
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_getPatternScale(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_setPatternScale(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Number of octaves covered by the detected keypoints.
+    /// </summary>
+    public int NOctaves
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_getNOctaves(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_FREAK_setNOctaves(Handle, value));
+        }
+    }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/HarrisLaplaceFeatureDetector.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/HarrisLaplaceFeatureDetector.cs
@@ -1,0 +1,125 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing the Harris-Laplace feature detector.
+/// </summary>
+public class HarrisLaplaceFeatureDetector : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private HarrisLaplaceFeatureDetector(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates a new implementation instance.
+    /// </summary>
+    /// <param name="numOctaves">The number of octaves in the scale-space pyramid.</param>
+    /// <param name="cornThresh">The threshold for the Harris cornerness measure.</param>
+    /// <param name="dogThresh">The threshold for the Difference-of-Gaussians scale selection.</param>
+    /// <param name="maxCorners">The maximum number of corners to consider.</param>
+    /// <param name="numLayers">The number of intermediate scales per octave.</param>
+    public static HarrisLaplaceFeatureDetector Create(
+        int numOctaves = 6, float cornThresh = 0.01f, float dogThresh = 0.01f,
+        int maxCorners = 5000, int numLayers = 4)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_create(
+                numOctaves, cornThresh, dogThresh, maxCorners, numLayers, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_get(ptr, out var rawPtr));
+        return new HarrisLaplaceFeatureDetector(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// The number of octaves in the scale-space pyramid.
+    /// </summary>
+    public int NumOctaves
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_getNumOctaves(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_setNumOctaves(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The threshold for the Harris cornerness measure.
+    /// </summary>
+    public float CornThresh
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_getCornThresh(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_setCornThresh(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The threshold for the Difference-of-Gaussians scale selection.
+    /// </summary>
+    public float DOGThresh
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_getDOGThresh(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_setDOGThresh(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The maximum number of corners to consider.
+    /// </summary>
+    public int MaxCorners
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_getMaxCorners(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_setMaxCorners(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// The number of intermediate scales per octave.
+    /// </summary>
+    public int NumLayers
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_getNumLayers(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_HarrisLaplaceFeatureDetector_setNumLayers(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/LATCH.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/LATCH.cs
@@ -41,4 +41,85 @@ public class LATCH : Feature2D
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_LATCH_get(ptr, out var rawPtr));
         return new LATCH(ptr, rawPtr);
     }
+
+    /// <summary>
+    /// The size of the descriptor - can be 64, 32, 16, 8, 4, 2 or 1.
+    /// </summary>
+    public int Bytes
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_getBytes(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_setBytes(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Whether or not the descriptor should compensate for orientation changes.
+    /// </summary>
+    public bool RotationInvariance
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_getRotationInvariance(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_setRotationInvariance(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// The size of half of the mini-patches size.
+    /// </summary>
+    public int HalfSSDsize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_getHalfSSDsize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_setHalfSSDsize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Sigma value for GaussianBlur smoothing of the source image. Source image will be used
+    /// without smoothing in case sigma value is 0.
+    /// </summary>
+    public double Sigma
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_getSigma(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LATCH_setSigma(Handle, value));
+        }
+    }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/LUCID.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/LUCID.cs
@@ -32,4 +32,44 @@ public class LUCID : Feature2D
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_LUCID_get(ptr, out var rawPtr));
         return new LUCID(ptr, rawPtr);
     }
+
+    /// <summary>
+    /// Kernel for descriptor construction, where 1=3x3, 2=5x5, 3=7x7 and so forth.
+    /// </summary>
+    public int LucidKernel
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LUCID_getLucidKernel(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LUCID_setLucidKernel(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Kernel for blurring image prior to descriptor construction, where 1=3x3, 2=5x5, 3=7x7 and so forth.
+    /// </summary>
+    public int BlurKernel
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LUCID_getBlurKernel(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_LUCID_setBlurKernel(Handle, value));
+        }
+    }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/MSDDetector.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/MSDDetector.cs
@@ -1,0 +1,203 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing the MSD (Maximal Self-Dissimilarity) keypoint detector.
+/// </summary>
+public class MSDDetector : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private MSDDetector(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_MSDDetector_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the MSD detector.
+    /// </summary>
+    /// <param name="patchRadius">Patch radius.</param>
+    /// <param name="searchAreaRadius">Search area radius.</param>
+    /// <param name="nmsRadius">Non maxima suppression radius.</param>
+    /// <param name="nmsScaleRadius">Non maxima suppression radius in scale space.</param>
+    /// <param name="thSaliency">Saliency threshold.</param>
+    /// <param name="kNN">Number of nearest neighbors.</param>
+    /// <param name="scaleFactor">Scale factor for building up the scale pyramid.</param>
+    /// <param name="nScales">Number of scales for the scale pyramid (-1 = auto).</param>
+    /// <param name="computeOrientation">Flag to compute the keypoints orientation.</param>
+    public static MSDDetector Create(
+        int patchRadius = 3, int searchAreaRadius = 5, int nmsRadius = 5, int nmsScaleRadius = 0,
+        float thSaliency = 250.0f, int kNN = 4, float scaleFactor = 1.25f, int nScales = -1,
+        bool computeOrientation = false)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_MSDDetector_create(
+                patchRadius, searchAreaRadius, nmsRadius, nmsScaleRadius, thSaliency,
+                kNN, scaleFactor, nScales, computeOrientation ? 1 : 0, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_MSDDetector_get(ptr, out var rawPtr));
+        return new MSDDetector(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Patch radius.
+    /// </summary>
+    public int PatchRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getPatchRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setPatchRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Search area radius.
+    /// </summary>
+    public int SearchAreaRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getSearchAreaRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setSearchAreaRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Non maxima suppression radius.
+    /// </summary>
+    public int NmsRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getNmsRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setNmsRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Non maxima suppression radius in scale space.
+    /// </summary>
+    public int NmsScaleRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getNmsScaleRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setNmsScaleRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Saliency threshold.
+    /// </summary>
+    public float ThSaliency
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getThSaliency(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setThSaliency(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Number of nearest neighbors.
+    /// </summary>
+    public int KNN
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getKNN(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setKNN(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Scale factor for building up the scale pyramid.
+    /// </summary>
+    public float ScaleFactor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getScaleFactor(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setScaleFactor(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Number of scales for the scale pyramid (-1 = auto).
+    /// </summary>
+    public int NScales
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getNScales(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setNScales(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Flag to compute the keypoints orientation.
+    /// </summary>
+    public bool ComputeOrientation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_getComputeOrientation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_MSDDetector_setComputeOrientation(Handle, value ? 1 : 0));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/PCTSignatures.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/PCTSignatures.cs
@@ -1,0 +1,573 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing PCT (position-color-texture) signature extraction, as described in
+/// KrulisLS16. The algorithm is divided into a feature sampler and a clusterizer. The feature
+/// sampler produces samples at a given set of coordinates, and the clusterizer produces clusters
+/// of these samples using the k-means algorithm; the resulting set of clusters is the signature
+/// of the input image.
+/// </summary>
+public class PCTSignatures : Algorithm
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private PCTSignatures(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignatures_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates PCTSignatures algorithm using sample and seed count. It generates its own sets of
+    /// sampling points and clusterization seed indexes.
+    /// </summary>
+    /// <param name="initSampleCount">Number of points used for image sampling.</param>
+    /// <param name="initSeedCount">Number of initial clusterization seeds. Must be lower or equal
+    /// to initSampleCount.</param>
+    /// <param name="pointDistribution">Distribution of generated points.</param>
+    public static PCTSignatures Create(
+        int initSampleCount = 2000, int initSeedCount = 400,
+        PCTSignaturesPointDistribution pointDistribution = PCTSignaturesPointDistribution.Uniform)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_create1(initSampleCount, initSeedCount, (int)pointDistribution, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignatures_get(ptr, out var rawPtr));
+        return new PCTSignatures(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates PCTSignatures algorithm using pre-generated sampling points and number of
+    /// clusterization seeds. It uses the provided sampling points and generates its own
+    /// clusterization seed indexes.
+    /// </summary>
+    /// <param name="initSamplingPoints">Sampling points used in image sampling.</param>
+    /// <param name="initSeedCount">Number of initial clusterization seeds. Must be lower or equal
+    /// to initSamplingPoints.Length.</param>
+    public static PCTSignatures Create(IEnumerable<Point2f> initSamplingPoints, int initSeedCount)
+    {
+        ArgumentNullException.ThrowIfNull(initSamplingPoints);
+        var pointsArray = initSamplingPoints.ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_create2(pointsArray, pointsArray.Length, initSeedCount, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignatures_get(ptr, out var rawPtr));
+        return new PCTSignatures(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Creates PCTSignatures algorithm using pre-generated sampling points and clusterization
+    /// seed indexes.
+    /// </summary>
+    /// <param name="initSamplingPoints">Sampling points used in image sampling.</param>
+    /// <param name="initClusterSeedIndexes">Indexes of initial clusterization seeds. Its size
+    /// must be lower or equal to initSamplingPoints.Length.</param>
+    public static PCTSignatures Create(IEnumerable<Point2f> initSamplingPoints, IEnumerable<int> initClusterSeedIndexes)
+    {
+        ArgumentNullException.ThrowIfNull(initSamplingPoints);
+        ArgumentNullException.ThrowIfNull(initClusterSeedIndexes);
+        var pointsArray = initSamplingPoints.ToArray();
+        var seedsArray = initClusterSeedIndexes.ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_create3(
+                pointsArray, pointsArray.Length, seedsArray, seedsArray.Length, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignatures_get(ptr, out var rawPtr));
+        return new PCTSignatures(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes signature of a given image.
+    /// </summary>
+    /// <param name="image">Input image of CV_8U type.</param>
+    /// <param name="signature">Output computed signature.</param>
+    public void ComputeSignature(InputArray image, OutputArray signature)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_computeSignature(Handle, image.Proxy, signature.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(signature.Source);
+    }
+
+    /// <summary>
+    /// Computes signatures for multiple images in parallel.
+    /// </summary>
+    /// <param name="images">Vector of input images of CV_8U type.</param>
+    /// <returns>Vector of computed signatures.</returns>
+    public Mat[] ComputeSignatures(IEnumerable<Mat> images)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(images);
+
+        var imagesArray = images.ToArray();
+        var imagesPtrs = imagesArray.Select(m => m.CvPtr).ToArray();
+        using var signaturesVec = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_computeSignatures(Handle, imagesPtrs, imagesPtrs.Length, signaturesVec.CvPtr));
+        GC.KeepAlive(imagesArray);
+        return signaturesVec.ToArray();
+    }
+
+    /// <summary>
+    /// Draws signature in the source image and outputs the result. Signatures are visualized as a
+    /// circle with radius based on signature weight and color based on signature color. Contrast
+    /// and entropy are not visualized.
+    /// </summary>
+    /// <param name="source">Source image.</param>
+    /// <param name="signature">Image signature.</param>
+    /// <param name="result">Output result.</param>
+    /// <param name="radiusToShorterSideRatio">Determines maximal radius of signature in the
+    /// output image.</param>
+    /// <param name="borderThickness">Border thickness of the visualized signature.</param>
+    public static void DrawSignature(
+        InputArray source, InputArray signature, OutputArray result,
+        float radiusToShorterSideRatio = 1.0f / 8, int borderThickness = 1)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_drawSignature(
+                source.Proxy, signature.Proxy, result.Proxy, radiusToShorterSideRatio, borderThickness));
+        GC.KeepAlive(source.Source);
+        GC.KeepAlive(signature.Source);
+        GC.KeepAlive(result.Source);
+    }
+
+    /// <summary>
+    /// Generates initial sampling points according to the selected point distribution.
+    /// </summary>
+    /// <param name="count">Number of points to generate.</param>
+    /// <param name="pointDistribution">Point distribution selector.</param>
+    /// <returns>The generated points, with coordinates in range [0..1).</returns>
+    public static Point2f[] GenerateInitPoints(int count, PCTSignaturesPointDistribution pointDistribution)
+    {
+        using var initPoints = new StdVector<Point2f>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_generateInitPoints(initPoints.CvPtr, count, (int)pointDistribution));
+        return initPoints.ToArray();
+    }
+
+    #region Sampler properties
+
+    /// <summary>
+    /// Number of initial samples taken from the image.
+    /// </summary>
+    /// <remarks>
+    /// OpenCV's native implementation of this getter is a known copy-paste bug: it returns the
+    /// same value as <see cref="GrayscaleBits"/> instead of the actual sample count passed to
+    /// Create().
+    /// </remarks>
+    public int SampleCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getSampleCount(Handle, out var ret));
+            return ret;
+        }
+    }
+
+    /// <summary>
+    /// Color resolution of the greyscale bitmap represented in allocated bits (i.e., value 4
+    /// means that 16 shades of grey are used). The greyscale bitmap is used for computing
+    /// contrast and entropy values.
+    /// </summary>
+    public int GrayscaleBits
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getGrayscaleBits(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setGrayscaleBits(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Size of the texture sampling window used to compute contrast and entropy (center of the
+    /// window is always in the pixel selected by x,y coordinates of the corresponding feature
+    /// sample).
+    /// </summary>
+    public int WindowRadius
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWindowRadius(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWindowRadius(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the x-axis of the feature space.
+    /// </summary>
+    public float WeightX
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightX(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightX(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the y-axis of the feature space.
+    /// </summary>
+    public float WeightY
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightY(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightY(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the L (lightness) axis of the
+    /// feature space.
+    /// </summary>
+    public float WeightL
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightL(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightL(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the a (CIE Lab) axis of the
+    /// feature space.
+    /// </summary>
+    public float WeightA
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightA(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightA(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the b (CIE Lab) axis of the
+    /// feature space.
+    /// </summary>
+    public float WeightB
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightB(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightB(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the contrast axis of the feature
+    /// space.
+    /// </summary>
+    public float WeightContrast
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightContrast(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightContrast(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Weight (multiplicative constant) that linearly stretches the entropy axis of the feature
+    /// space.
+    /// </summary>
+    public float WeightEntropy
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getWeightEntropy(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeightEntropy(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Initial samples taken from the image. These sampled features become the input for
+    /// clustering.
+    /// </summary>
+    /// <returns></returns>
+    public Point2f[] GetSamplingPoints()
+    {
+        ThrowIfDisposed();
+        using var points = new StdVector<Point2f>();
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getSamplingPoints(Handle, points.CvPtr));
+        return points.ToArray();
+    }
+
+    /// <summary>
+    /// Weights (multiplicative constants) that linearly stretch individual axes of the feature
+    /// space.
+    /// </summary>
+    /// <param name="idx">ID of the weight (0=weight, 1=x, 2=y, 3=L, 4=a, 5=b, 6=contrast, 7=entropy).</param>
+    /// <param name="value">Value of the weight.</param>
+    public void SetWeight(int idx, float value)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeight(Handle, idx, value));
+    }
+
+    /// <summary>
+    /// Weights (multiplicative constants) that linearly stretch individual axes of the feature
+    /// space.
+    /// </summary>
+    /// <param name="weights">Values of all weights (0=weight, 1=x, 2=y, 3=L, 4=a, 5=b, 6=contrast, 7=entropy).</param>
+    public void SetWeights(IEnumerable<float> weights)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(weights);
+        var weightsArray = weights.ToArray();
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setWeights(Handle, weightsArray, weightsArray.Length));
+    }
+
+    /// <summary>
+    /// Translations of the individual axes of the feature space.
+    /// </summary>
+    /// <param name="idx">ID of the translation (0=weight, 1=x, 2=y, 3=L, 4=a, 5=b, 6=contrast, 7=entropy).</param>
+    /// <param name="value">Value of the translation.</param>
+    public void SetTranslation(int idx, float value)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setTranslation(Handle, idx, value));
+    }
+
+    /// <summary>
+    /// Translations of the individual axes of the feature space.
+    /// </summary>
+    /// <param name="translations">Values of all translations (0=weight, 1=x, 2=y, 3=L, 4=a, 5=b, 6=contrast, 7=entropy).</param>
+    public void SetTranslations(IEnumerable<float> translations)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(translations);
+        var translationsArray = translations.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_setTranslations(Handle, translationsArray, translationsArray.Length));
+    }
+
+    /// <summary>
+    /// Sets sampling points used to sample the input image.
+    /// </summary>
+    /// <param name="samplingPoints">Vector of sampling points in range [0..1). Their count must
+    /// be greater or equal to the clusterization seed count.</param>
+    public void SetSamplingPoints(IEnumerable<Point2f> samplingPoints)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(samplingPoints);
+        var pointsArray = samplingPoints.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_setSamplingPoints(Handle, pointsArray, pointsArray.Length));
+    }
+
+    #endregion
+
+    #region Clusterizer properties
+
+    /// <summary>
+    /// Initial seeds (initial number of clusters) for the k-means algorithm.
+    /// </summary>
+    /// <returns></returns>
+    public int[] GetInitSeedIndexes()
+    {
+        ThrowIfDisposed();
+        using var indexes = new StdVector<int>();
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getInitSeedIndexes(Handle, indexes.CvPtr));
+        return indexes.ToArray();
+    }
+
+    /// <summary>
+    /// Initial seed indexes for the k-means algorithm.
+    /// </summary>
+    /// <param name="initSeedIndexes"></param>
+    public void SetInitSeedIndexes(IEnumerable<int> initSeedIndexes)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(initSeedIndexes);
+        var indexesArray = initSeedIndexes.ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignatures_setInitSeedIndexes(Handle, indexesArray, indexesArray.Length));
+    }
+
+    /// <summary>
+    /// Number of initial seeds (initial number of clusters) for the k-means algorithm.
+    /// </summary>
+    public int InitSeedCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getInitSeedCount(Handle, out var ret));
+            return ret;
+        }
+    }
+
+    /// <summary>
+    /// Number of iterations of the k-means clustering. We use a fixed number of iterations,
+    /// since the modified clustering is pruning clusters (not iteratively refining k clusters).
+    /// </summary>
+    public int IterationCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getIterationCount(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setIterationCount(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Maximal number of generated clusters. If the number is exceeded, the clusters are sorted
+    /// by their weights and the smallest clusters are cropped.
+    /// </summary>
+    public int MaxClustersCount
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getMaxClustersCount(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setMaxClustersCount(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// This parameter, multiplied by the index of iteration, gives the lower limit for cluster
+    /// size. Clusters containing fewer points than specified by the limit have their centroid
+    /// dismissed and points are reassigned.
+    /// </summary>
+    public int ClusterMinSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getClusterMinSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setClusterMinSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Threshold euclidean distance between two centroids. If two cluster centers are closer
+    /// than this distance, one of the centroids is dismissed and points are reassigned.
+    /// </summary>
+    public float JoiningDistance
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getJoiningDistance(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setJoiningDistance(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Remove centroids in k-means whose weight is lesser or equal to the given threshold.
+    /// </summary>
+    public float DropThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getDropThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setDropThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Distance function selector used for measuring distance between two points in k-means.
+    /// </summary>
+    public PCTSignaturesDistanceFunction DistanceFunction
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_getDistanceFunction(Handle, out var ret));
+            return (PCTSignaturesDistanceFunction)ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_PCTSignatures_setDistanceFunction(Handle, (int)value));
+        }
+    }
+
+    #endregion
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/PCTSignaturesSQFD.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/PCTSignaturesSQFD.cs
@@ -1,0 +1,85 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Class implementing Signature Quadratic Form Distance (SQFD).
+/// </summary>
+public class PCTSignaturesSQFD : Algorithm
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private PCTSignaturesSQFD(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignaturesSQFD_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the algorithm instance using the selected distance function, similarity function,
+    /// and similarity function parameter.
+    /// </summary>
+    /// <param name="distanceFunction">Distance function selector.</param>
+    /// <param name="similarityFunction">Similarity function selector.</param>
+    /// <param name="similarityParameter">Parameter of the similarity function.</param>
+    public static PCTSignaturesSQFD Create(
+        PCTSignaturesDistanceFunction distanceFunction = PCTSignaturesDistanceFunction.L2,
+        PCTSignaturesSimilarityFunction similarityFunction = PCTSignaturesSimilarityFunction.Heuristic,
+        float similarityParameter = 1.0f)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignaturesSQFD_create(
+                (int)distanceFunction, (int)similarityFunction, similarityParameter, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_PCTSignaturesSQFD_get(ptr, out var rawPtr));
+        return new PCTSignaturesSQFD(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Computes the Signature Quadratic Form Distance of two signatures.
+    /// </summary>
+    /// <param name="signature0">The first signature.</param>
+    /// <param name="signature1">The second signature.</param>
+    /// <returns></returns>
+    public float ComputeQuadraticFormDistance(InputArray signature0, InputArray signature1)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistance(
+                Handle, signature0.Proxy, signature1.Proxy, out var ret));
+        GC.KeepAlive(signature0.Source);
+        GC.KeepAlive(signature1.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Computes the Signature Quadratic Form Distance between the reference signature and each of
+    /// the other image signatures.
+    /// </summary>
+    /// <remarks>
+    /// OpenCV's native implementation has a known bug for <paramref name="imageSignatures"/> with
+    /// more than one element: it validates each signature via <c>mImageSignatures[i].empty()</c>
+    /// where <c>mImageSignatures</c> is a pointer to the whole vector rather than an element
+    /// accessor, so any index beyond 0 reads out-of-bounds memory. Prefer calling
+    /// <see cref="ComputeQuadraticFormDistance"/> in a loop for more than one signature.
+    /// </remarks>
+    /// <param name="sourceSignature">The signature to measure the distance of other signatures from.</param>
+    /// <param name="imageSignatures">Vector of signatures to measure the distance from the source signature.</param>
+    /// <returns>Measured distances.</returns>
+    public float[] ComputeQuadraticFormDistances(Mat sourceSignature, IEnumerable<Mat> imageSignatures)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(sourceSignature);
+        ArgumentNullException.ThrowIfNull(imageSignatures);
+
+        var imageSignaturesArray = imageSignatures.ToArray();
+        var imageSignaturesPtrs = imageSignaturesArray.Select(m => m.CvPtr).ToArray();
+        using var distances = new StdVector<float>();
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistances(
+                Handle, sourceSignature.CvPtr, imageSignaturesPtrs, imageSignaturesPtrs.Length, distances.CvPtr));
+        GC.KeepAlive(sourceSignature);
+        GC.KeepAlive(imageSignaturesArray);
+        return distances.ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/StarDetector.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/StarDetector.cs
@@ -36,4 +36,104 @@ public class StarDetector : Feature2D
         NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_StarDetector_get(ptr, out var rawPtr));
         return new StarDetector(ptr, rawPtr);
     }
+
+    /// <summary>
+    /// Maximum size of the features.
+    /// </summary>
+    public int MaxSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_getMaxSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_setMaxSize(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Response threshold.
+    /// </summary>
+    public int ResponseThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_getResponseThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_setResponseThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Line threshold used for the projected line filtering.
+    /// </summary>
+    public int LineThresholdProjected
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_getLineThresholdProjected(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_setLineThresholdProjected(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Line threshold used for the binarized line filtering.
+    /// </summary>
+    public int LineThresholdBinarized
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_getLineThresholdBinarized(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_setLineThresholdBinarized(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Non-maximum suppression size.
+    /// </summary>
+    public int SuppressNonmaxSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_getSuppressNonmaxSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.xfeatures2d_StarDetector_setSuppressNonmaxSize(Handle, value));
+        }
+    }
 }

--- a/src/OpenCvSharp/Modules/xfeatures2d/TBMR.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/TBMR.cs
@@ -4,9 +4,10 @@ namespace OpenCvSharp.XFeatures2D;
 
 /// <summary>
 /// Class implementing the Tree Based Morse Regions (TBMR) detector, extended with scaled
-/// extraction ability.
+/// extraction ability. Extends AffineFeature2D (mirroring cv::xfeatures2d::TBMR : AffineFeature2D),
+/// so DetectElliptic/DetectAndComputeElliptic are available in addition to the plain Feature2D API.
 /// </summary>
-public class TBMR : Feature2D
+public class TBMR : AffineFeature2D
 {
     /// <summary>
     ///

--- a/src/OpenCvSharp/Modules/xfeatures2d/TBMR.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/TBMR.cs
@@ -1,0 +1,105 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing the Tree Based Morse Regions (TBMR) detector, extended with scaled
+/// extraction ability.
+/// </summary>
+public class TBMR : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private TBMR(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_TBMR_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the TBMR detector.
+    /// </summary>
+    /// <param name="minArea">Prune areas smaller than minArea.</param>
+    /// <param name="maxAreaRelative">Prune areas bigger than maxArea = maxAreaRelative * input_image_size.</param>
+    /// <param name="scaleFactor">Scale factor for scaled extraction.</param>
+    /// <param name="nScales">Number of applications of the scale factor (octaves).</param>
+    public static TBMR Create(
+        int minArea = 60, float maxAreaRelative = 0.01f, float scaleFactor = 1.25f, int nScales = -1)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_TBMR_create(minArea, maxAreaRelative, scaleFactor, nScales, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_TBMR_get(ptr, out var rawPtr));
+        return new TBMR(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Prune areas smaller than this value.
+    /// </summary>
+    public int MinArea
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_getMinArea(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_setMinArea(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Prune areas bigger than maxArea = MaxAreaRelative * input_image_size.
+    /// </summary>
+    public float MaxAreaRelative
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_getMaxAreaRelative(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_setMaxAreaRelative(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Scale factor for scaled extraction.
+    /// </summary>
+    public float ScaleFactor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_getScaleFactor(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_setScaleFactor(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Number of applications of the scale factor (octaves).
+    /// </summary>
+    public int NScales
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_getNScales(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_TBMR_setNScales(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/TEBLID.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/TEBLID.cs
@@ -1,0 +1,33 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+/// <summary>
+/// Class implementing TEBLID (Triplet-based Efficient Binary Local Image Descriptor),
+/// an improvement over BEBLID that uses triplet loss, hard negative mining, and anchor swap.
+/// </summary>
+public class TEBLID : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private TEBLID(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_TEBLID_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the TEBLID descriptor.
+    /// </summary>
+    /// <param name="scaleFactor">Adjust the sampling window around detected keypoints:
+    /// 1.00f should be the scale for ORB keypoints, 6.75f for SIFT detected keypoints,
+    /// 6.25f (default) fits for KAZE/SURF detected keypoints,
+    /// 5.00f should be the scale for AKAZE, MSD, AGAST, FAST, BRISK keypoints.</param>
+    /// <param name="nBits">Determine the number of bits in the descriptor.</param>
+    public static TEBLID Create(float scaleFactor, TeblidSize nBits = TeblidSize.Size256Bits)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_TEBLID_create(scaleFactor, (int)nBits, out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_TEBLID_get(ptr, out var rawPtr));
+        return new TEBLID(ptr, rawPtr);
+    }
+}

--- a/src/OpenCvSharp/Modules/xfeatures2d/VGG.cs
+++ b/src/OpenCvSharp/Modules/xfeatures2d/VGG.cs
@@ -1,0 +1,130 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Class implementing the VGG (Oxford Visual Geometry Group) descriptor, trained end-to-end
+/// using "Descriptor Learning Using Convex Optimisation" (DLCO).
+/// </summary>
+public class VGG : Feature2D
+{
+    /// <summary>
+    ///
+    /// </summary>
+    private VGG(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_VGG_delete(p)))
+    { }
+
+    /// <summary>
+    /// Creates the VGG descriptor.
+    /// </summary>
+    /// <param name="desc">Type of descriptor to use.</param>
+    /// <param name="isigma">Gaussian kernel value for image blur.</param>
+    /// <param name="imgNormalize">Use image sample intensity normalization.</param>
+    /// <param name="useScaleOrientation">Sample patterns using keypoints orientation.</param>
+    /// <param name="scaleFactor">Adjust the sampling window of detected keypoints.</param>
+    /// <param name="dscNormalize">Clamp descriptors to 255 and convert to uchar CV_8UC1.</param>
+    public static VGG Create(
+        VGGDescriptorType desc = VGGDescriptorType.Vgg120, float isigma = 1.4f,
+        bool imgNormalize = true, bool useScaleOrientation = true,
+        float scaleFactor = 6.25f, bool dscNormalize = false)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.xfeatures2d_VGG_create(
+                (int)desc, isigma, imgNormalize ? 1 : 0, useScaleOrientation ? 1 : 0, scaleFactor, dscNormalize ? 1 : 0,
+                out var ptr));
+        NativeMethods.HandleException(NativeMethods.xfeatures2d_Ptr_VGG_get(ptr, out var rawPtr));
+        return new VGG(ptr, rawPtr);
+    }
+
+    /// <summary>
+    /// Gaussian kernel value for image blur.
+    /// </summary>
+    public float Sigma
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_getSigma(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_setSigma(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Use image sample intensity normalization.
+    /// </summary>
+    public bool UseNormalizeImage
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_getUseNormalizeImage(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_setUseNormalizeImage(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Sample patterns using keypoints orientation.
+    /// </summary>
+    public bool UseScaleOrientation
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_getUseScaleOrientation(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_setUseScaleOrientation(Handle, value ? 1 : 0));
+        }
+    }
+
+    /// <summary>
+    /// Adjust the sampling window of detected keypoints.
+    /// </summary>
+    public float ScaleFactor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_getScaleFactor(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_setScaleFactor(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Clamp descriptors to 255 and convert to uchar CV_8UC1.
+    /// </summary>
+    public bool UseNormalizeDescriptor
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_getUseNormalizeDescriptor(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.xfeatures2d_VGG_setUseNormalizeDescriptor(Handle, value ? 1 : 0));
+        }
+    }
+}

--- a/src/OpenCvSharpExtern/features.h
+++ b/src/OpenCvSharpExtern/features.h
@@ -191,17 +191,18 @@ CVAPI(ExceptionStatus) features_KeyPointsFilter_runByKeypointSize(
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask(
-    std::vector<cv::KeyPoint> *keypoints, cv::Mat *mask)
+    std::vector<cv::KeyPoint> *keypoints, const interop::InputArrayProxy *mask)
 {
     return cvTry([&] {
-        cv::KeyPointsFilter::runByPixelsMask(*keypoints, *mask);
+        const cv::Mat maskMat = static_cast<const cv::_InputArray&>(InProxy(*mask)).getMat();
+        cv::KeyPointsFilter::runByPixelsMask(*keypoints, maskMat);
     });
 }
 
 CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask2VectorPoint(
     std::vector<cv::KeyPoint> *keypoints,
     cv::Point **removeFrom, int removeFromSize1, int *removeFromSize2,
-    cv::Mat *mask,
+    const interop::InputArrayProxy *mask,
     std::vector<std::vector<cv::Point> > *removeFromResult)
 {
     return cvTry([&] {
@@ -210,7 +211,8 @@ CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask2VectorPoint(
         {
             removeFromVec.emplace_back(removeFrom[i], removeFrom[i] + removeFromSize2[i]);
         }
-        cv::KeyPointsFilter::runByPixelsMask2VectorPoint(*keypoints, removeFromVec, *mask);
+        const cv::Mat maskMat = static_cast<const cv::_InputArray&>(InProxy(*mask)).getMat();
+        cv::KeyPointsFilter::runByPixelsMask2VectorPoint(*keypoints, removeFromVec, maskMat);
         *removeFromResult = removeFromVec;
     });
 }

--- a/src/OpenCvSharpExtern/features.h
+++ b/src/OpenCvSharpExtern/features.h
@@ -198,6 +198,23 @@ CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask(
     });
 }
 
+CVAPI(ExceptionStatus) features_KeyPointsFilter_runByPixelsMask2VectorPoint(
+    std::vector<cv::KeyPoint> *keypoints,
+    cv::Point **removeFrom, int removeFromSize1, int *removeFromSize2,
+    cv::Mat *mask,
+    std::vector<std::vector<cv::Point> > *removeFromResult)
+{
+    return cvTry([&] {
+        std::vector<std::vector<cv::Point> > removeFromVec;
+        for (auto i = 0; i < removeFromSize1; i++)
+        {
+            removeFromVec.emplace_back(removeFrom[i], removeFrom[i] + removeFromSize2[i]);
+        }
+        cv::KeyPointsFilter::runByPixelsMask2VectorPoint(*keypoints, removeFromVec, *mask);
+        *removeFromResult = removeFromVec;
+    });
+}
+
 CVAPI(ExceptionStatus) features_KeyPointsFilter_removeDuplicated(
     std::vector<cv::KeyPoint> *keypoints)
 {

--- a/src/OpenCvSharpExtern/features_DescriptorMatcher.h
+++ b/src/OpenCvSharpExtern/features_DescriptorMatcher.h
@@ -171,6 +171,16 @@ CVAPI(ExceptionStatus) features_DescriptorMatcher_create(
     });
 }
 
+CVAPI(ExceptionStatus) features_DescriptorMatcher_create_MatcherType(
+    int matcherType, cv::Ptr<cv::DescriptorMatcher> **returnValue)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::DescriptorMatcher> ret = cv::DescriptorMatcher::create(
+            static_cast<cv::DescriptorMatcher::MatcherType>(matcherType));
+        *returnValue = new cv::Ptr<cv::DescriptorMatcher>(ret);
+    });
+}
+
 CVAPI(ExceptionStatus) features_Ptr_DescriptorMatcher_get(
     cv::Ptr<cv::DescriptorMatcher> *ptr, cv::DescriptorMatcher **returnValue)
 {

--- a/src/OpenCvSharpExtern/features_Feature2D.h
+++ b/src/OpenCvSharpExtern/features_Feature2D.h
@@ -639,6 +639,8 @@ struct SimpleBlobDetector_Params
 
     int filterByConvexity;
     float minConvexity, maxConvexity;
+
+    int collectContours;
 };
 
 CVAPI(ExceptionStatus) features_SimpleBlobDetector_create(
@@ -667,6 +669,7 @@ CVAPI(ExceptionStatus) features_SimpleBlobDetector_create(
             p2.filterByConvexity = p->filterByConvexity != 0;
             p2.minConvexity = p->minConvexity;
             p2.maxConvexity = p->maxConvexity;
+            p2.collectContours = p->collectContours != 0;
         }
         const auto ptr = cv::SimpleBlobDetector::create(p2);
         *returnValue = clone(ptr);
@@ -677,6 +680,14 @@ CVAPI(ExceptionStatus) features_Ptr_SimpleBlobDetector_delete(cv::Ptr<cv::Simple
 {
     return cvTry([&] {
         delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) features_SimpleBlobDetector_getBlobContours(
+    cv::SimpleBlobDetector *obj, std::vector<std::vector<cv::Point> > *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getBlobContours();
     });
 }
 

--- a/src/OpenCvSharpExtern/imgproc.h
+++ b/src/OpenCvSharpExtern/imgproc.h
@@ -356,8 +356,45 @@ CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack(
     double k)
 {
     return cvTry([&] {
-        cv::goodFeaturesToTrack(InProxy(*src), *corners, maxCorners, qualityLevel, minDistance, 
+        cv::goodFeaturesToTrack(InProxy(*src), *corners, maxCorners, qualityLevel, minDistance,
             InProxy(*mask), blockSize, useHarrisDetector != 0, k);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrack_gradientSize(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Point2f> *corners,
+    int maxCorners,
+    double qualityLevel,
+    double minDistance,
+    const interop::InputArrayProxy* mask,
+    int blockSize,
+    int gradientSize,
+    int useHarrisDetector,
+    double k)
+{
+    return cvTry([&] {
+        cv::goodFeaturesToTrack(InProxy(*src), *corners, maxCorners, qualityLevel, minDistance,
+            InProxy(*mask), blockSize, gradientSize, useHarrisDetector != 0, k);
+    });
+}
+
+CVAPI(ExceptionStatus) imgproc_goodFeaturesToTrackWithQuality(
+    const interop::InputArrayProxy* src,
+    std::vector<cv::Point2f> *corners,
+    int maxCorners,
+    double qualityLevel,
+    double minDistance,
+    const interop::InputArrayProxy* mask,
+    const interop::OutputArrayProxy* cornersQuality,
+    int blockSize,
+    int gradientSize,
+    int useHarrisDetector,
+    double k)
+{
+    return cvTry([&] {
+        cv::goodFeaturesToTrack(InProxy(*src), *corners, maxCorners, qualityLevel, minDistance,
+            InProxy(*mask), OutProxy(*cornersQuality), blockSize, gradientSize, useHarrisDetector != 0, k);
     });
 }
 

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -189,6 +189,11 @@ namespace interop
         float transf[6];
     };
 
+    // Used as a std::vector element and across the CVAPI boundary (see xfeatures2d_AffineFeature2D.h),
+    // so guard against a future edit accidentally making it non-POD.
+    static_assert(std::is_standard_layout_v<EllipticKeyPoint> && std::is_trivially_copyable_v<EllipticKeyPoint>,
+        "interop::EllipticKeyPoint must stay a C-ABI-compatible POD");
+
 #pragma endregion
 
     typedef struct Vec2b { uchar val[2]; } Vec2b;

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -177,6 +177,18 @@ namespace interop
         double weight;
     };
 
+    // Mirrors cv::xfeatures2d::Elliptic_KeyPoint by value: that type is not trivially copyable
+    // (it declares a virtual destructor, so it carries a vtable pointer), so it cannot be used
+    // directly as a std::vector element or CVAPI parameter/return type. transf holds the 2x3
+    // row-major affine matrix (cv::Matx23f).
+    struct EllipticKeyPoint
+    {
+        KeyPoint base;
+        Size2f axes;
+        float si;
+        float transf[6];
+    };
+
 #pragma endregion
 
     typedef struct Vec2b { uchar val[2]; } Vec2b;

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -131,6 +131,12 @@ CV_VECTOR_CORE(DMatch, cv::DMatch)
 CV_VECTOR_NEW2(DMatch, cv::DMatch)
 CV_VECTOR_NEW3(DMatch, cv::DMatch)
 
+// cv::Elliptic_KeyPoint is not trivially copyable (virtual destructor), so AffineFeature2D's
+// bridge converts to/from interop::EllipticKeyPoint at the boundary instead of using
+// cv::Elliptic_KeyPoint directly as a vector element.
+CV_VECTOR_CORE(EllipticKeyPoint, interop::EllipticKeyPoint)
+CV_VECTOR_NEW3(EllipticKeyPoint, interop::EllipticKeyPoint)
+
 #undef CV_VECTOR_NEW3
 #undef CV_VECTOR_NEW2
 #undef CV_VECTOR_CORE

--- a/src/OpenCvSharpExtern/xfeatures2d.cpp
+++ b/src/OpenCvSharpExtern/xfeatures2d.cpp
@@ -1,3 +1,5 @@
 #include "xfeatures2d.h"
 #include "xfeatures2d_FeatureDetectors.h"
 #include "xfeatures2d_BOW.h"
+#include "xfeatures2d_BEBLID.h"
+#include "xfeatures2d_Match.h"

--- a/src/OpenCvSharpExtern/xfeatures2d.cpp
+++ b/src/OpenCvSharpExtern/xfeatures2d.cpp
@@ -7,3 +7,4 @@
 #include "xfeatures2d_VGG.h"
 #include "xfeatures2d_HarrisLaplace.h"
 #include "xfeatures2d_DAISY.h"
+#include "xfeatures2d_PCTSignatures.h"

--- a/src/OpenCvSharpExtern/xfeatures2d.cpp
+++ b/src/OpenCvSharpExtern/xfeatures2d.cpp
@@ -8,3 +8,4 @@
 #include "xfeatures2d_HarrisLaplace.h"
 #include "xfeatures2d_DAISY.h"
 #include "xfeatures2d_PCTSignatures.h"
+#include "xfeatures2d_AffineFeature2D.h"

--- a/src/OpenCvSharpExtern/xfeatures2d.cpp
+++ b/src/OpenCvSharpExtern/xfeatures2d.cpp
@@ -6,3 +6,4 @@
 #include "xfeatures2d_MSDDetector.h"
 #include "xfeatures2d_VGG.h"
 #include "xfeatures2d_HarrisLaplace.h"
+#include "xfeatures2d_DAISY.h"

--- a/src/OpenCvSharpExtern/xfeatures2d.cpp
+++ b/src/OpenCvSharpExtern/xfeatures2d.cpp
@@ -3,3 +3,6 @@
 #include "xfeatures2d_BOW.h"
 #include "xfeatures2d_BEBLID.h"
 #include "xfeatures2d_Match.h"
+#include "xfeatures2d_MSDDetector.h"
+#include "xfeatures2d_VGG.h"
+#include "xfeatures2d_HarrisLaplace.h"

--- a/src/OpenCvSharpExtern/xfeatures2d.h
+++ b/src/OpenCvSharpExtern/xfeatures2d.h
@@ -12,10 +12,10 @@
 #pragma region BriefDescriptorExtractor
 
 CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_create(
-    int bytes, cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor> **returnValue)
+    int bytes, int useOrientation, cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor> **returnValue)
 {
     return cvTry([&] {
-        const auto ptr = cv::xfeatures2d::BriefDescriptorExtractor::create(bytes);
+        const auto ptr = cv::xfeatures2d::BriefDescriptorExtractor::create(bytes, useOrientation != 0);
         *returnValue = clone(ptr);
     });
 }

--- a/src/OpenCvSharpExtern/xfeatures2d.h
+++ b/src/OpenCvSharpExtern/xfeatures2d.h
@@ -68,6 +68,31 @@ CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_descriptorType(
     });
 }
 
+CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_setDescriptorSize(cv::xfeatures2d::BriefDescriptorExtractor *obj, int bytes)
+{
+    return cvTry([&] {
+        obj->setDescriptorSize(bytes);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_getDescriptorSize(cv::xfeatures2d::BriefDescriptorExtractor *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getDescriptorSize();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_setUseOrientation(cv::xfeatures2d::BriefDescriptorExtractor *obj, int useOrientation)
+{
+    return cvTry([&] {
+        obj->setUseOrientation(useOrientation != 0);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_BriefDescriptorExtractor_getUseOrientation(cv::xfeatures2d::BriefDescriptorExtractor *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getUseOrientation() ? 1 : 0;
+    });
+}
 
 #pragma endregion
 
@@ -101,6 +126,57 @@ CVAPI(ExceptionStatus) xfeatures2d_Ptr_FREAK_get(cv::Ptr<cv::xfeatures2d::FREAK>
     });
 }
 
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_setOrientationNormalized(cv::xfeatures2d::FREAK *obj, int val)
+{
+    return cvTry([&] {
+        obj->setOrientationNormalized(val != 0);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_getOrientationNormalized(cv::xfeatures2d::FREAK *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getOrientationNormalized() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_setScaleNormalized(cv::xfeatures2d::FREAK *obj, int val)
+{
+    return cvTry([&] {
+        obj->setScaleNormalized(val != 0);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_getScaleNormalized(cv::xfeatures2d::FREAK *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getScaleNormalized() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_setPatternScale(cv::xfeatures2d::FREAK *obj, double val)
+{
+    return cvTry([&] {
+        obj->setPatternScale(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_getPatternScale(cv::xfeatures2d::FREAK *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getPatternScale();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_setNOctaves(cv::xfeatures2d::FREAK *obj, int val)
+{
+    return cvTry([&] {
+        obj->setNOctaves(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_FREAK_getNOctaves(cv::xfeatures2d::FREAK *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNOctaves();
+    });
+}
 
 #pragma endregion
 
@@ -132,6 +208,70 @@ CVAPI(ExceptionStatus) xfeatures2d_Ptr_StarDetector_get(cv::Ptr<cv::xfeatures2d:
     });
 }
 
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_setMaxSize(cv::xfeatures2d::StarDetector *obj, int val)
+{
+    return cvTry([&] {
+        obj->setMaxSize(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_getMaxSize(cv::xfeatures2d::StarDetector *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getMaxSize();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_setResponseThreshold(cv::xfeatures2d::StarDetector *obj, int val)
+{
+    return cvTry([&] {
+        obj->setResponseThreshold(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_getResponseThreshold(cv::xfeatures2d::StarDetector *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getResponseThreshold();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_setLineThresholdProjected(cv::xfeatures2d::StarDetector *obj, int val)
+{
+    return cvTry([&] {
+        obj->setLineThresholdProjected(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_getLineThresholdProjected(cv::xfeatures2d::StarDetector *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getLineThresholdProjected();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_setLineThresholdBinarized(cv::xfeatures2d::StarDetector *obj, int val)
+{
+    return cvTry([&] {
+        obj->setLineThresholdBinarized(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_getLineThresholdBinarized(cv::xfeatures2d::StarDetector *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getLineThresholdBinarized();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_setSuppressNonmaxSize(cv::xfeatures2d::StarDetector *obj, int val)
+{
+    return cvTry([&] {
+        obj->setSuppressNonmaxSize(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_StarDetector_getSuppressNonmaxSize(cv::xfeatures2d::StarDetector *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSuppressNonmaxSize();
+    });
+}
 
 #pragma endregion
 
@@ -159,6 +299,31 @@ CVAPI(ExceptionStatus) xfeatures2d_Ptr_LUCID_get(cv::Ptr<cv::xfeatures2d::LUCID>
     });
 }
 
+CVAPI(ExceptionStatus) xfeatures2d_LUCID_setLucidKernel(cv::xfeatures2d::LUCID *obj, int val)
+{
+    return cvTry([&] {
+        obj->setLucidKernel(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LUCID_getLucidKernel(cv::xfeatures2d::LUCID *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getLucidKernel();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_LUCID_setBlurKernel(cv::xfeatures2d::LUCID *obj, int val)
+{
+    return cvTry([&] {
+        obj->setBlurKernel(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LUCID_getBlurKernel(cv::xfeatures2d::LUCID *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getBlurKernel();
+    });
+}
 
 #pragma endregion
 
@@ -188,6 +353,57 @@ CVAPI(ExceptionStatus) xfeatures2d_Ptr_LATCH_get(cv::Ptr<cv::xfeatures2d::LATCH>
     });
 }
 
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_setBytes(cv::xfeatures2d::LATCH *obj, int val)
+{
+    return cvTry([&] {
+        obj->setBytes(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_getBytes(cv::xfeatures2d::LATCH *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getBytes();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_setRotationInvariance(cv::xfeatures2d::LATCH *obj, int val)
+{
+    return cvTry([&] {
+        obj->setRotationInvariance(val != 0);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_getRotationInvariance(cv::xfeatures2d::LATCH *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getRotationInvariance() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_setHalfSSDsize(cv::xfeatures2d::LATCH *obj, int val)
+{
+    return cvTry([&] {
+        obj->setHalfSSDsize(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_getHalfSSDsize(cv::xfeatures2d::LATCH *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getHalfSSDsize();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_setSigma(cv::xfeatures2d::LATCH *obj, double val)
+{
+    return cvTry([&] {
+        obj->setSigma(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_LATCH_getSigma(cv::xfeatures2d::LATCH *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSigma();
+    });
+}
 
 #pragma endregion
 

--- a/src/OpenCvSharpExtern/xfeatures2d_AffineFeature2D.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_AffineFeature2D.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region AffineFeature2D
+
+namespace
+{
+    interop::EllipticKeyPoint toInterop(const cv::xfeatures2d::Elliptic_KeyPoint &kp)
+    {
+        interop::EllipticKeyPoint ekp{};
+        ekp.base.pt = interop::Point2f{ kp.pt.x, kp.pt.y };
+        ekp.base.size = kp.size;
+        ekp.base.angle = kp.angle;
+        ekp.base.response = kp.response;
+        ekp.base.octave = kp.octave;
+        ekp.base.class_id = kp.class_id;
+        ekp.axes = interop::Size2f{ kp.axes.width, kp.axes.height };
+        ekp.si = kp.si;
+        ekp.transf[0] = kp.transf(0, 0); ekp.transf[1] = kp.transf(0, 1); ekp.transf[2] = kp.transf(0, 2);
+        ekp.transf[3] = kp.transf(1, 0); ekp.transf[4] = kp.transf(1, 1); ekp.transf[5] = kp.transf(1, 2);
+        return ekp;
+    }
+
+    cv::xfeatures2d::Elliptic_KeyPoint fromInterop(const interop::EllipticKeyPoint &ekp)
+    {
+        cv::xfeatures2d::Elliptic_KeyPoint kp;
+        kp.pt = cv::Point2f(ekp.base.pt.x, ekp.base.pt.y);
+        kp.size = ekp.base.size;
+        kp.angle = ekp.base.angle;
+        kp.response = ekp.base.response;
+        kp.octave = ekp.base.octave;
+        kp.class_id = ekp.base.class_id;
+        kp.axes = cv::Size2f(ekp.axes.width, ekp.axes.height);
+        kp.si = ekp.si;
+        kp.transf = cv::Matx23f(
+            ekp.transf[0], ekp.transf[1], ekp.transf[2],
+            ekp.transf[3], ekp.transf[4], ekp.transf[5]);
+        return kp;
+    }
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_AffineFeature2D_create1(
+    cv::Ptr<cv::Feature2D> *keypointDetector, cv::Ptr<cv::Feature2D> *descriptorExtractor,
+    cv::Ptr<cv::xfeatures2d::AffineFeature2D> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::AffineFeature2D::create(*keypointDetector, *descriptorExtractor);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_AffineFeature2D_create2(
+    cv::Ptr<cv::Feature2D> *keypointDetector,
+    cv::Ptr<cv::xfeatures2d::AffineFeature2D> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::AffineFeature2D::create(*keypointDetector);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_AffineFeature2D_delete(cv::Ptr<cv::xfeatures2d::AffineFeature2D> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_AffineFeature2D_get(
+    cv::Ptr<cv::xfeatures2d::AffineFeature2D> *obj, cv::xfeatures2d::AffineFeature2D **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_AffineFeature2D_detect(
+    cv::xfeatures2d::AffineFeature2D *obj, const interop::InputArrayProxy *image,
+    std::vector<interop::EllipticKeyPoint> *keypoints, const interop::InputArrayProxy *mask)
+{
+    return cvTry([&] {
+        std::vector<cv::xfeatures2d::Elliptic_KeyPoint> kpVec;
+        obj->detect(InProxy(*image), kpVec, InProxy(*mask));
+        keypoints->clear();
+        keypoints->reserve(kpVec.size());
+        for (const auto &kp : kpVec)
+            keypoints->push_back(toInterop(kp));
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_AffineFeature2D_detectAndCompute(
+    cv::xfeatures2d::AffineFeature2D *obj, const interop::InputArrayProxy *image, const interop::InputArrayProxy *mask,
+    std::vector<interop::EllipticKeyPoint> *keypoints, const interop::OutputArrayProxy *descriptors, int useProvidedKeypoints)
+{
+    return cvTry([&] {
+        std::vector<cv::xfeatures2d::Elliptic_KeyPoint> kpVec;
+        if (useProvidedKeypoints != 0)
+        {
+            kpVec.reserve(keypoints->size());
+            for (const auto &ekp : *keypoints)
+                kpVec.push_back(fromInterop(ekp));
+        }
+        obj->detectAndCompute(InProxy(*image), InProxy(*mask), kpVec, OutProxy(*descriptors), useProvidedKeypoints != 0);
+        keypoints->clear();
+        keypoints->reserve(kpVec.size());
+        for (const auto &kp : kpVec)
+            keypoints->push_back(toInterop(kp));
+    });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_AffineFeature2D.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_AffineFeature2D.h
@@ -12,16 +12,14 @@
 
 namespace
 {
+    // pt/size/angle/response/octave/class_id and axes are byte-identical to cv::KeyPoint/cv::Size2f,
+    // so reuse the existing bit_cast converters (my_types.h) instead of copying those fields by hand.
+    // si and transf have no cv:: counterpart in interop:: and are copied directly.
     interop::EllipticKeyPoint toInterop(const cv::xfeatures2d::Elliptic_KeyPoint &kp)
     {
         interop::EllipticKeyPoint ekp{};
-        ekp.base.pt = interop::Point2f{ kp.pt.x, kp.pt.y };
-        ekp.base.size = kp.size;
-        ekp.base.angle = kp.angle;
-        ekp.base.response = kp.response;
-        ekp.base.octave = kp.octave;
-        ekp.base.class_id = kp.class_id;
-        ekp.axes = interop::Size2f{ kp.axes.width, kp.axes.height };
+        ekp.base = c(static_cast<const cv::KeyPoint&>(kp));
+        ekp.axes = c(kp.axes);
         ekp.si = kp.si;
         ekp.transf[0] = kp.transf(0, 0); ekp.transf[1] = kp.transf(0, 1); ekp.transf[2] = kp.transf(0, 2);
         ekp.transf[3] = kp.transf(1, 0); ekp.transf[4] = kp.transf(1, 1); ekp.transf[5] = kp.transf(1, 2);
@@ -31,13 +29,8 @@ namespace
     cv::xfeatures2d::Elliptic_KeyPoint fromInterop(const interop::EllipticKeyPoint &ekp)
     {
         cv::xfeatures2d::Elliptic_KeyPoint kp;
-        kp.pt = cv::Point2f(ekp.base.pt.x, ekp.base.pt.y);
-        kp.size = ekp.base.size;
-        kp.angle = ekp.base.angle;
-        kp.response = ekp.base.response;
-        kp.octave = ekp.base.octave;
-        kp.class_id = ekp.base.class_id;
-        kp.axes = cv::Size2f(ekp.axes.width, ekp.axes.height);
+        static_cast<cv::KeyPoint&>(kp) = cpp(ekp.base);
+        kp.axes = cpp(ekp.axes);
         kp.si = ekp.si;
         kp.transf = cv::Matx23f(
             ekp.transf[0], ekp.transf[1], ekp.transf[2],

--- a/src/OpenCvSharpExtern/xfeatures2d_BEBLID.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_BEBLID.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region BEBLID
+
+CVAPI(ExceptionStatus) xfeatures2d_BEBLID_create(
+    float scaleFactor, int nBits, cv::Ptr<cv::xfeatures2d::BEBLID> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::BEBLID::create(scaleFactor, nBits);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_BEBLID_delete(cv::Ptr<cv::xfeatures2d::BEBLID> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_BEBLID_get(cv::Ptr<cv::xfeatures2d::BEBLID> *obj, cv::xfeatures2d::BEBLID **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_BEBLID_setScaleFactor(cv::xfeatures2d::BEBLID *obj, float val)
+{
+    return cvTry([&] {
+        obj->setScaleFactor(val);
+    });
+}
+CVAPI(ExceptionStatus) xfeatures2d_BEBLID_getScaleFactor(cv::xfeatures2d::BEBLID *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getScaleFactor();
+    });
+}
+
+#pragma endregion
+
+#pragma region TEBLID
+
+CVAPI(ExceptionStatus) xfeatures2d_TEBLID_create(
+    float scaleFactor, int nBits, cv::Ptr<cv::xfeatures2d::TEBLID> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::TEBLID::create(scaleFactor, nBits);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_TEBLID_delete(cv::Ptr<cv::xfeatures2d::TEBLID> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_TEBLID_get(cv::Ptr<cv::xfeatures2d::TEBLID> *obj, cv::xfeatures2d::TEBLID **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
@@ -114,7 +114,20 @@ CVAPI(ExceptionStatus) xfeatures2d_DAISY_compute_roi(
     cv::xfeatures2d::DAISY *obj, const interop::InputArrayProxy *image, interop::Rect roi, const interop::OutputArrayProxy *descriptors)
 {
     return cvTry([&] {
-        obj->compute(InProxy(*image), cpp(roi), OutProxy(*descriptors));
+        const InProxy imageProxy(*image);
+        const cv::Rect roiRect = cpp(roi);
+        // DAISY_Impl::compute_descriptors (opencv_contrib xfeatures2d/src/daisy.cpp) indexes its
+        // output buffer using absolute image coordinates while sizing the buffer to only
+        // roi.width*roi.height rows, so it overflows unless roi covers the entire image. Guard
+        // here instead of silently corrupting memory.
+        const cv::Size imageSize = static_cast<const cv::_InputArray&>(imageProxy).size();
+        if (roiRect.x != 0 || roiRect.y != 0 || roiRect.width != imageSize.width || roiRect.height != imageSize.height)
+        {
+            CV_Error(cv::Error::StsBadArg,
+                "DAISY.Compute(image, roi, descriptors): due to an upstream OpenCV bug, roi must cover "
+                "the entire image (x=0, y=0, width=image.Cols, height=image.Rows)");
+        }
+        obj->compute(static_cast<const cv::_InputArray&>(imageProxy), roiRect, OutProxy(*descriptors));
     });
 }
 

--- a/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region DAISY
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_create(
+    float radius, int qRadius, int qTheta, int qHist, int norm, const interop::InputArrayProxy *h,
+    int interpolation, int useOrientation,
+    cv::Ptr<cv::xfeatures2d::DAISY> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::DAISY::create(
+            radius, qRadius, qTheta, qHist,
+            static_cast<cv::xfeatures2d::DAISY::NormalizationType>(norm), InProxy(*h),
+            interpolation != 0, useOrientation != 0);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_DAISY_delete(cv::Ptr<cv::xfeatures2d::DAISY> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_DAISY_get(cv::Ptr<cv::xfeatures2d::DAISY> *obj, cv::xfeatures2d::DAISY **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setRadius(cv::xfeatures2d::DAISY *obj, float val)
+{
+    return cvTry([&] { obj->setRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getRadius(cv::xfeatures2d::DAISY *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setQRadius(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setQRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getQRadius(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getQRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setQTheta(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setQTheta(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getQTheta(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getQTheta(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setQHist(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setQHist(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getQHist(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getQHist(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setNorm(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setNorm(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getNorm(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNorm(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setH(cv::xfeatures2d::DAISY *obj, const interop::InputArrayProxy *h)
+{
+    return cvTry([&] { obj->setH(InProxy(*h)); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getH(cv::xfeatures2d::DAISY *obj, cv::Mat *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getH(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setInterpolation(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setInterpolation(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getInterpolation(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getInterpolation() ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_setUseOrientation(cv::xfeatures2d::DAISY *obj, int val)
+{
+    return cvTry([&] { obj->setUseOrientation(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getUseOrientation(cv::xfeatures2d::DAISY *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getUseOrientation() ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_compute_roi(
+    cv::xfeatures2d::DAISY *obj, const interop::InputArrayProxy *image, interop::Rect roi, const interop::OutputArrayProxy *descriptors)
+{
+    return cvTry([&] {
+        obj->compute(InProxy(*image), cpp(roi), OutProxy(*descriptors));
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_compute_dense(
+    cv::xfeatures2d::DAISY *obj, const interop::InputArrayProxy *image, const interop::OutputArrayProxy *descriptors)
+{
+    return cvTry([&] {
+        obj->compute(InProxy(*image), OutProxy(*descriptors));
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_GetDescriptor1(
+    cv::xfeatures2d::DAISY *obj, double y, double x, int orientation, float *descriptor)
+{
+    return cvTry([&] {
+        obj->GetDescriptor(y, x, orientation, descriptor);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_GetDescriptor2(
+    cv::xfeatures2d::DAISY *obj, double y, double x, int orientation, float *descriptor, double *h, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->GetDescriptor(y, x, orientation, descriptor, h) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_GetUnnormalizedDescriptor1(
+    cv::xfeatures2d::DAISY *obj, double y, double x, int orientation, float *descriptor)
+{
+    return cvTry([&] {
+        obj->GetUnnormalizedDescriptor(y, x, orientation, descriptor);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_GetUnnormalizedDescriptor2(
+    cv::xfeatures2d::DAISY *obj, double y, double x, int orientation, float *descriptor, double *h, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->GetUnnormalizedDescriptor(y, x, orientation, descriptor, h) ? 1 : 0;
+    });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_DAISY.h
@@ -110,24 +110,22 @@ CVAPI(ExceptionStatus) xfeatures2d_DAISY_getUseOrientation(cv::xfeatures2d::DAIS
     return cvTry([&] { *returnValue = obj->getUseOrientation() ? 1 : 0; });
 }
 
+// Thin size accessor so the managed side (DAISY.Compute(InputArray, Rect, OutputArray)) can
+// validate roi against the image bounds itself before calling compute_roi below; see that
+// managed method for why the validation is needed (an upstream OpenCV buffer-overflow bug).
+CVAPI(ExceptionStatus) xfeatures2d_DAISY_getImageSize(const interop::InputArrayProxy *image, interop::Size *returnValue)
+{
+    return cvTry([&] {
+        const cv::Size sz = static_cast<const cv::_InputArray&>(InProxy(*image)).size();
+        *returnValue = interop::Size{ sz.width, sz.height };
+    });
+}
+
 CVAPI(ExceptionStatus) xfeatures2d_DAISY_compute_roi(
     cv::xfeatures2d::DAISY *obj, const interop::InputArrayProxy *image, interop::Rect roi, const interop::OutputArrayProxy *descriptors)
 {
     return cvTry([&] {
-        const InProxy imageProxy(*image);
-        const cv::Rect roiRect = cpp(roi);
-        // DAISY_Impl::compute_descriptors (opencv_contrib xfeatures2d/src/daisy.cpp) indexes its
-        // output buffer using absolute image coordinates while sizing the buffer to only
-        // roi.width*roi.height rows, so it overflows unless roi covers the entire image. Guard
-        // here instead of silently corrupting memory.
-        const cv::Size imageSize = static_cast<const cv::_InputArray&>(imageProxy).size();
-        if (roiRect.x != 0 || roiRect.y != 0 || roiRect.width != imageSize.width || roiRect.height != imageSize.height)
-        {
-            CV_Error(cv::Error::StsBadArg,
-                "DAISY.Compute(image, roi, descriptors): due to an upstream OpenCV bug, roi must cover "
-                "the entire image (x=0, y=0, width=image.Cols, height=image.Rows)");
-        }
-        obj->compute(static_cast<const cv::_InputArray&>(imageProxy), roiRect, OutProxy(*descriptors));
+        obj->compute(InProxy(*image), cpp(roi), OutProxy(*descriptors));
     });
 }
 

--- a/src/OpenCvSharpExtern/xfeatures2d_HarrisLaplace.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_HarrisLaplace.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region HarrisLaplaceFeatureDetector
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_create(
+    int numOctaves, float cornThresh, float dogThresh, int maxCorners, int numLayers,
+    cv::Ptr<cv::xfeatures2d::HarrisLaplaceFeatureDetector> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::HarrisLaplaceFeatureDetector::create(
+            numOctaves, cornThresh, dogThresh, maxCorners, numLayers);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_delete(cv::Ptr<cv::xfeatures2d::HarrisLaplaceFeatureDetector> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_HarrisLaplaceFeatureDetector_get(
+    cv::Ptr<cv::xfeatures2d::HarrisLaplaceFeatureDetector> *obj, cv::xfeatures2d::HarrisLaplaceFeatureDetector **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_setNumOctaves(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int val)
+{
+    return cvTry([&] { obj->setNumOctaves(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_getNumOctaves(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNumOctaves(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_setCornThresh(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, float val)
+{
+    return cvTry([&] { obj->setCornThresh(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_getCornThresh(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getCornThresh(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_setDOGThresh(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, float val)
+{
+    return cvTry([&] { obj->setDOGThresh(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_getDOGThresh(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getDOGThresh(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_setMaxCorners(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int val)
+{
+    return cvTry([&] { obj->setMaxCorners(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_getMaxCorners(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMaxCorners(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_setNumLayers(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int val)
+{
+    return cvTry([&] { obj->setNumLayers(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_HarrisLaplaceFeatureDetector_getNumLayers(cv::xfeatures2d::HarrisLaplaceFeatureDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNumLayers(); });
+}
+
+#pragma endregion
+
+#pragma region TBMR
+
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_create(
+    int minArea, float maxAreaRelative, float scaleFactor, int nScales,
+    cv::Ptr<cv::xfeatures2d::TBMR> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::TBMR::create(minArea, maxAreaRelative, scaleFactor, nScales);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_TBMR_delete(cv::Ptr<cv::xfeatures2d::TBMR> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_TBMR_get(cv::Ptr<cv::xfeatures2d::TBMR> *obj, cv::xfeatures2d::TBMR **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_setMinArea(cv::xfeatures2d::TBMR *obj, int val)
+{
+    return cvTry([&] { obj->setMinArea(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_getMinArea(cv::xfeatures2d::TBMR *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMinArea(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_setMaxAreaRelative(cv::xfeatures2d::TBMR *obj, float val)
+{
+    return cvTry([&] { obj->setMaxAreaRelative(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_getMaxAreaRelative(cv::xfeatures2d::TBMR *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMaxAreaRelative(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_setScaleFactor(cv::xfeatures2d::TBMR *obj, float val)
+{
+    return cvTry([&] { obj->setScaleFactor(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_getScaleFactor(cv::xfeatures2d::TBMR *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getScaleFactor(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_setNScales(cv::xfeatures2d::TBMR *obj, int val)
+{
+    return cvTry([&] { obj->setNScales(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_TBMR_getNScales(cv::xfeatures2d::TBMR *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNScales(); });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_MSDDetector.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_MSDDetector.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region MSDDetector
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_create(
+    int patchRadius, int searchAreaRadius, int nmsRadius, int nmsScaleRadius, float thSaliency,
+    int kNN, float scaleFactor, int nScales, int computeOrientation,
+    cv::Ptr<cv::xfeatures2d::MSDDetector> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::MSDDetector::create(
+            patchRadius, searchAreaRadius, nmsRadius, nmsScaleRadius, thSaliency,
+            kNN, scaleFactor, nScales, computeOrientation != 0);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_MSDDetector_delete(cv::Ptr<cv::xfeatures2d::MSDDetector> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_MSDDetector_get(cv::Ptr<cv::xfeatures2d::MSDDetector> *obj, cv::xfeatures2d::MSDDetector **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setPatchRadius(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setPatchRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getPatchRadius(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getPatchRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setSearchAreaRadius(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setSearchAreaRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getSearchAreaRadius(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getSearchAreaRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setNmsRadius(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setNmsRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getNmsRadius(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNmsRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setNmsScaleRadius(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setNmsScaleRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getNmsScaleRadius(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNmsScaleRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setThSaliency(cv::xfeatures2d::MSDDetector *obj, float val)
+{
+    return cvTry([&] { obj->setThSaliency(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getThSaliency(cv::xfeatures2d::MSDDetector *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getThSaliency(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setKNN(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setKNN(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getKNN(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getKNN(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setScaleFactor(cv::xfeatures2d::MSDDetector *obj, float val)
+{
+    return cvTry([&] { obj->setScaleFactor(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getScaleFactor(cv::xfeatures2d::MSDDetector *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getScaleFactor(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setNScales(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setNScales(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getNScales(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNScales(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_setComputeOrientation(cv::xfeatures2d::MSDDetector *obj, int val)
+{
+    return cvTry([&] { obj->setComputeOrientation(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_MSDDetector_getComputeOrientation(cv::xfeatures2d::MSDDetector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getComputeOrientation() ? 1 : 0; });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_Match.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_Match.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region matchGMS
+
+CVAPI(ExceptionStatus) xfeatures2d_matchGMS(
+    interop::Size size1, interop::Size size2,
+    std::vector<cv::KeyPoint> *keypoints1, std::vector<cv::KeyPoint> *keypoints2,
+    std::vector<cv::DMatch> *matches1to2,
+    std::vector<cv::DMatch> *matchesGMS,
+    int withRotation, int withScale, double thresholdFactor)
+{
+    return cvTry([&] {
+        cv::xfeatures2d::matchGMS(
+            cpp(size1), cpp(size2), *keypoints1, *keypoints2, *matches1to2, *matchesGMS,
+            withRotation != 0, withScale != 0, thresholdFactor);
+    });
+}
+
+#pragma endregion
+
+#pragma region matchLOGOS
+
+CVAPI(ExceptionStatus) xfeatures2d_matchLOGOS(
+    std::vector<cv::KeyPoint> *keypoints1, std::vector<cv::KeyPoint> *keypoints2,
+    std::vector<int> *nn1, std::vector<int> *nn2,
+    std::vector<cv::DMatch> *matches1to2)
+{
+    return cvTry([&] {
+        cv::xfeatures2d::matchLOGOS(*keypoints1, *keypoints2, *nn1, *nn2, *matches1to2);
+    });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_PCTSignatures.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_PCTSignatures.h
@@ -1,0 +1,352 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region PCTSignatures
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_create1(
+    int initSampleCount, int initSeedCount, int pointDistribution,
+    cv::Ptr<cv::xfeatures2d::PCTSignatures> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::PCTSignatures::create(initSampleCount, initSeedCount, pointDistribution);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_create2(
+    cv::Point2f *initSamplingPoints, int initSamplingPointsLength, int initSeedCount,
+    cv::Ptr<cv::xfeatures2d::PCTSignatures> **returnValue)
+{
+    return cvTry([&] {
+        const std::vector<cv::Point2f> pointsVec(initSamplingPoints, initSamplingPoints + initSamplingPointsLength);
+        const auto ptr = cv::xfeatures2d::PCTSignatures::create(pointsVec, initSeedCount);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_create3(
+    cv::Point2f *initSamplingPoints, int initSamplingPointsLength,
+    int *initClusterSeedIndexes, int initClusterSeedIndexesLength,
+    cv::Ptr<cv::xfeatures2d::PCTSignatures> **returnValue)
+{
+    return cvTry([&] {
+        const std::vector<cv::Point2f> pointsVec(initSamplingPoints, initSamplingPoints + initSamplingPointsLength);
+        const std::vector<int> seedsVec(initClusterSeedIndexes, initClusterSeedIndexes + initClusterSeedIndexesLength);
+        const auto ptr = cv::xfeatures2d::PCTSignatures::create(pointsVec, seedsVec);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_PCTSignatures_delete(cv::Ptr<cv::xfeatures2d::PCTSignatures> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_PCTSignatures_get(
+    cv::Ptr<cv::xfeatures2d::PCTSignatures> *obj, cv::xfeatures2d::PCTSignatures **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_computeSignature(
+    cv::xfeatures2d::PCTSignatures *obj, const interop::InputArrayProxy *image, const interop::OutputArrayProxy *signature)
+{
+    return cvTry([&] {
+        obj->computeSignature(InProxy(*image), OutProxy(*signature));
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_computeSignatures(
+    cv::xfeatures2d::PCTSignatures *obj, cv::Mat **images, int imagesLength, std::vector<cv::Mat> *signatures)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imagesVec(imagesLength);
+        for (int i = 0; i < imagesLength; i++)
+            imagesVec[i] = *images[i];
+        obj->computeSignatures(imagesVec, *signatures);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_drawSignature(
+    const interop::InputArrayProxy *source, const interop::InputArrayProxy *signature, const interop::OutputArrayProxy *result,
+    float radiusToShorterSideRatio, int borderThickness)
+{
+    return cvTry([&] {
+        cv::xfeatures2d::PCTSignatures::drawSignature(
+            InProxy(*source), InProxy(*signature), OutProxy(*result), radiusToShorterSideRatio, borderThickness);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_generateInitPoints(
+    std::vector<cv::Point2f> *initPoints, int count, int pointDistribution)
+{
+    return cvTry([&] {
+        cv::xfeatures2d::PCTSignatures::generateInitPoints(*initPoints, count, pointDistribution);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getSampleCount(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getSampleCount(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setGrayscaleBits(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setGrayscaleBits(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getGrayscaleBits(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getGrayscaleBits(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWindowRadius(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setWindowRadius(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWindowRadius(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWindowRadius(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightX(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightX(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightX(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightX(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightY(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightY(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightY(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightY(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightL(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightL(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightL(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightL(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightA(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightA(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightA(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightA(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightB(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightB(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightB(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightB(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightContrast(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightContrast(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightContrast(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightContrast(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeightEntropy(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setWeightEntropy(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getWeightEntropy(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWeightEntropy(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getSamplingPoints(
+    cv::xfeatures2d::PCTSignatures *obj, std::vector<cv::Point2f> *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getSamplingPoints(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeight(cv::xfeatures2d::PCTSignatures *obj, int idx, float value)
+{
+    return cvTry([&] { obj->setWeight(idx, value); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setWeights(cv::xfeatures2d::PCTSignatures *obj, float *weights, int weightsLength)
+{
+    return cvTry([&] {
+        const std::vector<float> weightsVec(weights, weights + weightsLength);
+        obj->setWeights(weightsVec);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setTranslation(cv::xfeatures2d::PCTSignatures *obj, int idx, float value)
+{
+    return cvTry([&] { obj->setTranslation(idx, value); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setTranslations(cv::xfeatures2d::PCTSignatures *obj, float *translations, int translationsLength)
+{
+    return cvTry([&] {
+        const std::vector<float> translationsVec(translations, translations + translationsLength);
+        obj->setTranslations(translationsVec);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setSamplingPoints(
+    cv::xfeatures2d::PCTSignatures *obj, cv::Point2f *samplingPoints, int samplingPointsLength)
+{
+    return cvTry([&] {
+        const std::vector<cv::Point2f> pointsVec(samplingPoints, samplingPoints + samplingPointsLength);
+        obj->setSamplingPoints(pointsVec);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getInitSeedIndexes(
+    cv::xfeatures2d::PCTSignatures *obj, std::vector<int> *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getInitSeedIndexes(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setInitSeedIndexes(
+    cv::xfeatures2d::PCTSignatures *obj, int *initSeedIndexes, int initSeedIndexesLength)
+{
+    return cvTry([&] {
+        const std::vector<int> seedsVec(initSeedIndexes, initSeedIndexes + initSeedIndexesLength);
+        obj->setInitSeedIndexes(seedsVec);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getInitSeedCount(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getInitSeedCount(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setIterationCount(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setIterationCount(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getIterationCount(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getIterationCount(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setMaxClustersCount(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setMaxClustersCount(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getMaxClustersCount(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMaxClustersCount(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setClusterMinSize(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setClusterMinSize(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getClusterMinSize(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getClusterMinSize(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setJoiningDistance(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setJoiningDistance(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getJoiningDistance(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getJoiningDistance(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setDropThreshold(cv::xfeatures2d::PCTSignatures *obj, float val)
+{
+    return cvTry([&] { obj->setDropThreshold(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getDropThreshold(cv::xfeatures2d::PCTSignatures *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getDropThreshold(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_setDistanceFunction(cv::xfeatures2d::PCTSignatures *obj, int val)
+{
+    return cvTry([&] { obj->setDistanceFunction(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignatures_getDistanceFunction(cv::xfeatures2d::PCTSignatures *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getDistanceFunction(); });
+}
+
+#pragma endregion
+
+#pragma region PCTSignaturesSQFD
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignaturesSQFD_create(
+    int distanceFunction, int similarityFunction, float similarityParameter,
+    cv::Ptr<cv::xfeatures2d::PCTSignaturesSQFD> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::PCTSignaturesSQFD::create(distanceFunction, similarityFunction, similarityParameter);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_PCTSignaturesSQFD_delete(cv::Ptr<cv::xfeatures2d::PCTSignaturesSQFD> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_PCTSignaturesSQFD_get(
+    cv::Ptr<cv::xfeatures2d::PCTSignaturesSQFD> *obj, cv::xfeatures2d::PCTSignaturesSQFD **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistance(
+    cv::xfeatures2d::PCTSignaturesSQFD *obj, const interop::InputArrayProxy *signature0, const interop::InputArrayProxy *signature1,
+    float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->computeQuadraticFormDistance(InProxy(*signature0), InProxy(*signature1));
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_PCTSignaturesSQFD_computeQuadraticFormDistances(
+    cv::xfeatures2d::PCTSignaturesSQFD *obj, cv::Mat *sourceSignature,
+    cv::Mat **imageSignatures, int imageSignaturesLength, std::vector<float> *distances)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imageSignaturesVec(imageSignaturesLength);
+        for (int i = 0; i < imageSignaturesLength; i++)
+            imageSignaturesVec[i] = *imageSignatures[i];
+        obj->computeQuadraticFormDistances(*sourceSignature, imageSignaturesVec, *distances);
+    });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/xfeatures2d_VGG.h
+++ b/src/OpenCvSharpExtern/xfeatures2d_VGG.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+#pragma region VGG
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_create(
+    int desc, float isigma, int imgNormalize, int useScaleOrientation, float scaleFactor, int dscNormalize,
+    cv::Ptr<cv::xfeatures2d::VGG> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::VGG::create(
+            desc, isigma, imgNormalize != 0, useScaleOrientation != 0, scaleFactor, dscNormalize != 0);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_VGG_delete(cv::Ptr<cv::xfeatures2d::VGG> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_VGG_get(cv::Ptr<cv::xfeatures2d::VGG> *obj, cv::xfeatures2d::VGG **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_setSigma(cv::xfeatures2d::VGG *obj, float val)
+{
+    return cvTry([&] { obj->setSigma(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_VGG_getSigma(cv::xfeatures2d::VGG *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getSigma(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_setUseNormalizeImage(cv::xfeatures2d::VGG *obj, int val)
+{
+    return cvTry([&] { obj->setUseNormalizeImage(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_VGG_getUseNormalizeImage(cv::xfeatures2d::VGG *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getUseNormalizeImage() ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_setUseScaleOrientation(cv::xfeatures2d::VGG *obj, int val)
+{
+    return cvTry([&] { obj->setUseScaleOrientation(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_VGG_getUseScaleOrientation(cv::xfeatures2d::VGG *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getUseScaleOrientation() ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_setScaleFactor(cv::xfeatures2d::VGG *obj, float val)
+{
+    return cvTry([&] { obj->setScaleFactor(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_VGG_getScaleFactor(cv::xfeatures2d::VGG *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getScaleFactor(); });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_VGG_setUseNormalizeDescriptor(cv::xfeatures2d::VGG *obj, int val)
+{
+    return cvTry([&] { obj->setUseNormalizeDescriptor(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_VGG_getUseNormalizeDescriptor(cv::xfeatures2d::VGG *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getUseNormalizeDescriptor() ? 1 : 0; });
+}
+
+#pragma endregion
+
+#pragma region BoostDesc
+
+CVAPI(ExceptionStatus) xfeatures2d_BoostDesc_create(
+    int desc, int useScaleOrientation, float scaleFactor,
+    cv::Ptr<cv::xfeatures2d::BoostDesc> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::xfeatures2d::BoostDesc::create(desc, useScaleOrientation != 0, scaleFactor);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_BoostDesc_delete(cv::Ptr<cv::xfeatures2d::BoostDesc> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_Ptr_BoostDesc_get(cv::Ptr<cv::xfeatures2d::BoostDesc> *obj, cv::xfeatures2d::BoostDesc **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->get();
+    });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_BoostDesc_setUseScaleOrientation(cv::xfeatures2d::BoostDesc *obj, int val)
+{
+    return cvTry([&] { obj->setUseScaleOrientation(val != 0); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_BoostDesc_getUseScaleOrientation(cv::xfeatures2d::BoostDesc *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getUseScaleOrientation() ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) xfeatures2d_BoostDesc_setScaleFactor(cv::xfeatures2d::BoostDesc *obj, float val)
+{
+    return cvTry([&] { obj->setScaleFactor(val); });
+}
+CVAPI(ExceptionStatus) xfeatures2d_BoostDesc_getScaleFactor(cv::xfeatures2d::BoostDesc *obj, float *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getScaleFactor(); });
+}
+
+#pragma endregion
+
+#endif // NO_CONTRIB

--- a/test/OpenCvSharp.Tests/features/DescriptorMatcherTest.cs
+++ b/test/OpenCvSharp.Tests/features/DescriptorMatcherTest.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+public class DescriptorMatcherTest : TestBase
+{
+    [Theory]
+    [InlineData(DescriptorMatcher.MatcherType.FlannBased)]
+    [InlineData(DescriptorMatcher.MatcherType.BruteForce)]
+    [InlineData(DescriptorMatcher.MatcherType.BruteForceL1)]
+    [InlineData(DescriptorMatcher.MatcherType.BruteForceHamming)]
+    [InlineData(DescriptorMatcher.MatcherType.BruteForceHammingLut)]
+    [InlineData(DescriptorMatcher.MatcherType.BruteForceSL2)]
+    public void CreateFromMatcherType(DescriptorMatcher.MatcherType matcherType)
+    {
+        using var matcher = DescriptorMatcher.Create(matcherType);
+
+        Assert.NotNull(matcher);
+        // A freshly created matcher has no train descriptors yet.
+        Assert.True(matcher.Empty());
+    }
+}

--- a/test/OpenCvSharp.Tests/features/KeyPointsFilterTest.cs
+++ b/test/OpenCvSharp.Tests/features/KeyPointsFilterTest.cs
@@ -26,4 +26,16 @@ public class KeyPointsFilterTest : TestBase
         Assert.Equal(5, resultKeypoints[0].Pt.X, 3);
         Assert.Single(resultRemoveFrom);
     }
+
+    [Fact]
+    public void RunByPixelsMaskWithNullMatThrowsArgumentNullException()
+    {
+        var keypoints = new[] { new KeyPoint(5, 5, 1) };
+        Mat? mask = null;
+
+        // InputArray's implicit operator from Mat (OpenCvSharp/Modules/core/InputArray.cs) calls
+        // ArgumentNullException.ThrowIfNull(mat) before RunByPixelsMask's body ever runs, so a null
+        // Mat is still rejected with a clear exception despite the mask parameter accepting InputArray.
+        Assert.Throws<ArgumentNullException>(() => KeyPointsFilter.RunByPixelsMask(keypoints, mask!));
+    }
 }

--- a/test/OpenCvSharp.Tests/features/KeyPointsFilterTest.cs
+++ b/test/OpenCvSharp.Tests/features/KeyPointsFilterTest.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+public class KeyPointsFilterTest : TestBase
+{
+    [Fact]
+    public void RunByPixelsMask2VectorPoint()
+    {
+        var keypoints = new[]
+        {
+            new KeyPoint(5, 5, 1),
+            new KeyPoint(50, 50, 1),
+        };
+        var removeFrom = new[]
+        {
+            new[] { new Point(5, 5), new Point(6, 6) },
+            new[] { new Point(50, 50) },
+        };
+        using var mask = new Mat(100, 100, MatType.CV_8UC1, Scalar.All(0));
+        mask.Set(5, 5, (byte)255);
+
+        var (resultKeypoints, resultRemoveFrom) = KeyPointsFilter.RunByPixelsMask2VectorPoint(keypoints, removeFrom, mask);
+
+        Assert.Single(resultKeypoints);
+        Assert.Equal(5, resultKeypoints[0].Pt.X, 3);
+        Assert.Single(resultRemoveFrom);
+    }
+}

--- a/test/OpenCvSharp.Tests/features/SimpleBlobDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/features/SimpleBlobDetectorTest.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Features;
+
+public class SimpleBlobDetectorTest : TestBase
+{
+    [Fact]
+    public void GetBlobContoursWithCollectContoursEnabled()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var parameters = new SimpleBlobDetector.Params
+        {
+            CollectContours = true,
+        };
+        using var detector = SimpleBlobDetector.Create(parameters);
+
+        var keypoints = detector.Detect(image);
+        var contours = detector.GetBlobContours();
+
+        Assert.NotEmpty(keypoints);
+        Assert.NotEmpty(contours);
+    }
+
+    [Fact]
+    public void GetBlobContoursWithCollectContoursDisabled()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var detector = SimpleBlobDetector.Create();
+
+        detector.Detect(image);
+        var contours = detector.GetBlobContours();
+
+        Assert.Empty(contours);
+    }
+}

--- a/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
+++ b/test/OpenCvSharp.Tests/imgproc/ImgProcTest.cs
@@ -1414,6 +1414,29 @@ public class ImgProcTest : TestBase
     }
 
     [Fact]
+    public void GoodFeaturesToTrackWithGradientSize()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var mask = new Mat();
+        var corners = Cv2.GoodFeaturesToTrack(src, 100, 0.01, 10, mask, 3, 3, false, 0.04);
+
+        Assert.True(corners.Length > 0);
+    }
+
+    [Fact]
+    public void GoodFeaturesToTrackWithQuality()
+    {
+        using var src = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var mask = new Mat();
+        using var cornersQuality = new Mat();
+        var corners = Cv2.GoodFeaturesToTrackWithQuality(src, 100, 0.01, 10, mask, cornersQuality);
+
+        Assert.True(corners.Length > 0);
+        Assert.False(cornersQuality.Empty());
+        Assert.Equal(corners.Length, (int)cornersQuality.Total());
+    }
+
+    [Fact]
     public void GrabCut()
     {
         using var color = LoadImage("lenna.png", ImreadModes.Color);

--- a/test/OpenCvSharp.Tests/xfeatures2d/AffineFeature2DTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/AffineFeature2DTest.cs
@@ -1,0 +1,75 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class AffineFeature2DTest : TestBase
+{
+    [Fact]
+    public void CreateWithSingleBackendAndDispose()
+    {
+        var orb = ORB.Create();
+        var affine = AffineFeature2D.Create(orb);
+        affine.Dispose();
+        orb.Dispose();
+    }
+
+    [Fact]
+    public void CreateWithSeparateDetectorAndExtractorAndDispose()
+    {
+        var detector = ORB.Create();
+        var extractor = ORB.Create();
+        var affine = AffineFeature2D.Create(detector, extractor);
+        affine.Dispose();
+        detector.Dispose();
+        extractor.Dispose();
+    }
+
+    [Fact]
+    public void DetectElliptic()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var orb = ORB.Create();
+        using var affine = AffineFeature2D.Create(orb);
+
+        var keypoints = affine.DetectElliptic(gray);
+
+        Assert.NotEmpty(keypoints);
+        Assert.All(keypoints, kp => Assert.True(kp.Axes.Width >= 0 && kp.Axes.Height >= 0));
+    }
+
+    [Fact]
+    public void DetectAndComputeElliptic()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var sift = SIFT.Create(50);
+        using var affine = AffineFeature2D.Create(sift);
+
+        var keypoints = affine.DetectAndComputeElliptic(gray, default, descriptors);
+
+        Assert.NotEmpty(keypoints);
+        Assert.False(descriptors.Empty());
+        Assert.Equal(keypoints.Length, descriptors.Rows);
+    }
+
+    [Fact]
+    public void DetectAndComputeEllipticWithProvidedKeypoints()
+    {
+        // AffineFeature2D's calcAffineCovariantDescriptors (opencv_contrib xfeatures2d/src/
+        // affine_feature2d.cpp) crashes with an assertion failure when wrapping ORB as the
+        // descriptor extractor (a binary/CV_8U descriptor), so use SIFT here instead.
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors1 = new Mat();
+        using var descriptors2 = new Mat();
+        using var sift = SIFT.Create(50);
+        using var affine = AffineFeature2D.Create(sift);
+
+        var keypoints = affine.DetectAndComputeElliptic(gray, default, descriptors1);
+        var keypoints2 = affine.DetectAndComputeElliptic(
+            gray, default, descriptors2, useProvidedKeypoints: true, providedKeypoints: keypoints);
+
+        Assert.Equal(keypoints.Length, keypoints2.Length);
+        Assert.Equal(descriptors1.Rows, descriptors2.Rows);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/BEBLIDTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/BEBLIDTest.cs
@@ -1,0 +1,41 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class BEBLIDTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var beblid = BEBLID.Create(6.25f);
+        beblid.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var beblid = BEBLID.Create(6.25f);
+        using var orb = ORB.Create();
+
+        var keypoints = orb.Detect(gray);
+        beblid.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void ScaleFactor()
+    {
+        using var alg = BEBLID.Create(6.25f);
+
+        Assert.Equal(6.25f, alg.ScaleFactor, 3);
+
+        alg.ScaleFactor = 1.0f;
+        Assert.Equal(1.0f, alg.ScaleFactor, 3);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/BoostDescTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/BoostDescTest.cs
@@ -1,0 +1,41 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class BoostDescTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var boostDesc = BoostDesc.Create();
+        boostDesc.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var boostDesc = BoostDesc.Create();
+        using var orb = ORB.Create();
+
+        var keypoints = orb.Detect(gray);
+        boostDesc.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = BoostDesc.Create();
+
+        alg.UseScaleOrientation = false;
+        Assert.False(alg.UseScaleOrientation);
+
+        alg.ScaleFactor = 1.0f;
+        Assert.Equal(1.0f, alg.ScaleFactor, 3);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/BriefDescriptorExtractorTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/BriefDescriptorExtractorTest.cs
@@ -40,4 +40,13 @@ public class BriefDescriptorExtractorTest : TestBase
         alg.UseOrientation = true;
         Assert.True(alg.UseOrientation);
     }
+
+    [Fact]
+    public void CreateWithUseOrientation()
+    {
+        using var alg = BriefDescriptorExtractor.Create(64, useOrientation: true);
+
+        Assert.Equal(64, alg.DescriptorSize);
+        Assert.True(alg.UseOrientation);
+    }
 }

--- a/test/OpenCvSharp.Tests/xfeatures2d/BriefDescriptorExtractorTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/BriefDescriptorExtractorTest.cs
@@ -1,0 +1,43 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class BriefDescriptorExtractorTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var brief = BriefDescriptorExtractor.Create();
+        brief.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var brief = BriefDescriptorExtractor.Create();
+        using var surf = SURF.Create(500);
+
+        var keypoints = surf.Detect(gray);
+        brief.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = BriefDescriptorExtractor.Create();
+
+        Assert.Equal(32, alg.DescriptorSize);
+
+        alg.DescriptorSize = 16;
+        Assert.Equal(16, alg.DescriptorSize);
+
+        alg.UseOrientation = true;
+        Assert.True(alg.UseOrientation);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
@@ -46,8 +46,8 @@ public class DAISYTest : TestBase
         // OpenCV's DAISY_Impl::compute_descriptors (opencv_contrib xfeatures2d/src/daisy.cpp)
         // indexes the output buffer using absolute image coordinates (y*image.cols+x) even though
         // the buffer is only sized roi.width*roi.height rows. That overflows for any roi other
-        // than the full image (x=0, y=0, width=image.cols, height=image.rows), so use the full
-        // image here to avoid tripping that upstream bug.
+        // than the full image (x=0, y=0, width=image.cols, height=image.rows), so the native
+        // bridge guards against it; use the full image here to satisfy that guard.
         using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
         using var descriptors = new Mat();
         using var daisy = DAISY.Create();
@@ -55,6 +55,16 @@ public class DAISYTest : TestBase
         daisy.Compute(gray, new Rect(0, 0, gray.Cols, gray.Rows), descriptors);
 
         Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void ComputeRoiWithPartialRoiThrows()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+
+        Assert.Throws<OpenCVException>(() => daisy.Compute(gray, new Rect(0, 10, gray.Cols, 50), descriptors));
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
@@ -1,0 +1,130 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class DAISYTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var daisy = DAISY.Create();
+        daisy.Dispose();
+    }
+
+    [Fact]
+    public void ComputeViaFeature2D()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+        using var orb = ORB.Create();
+
+        var keypoints = orb.Detect(gray);
+        daisy.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void ComputeDense()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+
+        daisy.Compute(gray, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void ComputeRoi()
+    {
+        // OpenCV's DAISY_Impl::compute_descriptors (opencv_contrib xfeatures2d/src/daisy.cpp)
+        // indexes the output buffer using absolute image coordinates (y*image.cols+x) even though
+        // the buffer is only sized roi.width*roi.height rows. That overflows for any roi other
+        // than the full image (x=0, y=0, width=image.cols, height=image.rows), so use the full
+        // image here to avoid tripping that upstream bug.
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+
+        daisy.Compute(gray, new Rect(0, 0, gray.Cols, gray.Rows), descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void GetDescriptor()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+
+        daisy.Compute(gray, descriptors);
+        var descriptor = daisy.GetDescriptor(100, 100, 0);
+
+        Assert.Equal(daisy.DescriptorSize, descriptor.Length);
+    }
+
+    [Fact]
+    public void GetUnnormalizedDescriptor()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var daisy = DAISY.Create();
+
+        daisy.Compute(gray, descriptors);
+        var descriptor = daisy.GetUnnormalizedDescriptor(100, 100, 0);
+
+        Assert.Equal(daisy.DescriptorSize, descriptor.Length);
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = DAISY.Create();
+
+        alg.Radius = 10;
+        Assert.Equal(10, alg.Radius, 3);
+
+        alg.QRadius = 2;
+        Assert.Equal(2, alg.QRadius);
+
+        alg.QTheta = 4;
+        Assert.Equal(4, alg.QTheta);
+
+        alg.QHist = 4;
+        Assert.Equal(4, alg.QHist);
+
+        alg.Norm = DAISYNormalizationType.Sift;
+        Assert.Equal(DAISYNormalizationType.Sift, alg.Norm);
+
+        alg.Interpolation = false;
+        Assert.False(alg.Interpolation);
+
+        alg.UseOrientation = true;
+        Assert.True(alg.UseOrientation);
+    }
+
+    [Fact]
+    public void HProperty()
+    {
+        using var alg = DAISY.Create();
+
+        using (var h = alg.H)
+        {
+            Assert.True(h.Empty());
+        }
+
+        using var identity = Mat.Eye(3, 3, MatType.CV_64FC1).ToMat();
+        alg.H = identity;
+
+        using var h2 = alg.H;
+        Assert.False(h2.Empty());
+        Assert.Equal(new Size(3, 3), h2.Size());
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/DAISYTest.cs
@@ -64,7 +64,7 @@ public class DAISYTest : TestBase
         using var descriptors = new Mat();
         using var daisy = DAISY.Create();
 
-        Assert.Throws<OpenCVException>(() => daisy.Compute(gray, new Rect(0, 10, gray.Cols, 50), descriptors));
+        Assert.Throws<ArgumentException>(() => daisy.Compute(gray, new Rect(0, 10, gray.Cols, 50), descriptors));
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/xfeatures2d/FREAKTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/FREAKTest.cs
@@ -1,0 +1,48 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class FREAKTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var freak = FREAK.Create();
+        freak.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var freak = FREAK.Create();
+        using var surf = SURF.Create(500);
+
+        var keypoints = surf.Detect(gray);
+        freak.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = FREAK.Create();
+
+        alg.OrientationNormalized = false;
+        Assert.False(alg.OrientationNormalized);
+
+        alg.ScaleNormalized = false;
+        Assert.False(alg.ScaleNormalized);
+
+        alg.PatternScale = 10.0;
+        Assert.Equal(10.0, alg.PatternScale, 6);
+
+        alg.NOctaves = 2;
+        Assert.Equal(2, alg.NOctaves);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/HarrisLaplaceFeatureDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/HarrisLaplaceFeatureDetectorTest.cs
@@ -1,0 +1,46 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class HarrisLaplaceFeatureDetectorTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var detector = HarrisLaplaceFeatureDetector.Create();
+        detector.Dispose();
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var detector = HarrisLaplaceFeatureDetector.Create();
+
+        var keypoints = detector.Detect(gray);
+
+        Assert.NotEmpty(keypoints);
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = HarrisLaplaceFeatureDetector.Create();
+
+        alg.NumOctaves = 4;
+        Assert.Equal(4, alg.NumOctaves);
+
+        alg.CornThresh = 0.02f;
+        Assert.Equal(0.02f, alg.CornThresh, 3);
+
+        alg.DOGThresh = 0.02f;
+        Assert.Equal(0.02f, alg.DOGThresh, 3);
+
+        alg.MaxCorners = 2000;
+        Assert.Equal(2000, alg.MaxCorners);
+
+        alg.NumLayers = 2;
+        Assert.Equal(2, alg.NumLayers);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/LATCHTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/LATCHTest.cs
@@ -46,4 +46,22 @@ public class LATCHTest : TestBase
             Assert.Equal(6, defnorm);
         }
     }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = LATCH.Create();
+
+        alg.Bytes = 16;
+        Assert.Equal(16, alg.Bytes);
+
+        alg.RotationInvariance = false;
+        Assert.False(alg.RotationInvariance);
+
+        alg.HalfSSDsize = 4;
+        Assert.Equal(4, alg.HalfSSDsize);
+
+        alg.Sigma = 1.5;
+        Assert.Equal(1.5, alg.Sigma, 6);
+    }
 }

--- a/test/OpenCvSharp.Tests/xfeatures2d/LUCIDTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/LUCIDTest.cs
@@ -46,4 +46,16 @@ public class LUCIDTest : TestBase
             Assert.Equal(6, defnorm);
         }
     }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = LUCID.Create();
+
+        alg.LucidKernel = 2;
+        Assert.Equal(2, alg.LucidKernel);
+
+        alg.BlurKernel = 3;
+        Assert.Equal(3, alg.BlurKernel);
+    }
 }

--- a/test/OpenCvSharp.Tests/xfeatures2d/MSDDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/MSDDetectorTest.cs
@@ -1,0 +1,58 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class MSDDetectorTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var msd = MSDDetector.Create();
+        msd.Dispose();
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var msd = MSDDetector.Create();
+
+        var keypoints = msd.Detect(gray);
+
+        Assert.NotEmpty(keypoints);
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = MSDDetector.Create();
+
+        alg.PatchRadius = 4;
+        Assert.Equal(4, alg.PatchRadius);
+
+        alg.SearchAreaRadius = 6;
+        Assert.Equal(6, alg.SearchAreaRadius);
+
+        alg.NmsRadius = 4;
+        Assert.Equal(4, alg.NmsRadius);
+
+        alg.NmsScaleRadius = 1;
+        Assert.Equal(1, alg.NmsScaleRadius);
+
+        alg.ThSaliency = 200.0f;
+        Assert.Equal(200.0f, alg.ThSaliency, 3);
+
+        alg.KNN = 5;
+        Assert.Equal(5, alg.KNN);
+
+        alg.ScaleFactor = 1.5f;
+        Assert.Equal(1.5f, alg.ScaleFactor, 3);
+
+        alg.NScales = 3;
+        Assert.Equal(3, alg.NScales);
+
+        alg.ComputeOrientation = true;
+        Assert.True(alg.ComputeOrientation);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/MatchGMSTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/MatchGMSTest.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class MatchGMSTest : TestBase
+{
+    [Fact]
+    public void MatchGMS()
+    {
+        using var img1 = LoadImage("tsukuba_left.png", ImreadModes.Grayscale);
+        using var img2 = LoadImage("tsukuba_right.png", ImreadModes.Grayscale);
+        using var orb = ORB.Create(10000);
+        using var descriptor1 = new Mat();
+        using var descriptor2 = new Mat();
+        orb.DetectAndCompute(img1, default, out var keypoints1, descriptor1);
+        orb.DetectAndCompute(img2, default, out var keypoints2, descriptor2);
+
+        using var matcher = new BFMatcher(NormTypes.Hamming);
+        var matches = matcher.Match(descriptor1, descriptor2);
+
+        var gmsMatches = Cv2.MatchGMS(img1.Size(), img2.Size(), keypoints1, keypoints2, matches);
+
+        Assert.NotNull(gmsMatches);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/MatchLOGOSTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/MatchLOGOSTest.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class MatchLOGOSTest : TestBase
+{
+    [Fact]
+    public void MatchLOGOS()
+    {
+        // OpenCV's matchLOGOS (opencv_contrib xfeatures2d/src/logos/Point.cpp,
+        // Point::nearestNeighboursNaive) reads out of bounds when fewer than
+        // NUM1/NUM2 (default 5) other points are available, so use a set large
+        // enough to avoid tripping that upstream bug.
+        var keypoints1 = Enumerable.Range(0, 10).Select(i => new KeyPoint(i * 10, i * 10, 1)).ToArray();
+        var keypoints2 = Enumerable.Range(0, 10).Select(i => new KeyPoint(i * 10 + 1, i * 10 + 1, 1)).ToArray();
+        var nn1 = Enumerable.Range(0, 10).ToArray();
+        var nn2 = Enumerable.Range(0, 10).ToArray();
+
+        var matches = Cv2.MatchLOGOS(keypoints1, keypoints2, nn1, nn2);
+
+        Assert.NotNull(matches);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/PCTSignaturesSQFDTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/PCTSignaturesSQFDTest.cs
@@ -1,0 +1,50 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class PCTSignaturesSQFDTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var sqfd = PCTSignaturesSQFD.Create();
+        sqfd.Dispose();
+    }
+
+    [Fact]
+    public void ComputeQuadraticFormDistance()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Color);
+        using var signature = new Mat();
+        using var signatures = PCTSignatures.Create(50, 10);
+        signatures.ComputeSignature(image, signature);
+
+        using var sqfd = PCTSignaturesSQFD.Create();
+        var distance = sqfd.ComputeQuadraticFormDistance(signature, signature);
+
+        Assert.Equal(0.0f, distance, 3);
+    }
+
+    [Fact]
+    public void ComputeQuadraticFormDistances()
+    {
+        // OpenCV's Parallel_computeSQFDs::operator() (opencv_contrib xfeatures2d/src/
+        // pct_signatures_sqfd.cpp:141) does mImageSignatures[i].empty() where mImageSignatures
+        // is a `const std::vector<Mat>*` (pointer to the whole vector) rather than
+        // (*mImageSignatures)[i], so for i>0 it's undefined behavior (pointer arithmetic past a
+        // single vector-sized block, read back as a std::vector<Mat>). It only happens to behave
+        // for a single-element vector, so that's all this wrapper can safely exercise.
+        using var image = LoadImage("lenna.png", ImreadModes.Color);
+        using var signature = new Mat();
+        using var signatures = PCTSignatures.Create(50, 10);
+        signatures.ComputeSignature(image, signature);
+
+        using var sqfd = PCTSignaturesSQFD.Create();
+        var distances = sqfd.ComputeQuadraticFormDistances(signature, [signature]);
+
+        Assert.Single(distances);
+        Assert.Equal(0.0f, distances[0], 3);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/PCTSignaturesTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/PCTSignaturesTest.cs
@@ -1,0 +1,191 @@
+using System.Linq;
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class PCTSignaturesTest : TestBase
+{
+    [Fact]
+    public void CreateDefaultAndDispose()
+    {
+        var alg = PCTSignatures.Create();
+        alg.Dispose();
+    }
+
+    [Fact]
+    public void CreateFromSamplingPointsAndSeedCount()
+    {
+        var points = PCTSignatures.GenerateInitPoints(200, PCTSignaturesPointDistribution.Regular);
+        using var alg = PCTSignatures.Create(points, 20);
+
+        Assert.NotEmpty(alg.GetSamplingPoints());
+    }
+
+    [Fact]
+    public void CreateFromSamplingPointsAndSeedIndexes()
+    {
+        var points = PCTSignatures.GenerateInitPoints(200, PCTSignaturesPointDistribution.Uniform);
+        var seedIndexes = Enumerable.Range(0, 20).ToArray();
+        using var alg = PCTSignatures.Create(points, seedIndexes);
+
+        Assert.Equal(seedIndexes.Length, alg.GetInitSeedIndexes().Length);
+    }
+
+    [Fact]
+    public void GenerateInitPoints()
+    {
+        var points = PCTSignatures.GenerateInitPoints(100, PCTSignaturesPointDistribution.Uniform);
+
+        Assert.Equal(100, points.Length);
+        Assert.All(points, p =>
+        {
+            Assert.InRange(p.X, 0.0f, 1.0f);
+            Assert.InRange(p.Y, 0.0f, 1.0f);
+        });
+    }
+
+    [Fact]
+    public void ComputeSignature()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Color);
+        using var signature = new Mat();
+        using var alg = PCTSignatures.Create(50, 10);
+
+        alg.ComputeSignature(image, signature);
+
+        Assert.False(signature.Empty());
+    }
+
+    [Fact]
+    public void ComputeSignatures()
+    {
+        using var image1 = LoadImage("lenna.png", ImreadModes.Color);
+        using var image2 = LoadImage("lenna.png", ImreadModes.Color);
+        using var alg = PCTSignatures.Create(50, 10);
+
+        var signatures = alg.ComputeSignatures([image1, image2]);
+
+        Assert.Equal(2, signatures.Length);
+        Assert.All(signatures, s => Assert.False(s.Empty()));
+        foreach (var s in signatures)
+            s.Dispose();
+    }
+
+    [Fact]
+    public void DrawSignature()
+    {
+        using var image = LoadImage("lenna.png", ImreadModes.Color);
+        using var signature = new Mat();
+        using var result = new Mat();
+        using var alg = PCTSignatures.Create(50, 10);
+
+        alg.ComputeSignature(image, signature);
+        PCTSignatures.DrawSignature(image, signature, result);
+
+        Assert.False(result.Empty());
+    }
+
+    [Fact]
+    public void SamplerProperties()
+    {
+        using var alg = PCTSignatures.Create(50, 10);
+
+        // OpenCV's PCTSignatures_Impl::getSampleCount() (opencv_contrib
+        // xfeatures2d/src/pct_signatures.cpp:132) is a copy-paste bug: it calls
+        // mSampler->getGrayscaleBits() instead of returning the actual sample count, so it's
+        // always identical to GrayscaleBits (default 4), never the value passed to Create().
+        Assert.Equal(4, alg.SampleCount);
+
+        alg.GrayscaleBits = 6;
+        Assert.Equal(6, alg.GrayscaleBits);
+
+        alg.WindowRadius = 4;
+        Assert.Equal(4, alg.WindowRadius);
+
+        alg.WeightX = 2.0f;
+        Assert.Equal(2.0f, alg.WeightX, 3);
+
+        alg.WeightY = 2.0f;
+        Assert.Equal(2.0f, alg.WeightY, 3);
+
+        alg.WeightL = 2.0f;
+        Assert.Equal(2.0f, alg.WeightL, 3);
+
+        alg.WeightA = 2.0f;
+        Assert.Equal(2.0f, alg.WeightA, 3);
+
+        alg.WeightB = 2.0f;
+        Assert.Equal(2.0f, alg.WeightB, 3);
+
+        alg.WeightContrast = 0.5f;
+        Assert.Equal(0.5f, alg.WeightContrast, 3);
+
+        alg.WeightEntropy = 0.5f;
+        Assert.Equal(0.5f, alg.WeightEntropy, 3);
+    }
+
+    [Fact]
+    public void SetWeightAndTranslation()
+    {
+        using var alg = PCTSignatures.Create(50, 10);
+
+        alg.SetWeight(1, 3.0f);
+        Assert.Equal(3.0f, alg.WeightX, 3);
+
+        alg.SetWeights([1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f]);
+        Assert.Equal(2f, alg.WeightX, 3);
+
+        // Translation has no getter on the native side; just verify the calls don't throw.
+        alg.SetTranslation(1, 0.1f);
+        alg.SetTranslations([0f, 0.1f, 0.1f, 0f, 0f, 0f, 0f, 0f]);
+    }
+
+    [Fact]
+    public void SetSamplingPoints()
+    {
+        var points = PCTSignatures.GenerateInitPoints(100, PCTSignaturesPointDistribution.Uniform);
+        using var alg = PCTSignatures.Create(50, 10);
+
+        alg.SetSamplingPoints(points);
+
+        Assert.Equal(100, alg.GetSamplingPoints().Length);
+    }
+
+    [Fact]
+    public void ClusterizerProperties()
+    {
+        using var alg = PCTSignatures.Create(50, 10);
+
+        Assert.Equal(10, alg.InitSeedCount);
+
+        alg.IterationCount = 5;
+        Assert.Equal(5, alg.IterationCount);
+
+        alg.MaxClustersCount = 10;
+        Assert.Equal(10, alg.MaxClustersCount);
+
+        alg.ClusterMinSize = 2;
+        Assert.Equal(2, alg.ClusterMinSize);
+
+        alg.JoiningDistance = 0.2f;
+        Assert.Equal(0.2f, alg.JoiningDistance, 3);
+
+        alg.DropThreshold = 0.1f;
+        Assert.Equal(0.1f, alg.DropThreshold, 3);
+
+        alg.DistanceFunction = PCTSignaturesDistanceFunction.L1;
+        Assert.Equal(PCTSignaturesDistanceFunction.L1, alg.DistanceFunction);
+    }
+
+    [Fact]
+    public void SetInitSeedIndexes()
+    {
+        using var alg = PCTSignatures.Create(50, 10);
+
+        var indexes = Enumerable.Range(0, 15).ToArray();
+        alg.SetInitSeedIndexes(indexes);
+
+        Assert.Equal(indexes, alg.GetInitSeedIndexes());
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/StarDetectorTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/StarDetectorTest.cs
@@ -1,0 +1,46 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+public class StarDetectorTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var star = StarDetector.Create();
+        star.Dispose();
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var star = StarDetector.Create();
+
+        var keypoints = star.Detect(gray);
+
+        Assert.NotEmpty(keypoints);
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = StarDetector.Create();
+
+        alg.MaxSize = 30;
+        Assert.Equal(30, alg.MaxSize);
+
+        alg.ResponseThreshold = 20;
+        Assert.Equal(20, alg.ResponseThreshold);
+
+        alg.LineThresholdProjected = 5;
+        Assert.Equal(5, alg.LineThresholdProjected);
+
+        alg.LineThresholdBinarized = 4;
+        Assert.Equal(4, alg.LineThresholdBinarized);
+
+        alg.SuppressNonmaxSize = 3;
+        Assert.Equal(3, alg.SuppressNonmaxSize);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/TBMRTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/TBMRTest.cs
@@ -41,4 +41,18 @@ public class TBMRTest : TestBase
         alg.NScales = 2;
         Assert.Equal(2, alg.NScales);
     }
+
+    [Fact]
+    public void DetectElliptic()
+    {
+        // TBMR extends AffineFeature2D natively (cv::xfeatures2d::TBMR : AffineFeature2D), so the
+        // elliptic-region detect API should be available on the C# type too, not just plain Detect().
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var tbmr = TBMR.Create();
+
+        var keypoints = tbmr.DetectElliptic(gray);
+
+        Assert.NotEmpty(keypoints);
+        Assert.All(keypoints, kp => Assert.True(kp.Axes.Width >= 0 && kp.Axes.Height >= 0));
+    }
 }

--- a/test/OpenCvSharp.Tests/xfeatures2d/TBMRTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/TBMRTest.cs
@@ -1,0 +1,44 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class TBMRTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var tbmr = TBMR.Create();
+        tbmr.Dispose();
+    }
+
+    [Fact]
+    public void Detect()
+    {
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var tbmr = TBMR.Create();
+
+        var keypoints = tbmr.Detect(gray);
+
+        Assert.NotNull(keypoints);
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = TBMR.Create();
+
+        alg.MinArea = 100;
+        Assert.Equal(100, alg.MinArea);
+
+        alg.MaxAreaRelative = 0.02f;
+        Assert.Equal(0.02f, alg.MaxAreaRelative, 3);
+
+        alg.ScaleFactor = 1.5f;
+        Assert.Equal(1.5f, alg.ScaleFactor, 3);
+
+        alg.NScales = 2;
+        Assert.Equal(2, alg.NScales);
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/TEBLIDTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/TEBLIDTest.cs
@@ -1,0 +1,30 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class TEBLIDTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var teblid = TEBLID.Create(6.25f);
+        teblid.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var teblid = TEBLID.Create(6.25f);
+        using var orb = ORB.Create();
+
+        var keypoints = orb.Detect(gray);
+        teblid.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+}

--- a/test/OpenCvSharp.Tests/xfeatures2d/VGGTest.cs
+++ b/test/OpenCvSharp.Tests/xfeatures2d/VGGTest.cs
@@ -1,0 +1,51 @@
+using OpenCvSharp.XFeatures2D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.XFeatures2D;
+
+// ReSharper disable once InconsistentNaming
+public class VGGTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        var vgg = VGG.Create();
+        vgg.Dispose();
+    }
+
+    [Fact]
+    public void Compute()
+    {
+        using var color = LoadImage("lenna.png", ImreadModes.Color);
+        using var gray = LoadImage("lenna.png", ImreadModes.Grayscale);
+        using var descriptors = new Mat();
+        using var vgg = VGG.Create();
+        using var orb = ORB.Create();
+
+        var keypoints = orb.Detect(gray);
+        vgg.Compute(color, ref keypoints, descriptors);
+
+        Assert.False(descriptors.Empty());
+    }
+
+    [Fact]
+    public void Properties()
+    {
+        using var alg = VGG.Create();
+
+        alg.Sigma = 1.0f;
+        Assert.Equal(1.0f, alg.Sigma, 3);
+
+        alg.UseNormalizeImage = false;
+        Assert.False(alg.UseNormalizeImage);
+
+        alg.UseScaleOrientation = false;
+        Assert.False(alg.UseScaleOrientation);
+
+        alg.ScaleFactor = 5.0f;
+        Assert.Equal(5.0f, alg.ScaleFactor, 3);
+
+        alg.UseNormalizeDescriptor = true;
+        Assert.True(alg.UseNormalizeDescriptor);
+    }
+}


### PR DESCRIPTION
## Summary

Closes all 23 items tracked in #2011: a full audit-driven coverage sweep of the `features` (core) and `xfeatures2d` (contrib) modules.

- **features** (4 small items): `SimpleBlobDetector.Params.CollectContours`/`GetBlobContours()`, `goodFeaturesToTrack` gradientSize + quality-output overloads, `DescriptorMatcher.Create(MatcherType)` + native enum, `KeyPointsFilter.RunByPixelsMask2VectorPoint`.
- **xfeatures2d** (19 items): property accessors added to `StarDetector`/`BriefDescriptorExtractor`/`LUCID`/`LATCH`/`FREAK`; new classes `BEBLID`, `TEBLID`, `MSDDetector`, `VGG`, `BoostDesc`, `HarrisLaplaceFeatureDetector`, `TBMR`, `DAISY`, `PCTSignatures`, `PCTSignaturesSQFD`, `AffineFeature2D` (+ `EllipticKeyPoint`); free functions `matchGMS`/`matchLOGOS`.

Each class/function was implemented across all three layers (native `OpenCvSharpExtern` bridge, managed `OpenCvSharp` wrapper, and xUnit test coverage), committed in one logical chunk per module group — see individual commits for details.

## Notable findings

While writing tests, three pre-existing upstream OpenCV bugs were found and documented (not fixed, since they live in `opencv`/`opencv_contrib`, not this repo):
- `opencv_contrib/modules/xfeatures2d/src/logos/Point.cpp` (`nearestNeighboursNaive`): loops past the end of its candidate vector when fewer than 5 points are available, an out-of-bounds read. Documented in `MatchLOGOSTest`.
- `opencv_contrib/modules/xfeatures2d/src/pct_signatures.cpp:132`: `PCTSignatures_Impl::getSampleCount()` is a copy-paste bug, returning `getGrayscaleBits()` instead of the actual sample count. Documented on `PCTSignatures.SampleCount`.
- `opencv_contrib/modules/xfeatures2d/src/pct_signatures_sqfd.cpp:141`: `Parallel_computeSQFDs::operator()` checks `mImageSignatures[i].empty()` using pointer arithmetic on a `std::vector<Mat>*` instead of `(*mImageSignatures)[i]`, so any index beyond 0 reads out-of-bounds memory. Documented on `PCTSignaturesSQFD.ComputeQuadraticFormDistances`.
- `opencv_contrib/modules/xfeatures2d/src/affine_feature2d.cpp` (`calcAffineCovariantDescriptors`): throws an assertion failure when the wrapped descriptor extractor is ORB (binary/CV_8U descriptor); SIFT-family extractors work correctly. Documented on `AffineFeature2D.DetectAndComputeElliptic`.
- `opencv_contrib/modules/xfeatures2d/src/daisy.cpp` (`DAISY_Impl::compute_descriptors`): the ROI `compute()` overload indexes its output buffer using absolute image coordinates while sizing the buffer to `roi.width * roi.height`, so it overflows unless the ROI covers the entire image. Documented on `DAISY.Compute(InputArray, Rect, OutputArray)`.

## Test plan

- [x] Native `OpenCvSharpExtern` builds clean (Release, x64)
- [x] Managed `OpenCvSharp` builds clean (0 warnings, 0 errors)
- [x] Full test suite: 1422 passed, 26 skipped (pre-existing, unrelated), 0 failed
- [x] `features`/`xfeatures2d` test subset (132 tests) run in isolation to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `Cv2.MatchGMS` and `Cv2.MatchLOGOS` for improved feature matching.
  - Added `Cv2.GoodFeaturesToTrack` overloads for explicit `gradientSize` and per-corner quality output.
  - Introduced new xfeatures2d APIs/wrappers: `DAISY`, `VGG`, `BoostDesc`, `BEBLID`, `TEBLID`, `AffineFeature2D` (with `EllipticKeyPoint`), `MSDDetector`, `HarrisLaplaceFeatureDetector`, `TBMR`, `StarDetector`, `PCTSignatures`/`PCTSignaturesSQFD`.
  - Enhanced `SimpleBlobDetector` with `CollectContours` and `GetBlobContours`.
  - Added `DescriptorMatcher.MatcherType` and `DescriptorMatcher.Create(MatcherType)`.

- **Tests**
  - Expanded unit tests for the new matchers, corner-detection overloads, blob contours, mask-based filtering, and xfeatures2d wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->