### PR TITLE
docs: link the Blazor WebAssembly live demo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 OpenCvSharp is a cross-platform .NET wrapper for OpenCV, providing a rich set of image processing and computer vision functionality.
 
-### 🚀 [Try the Live Demo](https://shimat.github.io/opencvsharp_blazor_sample/)
+## 🚀 [Try the Live Demo](https://shimat.github.io/opencvsharp_blazor_sample/)
 
 Run OpenCvSharp image processing right in your browser — Blazor WebAssembly, no install needed.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 OpenCvSharp is a cross-platform .NET wrapper for OpenCV, providing a rich set of image processing and computer vision functionality.
 
+### 🚀 [Try the Live Demo](https://shimat.github.io/opencvsharp_blazor_sample/)
+
+Run OpenCvSharp image processing right in your browser — Blazor WebAssembly, no install needed.
+
 ## Which version should I use?
 
 OpenCvSharp is published in two parallel package families:
@@ -178,6 +182,8 @@ Cv2.Canny(src, canny, 50, 200);   // an expression can be passed directly to a C
 
 ## Code samples
 https://github.com/shimat/opencvsharp_samples/
+
+Interactive browser-based samples (Blazor WebAssembly) are maintained separately at https://github.com/shimat/opencvsharp_blazor_sample/, with a [live demo](https://shimat.github.io/opencvsharp_blazor_sample/).
 
 ## API Documents
 http://shimat.github.io/opencvsharp/api/OpenCvSharp.html


### PR DESCRIPTION
## Summary
- Add a prominent CTA near the top of the README pointing to the interactive live demo at https://shimat.github.io/opencvsharp_blazor_sample/ (Blazor WebAssembly, runs entirely in the browser)
- Note the demo's source repo under **Code samples**, alongside the existing `opencvsharp_samples` link

## Test plan
- [x] Verified the live demo URL resolves (GitHub Pages, public) via `gh api repos/shimat/opencvsharp_blazor_sample/pages`
- [x] Previewed the rendered README section headings/links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the live OpenCVSharp Blazor WebAssembly demo, highlighting that it runs directly in the browser without installation.
  * Added links to interactive browser-based code samples and their live demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->