### PR TITLE
Add LINEMOD wrappers for rgbd module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See `.github/copilot-instructions.md` for development instructions.

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_linemod.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_linemod.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable CA1401
+#pragma warning disable IDE1006
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_ColorGradient_create(
+        float weakThreshold, nuint numFeatures, float strongThreshold, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_DepthNormal_create(
+        int distanceThreshold, int differenceThreshold, nuint numFeatures, int extractThreshold, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_create(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string modalityType, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_createFromFileNode(
+        OpenCvSafeHandle node, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Ptr_Modality_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Ptr_Modality_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_name(OpenCvSafeHandle obj, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_process(
+        OpenCvSafeHandle obj, OpenCvSafeHandle src, OpenCvSafeHandle mask, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_read(OpenCvSafeHandle obj, OpenCvSafeHandle node);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Modality_write(OpenCvSafeHandle obj, OpenCvSafeHandle fs);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_ColorGradient_get(
+        OpenCvSafeHandle obj, out float weakThreshold, out nuint numFeatures, out float strongThreshold);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_DepthNormal_get(
+        OpenCvSafeHandle obj, out int distanceThreshold, out int differenceThreshold,
+        out nuint numFeatures, out int extractThreshold);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Ptr_QuantizedPyramid_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Ptr_QuantizedPyramid_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_QuantizedPyramid_quantize(OpenCvSafeHandle obj, OpenCvSafeHandle dst);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_QuantizedPyramid_pyrDown(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_QuantizedPyramid_extractTemplate(
+        OpenCvSafeHandle obj, out int width, out int height, out int pyramidLevel, IntPtr features, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_new(
+        IntPtr[] modalities, int modalitiesLength, int[] tPyramid, int tPyramidLength, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_newEmpty(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_getDefaultLINE(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_getDefaultLINEMOD(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_addTemplate(
+        OpenCvSafeHandle obj, IntPtr sources, [MarshalAs(UnmanagedType.LPUTF8Str)] string classId,
+        OpenCvSafeHandle objectMask, out Rect boundingBox, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_addSyntheticTemplate(
+        OpenCvSafeHandle obj, IntPtr headers, IntPtr features,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string classId, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_match(
+        OpenCvSafeHandle obj, IntPtr sources, float threshold, IntPtr values, IntPtr classIds,
+        IntPtr filterClassIds, IntPtr quantizedImages, IntPtr masks);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_getT(OpenCvSafeHandle obj, int level, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_pyramidLevels(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_numTemplates(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_numTemplatesByClass(
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPUTF8Str)] string classId, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_numClasses(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_classIds(OpenCvSafeHandle obj, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_getTemplates(
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPUTF8Str)] string classId,
+        int templateId, IntPtr headers, IntPtr features);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_getModalitiesSize(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_getModality(OpenCvSafeHandle obj, int index, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_read(OpenCvSafeHandle obj, OpenCvSafeHandle node);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_write(OpenCvSafeHandle obj, OpenCvSafeHandle fs);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_readClass(
+        OpenCvSafeHandle obj, OpenCvSafeHandle node,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string classIdOverride, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_writeClass(
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPUTF8Str)] string classId, OpenCvSafeHandle fs);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_readClasses(
+        OpenCvSafeHandle obj, IntPtr classIds, [MarshalAs(UnmanagedType.LPUTF8Str)] string format);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_linemod_Detector_writeClasses(
+        OpenCvSafeHandle obj, [MarshalAs(UnmanagedType.LPUTF8Str)] string format);
+}

--- a/src/OpenCvSharp/Modules/rgbd/LinemodDetector.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodDetector.cs
@@ -1,0 +1,245 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>Object detector using LINE template matching with one or more modalities.</summary>
+public sealed class LinemodDetector : CvObject
+{
+    private LinemodDetector(IntPtr ptr)
+        => SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
+
+    /// <summary>Creates an empty detector intended to be initialized with <see cref="Read"/>.</summary>
+    public LinemodDetector()
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_newEmpty(out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
+    }
+
+    /// <summary>Creates a detector using the supplied modalities and sampling steps.</summary>
+    public LinemodDetector(IEnumerable<LinemodModality> modalities, IEnumerable<int> tPyramid)
+    {
+        ArgumentNullException.ThrowIfNull(modalities);
+        ArgumentNullException.ThrowIfNull(tPyramid);
+        var mods = modalities.ToArray();
+        var steps = tPyramid.ToArray();
+        if (mods.Length == 0 || steps.Length == 0)
+            throw new ArgumentException("At least one modality and pyramid sampling step are required.");
+        var pointers = mods.Select(m => m.SmartPtr).ToArray();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_new(
+            pointers, pointers.Length, steps, steps.Length, out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
+            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
+        foreach (var mod in mods) GC.KeepAlive(mod);
+    }
+
+    /// <summary>Creates the default color-gradient LINE detector.</summary>
+    public static LinemodDetector CreateDefaultLINE()
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_getDefaultLINE(out var ptr));
+        return new LinemodDetector(ptr);
+    }
+
+    /// <summary>Creates the default color-and-depth LINEMOD detector.</summary>
+    public static LinemodDetector CreateDefaultLINEMOD()
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_getDefaultLINEMOD(out var ptr));
+        return new LinemodDetector(ptr);
+    }
+
+    /// <summary>Extracts and registers a new object template.</summary>
+    public int AddTemplate(IEnumerable<Mat> sources, string classId, Mat objectMask, out Rect boundingBox)
+    {
+        ArgumentNullException.ThrowIfNull(sources); ArgumentException.ThrowIfNullOrEmpty(classId);
+        ArgumentNullException.ThrowIfNull(objectMask);
+        var sourceArray = sources.ToArray();
+        using var sourceVec = new VectorOfMat(sourceArray);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_addTemplate(
+            Handle, sourceVec.CvPtr, classId, objectMask.Handle, out boundingBox, out var result));
+        foreach (var source in sourceArray) GC.KeepAlive(source);
+        GC.KeepAlive(objectMask);
+        return result;
+    }
+
+    /// <summary>Adds a template pyramid computed externally.</summary>
+    public int AddSyntheticTemplate(IEnumerable<LinemodTemplate> templates, string classId)
+    {
+        ArgumentNullException.ThrowIfNull(templates); ArgumentException.ThrowIfNullOrEmpty(classId);
+        var templateArray = templates.ToArray();
+        using var headers = new StdVector<Vec4i>(templateArray.Select(t =>
+            new Vec4i(t.Width, t.Height, t.PyramidLevel, t.Features.Length)));
+        using var features = new StdVector<Vec4i>(templateArray.SelectMany(t => t.Features)
+            .Select(f => new Vec4i(f.X, f.Y, f.Label, 0)));
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_addSyntheticTemplate(
+            Handle, headers.CvPtr, features.CvPtr, classId, out var result));
+        return result;
+    }
+
+    /// <summary>Matches registered templates against source images.</summary>
+    public LinemodMatch[] Match(IEnumerable<Mat> sources, float threshold,
+        IEnumerable<string>? classIds = null, IEnumerable<Mat>? masks = null)
+        => Match(sources, threshold, out _, classIds, masks);
+
+    /// <summary>Matches templates and returns the generated quantized images.</summary>
+    public LinemodMatch[] Match(IEnumerable<Mat> sources, float threshold, out Mat[] quantizedImages,
+        IEnumerable<string>? classIds = null, IEnumerable<Mat>? masks = null)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        var sourceArray = sources.ToArray();
+        var maskArray = masks?.ToArray();
+        using var sourceVec = new VectorOfMat(sourceArray);
+        using var values = new StdVector<Vec4f>();
+        using var resultClassIds = new VectorOfString();
+        using var filter = classIds is null ? null : new VectorOfString(classIds);
+        using var quantized = new VectorOfMat();
+        using var maskVec = maskArray is null ? null : new VectorOfMat(maskArray);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_match(
+            Handle, sourceVec.CvPtr, threshold, values.CvPtr, resultClassIds.CvPtr,
+            filter?.CvPtr ?? IntPtr.Zero, quantized.CvPtr, maskVec?.CvPtr ?? IntPtr.Zero));
+        var nativeValues = values.ToArray();
+        var ids = resultClassIds.ToArray();
+        quantizedImages = quantized.ToArray();
+        var result = new LinemodMatch[nativeValues.Length];
+        for (var i = 0; i < result.Length; i++)
+        {
+            var v = nativeValues[i];
+            result[i] = new LinemodMatch((int)v.Item0, (int)v.Item1, v.Item2, ids[i], (int)v.Item3);
+        }
+        foreach (var source in sourceArray) GC.KeepAlive(source);
+        if (maskArray is not null) foreach (var mask in maskArray) GC.KeepAlive(mask);
+        return result;
+    }
+
+    /// <summary>Gets the number of pyramid levels.</summary>
+    public int PyramidLevels => GetValue(NativeMethods.rgbd_linemod_Detector_pyramidLevels);
+    /// <summary>Gets the total number of registered templates.</summary>
+    public int NumTemplates => GetValue(NativeMethods.rgbd_linemod_Detector_numTemplates);
+    /// <summary>Gets the number of registered classes.</summary>
+    public int NumClasses => GetValue(NativeMethods.rgbd_linemod_Detector_numClasses);
+
+    /// <summary>Gets the sampling step at a pyramid level.</summary>
+    public int GetT(int pyramidLevel)
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_getT(Handle, pyramidLevel, out var value));
+        return value;
+    }
+
+    /// <summary>Gets the number of templates registered for a class.</summary>
+    public int GetNumTemplates(string classId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(classId);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_numTemplatesByClass(Handle, classId, out var value));
+        return value;
+    }
+
+    /// <summary>Gets all registered class identifiers.</summary>
+    public string[] GetClassIds()
+    {
+        using var values = new VectorOfString();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_classIds(Handle, values.CvPtr));
+        return values.ToArray();
+    }
+
+    /// <summary>Gets the template pyramid identified by class and template ID.</summary>
+    public LinemodTemplate[] GetTemplates(string classId, int templateId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(classId);
+        using var headers = new StdVector<Vec4i>();
+        using var features = new StdVector<Vec4i>();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_getTemplates(
+            Handle, classId, templateId, headers.CvPtr, features.CvPtr));
+        var nativeHeaders = headers.ToArray();
+        var nativeFeatures = features.ToArray();
+        var result = new LinemodTemplate[nativeHeaders.Length];
+        var offset = 0;
+        for (var i = 0; i < result.Length; i++)
+        {
+            var h = nativeHeaders[i];
+            var featureArray = new LinemodFeature[h.Item3];
+            for (var j = 0; j < featureArray.Length; j++)
+            {
+                var f = nativeFeatures[offset++];
+                featureArray[j] = new LinemodFeature(f.Item0, f.Item1, f.Item2);
+            }
+            result[i] = new LinemodTemplate(h.Item0, h.Item1, h.Item2, featureArray);
+        }
+        return result;
+    }
+
+    /// <summary>Gets copies of the modalities used by this detector.</summary>
+    public LinemodModality[] GetModalities()
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_getModalitiesSize(Handle, out var count));
+        var result = new LinemodModality[count];
+        try
+        {
+            for (var i = 0; i < count; i++)
+            {
+                NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_getModality(Handle, i, out var ptr));
+                result[i] = new LinemodModality(ptr);
+            }
+            return result;
+        }
+        catch
+        {
+            foreach (var modality in result)
+                modality?.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Loads detector configuration from a file node.</summary>
+    public void Read(FileNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_read(Handle, node.Handle));
+        GC.KeepAlive(node);
+    }
+
+    /// <summary>Writes detector configuration to file storage.</summary>
+    public void Write(FileStorage storage)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_write(Handle, storage.Handle));
+        GC.KeepAlive(storage);
+    }
+
+    /// <summary>Loads one serialized template class and returns its class identifier.</summary>
+    public string ReadClass(FileNode node, string classIdOverride = "")
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        using var value = new StdString();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_readClass(
+            Handle, node.Handle, classIdOverride, value.CvPtr));
+        GC.KeepAlive(node);
+        return value.ToString();
+    }
+
+    /// <summary>Writes one template class to file storage.</summary>
+    public void WriteClass(string classId, FileStorage storage)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(classId); ArgumentNullException.ThrowIfNull(storage);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_writeClass(Handle, classId, storage.Handle));
+        GC.KeepAlive(storage);
+    }
+
+    /// <summary>Loads template classes from files matching a format string.</summary>
+    public void ReadClasses(IEnumerable<string> classIds, string format = "templates_%s.yml.gz")
+    {
+        using var values = new VectorOfString(classIds);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_readClasses(Handle, values.CvPtr, format));
+    }
+
+    /// <summary>Writes every template class to a separate file.</summary>
+    public void WriteClasses(string format = "templates_%s.yml.gz")
+        => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_writeClasses(Handle, format));
+
+    private delegate ExceptionStatus Getter(OpenCvSafeHandle obj, out int value);
+    private int GetValue(Getter getter)
+    {
+        NativeMethods.HandleException(getter(Handle, out var value));
+        return value;
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/LinemodDetector.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodDetector.cs
@@ -11,15 +11,20 @@ public sealed class LinemodDetector : CvObject
             static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
 
     /// <summary>Creates an empty detector intended to be initialized with <see cref="Read"/>.</summary>
-    public LinemodDetector()
+    public LinemodDetector() : this(CreateEmpty()) { }
+
+    private static IntPtr CreateEmpty()
     {
         NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_newEmpty(out var ptr));
-        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
-            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
+        return ptr;
     }
 
     /// <summary>Creates a detector using the supplied modalities and sampling steps.</summary>
     public LinemodDetector(IEnumerable<LinemodModality> modalities, IEnumerable<int> tPyramid)
+        : this(CreateNative(modalities, tPyramid)) { }
+
+    private static IntPtr CreateNative(
+        IEnumerable<LinemodModality> modalities, IEnumerable<int> tPyramid)
     {
         ArgumentNullException.ThrowIfNull(modalities);
         ArgumentNullException.ThrowIfNull(tPyramid);
@@ -30,9 +35,8 @@ public sealed class LinemodDetector : CvObject
         var pointers = mods.Select(m => m.SmartPtr).ToArray();
         NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_new(
             pointers, pointers.Length, steps, steps.Length, out var ptr));
-        SetSafeHandle(new OpenCvPtrSafeHandle(ptr, true,
-            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Detector_delete(p))));
         foreach (var mod in mods) GC.KeepAlive(mod);
+        return ptr;
     }
 
     /// <summary>Creates the default color-gradient LINE detector.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/LinemodModality.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodModality.cs
@@ -1,0 +1,191 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>Feature-extraction strategy used by a LINEMOD detector.</summary>
+public class LinemodModality : CvPtrObject
+{
+    internal LinemodModality(IntPtr smartPtr)
+        : base(smartPtr, GetRawPtr(smartPtr),
+            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Ptr_Modality_delete(p))) { }
+
+    private static IntPtr GetRawPtr(IntPtr smartPtr)
+    {
+        if (smartPtr == IntPtr.Zero)
+            throw new OpenCvSharpException("Failed to create LINEMOD modality");
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Ptr_Modality_get(smartPtr, out var rawPtr));
+        if (rawPtr == IntPtr.Zero)
+            throw new OpenCvSharpException("Failed to create LINEMOD modality");
+        return rawPtr;
+    }
+
+    /// <summary>Creates a modality by its OpenCV type name.</summary>
+    public static LinemodModality Create(string modalityType)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(modalityType);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_create(modalityType, out var ptr));
+        return new LinemodModality(ptr);
+    }
+
+    /// <summary>Creates a modality from a serialized file node.</summary>
+    public static LinemodModality Create(FileNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_createFromFileNode(node.Handle, out var ptr));
+        GC.KeepAlive(node);
+        return new LinemodModality(ptr);
+    }
+
+    /// <summary>The OpenCV modality type name.</summary>
+    public string Name
+    {
+        get
+        {
+            ThrowIfDisposed();
+            using var value = new StdString();
+            NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_name(Handle, value.CvPtr));
+            return value.ToString();
+        }
+    }
+
+    /// <summary>Forms a quantized image pyramid from a source image.</summary>
+    public QuantizedPyramid Process(Mat src, Mat? mask = null)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        src.ThrowIfDisposed();
+        mask?.ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_process(
+            Handle, src.Handle, mask?.Handle ?? OpenCvSafeHandle.Null, out var ptr));
+        GC.KeepAlive(src); GC.KeepAlive(mask);
+        return new QuantizedPyramid(ptr);
+    }
+
+    /// <summary>Loads modality parameters from a file node.</summary>
+    public void Read(FileNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_read(Handle, node.Handle));
+        GC.KeepAlive(node);
+    }
+
+    /// <summary>Writes modality parameters to file storage.</summary>
+    public void Write(FileStorage storage)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_write(Handle, storage.Handle));
+        GC.KeepAlive(storage);
+    }
+}
+
+/// <summary>Color-gradient LINEMOD modality.</summary>
+public sealed class ColorGradient : LinemodModality
+{
+    /// <summary>Creates a color-gradient modality.</summary>
+    public ColorGradient(float weakThreshold = 10f, nuint numFeatures = 63, float strongThreshold = 55f)
+        : base(CreateNative(weakThreshold, numFeatures, strongThreshold)) { }
+
+    private static IntPtr CreateNative(float weakThreshold, nuint numFeatures, float strongThreshold)
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_ColorGradient_create(
+            weakThreshold, numFeatures, strongThreshold, out var ptr));
+        return ptr;
+    }
+
+    private (float Weak, nuint Count, float Strong) Parameters
+    {
+        get
+        {
+            NativeMethods.HandleException(NativeMethods.rgbd_linemod_ColorGradient_get(
+                Handle, out var weak, out var count, out var strong));
+            return (weak, count, strong);
+        }
+    }
+
+    /// <summary>Gets the minimum gradient magnitude used during quantization.</summary>
+    public float WeakThreshold => Parameters.Weak;
+    /// <summary>Gets the number of features extracted for each template.</summary>
+    public nuint NumFeatures => Parameters.Count;
+    /// <summary>Gets the minimum gradient magnitude used for candidate features.</summary>
+    public float StrongThreshold => Parameters.Strong;
+}
+
+/// <summary>Depth-normal LINEMOD modality.</summary>
+public sealed class DepthNormal : LinemodModality
+{
+    /// <summary>Creates a depth-normal modality.</summary>
+    public DepthNormal(int distanceThreshold = 2000, int differenceThreshold = 50,
+        nuint numFeatures = 63, int extractThreshold = 2)
+        : base(CreateNative(distanceThreshold, differenceThreshold, numFeatures, extractThreshold)) { }
+
+    private static IntPtr CreateNative(int distanceThreshold, int differenceThreshold,
+        nuint numFeatures, int extractThreshold)
+    {
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_DepthNormal_create(
+            distanceThreshold, differenceThreshold, numFeatures, extractThreshold, out var ptr));
+        return ptr;
+    }
+
+    private (int Distance, int Difference, nuint Count, int Extract) Parameters
+    {
+        get
+        {
+            NativeMethods.HandleException(NativeMethods.rgbd_linemod_DepthNormal_get(
+                Handle, out var distance, out var difference, out var count, out var extract));
+            return (distance, difference, count, extract);
+        }
+    }
+
+    /// <summary>Gets the distance beyond which depth pixels are ignored.</summary>
+    public int DistanceThreshold => Parameters.Distance;
+    /// <summary>Gets the maximum depth difference used when computing normals.</summary>
+    public int DifferenceThreshold => Parameters.Difference;
+    /// <summary>Gets the number of features extracted for each template.</summary>
+    public nuint NumFeatures => Parameters.Count;
+    /// <summary>Gets the orientation-consistency distance used for feature extraction.</summary>
+    public int ExtractThreshold => Parameters.Extract;
+}
+
+/// <summary>A modality-specific quantized image pyramid.</summary>
+public sealed class QuantizedPyramid : CvPtrObject
+{
+    internal QuantizedPyramid(IntPtr smartPtr)
+        : base(smartPtr, GetRawPtr(smartPtr),
+            static p => NativeMethods.HandleException(NativeMethods.rgbd_linemod_Ptr_QuantizedPyramid_delete(p))) { }
+
+    private static IntPtr GetRawPtr(IntPtr smartPtr)
+    {
+        if (smartPtr == IntPtr.Zero)
+            throw new OpenCvSharpException("Failed to create QuantizedPyramid");
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_Ptr_QuantizedPyramid_get(smartPtr, out var rawPtr));
+        return rawPtr != IntPtr.Zero ? rawPtr : throw new OpenCvSharpException("Failed to create QuantizedPyramid");
+    }
+
+    /// <summary>Computes the quantized image at the current pyramid level.</summary>
+    public Mat Quantize()
+    {
+        ThrowIfDisposed();
+        var dst = new Mat();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_QuantizedPyramid_quantize(Handle, dst.Handle));
+        return dst;
+    }
+
+    /// <summary>Extracts the most discriminant features at the current pyramid level.</summary>
+    public bool ExtractTemplate(out LinemodTemplate template)
+    {
+        ThrowIfDisposed();
+        using var features = new StdVector<Vec4i>();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_QuantizedPyramid_extractTemplate(
+            Handle, out var width, out var height, out var level, features.CvPtr, out var result));
+        template = new LinemodTemplate(width, height, level,
+            features.ToArray().Select(v => new LinemodFeature(v.Item0, v.Item1, v.Item2)).ToArray());
+        return result != 0;
+    }
+
+    /// <summary>Advances to the next pyramid level.</summary>
+    public void PyrDown()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_linemod_QuantizedPyramid_pyrDown(Handle));
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/LinemodModality.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodModality.cs
@@ -52,6 +52,7 @@ public class LinemodModality : CvPtrObject
     /// <summary>Forms a quantized image pyramid from a source image.</summary>
     public QuantizedPyramid Process(Mat src, Mat? mask = null)
     {
+        ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(src);
         src.ThrowIfDisposed();
         mask?.ThrowIfDisposed();
@@ -64,6 +65,7 @@ public class LinemodModality : CvPtrObject
     /// <summary>Loads modality parameters from a file node.</summary>
     public void Read(FileNode node)
     {
+        ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(node);
         NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_read(Handle, node.Handle));
         GC.KeepAlive(node);
@@ -72,6 +74,7 @@ public class LinemodModality : CvPtrObject
     /// <summary>Writes modality parameters to file storage.</summary>
     public void Write(FileStorage storage)
     {
+        ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(storage);
         NativeMethods.HandleException(NativeMethods.rgbd_linemod_Modality_write(Handle, storage.Handle));
         GC.KeepAlive(storage);
@@ -96,6 +99,7 @@ public sealed class ColorGradient : LinemodModality
     {
         get
         {
+            ThrowIfDisposed();
             NativeMethods.HandleException(NativeMethods.rgbd_linemod_ColorGradient_get(
                 Handle, out var weak, out var count, out var strong));
             return (weak, count, strong);
@@ -130,6 +134,7 @@ public sealed class DepthNormal : LinemodModality
     {
         get
         {
+            ThrowIfDisposed();
             NativeMethods.HandleException(NativeMethods.rgbd_linemod_DepthNormal_get(
                 Handle, out var distance, out var difference, out var count, out var extract));
             return (distance, difference, count, extract);

--- a/src/OpenCvSharp/Modules/rgbd/LinemodTypes.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodTypes.cs
@@ -1,0 +1,11 @@
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>A discriminant LINEMOD feature.</summary>
+public readonly record struct LinemodFeature(int X, int Y, int Label);
+
+/// <summary>A template at one pyramid level.</summary>
+public sealed record LinemodTemplate(int Width, int Height, int PyramidLevel, LinemodFeature[] Features);
+
+/// <summary>A successful LINEMOD template match.</summary>
+public readonly record struct LinemodMatch(
+    int X, int Y, float Similarity, string ClassId, int TemplateId);

--- a/src/OpenCvSharp/Modules/rgbd/LinemodTypes.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LinemodTypes.cs
@@ -4,7 +4,28 @@ namespace OpenCvSharp.Rgbd;
 public readonly record struct LinemodFeature(int X, int Y, int Label);
 
 /// <summary>A template at one pyramid level.</summary>
-public sealed record LinemodTemplate(int Width, int Height, int PyramidLevel, LinemodFeature[] Features);
+public sealed record LinemodTemplate(int Width, int Height, int PyramidLevel, LinemodFeature[] Features)
+{
+    /// <inheritdoc />
+    public bool Equals(LinemodTemplate? other) =>
+        other is not null &&
+        Width == other.Width &&
+        Height == other.Height &&
+        PyramidLevel == other.PyramidLevel &&
+        Features.AsSpan().SequenceEqual(other.Features);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Width);
+        hash.Add(Height);
+        hash.Add(PyramidLevel);
+        foreach (var feature in Features)
+            hash.Add(feature);
+        return hash.ToHashCode();
+    }
+}
 
 /// <summary>A successful LINEMOD template match.</summary>
 public readonly record struct LinemodMatch(

--- a/src/OpenCvSharpExtern/include_opencv.h
+++ b/src/OpenCvSharpExtern/include_opencv.h
@@ -88,6 +88,9 @@
 #include <opencv2/xphoto.hpp>
 #include <opencv2/bgsegm.hpp>
 #include <opencv2/img_hash.hpp>
+#ifndef NO_CONTRIB
+#include <opencv2/rgbd/linemod.hpp>
+#endif
 
 // MP! Added: To correctly support imShow under WinRT.
 #ifdef _WINRT_DLL

--- a/src/OpenCvSharpExtern/rgbd.cpp
+++ b/src/OpenCvSharpExtern/rgbd.cpp
@@ -1,0 +1,2 @@
+// ReSharper disable CppUnusedIncludeDirective
+#include "rgbd_linemod.h"

--- a/src/OpenCvSharpExtern/rgbd_linemod.h
+++ b/src/OpenCvSharpExtern/rgbd_linemod.h
@@ -1,0 +1,255 @@
+#pragma once
+#ifndef NO_CONTRIB
+#include "include_opencv.h"
+
+// Keep the exported functions compact while using the repository's cvTry exception boundary.
+#define BEGIN_WRAP return cvTry([&] {
+#define END_WRAP });
+
+using cv::linemod::ColorGradient;
+using cv::linemod::DepthNormal;
+using cv::linemod::Detector;
+using cv::linemod::Feature;
+using cv::linemod::Match;
+using cv::linemod::Modality;
+using cv::linemod::QuantizedPyramid;
+using cv::linemod::Template;
+
+CVAPI(ExceptionStatus) rgbd_linemod_ColorGradient_create(
+    float weakThreshold, size_t numFeatures, float strongThreshold,
+    cv::Ptr<Modality> **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::Ptr<Modality>(ColorGradient::create(weakThreshold, numFeatures, strongThreshold));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_DepthNormal_create(
+    int distanceThreshold, int differenceThreshold, size_t numFeatures, int extractThreshold,
+    cv::Ptr<Modality> **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::Ptr<Modality>(DepthNormal::create(
+        distanceThreshold, differenceThreshold, numFeatures, extractThreshold));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_create(
+    const char *modalityType, cv::Ptr<Modality> **returnValue)
+{
+    BEGIN_WRAP *returnValue = new cv::Ptr<Modality>(Modality::create(modalityType)); END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_createFromFileNode(
+    cv::FileNode *node, cv::Ptr<Modality> **returnValue)
+{ BEGIN_WRAP *returnValue = new cv::Ptr<Modality>(Modality::create(*node)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Ptr_Modality_delete(cv::Ptr<Modality> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Ptr_Modality_get(
+    cv::Ptr<Modality> *obj, Modality **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_name(Modality *obj, std::string *returnValue)
+{ BEGIN_WRAP *returnValue = obj->name(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_process(
+    Modality *obj, cv::Mat *src, cv::Mat *mask, cv::Ptr<QuantizedPyramid> **returnValue)
+{
+    BEGIN_WRAP
+    *returnValue = new cv::Ptr<QuantizedPyramid>(obj->process(*src, mask == nullptr ? cv::Mat() : *mask));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_read(Modality *obj, cv::FileNode *node)
+{ BEGIN_WRAP obj->read(*node); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Modality_write(Modality *obj, cv::FileStorage *fs)
+{ BEGIN_WRAP obj->write(*fs); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_ColorGradient_get(
+    Modality *obj, float *weakThreshold, size_t *numFeatures, float *strongThreshold)
+{
+    BEGIN_WRAP
+    const auto p = dynamic_cast<ColorGradient *>(obj);
+    if (p == nullptr) CV_Error(cv::Error::StsBadArg, "Modality is not ColorGradient");
+    *weakThreshold = p->weak_threshold; *numFeatures = p->num_features; *strongThreshold = p->strong_threshold;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_DepthNormal_get(
+    Modality *obj, int *distanceThreshold, int *differenceThreshold, size_t *numFeatures, int *extractThreshold)
+{
+    BEGIN_WRAP
+    const auto p = dynamic_cast<DepthNormal *>(obj);
+    if (p == nullptr) CV_Error(cv::Error::StsBadArg, "Modality is not DepthNormal");
+    *distanceThreshold = p->distance_threshold; *differenceThreshold = p->difference_threshold;
+    *numFeatures = p->num_features; *extractThreshold = p->extract_threshold;
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Ptr_QuantizedPyramid_delete(cv::Ptr<QuantizedPyramid> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Ptr_QuantizedPyramid_get(
+    cv::Ptr<QuantizedPyramid> *obj, QuantizedPyramid **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_QuantizedPyramid_quantize(QuantizedPyramid *obj, cv::Mat *dst)
+{ BEGIN_WRAP obj->quantize(*dst); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_QuantizedPyramid_pyrDown(QuantizedPyramid *obj)
+{ BEGIN_WRAP obj->pyrDown(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_QuantizedPyramid_extractTemplate(
+    QuantizedPyramid *obj, int *width, int *height, int *pyramidLevel,
+    std::vector<cv::Vec4i> *features, int *returnValue)
+{
+    BEGIN_WRAP
+    Template t;
+    *returnValue = obj->extractTemplate(t) ? 1 : 0;
+    *width = t.width; *height = t.height; *pyramidLevel = t.pyramid_level;
+    features->clear();
+    for (const auto &f : t.features) features->emplace_back(f.x, f.y, f.label, 0);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_new(
+    cv::Ptr<Modality> **modalities, int modalitiesLength, int *tPyramid, int tPyramidLength,
+    Detector **returnValue)
+{
+    BEGIN_WRAP
+    std::vector<cv::Ptr<Modality>> mods;
+    mods.reserve(modalitiesLength);
+    for (int i = 0; i < modalitiesLength; i++) mods.push_back(*modalities[i]);
+    *returnValue = new Detector(mods, std::vector<int>(tPyramid, tPyramid + tPyramidLength));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_newEmpty(Detector **returnValue)
+{ BEGIN_WRAP *returnValue = new Detector(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_getDefaultLINE(Detector **returnValue)
+{ BEGIN_WRAP *returnValue = new Detector(*cv::linemod::getDefaultLINE()); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_getDefaultLINEMOD(Detector **returnValue)
+{ BEGIN_WRAP *returnValue = new Detector(*cv::linemod::getDefaultLINEMOD()); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_delete(Detector *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_addTemplate(
+    Detector *obj, std::vector<cv::Mat> *sources, const char *classId,
+    cv::Mat *objectMask, interop::Rect *boundingBox, int *returnValue)
+{
+    BEGIN_WRAP
+    cv::Rect rect;
+    *returnValue = obj->addTemplate(*sources, classId, *objectMask, boundingBox == nullptr ? nullptr : &rect);
+    if (boundingBox != nullptr) *boundingBox = c(rect);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_addSyntheticTemplate(
+    Detector *obj, std::vector<cv::Vec4i> *headers, std::vector<cv::Vec4i> *features,
+    const char *classId, int *returnValue)
+{
+    BEGIN_WRAP
+    std::vector<Template> templates;
+    size_t featureOffset = 0;
+    for (const auto &h : *headers)
+    {
+        Template t;
+        t.width = h[0]; t.height = h[1]; t.pyramid_level = h[2];
+        const auto count = static_cast<size_t>(h[3]);
+        if (featureOffset + count > features->size())
+            CV_Error(cv::Error::StsBadArg, "Invalid flattened LINEMOD feature data");
+        for (size_t i = 0; i < count; i++)
+        {
+            const auto &f = (*features)[featureOffset++];
+            t.features.emplace_back(f[0], f[1], f[2]);
+        }
+        templates.push_back(std::move(t));
+    }
+    if (featureOffset != features->size())
+        CV_Error(cv::Error::StsBadArg, "Invalid flattened LINEMOD feature data");
+    *returnValue = obj->addSyntheticTemplate(templates, classId);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_match(
+    Detector *obj, std::vector<cv::Mat> *sources, float threshold,
+    std::vector<cv::Vec4f> *values, std::vector<cv::String> *classIds,
+    std::vector<cv::String> *filterClassIds, std::vector<cv::Mat> *quantizedImages,
+    std::vector<cv::Mat> *masks)
+{
+    BEGIN_WRAP
+    std::vector<Match> matches;
+    obj->match(*sources, threshold, matches,
+        filterClassIds == nullptr ? std::vector<cv::String>() : *filterClassIds,
+        quantizedImages == nullptr ? cv::noArray() : cv::OutputArrayOfArrays(*quantizedImages),
+        masks == nullptr ? std::vector<cv::Mat>() : *masks);
+    values->clear(); classIds->clear();
+    for (const auto &m : matches)
+    {
+        values->emplace_back(static_cast<float>(m.x), static_cast<float>(m.y), m.similarity,
+            static_cast<float>(m.template_id));
+        classIds->push_back(m.class_id);
+    }
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_getT(Detector *obj, int level, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->getT(level); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_pyramidLevels(Detector *obj, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->pyramidLevels(); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_numTemplates(Detector *obj, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->numTemplates(); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_numTemplatesByClass(Detector *obj, const char *classId, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->numTemplates(classId); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_numClasses(Detector *obj, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->numClasses(); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_classIds(Detector *obj, std::vector<cv::String> *returnValue)
+{ BEGIN_WRAP *returnValue = obj->classIds(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_getTemplates(
+    Detector *obj, const char *classId, int templateId,
+    std::vector<cv::Vec4i> *headers, std::vector<cv::Vec4i> *features)
+{
+    BEGIN_WRAP
+    headers->clear(); features->clear();
+    for (const auto &t : obj->getTemplates(classId, templateId))
+    {
+        headers->emplace_back(t.width, t.height, t.pyramid_level, static_cast<int>(t.features.size()));
+        for (const auto &f : t.features) features->emplace_back(f.x, f.y, f.label, 0);
+    }
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_getModalitiesSize(Detector *obj, int *returnValue)
+{ BEGIN_WRAP *returnValue = static_cast<int>(obj->getModalities().size()); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_getModality(
+    Detector *obj, int index, cv::Ptr<Modality> **returnValue)
+{
+    BEGIN_WRAP *returnValue = new cv::Ptr<Modality>(obj->getModalities().at(index)); END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_read(Detector *obj, cv::FileNode *node)
+{ BEGIN_WRAP obj->read(*node); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_write(Detector *obj, cv::FileStorage *fs)
+{ BEGIN_WRAP obj->write(*fs); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_readClass(
+    Detector *obj, cv::FileNode *node, const char *classIdOverride, std::string *returnValue)
+{ BEGIN_WRAP *returnValue = obj->readClass(*node, classIdOverride); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_writeClass(
+    Detector *obj, const char *classId, cv::FileStorage *fs)
+{ BEGIN_WRAP obj->writeClass(classId, *fs); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_readClasses(
+    Detector *obj, std::vector<cv::String> *classIds, const char *format)
+{ BEGIN_WRAP obj->readClasses(*classIds, format); END_WRAP }
+CVAPI(ExceptionStatus) rgbd_linemod_Detector_writeClasses(Detector *obj, const char *format)
+{ BEGIN_WRAP obj->writeClasses(format); END_WRAP }
+#undef BEGIN_WRAP
+#undef END_WRAP
+#endif

--- a/test/OpenCvSharp.Tests/rgbd/LinemodTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/LinemodTest.cs
@@ -1,0 +1,132 @@
+using OpenCvSharp.Rgbd;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Rgbd;
+
+public class LinemodTest
+{
+    [Fact]
+    public void ModalitiesExposeParametersAndNames()
+    {
+        using var color = new ColorGradient(12f, 48, 60f);
+        Assert.Equal("ColorGradient", color.Name);
+        Assert.Equal(12f, color.WeakThreshold);
+        Assert.Equal((nuint)48, color.NumFeatures);
+        Assert.Equal(60f, color.StrongThreshold);
+
+        using var depth = new DepthNormal(1500, 40, 32, 3);
+        Assert.Equal("DepthNormal", depth.Name);
+        Assert.Equal(1500, depth.DistanceThreshold);
+        Assert.Equal(40, depth.DifferenceThreshold);
+        Assert.Equal((nuint)32, depth.NumFeatures);
+        Assert.Equal(3, depth.ExtractThreshold);
+    }
+
+    [Fact]
+    public void ColorGradientCreatesQuantizedPyramid()
+    {
+        using var image = CreateTestImage();
+        using var modality = new ColorGradient();
+        using var pyramid = modality.Process(image);
+        using var quantized = pyramid.Quantize();
+
+        Assert.Equal(image.Size(), quantized.Size());
+        Assert.Equal(MatType.CV_8UC1, quantized.Type());
+    }
+
+    [Fact]
+    public void ModalityCanRoundTripThroughFileStorage()
+    {
+        string yaml;
+        using (var modality = new ColorGradient(12f, 48, 60f))
+        using (var storage = new FileStorage("yml", FileStorage.Modes.Write | FileStorage.Modes.Memory))
+        {
+            storage.StartWriteStruct("modality", FileNode.Types.Map);
+            modality.Write(storage);
+            storage.EndWriteStruct();
+            yaml = storage.ReleaseAndGetString();
+        }
+
+        using var input = new FileStorage(yaml, FileStorage.Modes.Read | FileStorage.Modes.Memory);
+        using var node = input["modality"]!;
+        using var restored = LinemodModality.Create(node);
+        Assert.Equal("ColorGradient", restored.Name);
+    }
+
+    [Fact]
+    public void DefaultLineCanAddAndMatchTemplate()
+    {
+        using var image = CreateTestImage();
+        using var mask = new Mat(image.Size(), MatType.CV_8UC1, Scalar.Black);
+        Cv2.Rectangle(mask, new Rect(12, 12, 104, 104), Scalar.White, -1);
+        using var modality = new ColorGradient(1f, 4, 2f);
+        using (var pyramid = modality.Process(image, mask))
+            Assert.True(pyramid.ExtractTemplate(out _));
+        using var detector = new LinemodDetector([modality], [4]);
+
+        var templateId = detector.AddTemplate([image], "shape", mask, out var bounds);
+
+        Assert.True(templateId >= 0);
+        Assert.Equal(1, detector.NumClasses);
+        Assert.Equal(1, detector.GetNumTemplates("shape"));
+        Assert.Contains("shape", detector.GetClassIds());
+        Assert.True(bounds.Width > 0);
+        Assert.True(bounds.Height > 0);
+
+        var templates = detector.GetTemplates("shape", templateId);
+        Assert.Single(templates);
+        Assert.Equal(4, templates[0].Features.Length);
+        var detectorModalities = detector.GetModalities();
+        try
+        {
+            Assert.Single(detectorModalities);
+            Assert.Equal("ColorGradient", detectorModalities[0].Name);
+        }
+        finally
+        {
+            foreach (var detectorModality in detectorModalities)
+                detectorModality.Dispose();
+        }
+
+        using var syntheticDetector = new LinemodDetector([modality], [4]);
+        Assert.Equal(0, syntheticDetector.AddSyntheticTemplate(templates, "synthetic"));
+        Assert.Equal(1, syntheticDetector.GetNumTemplates("synthetic"));
+
+        string serializedClass;
+        using (var storage = new FileStorage("yml", FileStorage.Modes.Write | FileStorage.Modes.Memory))
+        {
+            detector.WriteClass("shape", storage);
+            serializedClass = storage.ReleaseAndGetString();
+        }
+        using (var input = new FileStorage(serializedClass, FileStorage.Modes.Read | FileStorage.Modes.Memory))
+        using (var root = input.Root()!)
+        using (var restoredDetector = new LinemodDetector([modality], [4]))
+        {
+            Assert.Equal("shape", restoredDetector.ReadClass(root));
+            Assert.Equal(1, restoredDetector.GetNumTemplates("shape"));
+        }
+
+        var matches = detector.Match([image], 80f, out var quantizedImages);
+        try
+        {
+            Assert.Contains(matches, m => m.ClassId == "shape" && m.TemplateId == templateId);
+            Assert.NotEmpty(quantizedImages);
+        }
+        finally
+        {
+            foreach (var quantized in quantizedImages)
+                quantized.Dispose();
+        }
+    }
+
+    private static Mat CreateTestImage()
+    {
+        var image = new Mat(128, 128, MatType.CV_8UC3, Scalar.Black);
+        for (var x = 0; x < image.Cols; x += 16)
+            Cv2.Rectangle(image, new Rect(x, 0, 8, image.Rows), Scalar.White, -1);
+        Cv2.Rectangle(image, new Rect(20, 20, 80, 80), Scalar.White, 4);
+        Cv2.Line(image, new Point(24, 24), new Point(94, 94), Scalar.Red, 5);
+        Cv2.Circle(image, new Point(64, 64), 20, Scalar.Green, 4);
+        return image;
+    }
+}

--- a/test/OpenCvSharp.Tests/rgbd/LinemodTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/LinemodTest.cs
@@ -23,6 +23,16 @@ public class LinemodTest
     }
 
     [Fact]
+    public void TemplateEqualityUsesFeatureContents()
+    {
+        var first = new LinemodTemplate(10, 20, 1, [new LinemodFeature(2, 3, 4)]);
+        var second = new LinemodTemplate(10, 20, 1, [new LinemodFeature(2, 3, 4)]);
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
     public void ColorGradientCreatesQuantizedPyramid()
     {
         using var image = CreateTestImage();


### PR DESCRIPTION
## Summary

- add native and managed wrappers for `cv::linemod::Detector`, `Modality`, `ColorGradient`, `DepthNormal`, and `QuantizedPyramid`
- support template registration/matching, synthetic templates, modality/template inspection, and FileStorage persistence
- add Codex `AGENTS.md` that shares the existing Copilot development instructions
- add LINEMOD interop tests covering modality parameters, quantization, matching, synthetic templates, and serialization

This implements the LINEMOD portion of #2018. The KinFu family remains for follow-up PRs.

## Testing

- `cmake --build src\build --config Release -j 8`
- `dotnet build src\OpenCvSharp\OpenCvSharp.csproj -c Release --no-restore`
- `dotnet test test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~LinemodTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB-D LINEMOD support for feature extraction, template creation, object detection, and matching.
  * Introduced ColorGradient and DepthNormal modalities, plus LINEMOD feature/template/match types and a configurable LinemodDetector (including synthetic templates and detector/template persistence).
* **Tests**
  * Added/expanded LINEMOD tests covering template equality, modality behavior, end-to-end detection, and read/write round-trips.
* **Documentation**
  * Updated contributor development instructions in AGENTS.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->