### PR TITLE
wasm: enable JPEG/PNG/TIFF codecs

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   EM_VERSION: 4.0.23
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 5
+  OPENCV_CACHE_VERSION: 6
 
 jobs:
   build:
@@ -123,10 +123,10 @@ jobs:
             -DWITH_ADE=OFF \
             -DOPENCV_ENABLE_NONFREE=ON \
             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_wasm \
-            -DCMAKE_C_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' \
+            -DCMAKE_C_FLAGS='-s WASM=1' -DCMAKE_CXX_FLAGS='-s WASM=1' \
             -DWITH_ITT=OFF \
             -DWITH_JPEG=ON \
-            -DWITH_TIFF=OFF \
+            -DWITH_TIFF=ON \
             -DWITH_PNG=ON \
             -DWITH_IPP=OFF \
             -DWITH_LAPACK=OFF \
@@ -154,10 +154,7 @@ jobs:
         run: |
           ls ${GITHUB_WORKSPACE}/opencv_wasm
           echo "-----"
-          # -fwasm-exceptions -sSUPPORT_LONGJMP=wasm must match the OpenCV build above and the .NET wasm SDK's
-          # own default (WasmEnableExceptionHandling=true), since this static lib gets linked together with the
-          # .NET runtime later; a mismatched exception/setjmp-longjmp lowering model fails at that final link step.
-          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o -DCMAKE_C_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm'
+          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o
           cmake --build src/build --parallel $(nproc)
           ls src/build/OpenCvSharpExtern
           cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.a ${GITHUB_WORKSPACE}/packaging/nuget/OpenCvSharpExtern.a

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   EM_VERSION: 4.0.23
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 2
+  OPENCV_CACHE_VERSION: 3
 
 jobs:
   build:
@@ -125,9 +125,9 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_wasm \
             -DCMAKE_C_FLAGS='-s WASM=1' -DCMAKE_CXX_FLAGS='-s WASM=1' \
             -DWITH_ITT=OFF \
-            -DWITH_JPEG=OFF \
-            -DWITH_TIFF=OFF \
-            -DWITH_PNG=OFF \
+            -DWITH_JPEG=ON \
+            -DWITH_TIFF=ON \
+            -DWITH_PNG=ON \
             -DWITH_IPP=OFF \
             -DWITH_LAPACK=OFF \
             -DWITH_OPENCL=OFF \

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   EM_VERSION: 4.0.23
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 3
+  OPENCV_CACHE_VERSION: 4
 
 jobs:
   build:
@@ -123,7 +123,7 @@ jobs:
             -DWITH_ADE=OFF \
             -DOPENCV_ENABLE_NONFREE=ON \
             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_wasm \
-            -DCMAKE_C_FLAGS='-s WASM=1' -DCMAKE_CXX_FLAGS='-s WASM=1' \
+            -DCMAKE_C_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' \
             -DWITH_ITT=OFF \
             -DWITH_JPEG=ON \
             -DWITH_TIFF=ON \
@@ -154,7 +154,10 @@ jobs:
         run: |
           ls ${GITHUB_WORKSPACE}/opencv_wasm
           echo "-----"
-          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o
+          # -fwasm-exceptions -sSUPPORT_LONGJMP=wasm must match the OpenCV build above and the .NET wasm SDK's
+          # own default (WasmEnableExceptionHandling=true), since this static lib gets linked together with the
+          # .NET runtime later; a mismatched exception/setjmp-longjmp lowering model fails at that final link step.
+          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o -DCMAKE_C_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm'
           cmake --build src/build --parallel $(nproc)
           ls src/build/OpenCvSharpExtern
           cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.a ${GITHUB_WORKSPACE}/packaging/nuget/OpenCvSharpExtern.a

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -179,6 +179,24 @@ jobs:
       - name: Install wasm-tools workload
         run: dotnet workload install wasm-tools
 
+      - name: Verify EM_VERSION matches the .NET wasm SDK's bundled Emscripten
+        run: |
+          pack_dir=$(ls -d /usr/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.*.Sdk.* 2>/dev/null | head -1)
+          if [ -z "$pack_dir" ]; then
+            echo "::error::Could not find an installed Microsoft.NET.Runtime.Emscripten.*.Sdk pack under /usr/share/dotnet/packs - can't verify EM_VERSION."
+            exit 1
+          fi
+          installed=$(basename "$pack_dir" | sed -E 's/Microsoft\.NET\.Runtime\.Emscripten\.([0-9]+\.[0-9]+\.[0-9]+)\.Sdk.*/\1/')
+          echo "wasm.yml EM_VERSION: ${EM_VERSION}"
+          echo ".NET wasm SDK's bundled Emscripten: ${installed}"
+          if [ "$installed" != "$EM_VERSION" ]; then
+            echo "::error::EM_VERSION (${EM_VERSION}) no longer matches the .NET wasm SDK's bundled Emscripten (${installed})."\
+                 "OpenCvSharpExtern.a was built with the wrong toolchain version relative to the one that will"\
+                 "statically link it later - update EM_VERSION in wasm.yml to ${installed}. See #2043 for what"\
+                 "this class of mismatch already broke once (a setjmp/longjmp hang)."
+            exit 1
+          fi
+
       - name: Create NuGet package
         env:
           BETA: "-beta"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   EM_VERSION: 4.0.23
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 6
+  OPENCV_CACHE_VERSION: 3
 
 jobs:
   build:
@@ -131,6 +131,7 @@ jobs:
             -DWITH_IPP=OFF \
             -DWITH_LAPACK=OFF \
             -DWITH_OPENCL=OFF \
+            -DWITH_PTHREADS_PF=OFF \
             -DCV_ENABLE_INTRINSICS=OFF \
             -DBUILD_opencv_dnn=ON
           cmake --build opencv-${OPENCV_VERSION}/build --parallel $(nproc)

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,7 +18,7 @@ env:
   EM_VERSION: 3.1.56
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 3
+  OPENCV_CACHE_VERSION: 4
 
 jobs:
   build:
@@ -128,7 +128,7 @@ jobs:
             -DWITH_ADE=OFF \
             -DOPENCV_ENABLE_NONFREE=ON \
             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_wasm \
-            -DCMAKE_C_FLAGS='-s WASM=1' -DCMAKE_CXX_FLAGS='-s WASM=1' \
+            -DCMAKE_C_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' \
             -DWITH_ITT=OFF \
             -DWITH_JPEG=ON \
             -DWITH_TIFF=ON \
@@ -160,7 +160,10 @@ jobs:
         run: |
           ls ${GITHUB_WORKSPACE}/opencv_wasm
           echo "-----"
-          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o
+          # Must match the OpenCV build above and the .NET wasm SDK's own default
+          # (WasmEnableExceptionHandling=true) - this static lib gets linked together with the .NET
+          # runtime later, and a mismatched exception/setjmp-longjmp lowering model fails at that link step.
+          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o -DCMAKE_C_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm'
           cmake --build src/build --parallel $(nproc)
           ls src/build/OpenCvSharpExtern
           cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.a ${GITHUB_WORKSPACE}/packaging/nuget/OpenCvSharpExtern.a

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   EM_VERSION: 4.0.23
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 4
+  OPENCV_CACHE_VERSION: 5
 
 jobs:
   build:
@@ -126,7 +126,7 @@ jobs:
             -DCMAKE_C_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' \
             -DWITH_ITT=OFF \
             -DWITH_JPEG=ON \
-            -DWITH_TIFF=ON \
+            -DWITH_TIFF=OFF \
             -DWITH_PNG=ON \
             -DWITH_IPP=OFF \
             -DWITH_LAPACK=OFF \

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,7 +10,12 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   OPENCV_VERSION: 5.0.0
-  EM_VERSION: 4.0.23
+  # Must match the Emscripten version bundled with the .NET wasm SDK below (currently
+  # Microsoft.NET.Runtime.Emscripten.3.1.56.Sdk), since OpenCvSharpExtern.a built here gets
+  # statically linked by that SDK's own emcc/wasm-ld later - mixing Emscripten versions across
+  # that link boundary is unsupported and has already caused one silent bug (#2039, a wasm-opt
+  # feature-flag mismatch) plus a suspected second one (a setjmp/longjmp hang; see #2043).
+  EM_VERSION: 3.1.56
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
   OPENCV_CACHE_VERSION: 3

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,7 +18,7 @@ env:
   EM_VERSION: 3.1.56
   EM_CACHE_FOLDER: 'emsdk-cache'
   # Bump this whenever the OpenCV cmake flags below change, to bust the OpenCV build cache.
-  OPENCV_CACHE_VERSION: 4
+  OPENCV_CACHE_VERSION: 3
 
 jobs:
   build:
@@ -128,7 +128,7 @@ jobs:
             -DWITH_ADE=OFF \
             -DOPENCV_ENABLE_NONFREE=ON \
             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_wasm \
-            -DCMAKE_C_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-s WASM=1 -fwasm-exceptions -sSUPPORT_LONGJMP=wasm' \
+            -DCMAKE_C_FLAGS='-s WASM=1' -DCMAKE_CXX_FLAGS='-s WASM=1' \
             -DWITH_ITT=OFF \
             -DWITH_JPEG=ON \
             -DWITH_TIFF=ON \
@@ -160,10 +160,7 @@ jobs:
         run: |
           ls ${GITHUB_WORKSPACE}/opencv_wasm
           echo "-----"
-          # Must match the OpenCV build above and the .NET wasm SDK's own default
-          # (WasmEnableExceptionHandling=true) - this static lib gets linked together with the .NET
-          # runtime later, and a mismatched exception/setjmp-longjmp lowering model fails at that link step.
-          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o -DCMAKE_C_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm' -DCMAKE_CXX_FLAGS='-fwasm-exceptions -sSUPPORT_LONGJMP=wasm'
+          emcmake cmake -S src -B src/build -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=${GITHUB_WORKSPACE}/opencv_wasm/lib/cmake/opencv5 -DWASM_LIB=${GITHUB_WORKSPACE}/opencv_wasm/libopencv.o
           cmake --build src/build --parallel $(nproc)
           ls src/build/OpenCvSharpExtern
           cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.a ${GITHUB_WORKSPACE}/packaging/nuget/OpenCvSharpExtern.a

--- a/packaging/nuget/OpenCvSharp5.runtime.wasm.props
+++ b/packaging/nuget/OpenCvSharp5.runtime.wasm.props
@@ -1,5 +1,17 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <Project>
+  <PropertyGroup>
+    <!--
+      OpenCvSharpExtern.a statically links libjpeg-turbo/libtiff, which use setjmp/longjmp for
+      error handling. The .NET wasm SDK's default (WasmEnableExceptionHandling=true) lowers native
+      exceptions/setjmp-longjmp through the newer WebAssembly exception-handling proposal, whose
+      setjmp/longjmp emulation doesn't yet handle libjpeg's jmp_buf-in-a-struct usage pattern
+      correctly - observed as OnInitialized hanging indefinitely, not throwing. Force the older,
+      JS-based invoke_ mechanism instead, which has years of testing against exactly this pattern.
+    -->
+    <WasmEnableExceptionHandling>false</WasmEnableExceptionHandling>
+  </PropertyGroup>
+
   <ItemGroup>
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\browser-wasm\4.0.23\OpenCvSharpExtern.a" />
   </ItemGroup>

--- a/packaging/nuget/OpenCvSharp5.runtime.wasm.props
+++ b/packaging/nuget/OpenCvSharp5.runtime.wasm.props
@@ -1,17 +1,5 @@
 <?xml version="1.0"  encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <!--
-      OpenCvSharpExtern.a statically links libjpeg-turbo/libtiff, which use setjmp/longjmp for
-      error handling. The .NET wasm SDK's default (WasmEnableExceptionHandling=true) lowers native
-      exceptions/setjmp-longjmp through the newer WebAssembly exception-handling proposal, whose
-      setjmp/longjmp emulation doesn't yet handle libjpeg's jmp_buf-in-a-struct usage pattern
-      correctly - observed as OnInitialized hanging indefinitely, not throwing. Force the older,
-      JS-based invoke_ mechanism instead, which has years of testing against exactly this pattern.
-    -->
-    <WasmEnableExceptionHandling>false</WasmEnableExceptionHandling>
-  </PropertyGroup>
-
   <ItemGroup>
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\browser-wasm\4.0.23\OpenCvSharpExtern.a" />
   </ItemGroup>

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -3,7 +3,9 @@
    "running" and asserts data-status="ok". A native module name mismatch (#2039) throws
    DllNotFoundException here; an OpenCL/UMat probe crash (#2037) either throws or hangs this
    component forever, which the runner's timeout also catches. An ImEncode/ImDecode round trip
-   for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing on wasm (#2043). *@
+   for JPEG/PNG guards against the codecs building but silently no-op'ing on wasm (#2043). TIFF is
+   deferred (see #2043): enabling it made this component hang instead of throwing, and libtiff's
+   use of setjmp/longjmp for error handling is a likely suspect. *@
 
 <pre id="result" data-status="@status">@status: @detail</pre>
 
@@ -26,7 +28,7 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
+            foreach (var ext in new[] { ".jpg", ".png" })
             {
                 var encoded = Cv2.ImEncode(ext, mat, out var buf);
                 if (!encoded || buf.Length == 0)

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -30,13 +30,20 @@
 
             foreach (var ext in new[] { ".jpg", ".png" })
             {
+                // TEMP bisection diagnostics for the TIFF wasm hang investigation (#2043): Blazor wasm
+                // routes Console.Error to console.error, which run-e2e.mjs's pageerror/console capture
+                // already surfaces in the CI log. Revert once JPEG/PNG are confirmed not to hang too.
+                Console.Error.WriteLine($"[E2E] before ImEncode({ext})");
                 var encoded = Cv2.ImEncode(ext, mat, out var buf);
                 if (!encoded || buf.Length == 0)
                     throw new InvalidOperationException($"ImEncode({ext}) failed or produced an empty buffer");
 
+                Console.Error.WriteLine($"[E2E] before ImDecode({ext})");
                 using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
                 if (decoded.Empty() || decoded.Size() != mat.Size())
                     throw new InvalidOperationException($"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
+
+                Console.Error.WriteLine($"[E2E] {ext} round trip ok");
             }
 
             status = "ok";

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -30,13 +30,19 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            // TEMP: bisecting a wasm hang inside ImEncode (#2043) - it hangs for both ".jpg" and
-            // ".png", so it's not codec-specific. Neither the exception/setjmp-longjmp lowering
-            // model nor OpenCV's pthreads-based parallel_for backend explained it either.
-            // opencvsharp_blazor_sample's own JPEG/PNG workaround (PR #13) only ever calls
-            // ImDecode (decoding a hand-rolled BMP built in JS) and never ImEncode, so ImDecode
-            // working there is not actually evidence ImEncode works. Bypass ImEncode entirely here
-            // and feed ImDecode a hardcoded, known-valid 1x1 PNG to check whether decode alone hangs.
+            // TEMP: bisecting a wasm hang inside ImDecode/ImEncode (#2043) - the hang isn't specific
+            // to ImEncode, JPEG, or PNG: even a bare ImDecode of a hardcoded, known-valid PNG buffer
+            // hangs the same way. Before concluding this is JPEG/PNG-specific, check whether BMP -
+            // never touching libjpeg-turbo/libpng at all, and the format opencvsharp_blazor_sample's
+            // workaround already proved decodes fine on the *old* (pre-this-PR) wasm build - still
+            // decodes on *this* build. If BMP also hangs, something broader in imgcodecs broke.
+            Console.Error.WriteLine("[E2E] before ImDecode(hardcoded bmp)");
+            var bmpBytes = Convert.FromBase64String("Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wAAAA==");
+            using var decodedBmp = Cv2.ImDecode(bmpBytes, ImreadModes.Unchanged);
+            if (decodedBmp.Empty())
+                throw new InvalidOperationException("ImDecode(hardcoded bmp) failed or produced an empty Mat");
+            Console.Error.WriteLine($"[E2E] hardcoded bmp decode ok: {decodedBmp.Size()}");
+
             Console.Error.WriteLine("[E2E] before ImDecode(hardcoded png)");
             var pngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=");
             using var decodedPng = Cv2.ImDecode(pngBytes, ImreadModes.Unchanged);

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -30,27 +30,19 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            // TEMP: JPEG/TIFF excluded while bisecting a wasm hang inside ImEncode(".jpg") (#2043).
-            // Neither the exception/setjmp-longjmp lowering model nor OpenCV's pthreads-based
-            // parallel_for backend explained it; testing PNG alone next to see whether the hang is
-            // libjpeg-turbo-specific or affects imgcodecs more broadly.
-            foreach (var ext in new[] { ".png" })
-            {
-                // TEMP bisection diagnostics for the wasm hang investigation (#2043): Blazor wasm
-                // routes Console.Error to console.error, which run-e2e.mjs's pageerror/console capture
-                // already surfaces in the CI log. Revert once all three are confirmed not to hang.
-                Console.Error.WriteLine($"[E2E] before ImEncode({ext})");
-                var encoded = Cv2.ImEncode(ext, mat, out var buf);
-                if (!encoded || buf.Length == 0)
-                    throw new InvalidOperationException($"ImEncode({ext}) failed or produced an empty buffer");
-
-                Console.Error.WriteLine($"[E2E] before ImDecode({ext})");
-                using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
-                if (decoded.Empty() || decoded.Size() != mat.Size())
-                    throw new InvalidOperationException($"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
-
-                Console.Error.WriteLine($"[E2E] {ext} round trip ok");
-            }
+            // TEMP: bisecting a wasm hang inside ImEncode (#2043) - it hangs for both ".jpg" and
+            // ".png", so it's not codec-specific. Neither the exception/setjmp-longjmp lowering
+            // model nor OpenCV's pthreads-based parallel_for backend explained it either.
+            // opencvsharp_blazor_sample's own JPEG/PNG workaround (PR #13) only ever calls
+            // ImDecode (decoding a hand-rolled BMP built in JS) and never ImEncode, so ImDecode
+            // working there is not actually evidence ImEncode works. Bypass ImEncode entirely here
+            // and feed ImDecode a hardcoded, known-valid 1x1 PNG to check whether decode alone hangs.
+            Console.Error.WriteLine("[E2E] before ImDecode(hardcoded png)");
+            var pngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=");
+            using var decodedPng = Cv2.ImDecode(pngBytes, ImreadModes.Unchanged);
+            if (decodedPng.Empty())
+                throw new InvalidOperationException("ImDecode(hardcoded png) failed or produced an empty Mat");
+            Console.Error.WriteLine($"[E2E] hardcoded png decode ok: {decodedPng.Size()}");
 
             status = "ok";
             detail = $"OpenCV {version}, ORB keypoints: {keypoints.Length}";

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -3,9 +3,11 @@
    "running" and asserts data-status="ok". A native module name mismatch (#2039) throws
    DllNotFoundException here; an OpenCL/UMat probe crash (#2037) either throws or hangs this
    component forever, which the runner's timeout also catches. An ImEncode/ImDecode round trip
-   for JPEG/PNG guards against the codecs building but silently no-op'ing on wasm (#2043). TIFF is
-   deferred (see #2043): enabling it made this component hang instead of throwing, and libtiff's
-   use of setjmp/longjmp for error handling is a likely suspect. *@
+   for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing on wasm (#2043).
+   These formats' libjpeg-turbo/libtiff backends use setjmp/longjmp for error handling, which hung
+   (rather than threw) under the .NET wasm SDK's default WebAssembly-exception-handling-based
+   setjmp/longjmp emulation; see OpenCvSharp5.runtime.wasm.props for the WasmEnableExceptionHandling
+   workaround. *@
 
 <pre id="result" data-status="@status">@status: @detail</pre>
 
@@ -28,11 +30,11 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            foreach (var ext in new[] { ".jpg", ".png" })
+            foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
             {
-                // TEMP bisection diagnostics for the TIFF wasm hang investigation (#2043): Blazor wasm
+                // TEMP bisection diagnostics for the wasm hang investigation (#2043): Blazor wasm
                 // routes Console.Error to console.error, which run-e2e.mjs's pageerror/console capture
-                // already surfaces in the CI log. Revert once JPEG/PNG are confirmed not to hang too.
+                // already surfaces in the CI log. Revert once all three are confirmed not to hang.
                 Console.Error.WriteLine($"[E2E] before ImEncode({ext})");
                 var encoded = Cv2.ImEncode(ext, mat, out var buf);
                 if (!encoded || buf.Length == 0)

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -2,7 +2,8 @@
    The headless test runner (see .github/workflows/wasm.yml) waits for #result's text to leave
    "running" and asserts data-status="ok". A native module name mismatch (#2039) throws
    DllNotFoundException here; an OpenCL/UMat probe crash (#2037) either throws or hangs this
-   component forever, which the runner's timeout also catches. *@
+   component forever, which the runner's timeout also catches. An ImEncode/ImDecode round trip
+   for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing on wasm (#2043). *@
 
 <pre id="result" data-status="@status">@status: @detail</pre>
 
@@ -24,6 +25,17 @@
             using var orb = ORB.Create(500);
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
+
+            foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
+            {
+                Cv2.ImEncode(ext, mat, out var buf);
+                if (buf.Length == 0)
+                    throw new InvalidOperationException($"ImEncode({ext}) produced an empty buffer");
+
+                using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
+                if (decoded.Empty() || decoded.Size() != mat.Size())
+                    throw new InvalidOperationException($"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
+            }
 
             status = "ok";
             detail = $"OpenCV {version}, ORB keypoints: {keypoints.Length}";

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -30,7 +30,11 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
+            // TEMP: JPEG/TIFF excluded while bisecting a wasm hang inside ImEncode(".jpg") (#2043).
+            // Neither the exception/setjmp-longjmp lowering model nor OpenCV's pthreads-based
+            // parallel_for backend explained it; testing PNG alone next to see whether the hang is
+            // libjpeg-turbo-specific or affects imgcodecs more broadly.
+            foreach (var ext in new[] { ".png" })
             {
                 // TEMP bisection diagnostics for the wasm hang investigation (#2043): Blazor wasm
                 // routes Console.Error to console.error, which run-e2e.mjs's pageerror/console capture

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -3,11 +3,10 @@
    "running" and asserts data-status="ok". A native module name mismatch (#2039) throws
    DllNotFoundException here; an OpenCL/UMat probe crash (#2037) either throws or hangs this
    component forever, which the runner's timeout also catches. An ImEncode/ImDecode round trip
-   for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing on wasm (#2043).
-   These formats' libjpeg-turbo/libtiff backends use setjmp/longjmp for error handling, which hung
-   (rather than threw) under the .NET wasm SDK's default WebAssembly-exception-handling-based
-   setjmp/longjmp emulation; see OpenCvSharp5.runtime.wasm.props for the WasmEnableExceptionHandling
-   workaround. *@
+   for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing - or hanging - on
+   wasm (#2043). libjpeg-turbo/libpng/libtiff use setjmp/longjmp for error handling, which hung
+   (rather than threw) when OpenCvSharpExtern.a was built with a different Emscripten version than
+   the one the .NET wasm SDK links it with; see EM_VERSION in .github/workflows/wasm.yml. *@
 
 <pre id="result" data-status="@status">@status: @detail</pre>
 
@@ -30,25 +29,16 @@
             using var descriptors = new Mat();
             orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
 
-            // TEMP: bisecting a wasm hang inside ImDecode/ImEncode (#2043) - the hang isn't specific
-            // to ImEncode, JPEG, or PNG: even a bare ImDecode of a hardcoded, known-valid PNG buffer
-            // hangs the same way. Before concluding this is JPEG/PNG-specific, check whether BMP -
-            // never touching libjpeg-turbo/libpng at all, and the format opencvsharp_blazor_sample's
-            // workaround already proved decodes fine on the *old* (pre-this-PR) wasm build - still
-            // decodes on *this* build. If BMP also hangs, something broader in imgcodecs broke.
-            Console.Error.WriteLine("[E2E] before ImDecode(hardcoded bmp)");
-            var bmpBytes = Convert.FromBase64String("Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wAAAA==");
-            using var decodedBmp = Cv2.ImDecode(bmpBytes, ImreadModes.Unchanged);
-            if (decodedBmp.Empty())
-                throw new InvalidOperationException("ImDecode(hardcoded bmp) failed or produced an empty Mat");
-            Console.Error.WriteLine($"[E2E] hardcoded bmp decode ok: {decodedBmp.Size()}");
+            foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
+            {
+                var encoded = Cv2.ImEncode(ext, mat, out var buf);
+                if (!encoded || buf.Length == 0)
+                    throw new InvalidOperationException($"ImEncode({ext}) failed or produced an empty buffer");
 
-            Console.Error.WriteLine("[E2E] before ImDecode(hardcoded png)");
-            var pngBytes = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=");
-            using var decodedPng = Cv2.ImDecode(pngBytes, ImreadModes.Unchanged);
-            if (decodedPng.Empty())
-                throw new InvalidOperationException("ImDecode(hardcoded png) failed or produced an empty Mat");
-            Console.Error.WriteLine($"[E2E] hardcoded png decode ok: {decodedPng.Size()}");
+                using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
+                if (decoded.Empty() || decoded.Size() != mat.Size())
+                    throw new InvalidOperationException($"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
+            }
 
             status = "ok";
             detail = $"OpenCV {version}, ORB keypoints: {keypoints.Length}";

--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -28,9 +28,9 @@
 
             foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
             {
-                Cv2.ImEncode(ext, mat, out var buf);
-                if (buf.Length == 0)
-                    throw new InvalidOperationException($"ImEncode({ext}) produced an empty buffer");
+                var encoded = Cv2.ImEncode(ext, mat, out var buf);
+                if (!encoded || buf.Length == 0)
+                    throw new InvalidOperationException($"ImEncode({ext}) failed or produced an empty buffer");
 
                 using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
                 if (decoded.Empty() || decoded.Size() != mat.Size())


### PR DESCRIPTION
## Summary

Enables `-DWITH_JPEG=ON -DWITH_TIFF=ON -DWITH_PNG=ON` for the wasm build (previously all `OFF`), and bumps the OpenCV build cache key so CI rebuilds with the new flags instead of reusing a stale cache.

## Background

These codecs were disabled in `.github/workflows/wasm.yml` since the workflow's very first commit, apparently copied from OpenCV's own `opencv.js` build recipe (`opencv/platforms/js/build_js.py`), which disables the same set of codecs. That makes sense for `opencv.js`, since it decodes images via the browser's Canvas/Image API and never touches `imgcodecs` at all.

OpenCvSharp's wasm target has no equivalent JS-side decode path, though: `Cv2.ImDecode` / `Mat.FromImageData` are the only decode entry points exposed to .NET code. With the codecs disabled, these silently returned an empty `Mat` instead of throwing, which was hard to diagnose (confirmed in #2043).

`find_package(JPEG/PNG/TIFF)` fails to find a system library under the Emscripten cross-compile toolchain, so `WITH_*=ON` alone is enough to fall back to the bundled `3rdparty/libjpeg-turbo` / `libpng` / `libtiff` sources (`opencv/cmake/OpenCVFindLibsGrfmt.cmake`). libjpeg-turbo's SIMD detection also degrades gracefully to a non-SIMD build for unrecognized CPU types rather than failing.

Fixes #2043

## Test plan

- [ ] CI wasm build passes with the new cache key (forces a full OpenCV rebuild)
- [ ] `Cv2.GetBuildInformation()` on the resulting wasm build shows JPEG/PNG/TIFF as available under Media I/O
- [ ] `Cv2.ImDecode` / `Mat.FromImageData` successfully decode a JPEG/PNG (not TIFF, not empty) byte array on wasm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly build caching to automatically refresh cached OpenCV builds when configuration changes.
  * Aligned WebAssembly exception/long-jump handling for more reliable OpenCV wasm behavior.
* **New Features**
  * Enabled additional OpenCV WebAssembly image support, including JPEG, PNG, and TIFF.
* **Tests**
  * Strengthened the WebAssembly smoke test to perform JPEG/PNG/TIFF encode/decode round-trips, validate results, and more reliably catch silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->