### PR TITLE
Add a dnn smoke check to the wasm E2E test

### DIFF
--- a/test/OpenCvSharp.Tests.Wasm/App.razor
+++ b/test/OpenCvSharp.Tests.Wasm/App.razor
@@ -6,7 +6,10 @@
    for JPEG/PNG/TIFF guards against the codecs building but silently no-op'ing - or hanging - on
    wasm (#2043). libjpeg-turbo/libpng/libtiff use setjmp/longjmp for error handling, which hung
    (rather than threw) when OpenCvSharpExtern.a was built with a different Emscripten version than
-   the one the .NET wasm SDK links it with; see EM_VERSION in .github/workflows/wasm.yml. *@
+   the one the .NET wasm SDK links it with; see EM_VERSION in .github/workflows/wasm.yml. A
+   Cv2.Dnn.BlobFromImage call exercises the dnn module's native wrapper without needing a trained
+   model file on disk, guarding against the OpenCV build config showing dnn as built while the
+   wasm wrapper actually fails to link or crashes at runtime. *@
 
 <pre id="result" data-status="@status">@status: @detail</pre>
 
@@ -40,8 +43,17 @@
                     throw new InvalidOperationException($"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
             }
 
+            // Exercises the dnn module's native wrapper (cv::dnn::blobFromImage) without loading a trained
+            // model file - just confirms the wasm build actually links and runs dnn, not merely that OpenCV's
+            // CMake config reports it as built.
+            using var blob = Cv2.Dnn.BlobFromImage(mat, size: new Size(64, 64));
+            if (blob.Empty())
+                throw new InvalidOperationException("Cv2.Dnn.BlobFromImage produced an empty blob");
+
+            var blobShape = string.Join('x', Enumerable.Range(0, blob.Dims).Select(blob.Size));
+
             status = "ok";
-            detail = $"OpenCV {version}, ORB keypoints: {keypoints.Length}";
+            detail = $"OpenCV {version}, ORB keypoints: {keypoints.Length}, dnn blob shape: {blobShape}";
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Add a `Cv2.Dnn.BlobFromImage` call to the wasm E2E smoke test in `test/OpenCvSharp.Tests.Wasm/App.razor`, verifying that the dnn module actually links and runs in the wasm build rather than relying only on the OpenCV CMake config's "to be built" listing.
- No trained model file is required since `blobFromImage` only operates on an in-memory `Mat`, so this stays a lightweight addition to the existing headless test that already probes ORB/OpenCL and JPEG/PNG/TIFF codec round trips.

## Test plan
- [ ] CI's `Wasm` workflow (`.github/workflows/wasm.yml`) runs the E2E consumer test via Playwright and should report `status="ok"` with the new `dnn blob shape` detail in the result text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the WebAssembly smoke test to verify that deep neural network image-blob processing works correctly.
  * Added validation that the generated blob is non-empty and reports its dimensions in the test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->