### PR TITLE
Add KinFu family wrappers for rgbd module

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_colored_kinfu.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_colored_kinfu.cs
@@ -1,0 +1,92 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+/// <summary>
+/// Blittable P/Invoke representation of the scalar/fixed-size fields of
+/// <c>colored_kinfu::Params</c>. The Matx33f/Matx44f fields (Intr, RgbIntr, VolumePose) and the
+/// icpIterations vector are marshaled as separate arguments alongside this struct.
+/// This type is internal; use <c>OpenCvSharp.Rgbd.ColoredKinFuParams</c> in consumer code.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct CvColoredKinFuParams
+{
+    public Size FrameSize;
+    public Size RgbFrameSize;
+    public int VolumeKind;
+    public float DepthFactor;
+    public float BilateralSigmaDepth;
+    public float BilateralSigmaSpatial;
+    public int BilateralKernelSize;
+    public int PyramidLevels;
+    public Vec3i VolumeDims;
+    public float VoxelSize;
+    public float TsdfMinCameraMovement;
+    public float TsdfTruncDist;
+    public int TsdfMaxWeight;
+    public float RaycastStepFactor;
+    public Vec3f LightPose;
+    public float IcpDistThresh;
+    public float IcpAngleThresh;
+    public float TruncateThreshold;
+}
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Params_defaultParams(
+        out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Params_coarseParams(
+        out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Params_hashTSDFParams(
+        int isCoarse, out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Params_coloredTSDFParams(
+        int isCoarse, out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Ptr_ColoredKinFu_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_Ptr_ColoredKinFu_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_create(
+        in CvColoredKinFuParams pod, in InputArrayProxy intr, in InputArrayProxy rgbIntr,
+        in InputArrayProxy volumePose, IntPtr icpIterations, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_getParams(
+        OpenCvSafeHandle obj, out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_render(OpenCvSafeHandle obj, in OutputArrayProxy image);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_renderWithPose(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, in InputArrayProxy cameraPose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_getCloud(
+        OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_getPoints(OpenCvSafeHandle obj, in OutputArrayProxy points);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_getNormals(
+        OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_reset(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_getPose(OpenCvSafeHandle obj, in OutputArrayProxy pose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_colored_kinfu_ColoredKinFu_update(
+        OpenCvSafeHandle obj, in InputArrayProxy depth, in InputArrayProxy rgb, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_dynafu.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_dynafu.cs
@@ -1,0 +1,52 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable CA1401
+#pragma warning disable IDE1006
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_Ptr_DynaFu_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_Ptr_DynaFu_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_create(
+        in CvKinFuParams pod, in InputArrayProxy intr, in InputArrayProxy rgbIntr,
+        in InputArrayProxy volumePose, IntPtr icpIterations, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getParams(
+        OpenCvSafeHandle obj, out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_render(OpenCvSafeHandle obj, in OutputArrayProxy image);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_renderWithPose(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, in InputArrayProxy cameraPose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getCloud(
+        OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getPoints(OpenCvSafeHandle obj, in OutputArrayProxy points);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getNormals(
+        OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_reset(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getPose(OpenCvSafeHandle obj, in OutputArrayProxy pose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_update(
+        OpenCvSafeHandle obj, in InputArrayProxy depth, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_getNodesPos(OpenCvSafeHandle obj, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_marchCubes(
+        OpenCvSafeHandle obj, in OutputArrayProxy vertices, in OutputArrayProxy edges);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_dynafu_DynaFu_renderSurface(
+        OpenCvSafeHandle obj, in OutputArrayProxy depthImage, in OutputArrayProxy vertImage,
+        in OutputArrayProxy normImage, int warp);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_kinfu.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_kinfu.cs
@@ -1,0 +1,92 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+/// <summary>
+/// Blittable P/Invoke representation of the scalar/fixed-size fields of <c>kinfu::Params</c>
+/// (also used for <c>dynafu::Params</c>, which is a C++ alias of the same type). The
+/// <c>Matx33f</c>/<c>Matx44f</c> fields (Intr, RgbIntr, VolumePose) and the icpIterations vector
+/// are marshaled as separate arguments alongside this struct, not embedded in it.
+/// This type is internal; use <c>OpenCvSharp.Rgbd.KinFuParams</c> in consumer code.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct CvKinFuParams
+{
+    public Size FrameSize;
+    public int VolumeKind;
+    public float DepthFactor;
+    public float BilateralSigmaDepth;
+    public float BilateralSigmaSpatial;
+    public int BilateralKernelSize;
+    public int PyramidLevels;
+    public Vec3i VolumeDims;
+    public float VoxelSize;
+    public float TsdfMinCameraMovement;
+    public float TsdfTruncDist;
+    public int TsdfMaxWeight;
+    public float RaycastStepFactor;
+    public Vec3f LightPose;
+    public float IcpDistThresh;
+    public float IcpAngleThresh;
+    public float TruncateThreshold;
+}
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Params_defaultParams(
+        out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Params_coarseParams(
+        out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Params_hashTSDFParams(
+        int isCoarse, out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Params_coloredTSDFParams(
+        int isCoarse, out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Ptr_KinFu_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_Ptr_KinFu_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_create(
+        in CvKinFuParams pod, in InputArrayProxy intr, in InputArrayProxy rgbIntr,
+        in InputArrayProxy volumePose, IntPtr icpIterations, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_getParams(
+        OpenCvSafeHandle obj, out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_render(OpenCvSafeHandle obj, in OutputArrayProxy image);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_renderWithPose(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, in InputArrayProxy cameraPose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_getCloud(
+        OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_getPoints(OpenCvSafeHandle obj, in OutputArrayProxy points);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_getNormals(
+        OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_reset(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_getPose(OpenCvSafeHandle obj, in OutputArrayProxy pose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_kinfu_KinFu_update(
+        OpenCvSafeHandle obj, in InputArrayProxy depth, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_large_kinfu.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_large_kinfu.cs
@@ -1,0 +1,110 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+/// <summary>
+/// Blittable P/Invoke representation of the scalar fields of <c>large_kinfu::VolumeParams</c>.
+/// The Matx44f pose field is marshaled as a separate argument.
+/// This type is internal; use <c>OpenCvSharp.Rgbd.LargeKinfuVolumeParams</c> in consumer code.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct CvLargeKinfuVolumeParams
+{
+    public int Kind;
+    public int ResolutionX;
+    public int ResolutionY;
+    public int ResolutionZ;
+    public int UnitResolution;
+    public float VolumSize;
+    public float VoxelSize;
+    public float TsdfTruncDist;
+    public int MaxWeight;
+    public float DepthTruncThreshold;
+    public float RaycastStepFactor;
+}
+
+/// <summary>
+/// Blittable P/Invoke representation of the scalar/fixed-size fields of <c>large_kinfu::Params</c>
+/// (excluding its nested VolumeParams, marshaled separately as <see cref="CvLargeKinfuVolumeParams"/>).
+/// The Matx33f fields (Intr, RgbIntr) and the icpIterations vector are marshaled as separate arguments.
+/// This type is internal; use <c>OpenCvSharp.Rgbd.LargeKinfuParams</c> in consumer code.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct CvLargeKinfuParams
+{
+    public Size FrameSize;
+    public float DepthFactor;
+    public float BilateralSigmaDepth;
+    public float BilateralSigmaSpatial;
+    public int BilateralKernelSize;
+    public int PyramidLevels;
+    public float TsdfMinCameraMovement;
+    public Vec3f LightPose;
+    public float IcpDistThresh;
+    public float IcpAngleThresh;
+    public float TruncateThreshold;
+}
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_VolumeParams_defaultParams(
+        int volumeType, out CvLargeKinfuVolumeParams pod, in OutputArrayProxy pose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_VolumeParams_coarseParams(
+        int volumeType, out CvLargeKinfuVolumeParams pod, in OutputArrayProxy pose);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_Params_defaultParams(
+        out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_Params_coarseParams(
+        out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_Params_hashTSDFParams(
+        int isCoarse, out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_Ptr_LargeKinfu_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_Ptr_LargeKinfu_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_create(
+        in CvLargeKinfuParams pod, in InputArrayProxy intr, in InputArrayProxy rgbIntr,
+        IntPtr icpIterations, in CvLargeKinfuVolumeParams volumePod, in InputArrayProxy volumePose,
+        out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_getParams(
+        OpenCvSafeHandle obj, out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_render(OpenCvSafeHandle obj, in OutputArrayProxy image);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_renderWithPose(
+        OpenCvSafeHandle obj, in OutputArrayProxy image, in InputArrayProxy cameraPose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_getCloud(
+        OpenCvSafeHandle obj, in OutputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_getPoints(OpenCvSafeHandle obj, in OutputArrayProxy points);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_getNormals(
+        OpenCvSafeHandle obj, in InputArrayProxy points, in OutputArrayProxy normals);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_reset(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_getPose(OpenCvSafeHandle obj, in OutputArrayProxy pose);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus rgbd_large_kinfu_LargeKinfu_update(
+        OpenCvSafeHandle obj, in InputArrayProxy depth, out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_large_kinfu.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/rgbd/NativeMethods_rgbd_large_kinfu.cs
@@ -22,7 +22,7 @@ public struct CvLargeKinfuVolumeParams
     public int ResolutionY;
     public int ResolutionZ;
     public int UnitResolution;
-    public float VolumSize;
+    public float VolumeSize;
     public float VoxelSize;
     public float TsdfTruncDist;
     public int MaxWeight;

--- a/src/OpenCvSharp/Modules/rgbd/ColoredKinFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/ColoredKinFu.cs
@@ -36,14 +36,22 @@ public class ColoredKinFu : CvPtrObject
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getParams(
-            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getParams(
+                Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
@@ -98,10 +106,18 @@ public class ColoredKinFu : CvPtrObject
     {
         ThrowIfDisposed();
         var pose = new Mat();
-        OutputArray poseArray = pose;
-        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getPose(Handle, poseArray.Proxy));
-        GC.KeepAlive(pose);
-        return pose;
+        try
+        {
+            OutputArray poseArray = pose;
+            NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getPose(Handle, poseArray.Proxy));
+            GC.KeepAlive(pose);
+            return pose;
+        }
+        catch
+        {
+            pose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Integrates the next registered depth and color frame with respect to its ICP-calculated pose.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/ColoredKinFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/ColoredKinFu.cs
@@ -1,0 +1,119 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>
+/// Color-aware KinectFusion implementation. Reconstructs a 3D scene in real time from a sequence
+/// of registered depth and color images.
+/// </summary>
+public class ColoredKinFu : CvPtrObject
+{
+    private ColoredKinFu(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_Ptr_ColoredKinFu_delete(p)))
+    { }
+
+    /// <summary>Creates a ColoredKinFu instance with the supplied parameters.</summary>
+    public static ColoredKinFu Create(ColoredKinFuParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var native = parameters.ToNative();
+        InputArray intr = parameters.Intr;
+        InputArray rgbIntr = parameters.RgbIntr;
+        InputArray volumePose = parameters.VolumePose;
+        using var icpIterations = new StdVector<int>(parameters.IcpIterations);
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_create(
+            in native, intr.Proxy, rgbIntr.Proxy, volumePose.Proxy, icpIterations.CvPtr, out var smartPtr));
+        GC.KeepAlive(parameters.Intr); GC.KeepAlive(parameters.RgbIntr); GC.KeepAlive(parameters.VolumePose);
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_Ptr_ColoredKinFu_get(smartPtr, out var rawPtr));
+        return new ColoredKinFu(smartPtr, rawPtr);
+    }
+
+    /// <summary>Gets the current parameters.</summary>
+    public virtual ColoredKinFuParams GetParams()
+    {
+        ThrowIfDisposed();
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getParams(
+            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
+    public virtual void Render(OutputArray image)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_render(Handle, image.Proxy));
+        GC.KeepAlive(image.Source);
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the given camera pose.</summary>
+    public virtual void Render(OutputArray image, InputArray cameraPose)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_renderWithPose(Handle, image.Proxy, cameraPose.Proxy));
+        GC.KeepAlive(image.Source); GC.KeepAlive(cameraPose.Source);
+    }
+
+    /// <summary>Gets points and normals of the current 3D mesh. The order of points is undefined; normals correspond to points.</summary>
+    public virtual void GetCloud(OutputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getCloud(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Gets points of the current 3D mesh. The order of points is undefined.</summary>
+    public virtual void GetPoints(OutputArray points)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getPoints(Handle, points.Proxy));
+        GC.KeepAlive(points.Source);
+    }
+
+    /// <summary>Calculates normals for the given points.</summary>
+    public virtual void GetNormals(InputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getNormals(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Clears the current model and resets the pose.</summary>
+    public virtual void Reset()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_reset(Handle));
+    }
+
+    /// <summary>Gets the current pose in voxel space, as a 4x4 homogeneous transform matrix.</summary>
+    public virtual Mat GetPose()
+    {
+        ThrowIfDisposed();
+        var pose = new Mat();
+        OutputArray poseArray = pose;
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_getPose(Handle, poseArray.Proxy));
+        GC.KeepAlive(pose);
+        return pose;
+    }
+
+    /// <summary>Integrates the next registered depth and color frame with respect to its ICP-calculated pose.</summary>
+    /// <param name="depth">Input depth frame.</param>
+    /// <param name="rgb">Input color frame.</param>
+    /// <returns>true if the new frame was successfully aligned with the current scene, false otherwise.</returns>
+    public virtual bool Update(InputArray depth, InputArray rgb)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_colored_kinfu_ColoredKinFu_update(
+            Handle, depth.Proxy, rgb.Proxy, out var result));
+        GC.KeepAlive(depth.Source); GC.KeepAlive(rgb.Source);
+        return result != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/ColoredKinFuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/ColoredKinFuParams.cs
@@ -1,0 +1,168 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>Parameters for <see cref="ColoredKinFu"/>.</summary>
+/// <remarks>
+/// Instances can only be obtained via <see cref="DefaultParams"/>, <see cref="CoarseParams"/>,
+/// <see cref="HashTsdfParams"/>, <see cref="ColoredTsdfParams"/>, or <see cref="ColoredKinFu.GetParams"/>,
+/// ensuring the values are always initialized from the native C++ defaults.
+/// </remarks>
+public sealed class ColoredKinFuParams
+{
+    internal ColoredKinFuParams(CvColoredKinFuParams p, Mat intr, Mat rgbIntr, Mat volumePose, int[] icpIterations)
+    {
+        FrameSize = p.FrameSize;
+        RgbFrameSize = p.RgbFrameSize;
+        VolumeKind = (VolumeType)p.VolumeKind;
+        DepthFactor = p.DepthFactor;
+        BilateralSigmaDepth = p.BilateralSigmaDepth;
+        BilateralSigmaSpatial = p.BilateralSigmaSpatial;
+        BilateralKernelSize = p.BilateralKernelSize;
+        PyramidLevels = p.PyramidLevels;
+        VolumeDims = p.VolumeDims;
+        VoxelSize = p.VoxelSize;
+        TsdfMinCameraMovement = p.TsdfMinCameraMovement;
+        TsdfTruncDist = p.TsdfTruncDist;
+        TsdfMaxWeight = p.TsdfMaxWeight;
+        RaycastStepFactor = p.RaycastStepFactor;
+        LightPose = p.LightPose;
+        IcpDistThresh = p.IcpDistThresh;
+        IcpAngleThresh = p.IcpAngleThresh;
+        TruncateThreshold = p.TruncateThreshold;
+        Intr = intr;
+        RgbIntr = rgbIntr;
+        VolumePose = volumePose;
+        IcpIterations = icpIterations;
+    }
+
+    private delegate ExceptionStatus Factory(
+        out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+
+    private static ColoredKinFuParams FromFactory(Factory factory)
+    {
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(factory(
+            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+    }
+
+    /// <summary>Default parameters providing better model quality, can be very slow.</summary>
+    public static ColoredKinFuParams DefaultParams() =>
+        FromFactory(NativeMethods.rgbd_colored_kinfu_Params_defaultParams);
+
+    /// <summary>Coarse parameters providing better speed, can fail to match frames in case of rapid sensor motion.</summary>
+    public static ColoredKinFuParams CoarseParams() =>
+        FromFactory(NativeMethods.rgbd_colored_kinfu_Params_coarseParams);
+
+    /// <summary>Parameters suitable for use with a hash-based TSDF volume.</summary>
+    public static ColoredKinFuParams HashTsdfParams(bool isCoarse) =>
+        FromFactory((out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+                in OutputArrayProxy volumePose, IntPtr icpIterations) =>
+            NativeMethods.rgbd_colored_kinfu_Params_hashTSDFParams(
+                isCoarse ? 1 : 0, out pod, intr, rgbIntr, volumePose, icpIterations));
+
+    /// <summary>Parameters suitable for use with a colored TSDF volume.</summary>
+    public static ColoredKinFuParams ColoredTsdfParams(bool isCoarse) =>
+        FromFactory((out CvColoredKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+                in OutputArrayProxy volumePose, IntPtr icpIterations) =>
+            NativeMethods.rgbd_colored_kinfu_Params_coloredTSDFParams(
+                isCoarse ? 1 : 0, out pod, intr, rgbIntr, volumePose, icpIterations));
+
+    internal CvColoredKinFuParams ToNative() => new()
+    {
+        FrameSize = FrameSize,
+        RgbFrameSize = RgbFrameSize,
+        VolumeKind = (int)VolumeKind,
+        DepthFactor = DepthFactor,
+        BilateralSigmaDepth = BilateralSigmaDepth,
+        BilateralSigmaSpatial = BilateralSigmaSpatial,
+        BilateralKernelSize = BilateralKernelSize,
+        PyramidLevels = PyramidLevels,
+        VolumeDims = VolumeDims,
+        VoxelSize = VoxelSize,
+        TsdfMinCameraMovement = TsdfMinCameraMovement,
+        TsdfTruncDist = TsdfTruncDist,
+        TsdfMaxWeight = TsdfMaxWeight,
+        RaycastStepFactor = RaycastStepFactor,
+        LightPose = LightPose,
+        IcpDistThresh = IcpDistThresh,
+        IcpAngleThresh = IcpAngleThresh,
+        TruncateThreshold = TruncateThreshold,
+    };
+
+    /// <summary>Depth frame size in pixels.</summary>
+    public Size FrameSize { get; set; }
+
+    /// <summary>RGB frame size in pixels.</summary>
+    public Size RgbFrameSize { get; set; }
+
+    /// <summary>Volume kind.</summary>
+    public VolumeType VolumeKind { get; set; }
+
+    /// <summary>Camera intrinsics (3x3).</summary>
+    public Mat Intr { get; set; }
+
+    /// <summary>RGB camera intrinsics (3x3).</summary>
+    public Mat RgbIntr { get; set; }
+
+    /// <summary>Pre-scale per 1 meter for input depth values.</summary>
+    public float DepthFactor { get; set; }
+
+    /// <summary>Depth sigma in meters for bilateral smoothing.</summary>
+    public float BilateralSigmaDepth { get; set; }
+
+    /// <summary>Spatial sigma in pixels for bilateral smoothing.</summary>
+    public float BilateralSigmaSpatial { get; set; }
+
+    /// <summary>Kernel size in pixels for bilateral smoothing.</summary>
+    public int BilateralKernelSize { get; set; }
+
+    /// <summary>Number of pyramid levels for ICP.</summary>
+    public int PyramidLevels { get; set; }
+
+    /// <summary>Resolution of voxel space (number of voxels in each dimension).</summary>
+    public Vec3i VolumeDims { get; set; }
+
+    /// <summary>Size of voxel in meters.</summary>
+    public float VoxelSize { get; set; }
+
+    /// <summary>Minimal camera movement in meters; a new depth frame is integrated only if camera movement exceeds this value.</summary>
+    public float TsdfMinCameraMovement { get; set; }
+
+    /// <summary>Initial volume pose in meters (4x4 homogeneous transform).</summary>
+    public Mat VolumePose { get; set; }
+
+    /// <summary>Distance to truncate in meters; distances beyond this value are truncated to 1.0.</summary>
+    public float TsdfTruncDist { get; set; }
+
+    /// <summary>Max number of frames per voxel; each voxel keeps a running average of distances no longer than this value.</summary>
+    public int TsdfMaxWeight { get; set; }
+
+    /// <summary>Fraction of a voxel size skipped per raycast step.</summary>
+    public float RaycastStepFactor { get; set; }
+
+    /// <summary>Light pose for rendering, in meters.</summary>
+    public Vec3f LightPose { get; set; }
+
+    /// <summary>Distance threshold for ICP, in meters.</summary>
+    public float IcpDistThresh { get; set; }
+
+    /// <summary>Angle threshold for ICP, in radians.</summary>
+    public float IcpAngleThresh { get; set; }
+
+    /// <summary>Number of ICP iterations for each pyramid level.</summary>
+    public int[] IcpIterations { get; set; }
+
+    /// <summary>Threshold for depth truncation in meters; depth values beyond this threshold are set to zero.</summary>
+    public float TruncateThreshold { get; set; }
+}

--- a/src/OpenCvSharp/Modules/rgbd/ColoredKinFuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/ColoredKinFuParams.cs
@@ -46,14 +46,22 @@ public sealed class ColoredKinFuParams
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(factory(
-            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(factory(
+                out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            return new ColoredKinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Default parameters providing better model quality, can be very slow.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/DynaFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/DynaFu.cs
@@ -1,0 +1,146 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>
+/// DynamicFusion implementation. Extends <see cref="KinFu"/> to handle non-rigidly deforming
+/// scenes by maintaining a sparse set of nodes covering the geometry, each holding a warp that
+/// transforms it from a canonical space to the live frame.
+/// </summary>
+public class DynaFu : CvPtrObject
+{
+    private DynaFu(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.rgbd_dynafu_Ptr_DynaFu_delete(p)))
+    { }
+
+    /// <summary>Creates a DynaFu instance with the supplied parameters (shared with <see cref="KinFu"/>).</summary>
+    public static DynaFu Create(KinFuParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var native = parameters.ToNative();
+        InputArray intr = parameters.Intr;
+        InputArray rgbIntr = parameters.RgbIntr;
+        InputArray volumePose = parameters.VolumePose;
+        using var icpIterations = new StdVector<int>(parameters.IcpIterations);
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_create(
+            in native, intr.Proxy, rgbIntr.Proxy, volumePose.Proxy, icpIterations.CvPtr, out var smartPtr));
+        GC.KeepAlive(parameters.Intr); GC.KeepAlive(parameters.RgbIntr); GC.KeepAlive(parameters.VolumePose);
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_Ptr_DynaFu_get(smartPtr, out var rawPtr));
+        return new DynaFu(smartPtr, rawPtr);
+    }
+
+    /// <summary>Gets the current parameters.</summary>
+    public virtual KinFuParams GetParams()
+    {
+        ThrowIfDisposed();
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getParams(
+            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
+    public virtual void Render(OutputArray image)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_render(Handle, image.Proxy));
+        GC.KeepAlive(image.Source);
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the given camera pose.</summary>
+    public virtual void Render(OutputArray image, InputArray cameraPose)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_renderWithPose(Handle, image.Proxy, cameraPose.Proxy));
+        GC.KeepAlive(image.Source); GC.KeepAlive(cameraPose.Source);
+    }
+
+    /// <summary>Gets points and normals of the current 3D mesh. The order of points is undefined; normals correspond to points.</summary>
+    public virtual void GetCloud(OutputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getCloud(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Gets points of the current 3D mesh. The order of points is undefined.</summary>
+    public virtual void GetPoints(OutputArray points)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getPoints(Handle, points.Proxy));
+        GC.KeepAlive(points.Source);
+    }
+
+    /// <summary>Calculates normals for the given points.</summary>
+    public virtual void GetNormals(InputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getNormals(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Clears the current model and resets the pose.</summary>
+    public virtual void Reset()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_reset(Handle));
+    }
+
+    /// <summary>Gets the current pose in voxel space, as a 4x4 homogeneous transform matrix.</summary>
+    public virtual Mat GetPose()
+    {
+        ThrowIfDisposed();
+        var pose = new Mat();
+        OutputArray poseArray = pose;
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getPose(Handle, poseArray.Proxy));
+        GC.KeepAlive(pose);
+        return pose;
+    }
+
+    /// <summary>
+    /// Integrates the next depth frame with respect to its ICP-calculated pose.
+    /// The input image is converted to CV_32F internally if it has another type.
+    /// </summary>
+    /// <returns>true if the new frame was successfully aligned with the current scene, false otherwise.</returns>
+    public virtual bool Update(InputArray depth)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_update(Handle, depth.Proxy, out var result));
+        GC.KeepAlive(depth.Source);
+        return result != 0;
+    }
+
+    /// <summary>Gets the positions of the deformation-graph nodes.</summary>
+    public virtual Point3f[] GetNodesPos()
+    {
+        ThrowIfDisposed();
+        using var nodes = new StdVector<Point3f>();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getNodesPos(Handle, nodes.CvPtr));
+        return nodes.ToArray();
+    }
+
+    /// <summary>Extracts a triangle mesh of the current model using the marching cubes algorithm.</summary>
+    public virtual void MarchCubes(OutputArray vertices, OutputArray edges)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_marchCubes(Handle, vertices.Proxy, edges.Proxy));
+        GC.KeepAlive(vertices.Source); GC.KeepAlive(edges.Source);
+    }
+
+    /// <summary>Renders the depth, vertex and normal images of the current (optionally warped) surface.</summary>
+    public virtual void RenderSurface(OutputArray depthImage, OutputArray vertImage, OutputArray normImage, bool warp = true)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_renderSurface(
+            Handle, depthImage.Proxy, vertImage.Proxy, normImage.Proxy, warp ? 1 : 0));
+        GC.KeepAlive(depthImage.Source); GC.KeepAlive(vertImage.Source); GC.KeepAlive(normImage.Source);
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/DynaFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/DynaFu.cs
@@ -37,14 +37,22 @@ public class DynaFu : CvPtrObject
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getParams(
-            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getParams(
+                Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
@@ -99,10 +107,18 @@ public class DynaFu : CvPtrObject
     {
         ThrowIfDisposed();
         var pose = new Mat();
-        OutputArray poseArray = pose;
-        NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getPose(Handle, poseArray.Proxy));
-        GC.KeepAlive(pose);
-        return pose;
+        try
+        {
+            OutputArray poseArray = pose;
+            NativeMethods.HandleException(NativeMethods.rgbd_dynafu_DynaFu_getPose(Handle, poseArray.Proxy));
+            GC.KeepAlive(pose);
+            return pose;
+        }
+        catch
+        {
+            pose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/rgbd/KinFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/KinFu.cs
@@ -1,0 +1,122 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>
+/// KinectFusion implementation. Reconstructs a 3D scene in real time from a sequence of depth
+/// images, and can render the model or extract a point cloud with normals.
+/// </summary>
+public class KinFu : CvPtrObject
+{
+    private KinFu(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.rgbd_kinfu_Ptr_KinFu_delete(p)))
+    { }
+
+    /// <summary>Creates a KinFu instance with the supplied parameters.</summary>
+    public static KinFu Create(KinFuParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var native = parameters.ToNative();
+        InputArray intr = parameters.Intr;
+        InputArray rgbIntr = parameters.RgbIntr;
+        InputArray volumePose = parameters.VolumePose;
+        using var icpIterations = new StdVector<int>(parameters.IcpIterations);
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_create(
+            in native, intr.Proxy, rgbIntr.Proxy, volumePose.Proxy, icpIterations.CvPtr, out var smartPtr));
+        GC.KeepAlive(parameters.Intr); GC.KeepAlive(parameters.RgbIntr); GC.KeepAlive(parameters.VolumePose);
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_Ptr_KinFu_get(smartPtr, out var rawPtr));
+        return new KinFu(smartPtr, rawPtr);
+    }
+
+    /// <summary>Gets the current parameters.</summary>
+    public virtual KinFuParams GetParams()
+    {
+        ThrowIfDisposed();
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getParams(
+            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
+    public virtual void Render(OutputArray image)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_render(Handle, image.Proxy));
+        GC.KeepAlive(image.Source);
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the given camera pose.</summary>
+    /// <param name="image">Resulting image.</param>
+    /// <param name="cameraPose">4x4 camera pose to render from.</param>
+    public virtual void Render(OutputArray image, InputArray cameraPose)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_renderWithPose(Handle, image.Proxy, cameraPose.Proxy));
+        GC.KeepAlive(image.Source); GC.KeepAlive(cameraPose.Source);
+    }
+
+    /// <summary>Gets points and normals of the current 3D mesh. The order of points is undefined; normals correspond to points.</summary>
+    public virtual void GetCloud(OutputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getCloud(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Gets points of the current 3D mesh. The order of points is undefined.</summary>
+    public virtual void GetPoints(OutputArray points)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getPoints(Handle, points.Proxy));
+        GC.KeepAlive(points.Source);
+    }
+
+    /// <summary>Calculates normals for the given points.</summary>
+    public virtual void GetNormals(InputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getNormals(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Clears the current model and resets the pose.</summary>
+    public virtual void Reset()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_reset(Handle));
+    }
+
+    /// <summary>Gets the current pose in voxel space, as a 4x4 homogeneous transform matrix.</summary>
+    public virtual Mat GetPose()
+    {
+        ThrowIfDisposed();
+        var pose = new Mat();
+        OutputArray poseArray = pose;
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getPose(Handle, poseArray.Proxy));
+        GC.KeepAlive(pose);
+        return pose;
+    }
+
+    /// <summary>
+    /// Integrates the next depth frame with respect to its ICP-calculated pose.
+    /// The input image is converted to CV_32F internally if it has another type.
+    /// </summary>
+    /// <param name="depth">One-channel image whose size and depth scale is described in the algorithm's parameters.</param>
+    /// <returns>true if the new frame was successfully aligned with the current scene, false otherwise.</returns>
+    public virtual bool Update(InputArray depth)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_update(Handle, depth.Proxy, out var result));
+        GC.KeepAlive(depth.Source);
+        return result != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/KinFu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/KinFu.cs
@@ -36,14 +36,22 @@ public class KinFu : CvPtrObject
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getParams(
-            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getParams(
+                Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
@@ -100,10 +108,18 @@ public class KinFu : CvPtrObject
     {
         ThrowIfDisposed();
         var pose = new Mat();
-        OutputArray poseArray = pose;
-        NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getPose(Handle, poseArray.Proxy));
-        GC.KeepAlive(pose);
-        return pose;
+        try
+        {
+            OutputArray poseArray = pose;
+            NativeMethods.HandleException(NativeMethods.rgbd_kinfu_KinFu_getPose(Handle, poseArray.Proxy));
+            GC.KeepAlive(pose);
+            return pose;
+        }
+        catch
+        {
+            pose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/rgbd/KinFuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/KinFuParams.cs
@@ -48,14 +48,22 @@ public sealed class KinFuParams
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(factory(
-            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(factory(
+                out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Default parameters providing better model quality, can be very slow.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/KinFuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/KinFuParams.cs
@@ -1,0 +1,166 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>
+/// Parameters for <see cref="KinFu"/> (and <see cref="DynaFu"/>, which shares the same
+/// <c>kinfu::Params</c> type in native OpenCV).
+/// </summary>
+/// <remarks>
+/// Instances can only be obtained via <see cref="DefaultParams"/>, <see cref="CoarseParams"/>,
+/// <see cref="HashTsdfParams"/>, <see cref="ColoredTsdfParams"/>, or <see cref="KinFu.GetParams"/>,
+/// ensuring the values are always initialized from the native C++ defaults.
+/// </remarks>
+public sealed class KinFuParams
+{
+    internal KinFuParams(CvKinFuParams p, Mat intr, Mat rgbIntr, Mat volumePose, int[] icpIterations)
+    {
+        FrameSize = p.FrameSize;
+        VolumeKind = (VolumeType)p.VolumeKind;
+        DepthFactor = p.DepthFactor;
+        BilateralSigmaDepth = p.BilateralSigmaDepth;
+        BilateralSigmaSpatial = p.BilateralSigmaSpatial;
+        BilateralKernelSize = p.BilateralKernelSize;
+        PyramidLevels = p.PyramidLevels;
+        VolumeDims = p.VolumeDims;
+        VoxelSize = p.VoxelSize;
+        TsdfMinCameraMovement = p.TsdfMinCameraMovement;
+        TsdfTruncDist = p.TsdfTruncDist;
+        TsdfMaxWeight = p.TsdfMaxWeight;
+        RaycastStepFactor = p.RaycastStepFactor;
+        LightPose = p.LightPose;
+        IcpDistThresh = p.IcpDistThresh;
+        IcpAngleThresh = p.IcpAngleThresh;
+        TruncateThreshold = p.TruncateThreshold;
+        Intr = intr;
+        RgbIntr = rgbIntr;
+        VolumePose = volumePose;
+        IcpIterations = icpIterations;
+    }
+
+    private delegate ExceptionStatus Factory(
+        out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        in OutputArrayProxy volumePose, IntPtr icpIterations);
+
+    private static KinFuParams FromFactory(Factory factory)
+    {
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(factory(
+            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, volumePoseArray.Proxy, icpIterations.CvPtr));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        return new KinFuParams(pod, intr, rgbIntr, volumePose, icpIterations.ToArray());
+    }
+
+    /// <summary>Default parameters providing better model quality, can be very slow.</summary>
+    public static KinFuParams DefaultParams() =>
+        FromFactory(NativeMethods.rgbd_kinfu_Params_defaultParams);
+
+    /// <summary>Coarse parameters providing better speed, can fail to match frames in case of rapid sensor motion.</summary>
+    public static KinFuParams CoarseParams() =>
+        FromFactory(NativeMethods.rgbd_kinfu_Params_coarseParams);
+
+    /// <summary>Parameters suitable for use with a hash-based TSDF volume.</summary>
+    public static KinFuParams HashTsdfParams(bool isCoarse) =>
+        FromFactory((out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+                in OutputArrayProxy volumePose, IntPtr icpIterations) =>
+            NativeMethods.rgbd_kinfu_Params_hashTSDFParams(
+                isCoarse ? 1 : 0, out pod, intr, rgbIntr, volumePose, icpIterations));
+
+    /// <summary>Parameters suitable for use with a colored TSDF volume.</summary>
+    public static KinFuParams ColoredTsdfParams(bool isCoarse) =>
+        FromFactory((out CvKinFuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+                in OutputArrayProxy volumePose, IntPtr icpIterations) =>
+            NativeMethods.rgbd_kinfu_Params_coloredTSDFParams(
+                isCoarse ? 1 : 0, out pod, intr, rgbIntr, volumePose, icpIterations));
+
+    internal CvKinFuParams ToNative() => new()
+    {
+        FrameSize = FrameSize,
+        VolumeKind = (int)VolumeKind,
+        DepthFactor = DepthFactor,
+        BilateralSigmaDepth = BilateralSigmaDepth,
+        BilateralSigmaSpatial = BilateralSigmaSpatial,
+        BilateralKernelSize = BilateralKernelSize,
+        PyramidLevels = PyramidLevels,
+        VolumeDims = VolumeDims,
+        VoxelSize = VoxelSize,
+        TsdfMinCameraMovement = TsdfMinCameraMovement,
+        TsdfTruncDist = TsdfTruncDist,
+        TsdfMaxWeight = TsdfMaxWeight,
+        RaycastStepFactor = RaycastStepFactor,
+        LightPose = LightPose,
+        IcpDistThresh = IcpDistThresh,
+        IcpAngleThresh = IcpAngleThresh,
+        TruncateThreshold = TruncateThreshold,
+    };
+
+    /// <summary>Frame size in pixels.</summary>
+    public Size FrameSize { get; set; }
+
+    /// <summary>Volume kind.</summary>
+    public VolumeType VolumeKind { get; set; }
+
+    /// <summary>Camera intrinsics (3x3).</summary>
+    public Mat Intr { get; set; }
+
+    /// <summary>RGB camera intrinsics (3x3).</summary>
+    public Mat RgbIntr { get; set; }
+
+    /// <summary>Pre-scale per 1 meter for input depth values.</summary>
+    public float DepthFactor { get; set; }
+
+    /// <summary>Depth sigma in meters for bilateral smoothing.</summary>
+    public float BilateralSigmaDepth { get; set; }
+
+    /// <summary>Spatial sigma in pixels for bilateral smoothing.</summary>
+    public float BilateralSigmaSpatial { get; set; }
+
+    /// <summary>Kernel size in pixels for bilateral smoothing.</summary>
+    public int BilateralKernelSize { get; set; }
+
+    /// <summary>Number of pyramid levels for ICP.</summary>
+    public int PyramidLevels { get; set; }
+
+    /// <summary>Resolution of voxel space (number of voxels in each dimension).</summary>
+    public Vec3i VolumeDims { get; set; }
+
+    /// <summary>Size of voxel in meters.</summary>
+    public float VoxelSize { get; set; }
+
+    /// <summary>Minimal camera movement in meters; a new depth frame is integrated only if camera movement exceeds this value.</summary>
+    public float TsdfMinCameraMovement { get; set; }
+
+    /// <summary>Initial volume pose in meters (4x4 homogeneous transform).</summary>
+    public Mat VolumePose { get; set; }
+
+    /// <summary>Distance to truncate in meters; distances beyond this value are truncated to 1.0.</summary>
+    public float TsdfTruncDist { get; set; }
+
+    /// <summary>Max number of frames per voxel; each voxel keeps a running average of distances no longer than this value.</summary>
+    public int TsdfMaxWeight { get; set; }
+
+    /// <summary>Fraction of a voxel size skipped per raycast step.</summary>
+    public float RaycastStepFactor { get; set; }
+
+    /// <summary>Light pose for rendering, in meters.</summary>
+    public Vec3f LightPose { get; set; }
+
+    /// <summary>Distance threshold for ICP, in meters.</summary>
+    public float IcpDistThresh { get; set; }
+
+    /// <summary>Angle threshold for ICP, in radians.</summary>
+    public float IcpAngleThresh { get; set; }
+
+    /// <summary>Number of ICP iterations for each pyramid level.</summary>
+    public int[] IcpIterations { get; set; }
+
+    /// <summary>Threshold for depth truncation in meters; depth values beyond this threshold are set to zero.</summary>
+    public float TruncateThreshold { get; set; }
+}

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfu.cs
@@ -1,0 +1,125 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>
+/// Large-scale dense depth fusion implementation. Reconstructs larger environments using
+/// spatially hashed TSDF volume "submaps", with periodic pose-graph optimization to reduce
+/// drift over long sequences.
+/// </summary>
+public class LargeKinfu : CvPtrObject
+{
+    private LargeKinfu(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_Ptr_LargeKinfu_delete(p)))
+    { }
+
+    /// <summary>Creates a LargeKinfu instance with the supplied parameters.</summary>
+    public static LargeKinfu Create(LargeKinfuParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        ArgumentNullException.ThrowIfNull(parameters.VolumeParams);
+        var native = parameters.ToNative();
+        var volumeNative = parameters.VolumeParams.ToNative();
+        InputArray intr = parameters.Intr;
+        InputArray rgbIntr = parameters.RgbIntr;
+        InputArray volumePose = parameters.VolumeParams.Pose;
+        using var icpIterations = new StdVector<int>(parameters.IcpIterations);
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_create(
+            in native, intr.Proxy, rgbIntr.Proxy, icpIterations.CvPtr, in volumeNative, volumePose.Proxy,
+            out var smartPtr));
+        GC.KeepAlive(parameters.Intr); GC.KeepAlive(parameters.RgbIntr); GC.KeepAlive(parameters.VolumeParams.Pose);
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_Ptr_LargeKinfu_get(smartPtr, out var rawPtr));
+        return new LargeKinfu(smartPtr, rawPtr);
+    }
+
+    /// <summary>Gets the current parameters.</summary>
+    public virtual LargeKinfuParams GetParams()
+    {
+        ThrowIfDisposed();
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getParams(
+            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
+            out var volumePod, volumePoseArray.Proxy));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
+        return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
+    public virtual void Render(OutputArray image)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_render(Handle, image.Proxy));
+        GC.KeepAlive(image.Source);
+    }
+
+    /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the given camera pose.</summary>
+    public virtual void Render(OutputArray image, InputArray cameraPose)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_renderWithPose(Handle, image.Proxy, cameraPose.Proxy));
+        GC.KeepAlive(image.Source); GC.KeepAlive(cameraPose.Source);
+    }
+
+    /// <summary>Gets points and normals of the current 3D mesh. The order of points is undefined; normals correspond to points.</summary>
+    public virtual void GetCloud(OutputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getCloud(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Gets points of the current 3D mesh. The order of points is undefined.</summary>
+    public virtual void GetPoints(OutputArray points)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getPoints(Handle, points.Proxy));
+        GC.KeepAlive(points.Source);
+    }
+
+    /// <summary>Calculates normals for the given points.</summary>
+    public virtual void GetNormals(InputArray points, OutputArray normals)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getNormals(Handle, points.Proxy, normals.Proxy));
+        GC.KeepAlive(points.Source); GC.KeepAlive(normals.Source);
+    }
+
+    /// <summary>Clears the current model and resets the pose.</summary>
+    public virtual void Reset()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_reset(Handle));
+    }
+
+    /// <summary>Gets the current pose in voxel space, as a 4x4 homogeneous transform matrix.</summary>
+    public virtual Mat GetPose()
+    {
+        ThrowIfDisposed();
+        var pose = new Mat();
+        OutputArray poseArray = pose;
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getPose(Handle, poseArray.Proxy));
+        GC.KeepAlive(pose);
+        return pose;
+    }
+
+    /// <summary>
+    /// Integrates the next depth frame with respect to its ICP-calculated pose.
+    /// The input image is converted to CV_32F internally if it has another type.
+    /// </summary>
+    /// <returns>true if the new frame was successfully aligned with the current scene, false otherwise.</returns>
+    public virtual bool Update(InputArray depth)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_update(Handle, depth.Proxy, out var result));
+        GC.KeepAlive(depth.Source);
+        return result != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfu.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfu.cs
@@ -40,16 +40,24 @@ public class LargeKinfu : CvPtrObject
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getParams(
-            Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
-            out var volumePod, volumePoseArray.Proxy));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
-        return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getParams(
+                Handle, out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
+                out var volumePod, volumePoseArray.Proxy));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
+            return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Renders a 0-surface of the TSDF using Phong shading into a CV_8UC4 image, from the last frame's camera pose.</summary>
@@ -104,10 +112,18 @@ public class LargeKinfu : CvPtrObject
     {
         ThrowIfDisposed();
         var pose = new Mat();
-        OutputArray poseArray = pose;
-        NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getPose(Handle, poseArray.Proxy));
-        GC.KeepAlive(pose);
-        return pose;
+        try
+        {
+            OutputArray poseArray = pose;
+            NativeMethods.HandleException(NativeMethods.rgbd_large_kinfu_LargeKinfu_getPose(Handle, poseArray.Proxy));
+            GC.KeepAlive(pose);
+            return pose;
+        }
+        catch
+        {
+            pose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfuParams.cs
@@ -40,16 +40,24 @@ public sealed class LargeKinfuParams
         var intr = new Mat();
         var rgbIntr = new Mat();
         var volumePose = new Mat();
-        using var icpIterations = new StdVector<int>();
-        OutputArray intrArray = intr;
-        OutputArray rgbIntrArray = rgbIntr;
-        OutputArray volumePoseArray = volumePose;
-        NativeMethods.HandleException(factory(
-            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
-            out var volumePod, volumePoseArray.Proxy));
-        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
-        var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
-        return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+        try
+        {
+            using var icpIterations = new StdVector<int>();
+            OutputArray intrArray = intr;
+            OutputArray rgbIntrArray = rgbIntr;
+            OutputArray volumePoseArray = volumePose;
+            NativeMethods.HandleException(factory(
+                out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
+                out var volumePod, volumePoseArray.Proxy));
+            GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+            var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
+            return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+        }
+        catch
+        {
+            intr.Dispose(); rgbIntr.Dispose(); volumePose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Default parameters providing better model quality, can be very slow.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfuParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfuParams.cs
@@ -1,0 +1,129 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>Parameters for <see cref="LargeKinfu"/>.</summary>
+/// <remarks>
+/// Instances can only be obtained via <see cref="DefaultParams"/>, <see cref="CoarseParams"/>,
+/// <see cref="HashTsdfParams"/>, or <see cref="LargeKinfu.GetParams"/>, ensuring the values are
+/// always initialized from the native C++ defaults.
+/// </remarks>
+public sealed class LargeKinfuParams
+{
+    internal LargeKinfuParams(
+        CvLargeKinfuParams p, Mat intr, Mat rgbIntr, int[] icpIterations, LargeKinfuVolumeParams volumeParams)
+    {
+        FrameSize = p.FrameSize;
+        DepthFactor = p.DepthFactor;
+        BilateralSigmaDepth = p.BilateralSigmaDepth;
+        BilateralSigmaSpatial = p.BilateralSigmaSpatial;
+        BilateralKernelSize = p.BilateralKernelSize;
+        PyramidLevels = p.PyramidLevels;
+        TsdfMinCameraMovement = p.TsdfMinCameraMovement;
+        LightPose = p.LightPose;
+        IcpDistThresh = p.IcpDistThresh;
+        IcpAngleThresh = p.IcpAngleThresh;
+        TruncateThreshold = p.TruncateThreshold;
+        Intr = intr;
+        RgbIntr = rgbIntr;
+        IcpIterations = icpIterations;
+        VolumeParams = volumeParams;
+    }
+
+    private delegate ExceptionStatus Factory(
+        out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+        IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose);
+
+    private static LargeKinfuParams FromFactory(Factory factory)
+    {
+        var intr = new Mat();
+        var rgbIntr = new Mat();
+        var volumePose = new Mat();
+        using var icpIterations = new StdVector<int>();
+        OutputArray intrArray = intr;
+        OutputArray rgbIntrArray = rgbIntr;
+        OutputArray volumePoseArray = volumePose;
+        NativeMethods.HandleException(factory(
+            out var pod, intrArray.Proxy, rgbIntrArray.Proxy, icpIterations.CvPtr,
+            out var volumePod, volumePoseArray.Proxy));
+        GC.KeepAlive(intr); GC.KeepAlive(rgbIntr); GC.KeepAlive(volumePose);
+        var volumeParams = new LargeKinfuVolumeParams(volumePod, volumePose);
+        return new LargeKinfuParams(pod, intr, rgbIntr, icpIterations.ToArray(), volumeParams);
+    }
+
+    /// <summary>Default parameters providing better model quality, can be very slow.</summary>
+    public static LargeKinfuParams DefaultParams() =>
+        FromFactory(NativeMethods.rgbd_large_kinfu_Params_defaultParams);
+
+    /// <summary>Coarse parameters providing better speed, can fail to match frames in case of rapid sensor motion.</summary>
+    public static LargeKinfuParams CoarseParams() =>
+        FromFactory(NativeMethods.rgbd_large_kinfu_Params_coarseParams);
+
+    /// <summary>Parameters suitable for use with a hash-based TSDF volume.</summary>
+    public static LargeKinfuParams HashTsdfParams(bool isCoarse) =>
+        FromFactory((out CvLargeKinfuParams pod, in OutputArrayProxy intr, in OutputArrayProxy rgbIntr,
+                IntPtr icpIterations, out CvLargeKinfuVolumeParams volumePod, in OutputArrayProxy volumePose) =>
+            NativeMethods.rgbd_large_kinfu_Params_hashTSDFParams(
+                isCoarse ? 1 : 0, out pod, intr, rgbIntr, icpIterations, out volumePod, volumePose));
+
+    internal CvLargeKinfuParams ToNative() => new()
+    {
+        FrameSize = FrameSize,
+        DepthFactor = DepthFactor,
+        BilateralSigmaDepth = BilateralSigmaDepth,
+        BilateralSigmaSpatial = BilateralSigmaSpatial,
+        BilateralKernelSize = BilateralKernelSize,
+        PyramidLevels = PyramidLevels,
+        TsdfMinCameraMovement = TsdfMinCameraMovement,
+        LightPose = LightPose,
+        IcpDistThresh = IcpDistThresh,
+        IcpAngleThresh = IcpAngleThresh,
+        TruncateThreshold = TruncateThreshold,
+    };
+
+    /// <summary>Frame size in pixels.</summary>
+    public Size FrameSize { get; set; }
+
+    /// <summary>Camera intrinsics (3x3).</summary>
+    public Mat Intr { get; set; }
+
+    /// <summary>RGB camera intrinsics (3x3).</summary>
+    public Mat RgbIntr { get; set; }
+
+    /// <summary>Pre-scale per 1 meter for input depth values.</summary>
+    public float DepthFactor { get; set; }
+
+    /// <summary>Depth sigma in meters for bilateral smoothing.</summary>
+    public float BilateralSigmaDepth { get; set; }
+
+    /// <summary>Spatial sigma in pixels for bilateral smoothing.</summary>
+    public float BilateralSigmaSpatial { get; set; }
+
+    /// <summary>Kernel size in pixels for bilateral smoothing.</summary>
+    public int BilateralKernelSize { get; set; }
+
+    /// <summary>Number of pyramid levels for ICP.</summary>
+    public int PyramidLevels { get; set; }
+
+    /// <summary>Minimal camera movement in meters; a new depth frame is integrated only if camera movement exceeds this value.</summary>
+    public float TsdfMinCameraMovement { get; set; }
+
+    /// <summary>Light pose for rendering, in meters.</summary>
+    public Vec3f LightPose { get; set; }
+
+    /// <summary>Distance threshold for ICP, in meters.</summary>
+    public float IcpDistThresh { get; set; }
+
+    /// <summary>Angle threshold for ICP, in radians.</summary>
+    public float IcpAngleThresh { get; set; }
+
+    /// <summary>Number of ICP iterations for each pyramid level.</summary>
+    public int[] IcpIterations { get; set; }
+
+    /// <summary>Threshold for depth truncation in meters; depth values beyond this threshold are set to zero.</summary>
+    public float TruncateThreshold { get; set; }
+
+    /// <summary>Volume parameters.</summary>
+    public LargeKinfuVolumeParams VolumeParams { get; set; }
+}

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
@@ -30,10 +30,18 @@ public sealed class LargeKinfuVolumeParams
     private static LargeKinfuVolumeParams FromFactory(Factory factory, VolumeType volumeType)
     {
         var pose = new Mat();
-        OutputArray poseArray = pose;
-        NativeMethods.HandleException(factory((int)volumeType, out var pod, poseArray.Proxy));
-        GC.KeepAlive(pose);
-        return new LargeKinfuVolumeParams(pod, pose);
+        try
+        {
+            OutputArray poseArray = pose;
+            NativeMethods.HandleException(factory((int)volumeType, out var pod, poseArray.Proxy));
+            GC.KeepAlive(pose);
+            return new LargeKinfuVolumeParams(pod, pose);
+        }
+        catch
+        {
+            pose.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Default parameters providing higher-quality reconstruction at the cost of slower performance.</summary>

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
@@ -16,7 +16,7 @@ public sealed class LargeKinfuVolumeParams
         ResolutionY = v.ResolutionY;
         ResolutionZ = v.ResolutionZ;
         UnitResolution = v.UnitResolution;
-        VolumSize = v.VolumSize;
+        VolumeSize = v.VolumeSize;
         VoxelSize = v.VoxelSize;
         TsdfTruncDist = v.TsdfTruncDist;
         MaxWeight = v.MaxWeight;
@@ -59,7 +59,7 @@ public sealed class LargeKinfuVolumeParams
         ResolutionY = ResolutionY,
         ResolutionZ = ResolutionZ,
         UnitResolution = UnitResolution,
-        VolumSize = VolumSize,
+        VolumeSize = VolumeSize,
         VoxelSize = VoxelSize,
         TsdfTruncDist = TsdfTruncDist,
         MaxWeight = MaxWeight,
@@ -83,7 +83,7 @@ public sealed class LargeKinfuVolumeParams
     public int UnitResolution { get; set; }
 
     /// <summary>Size of the volume in meters.</summary>
-    public float VolumSize { get; set; }
+    public float VolumeSize { get; set; }
 
     /// <summary>Initial pose of the volume in meters (4x4 homogeneous transform).</summary>
     public Mat Pose { get; set; }

--- a/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
+++ b/src/OpenCvSharp/Modules/rgbd/LargeKinfuVolumeParams.cs
@@ -1,0 +1,97 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Rgbd;
+
+/// <summary>Volume parameters used by <see cref="LargeKinfuParams"/>.</summary>
+/// <remarks>
+/// Instances can only be obtained via <see cref="DefaultParams"/> or <see cref="CoarseParams"/>,
+/// ensuring the values are always initialized from the native C++ defaults.
+/// </remarks>
+public sealed class LargeKinfuVolumeParams
+{
+    internal LargeKinfuVolumeParams(CvLargeKinfuVolumeParams v, Mat pose)
+    {
+        Kind = (VolumeType)v.Kind;
+        ResolutionX = v.ResolutionX;
+        ResolutionY = v.ResolutionY;
+        ResolutionZ = v.ResolutionZ;
+        UnitResolution = v.UnitResolution;
+        VolumSize = v.VolumSize;
+        VoxelSize = v.VoxelSize;
+        TsdfTruncDist = v.TsdfTruncDist;
+        MaxWeight = v.MaxWeight;
+        DepthTruncThreshold = v.DepthTruncThreshold;
+        RaycastStepFactor = v.RaycastStepFactor;
+        Pose = pose;
+    }
+
+    private delegate ExceptionStatus Factory(int volumeType, out CvLargeKinfuVolumeParams pod, in OutputArrayProxy pose);
+
+    private static LargeKinfuVolumeParams FromFactory(Factory factory, VolumeType volumeType)
+    {
+        var pose = new Mat();
+        OutputArray poseArray = pose;
+        NativeMethods.HandleException(factory((int)volumeType, out var pod, poseArray.Proxy));
+        GC.KeepAlive(pose);
+        return new LargeKinfuVolumeParams(pod, pose);
+    }
+
+    /// <summary>Default parameters providing higher-quality reconstruction at the cost of slower performance.</summary>
+    public static LargeKinfuVolumeParams DefaultParams(VolumeType volumeType) =>
+        FromFactory(NativeMethods.rgbd_large_kinfu_VolumeParams_defaultParams, volumeType);
+
+    /// <summary>Coarse parameters providing relatively higher performance at the cost of reconstruction quality.</summary>
+    public static LargeKinfuVolumeParams CoarseParams(VolumeType volumeType) =>
+        FromFactory(NativeMethods.rgbd_large_kinfu_VolumeParams_coarseParams, volumeType);
+
+    internal CvLargeKinfuVolumeParams ToNative() => new()
+    {
+        Kind = (int)Kind,
+        ResolutionX = ResolutionX,
+        ResolutionY = ResolutionY,
+        ResolutionZ = ResolutionZ,
+        UnitResolution = UnitResolution,
+        VolumSize = VolumSize,
+        VoxelSize = VoxelSize,
+        TsdfTruncDist = TsdfTruncDist,
+        MaxWeight = MaxWeight,
+        DepthTruncThreshold = DepthTruncThreshold,
+        RaycastStepFactor = RaycastStepFactor,
+    };
+
+    /// <summary>Kind of volume (TSDF or HashTSDF).</summary>
+    public VolumeType Kind { get; set; }
+
+    /// <summary>Resolution of voxel space along X (number of voxels). Applicable only for TSDF volume.</summary>
+    public int ResolutionX { get; set; }
+
+    /// <summary>Resolution of voxel space along Y (number of voxels). Applicable only for TSDF volume.</summary>
+    public int ResolutionY { get; set; }
+
+    /// <summary>Resolution of voxel space along Z (number of voxels). Applicable only for TSDF volume.</summary>
+    public int ResolutionZ { get; set; }
+
+    /// <summary>Resolution of a volume unit in voxel space. Applicable only for HashTSDF.</summary>
+    public int UnitResolution { get; set; }
+
+    /// <summary>Size of the volume in meters.</summary>
+    public float VolumSize { get; set; }
+
+    /// <summary>Initial pose of the volume in meters (4x4 homogeneous transform).</summary>
+    public Mat Pose { get; set; }
+
+    /// <summary>Length of voxels in meters.</summary>
+    public float VoxelSize { get; set; }
+
+    /// <summary>TSDF truncation distance; distances greater than this from the surface are truncated to 1.0.</summary>
+    public float TsdfTruncDist { get; set; }
+
+    /// <summary>Max number of frames to integrate per voxel.</summary>
+    public int MaxWeight { get; set; }
+
+    /// <summary>Threshold for depth truncation in meters; depth greater than this is truncated to 0.</summary>
+    public float DepthTruncThreshold { get; set; }
+
+    /// <summary>Length of a single raycast step, as a fraction of the voxel length.</summary>
+    public float RaycastStepFactor { get; set; }
+}

--- a/src/OpenCvSharpExtern/include_opencv.h
+++ b/src/OpenCvSharpExtern/include_opencv.h
@@ -90,6 +90,10 @@
 #include <opencv2/img_hash.hpp>
 #ifndef NO_CONTRIB
 #include <opencv2/rgbd/linemod.hpp>
+#include <opencv2/rgbd/kinfu.hpp>
+#include <opencv2/rgbd/dynafu.hpp>
+#include <opencv2/rgbd/colored_kinfu.hpp>
+#include <opencv2/rgbd/large_kinfu.hpp>
 #endif
 
 // MP! Added: To correctly support imShow under WinRT.

--- a/src/OpenCvSharpExtern/rgbd.cpp
+++ b/src/OpenCvSharpExtern/rgbd.cpp
@@ -1,2 +1,6 @@
 // ReSharper disable CppUnusedIncludeDirective
 #include "rgbd_linemod.h"
+#include "rgbd_kinfu.h"
+#include "rgbd_dynafu.h"
+#include "rgbd_colored_kinfu.h"
+#include "rgbd_large_kinfu.h"

--- a/src/OpenCvSharpExtern/rgbd_colored_kinfu.h
+++ b/src/OpenCvSharpExtern/rgbd_colored_kinfu.h
@@ -1,0 +1,207 @@
+#pragma once
+#ifndef NO_CONTRIB
+#include "include_opencv.h"
+#include "rgbd_kinfu.h" // toCv/toInterop Vec3i/Vec3f helpers
+
+// Keep the exported functions compact while using the repository's cvTry exception boundary.
+#define BEGIN_WRAP return cvTry([&] {
+#define END_WRAP });
+
+using cv::colored_kinfu::ColoredKinFu;
+using ColoredKinFuParams = cv::colored_kinfu::Params;
+
+/// <summary>
+/// Plain-C struct for marshaling the scalar/fixed-size fields of colored_kinfu::Params across the
+/// P/Invoke boundary. Matx33f/Matx44f fields (intr, rgb_intr, volumePose) and the icpIterations
+/// vector are marshaled as separate arguments alongside this struct, not embedded in it.
+/// Layout must stay in sync with OpenCvSharp.Rgbd.ColoredKinFuParams in C#.
+/// </summary>
+struct CvColoredKinFuParams
+{
+    interop::Size FrameSize;
+    interop::Size RgbFrameSize;
+    int32_t       VolumeKind;
+    float         DepthFactor;
+    float         BilateralSigmaDepth;
+    float         BilateralSigmaSpatial;
+    int32_t       BilateralKernelSize;
+    int32_t       PyramidLevels;
+    interop::Vec3i VolumeDims;
+    float         VoxelSize;
+    float         TsdfMinCameraMovement;
+    float         TsdfTruncDist;
+    int32_t       TsdfMaxWeight;
+    float         RaycastStepFactor;
+    interop::Vec3f LightPose;
+    float         IcpDistThresh;
+    float         IcpAngleThresh;
+    float         TruncateThreshold;
+};
+
+static cv::colored_kinfu::Params BuildColoredKinfuParams(
+    const CvColoredKinFuParams *pod,
+    const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const interop::InputArrayProxy *volumePose, const std::vector<int> *icpIterations)
+{
+    cv::colored_kinfu::Params p;
+    p.frameSize = cpp(pod->FrameSize);
+    p.rgb_frameSize = cpp(pod->RgbFrameSize);
+    p.volumeKind = static_cast<cv::VolumeType>(pod->VolumeKind);
+    p.intr = cv::Matx33f(getMatFromProxy(*intr));
+    p.rgb_intr = cv::Matx33f(getMatFromProxy(*rgbIntr));
+    p.depthFactor = pod->DepthFactor;
+    p.bilateral_sigma_depth = pod->BilateralSigmaDepth;
+    p.bilateral_sigma_spatial = pod->BilateralSigmaSpatial;
+    p.bilateral_kernel_size = pod->BilateralKernelSize;
+    p.pyramidLevels = pod->PyramidLevels;
+    p.volumeDims = toCv(pod->VolumeDims);
+    p.voxelSize = pod->VoxelSize;
+    p.tsdf_min_camera_movement = pod->TsdfMinCameraMovement;
+    p.volumePose = cv::Matx44f(getMatFromProxy(*volumePose));
+    p.tsdf_trunc_dist = pod->TsdfTruncDist;
+    p.tsdf_max_weight = pod->TsdfMaxWeight;
+    p.raycast_step_factor = pod->RaycastStepFactor;
+    p.lightPose = toCv(pod->LightPose);
+    p.icpDistThresh = pod->IcpDistThresh;
+    p.icpAngleThresh = pod->IcpAngleThresh;
+    p.icpIterations = *icpIterations;
+    p.truncateThreshold = pod->TruncateThreshold;
+    return p;
+}
+
+static void ReadColoredKinfuParams(
+    const cv::colored_kinfu::Params &p, CvColoredKinFuParams *pod,
+    const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    pod->FrameSize = c(p.frameSize);
+    pod->RgbFrameSize = c(p.rgb_frameSize);
+    pod->VolumeKind = static_cast<int32_t>(p.volumeKind);
+    pod->DepthFactor = p.depthFactor;
+    pod->BilateralSigmaDepth = p.bilateral_sigma_depth;
+    pod->BilateralSigmaSpatial = p.bilateral_sigma_spatial;
+    pod->BilateralKernelSize = p.bilateral_kernel_size;
+    pod->PyramidLevels = p.pyramidLevels;
+    pod->VolumeDims = toInterop(p.volumeDims);
+    pod->VoxelSize = p.voxelSize;
+    pod->TsdfMinCameraMovement = p.tsdf_min_camera_movement;
+    pod->TsdfTruncDist = p.tsdf_trunc_dist;
+    pod->TsdfMaxWeight = p.tsdf_max_weight;
+    pod->RaycastStepFactor = p.raycast_step_factor;
+    pod->LightPose = toInterop(p.lightPose);
+    pod->IcpDistThresh = p.icpDistThresh;
+    pod->IcpAngleThresh = p.icpAngleThresh;
+    pod->TruncateThreshold = p.truncateThreshold;
+    cv::Mat(p.intr).copyTo(OutProxy(*intr));
+    cv::Mat(p.rgb_intr).copyTo(OutProxy(*rgbIntr));
+    cv::Mat(p.volumePose).copyTo(OutProxy(*volumePose));
+    *icpIterations = p.icpIterations;
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Params_defaultParams(
+    CvColoredKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = ColoredKinFuParams::defaultParams();
+    ReadColoredKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Params_coarseParams(
+    CvColoredKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = ColoredKinFuParams::coarseParams();
+    ReadColoredKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Params_hashTSDFParams(
+    int isCoarse, CvColoredKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = ColoredKinFuParams::hashTSDFParams(isCoarse != 0);
+    ReadColoredKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Params_coloredTSDFParams(
+    int isCoarse, CvColoredKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = ColoredKinFuParams::coloredTSDFParams(isCoarse != 0);
+    ReadColoredKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Ptr_ColoredKinFu_delete(cv::Ptr<ColoredKinFu> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_Ptr_ColoredKinFu_get(cv::Ptr<ColoredKinFu> *obj, ColoredKinFu **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_create(
+    const CvColoredKinFuParams *pod, const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const interop::InputArrayProxy *volumePose, const std::vector<int> *icpIterations,
+    cv::Ptr<ColoredKinFu> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = BuildColoredKinfuParams(pod, intr, rgbIntr, volumePose, icpIterations);
+    *returnValue = new cv::Ptr<ColoredKinFu>(ColoredKinFu::create(cv::makePtr<ColoredKinFuParams>(p)));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_getParams(
+    ColoredKinFu *obj, CvColoredKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    ReadColoredKinfuParams(obj->getParams(), pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_render(ColoredKinFu *obj, const interop::OutputArrayProxy *image)
+{ BEGIN_WRAP obj->render(OutProxy(*image)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_renderWithPose(
+    ColoredKinFu *obj, const interop::OutputArrayProxy *image, const interop::InputArrayProxy *cameraPose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f pose(getMatFromProxy(*cameraPose));
+    obj->render(OutProxy(*image), pose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_getCloud(
+    ColoredKinFu *obj, const interop::OutputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getCloud(OutProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_getPoints(ColoredKinFu *obj, const interop::OutputArrayProxy *points)
+{ BEGIN_WRAP obj->getPoints(OutProxy(*points)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_getNormals(
+    ColoredKinFu *obj, const interop::InputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getNormals(InProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_reset(ColoredKinFu *obj)
+{ BEGIN_WRAP obj->reset(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_getPose(ColoredKinFu *obj, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f m = obj->getPose().matrix;
+    cv::Mat(m).copyTo(OutProxy(*pose));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_colored_kinfu_ColoredKinFu_update(
+    ColoredKinFu *obj, const interop::InputArrayProxy *depth, const interop::InputArrayProxy *rgb, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->update(InProxy(*depth), InProxy(*rgb)) ? 1 : 0; END_WRAP }
+
+#undef BEGIN_WRAP
+#undef END_WRAP
+#endif

--- a/src/OpenCvSharpExtern/rgbd_dynafu.h
+++ b/src/OpenCvSharpExtern/rgbd_dynafu.h
@@ -1,0 +1,89 @@
+#pragma once
+#ifndef NO_CONTRIB
+#include "include_opencv.h"
+#include "rgbd_kinfu.h" // BuildKinfuParams / ReadKinfuParams (dynafu::Params is an alias of kinfu::Params)
+
+// Keep the exported functions compact while using the repository's cvTry exception boundary.
+#define BEGIN_WRAP return cvTry([&] {
+#define END_WRAP });
+
+using cv::dynafu::DynaFu;
+
+CVAPI(ExceptionStatus) rgbd_dynafu_Ptr_DynaFu_delete(cv::Ptr<DynaFu> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_Ptr_DynaFu_get(cv::Ptr<DynaFu> *obj, DynaFu **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_create(
+    const CvKinFuParams *pod, const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const interop::InputArrayProxy *volumePose, const std::vector<int> *icpIterations,
+    cv::Ptr<DynaFu> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = BuildKinfuParams(pod, intr, rgbIntr, volumePose, icpIterations);
+    *returnValue = new cv::Ptr<DynaFu>(DynaFu::create(cv::makePtr<cv::kinfu::Params>(p)));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getParams(
+    DynaFu *obj, CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    ReadKinfuParams(obj->getParams(), pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_render(DynaFu *obj, const interop::OutputArrayProxy *image)
+{ BEGIN_WRAP obj->render(OutProxy(*image)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_renderWithPose(
+    DynaFu *obj, const interop::OutputArrayProxy *image, const interop::InputArrayProxy *cameraPose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f pose(getMatFromProxy(*cameraPose));
+    obj->render(OutProxy(*image), pose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getCloud(
+    DynaFu *obj, const interop::OutputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getCloud(OutProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getPoints(DynaFu *obj, const interop::OutputArrayProxy *points)
+{ BEGIN_WRAP obj->getPoints(OutProxy(*points)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getNormals(
+    DynaFu *obj, const interop::InputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getNormals(InProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_reset(DynaFu *obj)
+{ BEGIN_WRAP obj->reset(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getPose(DynaFu *obj, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f m = obj->getPose().matrix;
+    cv::Mat(m).copyTo(OutProxy(*pose));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_update(DynaFu *obj, const interop::InputArrayProxy *depth, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->update(InProxy(*depth)) ? 1 : 0; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_getNodesPos(DynaFu *obj, std::vector<cv::Point3f> *returnValue)
+{ BEGIN_WRAP *returnValue = obj->getNodesPos(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_marchCubes(
+    DynaFu *obj, const interop::OutputArrayProxy *vertices, const interop::OutputArrayProxy *edges)
+{ BEGIN_WRAP obj->marchCubes(OutProxy(*vertices), OutProxy(*edges)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_dynafu_DynaFu_renderSurface(
+    DynaFu *obj, const interop::OutputArrayProxy *depthImage, const interop::OutputArrayProxy *vertImage,
+    const interop::OutputArrayProxy *normImage, int warp)
+{ BEGIN_WRAP obj->renderSurface(OutProxy(*depthImage), OutProxy(*vertImage), OutProxy(*normImage), warp != 0); END_WRAP }
+
+#undef BEGIN_WRAP
+#undef END_WRAP
+#endif

--- a/src/OpenCvSharpExtern/rgbd_kinfu.h
+++ b/src/OpenCvSharpExtern/rgbd_kinfu.h
@@ -1,0 +1,232 @@
+#pragma once
+#ifndef NO_CONTRIB
+#include "include_opencv.h"
+
+// Keep the exported functions compact while using the repository's cvTry exception boundary.
+#define BEGIN_WRAP return cvTry([&] {
+#define END_WRAP });
+
+using cv::kinfu::KinFu;
+using KinFuParams = cv::kinfu::Params;
+
+/// <summary>
+/// Plain-C struct for marshaling the scalar/fixed-size fields of kinfu::Params (and its
+/// dynafu::Params alias) across the P/Invoke boundary. Matx33f/Matx44f fields (intr, rgb_intr,
+/// volumePose) and the icpIterations vector are marshaled as separate arguments alongside this
+/// struct, not embedded in it.
+/// Layout must stay in sync with OpenCvSharp.Rgbd.KinFuParams in C#.
+/// </summary>
+struct CvKinFuParams
+{
+    interop::Size FrameSize;
+    int32_t       VolumeKind;
+    float         DepthFactor;
+    float         BilateralSigmaDepth;
+    float         BilateralSigmaSpatial;
+    int32_t       BilateralKernelSize;
+    int32_t       PyramidLevels;
+    interop::Vec3i VolumeDims;
+    float         VoxelSize;
+    float         TsdfMinCameraMovement;
+    float         TsdfTruncDist;
+    int32_t       TsdfMaxWeight;
+    float         RaycastStepFactor;
+    interop::Vec3f LightPose;
+    float         IcpDistThresh;
+    float         IcpAngleThresh;
+    float         TruncateThreshold;
+};
+
+// Shared by rgbd_dynafu.h (dynafu::Params is an alias of kinfu::Params).
+// cv::Vec3i/Vec3f are Matx-derived (user-provided copy/move ops) and are not trivially
+// copyable, so they cannot go through the OCS_INTEROP_BITCAST c()/cpp() helpers; convert
+// element-by-element instead (same approach as core_FileNode.h's Vec3x readers).
+
+static cv::Vec3i toCv(const interop::Vec3i &v) { return cv::Vec3i(v.val); }
+static cv::Vec3f toCv(const interop::Vec3f &v) { return cv::Vec3f(v.val); }
+
+// InProxy only exposes an implicit conversion to cv::_InputArray, not getMat() directly;
+// materialize the Mat through that conversion so Matx33f/Matx44f fields can be built from it.
+static cv::Mat getMatFromProxy(const interop::InputArrayProxy &p)
+{
+    return static_cast<const cv::_InputArray &>(InProxy(p)).getMat();
+}
+
+static interop::Vec3i toInterop(const cv::Vec3i &v)
+{
+    interop::Vec3i ret;
+    std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val));
+    return ret;
+}
+
+static interop::Vec3f toInterop(const cv::Vec3f &v)
+{
+    interop::Vec3f ret;
+    std::copy(std::begin(v.val), std::end(v.val), std::begin(ret.val));
+    return ret;
+}
+
+static cv::kinfu::Params BuildKinfuParams(
+    const CvKinFuParams *pod,
+    const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const interop::InputArrayProxy *volumePose, const std::vector<int> *icpIterations)
+{
+    cv::kinfu::Params p;
+    p.frameSize = cpp(pod->FrameSize);
+    p.volumeKind = static_cast<cv::VolumeType>(pod->VolumeKind);
+    p.intr = cv::Matx33f(getMatFromProxy(*intr));
+    p.rgb_intr = cv::Matx33f(getMatFromProxy(*rgbIntr));
+    p.depthFactor = pod->DepthFactor;
+    p.bilateral_sigma_depth = pod->BilateralSigmaDepth;
+    p.bilateral_sigma_spatial = pod->BilateralSigmaSpatial;
+    p.bilateral_kernel_size = pod->BilateralKernelSize;
+    p.pyramidLevels = pod->PyramidLevels;
+    p.volumeDims = toCv(pod->VolumeDims);
+    p.voxelSize = pod->VoxelSize;
+    p.tsdf_min_camera_movement = pod->TsdfMinCameraMovement;
+    p.volumePose = cv::Matx44f(getMatFromProxy(*volumePose));
+    p.tsdf_trunc_dist = pod->TsdfTruncDist;
+    p.tsdf_max_weight = pod->TsdfMaxWeight;
+    p.raycast_step_factor = pod->RaycastStepFactor;
+    p.lightPose = toCv(pod->LightPose);
+    p.icpDistThresh = pod->IcpDistThresh;
+    p.icpAngleThresh = pod->IcpAngleThresh;
+    p.icpIterations = *icpIterations;
+    p.truncateThreshold = pod->TruncateThreshold;
+    return p;
+}
+
+static void ReadKinfuParams(
+    const cv::kinfu::Params &p, CvKinFuParams *pod,
+    const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    pod->FrameSize = c(p.frameSize);
+    pod->VolumeKind = static_cast<int32_t>(p.volumeKind);
+    pod->DepthFactor = p.depthFactor;
+    pod->BilateralSigmaDepth = p.bilateral_sigma_depth;
+    pod->BilateralSigmaSpatial = p.bilateral_sigma_spatial;
+    pod->BilateralKernelSize = p.bilateral_kernel_size;
+    pod->PyramidLevels = p.pyramidLevels;
+    pod->VolumeDims = toInterop(p.volumeDims);
+    pod->VoxelSize = p.voxelSize;
+    pod->TsdfMinCameraMovement = p.tsdf_min_camera_movement;
+    pod->TsdfTruncDist = p.tsdf_trunc_dist;
+    pod->TsdfMaxWeight = p.tsdf_max_weight;
+    pod->RaycastStepFactor = p.raycast_step_factor;
+    pod->LightPose = toInterop(p.lightPose);
+    pod->IcpDistThresh = p.icpDistThresh;
+    pod->IcpAngleThresh = p.icpAngleThresh;
+    pod->TruncateThreshold = p.truncateThreshold;
+    cv::Mat(p.intr).copyTo(OutProxy(*intr));
+    cv::Mat(p.rgb_intr).copyTo(OutProxy(*rgbIntr));
+    cv::Mat(p.volumePose).copyTo(OutProxy(*volumePose));
+    *icpIterations = p.icpIterations;
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Params_defaultParams(
+    CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = cv::kinfu::Params::defaultParams();
+    ReadKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Params_coarseParams(
+    CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = cv::kinfu::Params::coarseParams();
+    ReadKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Params_hashTSDFParams(
+    int isCoarse, CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = cv::kinfu::Params::hashTSDFParams(isCoarse != 0);
+    ReadKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Params_coloredTSDFParams(
+    int isCoarse, CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    const auto p = cv::kinfu::Params::coloredTSDFParams(isCoarse != 0);
+    ReadKinfuParams(*p, pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Ptr_KinFu_delete(cv::Ptr<KinFu> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_Ptr_KinFu_get(cv::Ptr<KinFu> *obj, KinFu **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_create(
+    const CvKinFuParams *pod, const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const interop::InputArrayProxy *volumePose, const std::vector<int> *icpIterations,
+    cv::Ptr<KinFu> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = BuildKinfuParams(pod, intr, rgbIntr, volumePose, icpIterations);
+    *returnValue = new cv::Ptr<KinFu>(KinFu::create(cv::makePtr<KinFuParams>(p)));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_getParams(
+    KinFu *obj, CvKinFuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    const interop::OutputArrayProxy *volumePose, std::vector<int> *icpIterations)
+{
+    BEGIN_WRAP
+    ReadKinfuParams(obj->getParams(), pod, intr, rgbIntr, volumePose, icpIterations);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_render(KinFu *obj, const interop::OutputArrayProxy *image)
+{ BEGIN_WRAP obj->render(OutProxy(*image)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_renderWithPose(
+    KinFu *obj, const interop::OutputArrayProxy *image, const interop::InputArrayProxy *cameraPose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f pose(getMatFromProxy(*cameraPose));
+    obj->render(OutProxy(*image), pose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_getCloud(
+    KinFu *obj, const interop::OutputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getCloud(OutProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_getPoints(KinFu *obj, const interop::OutputArrayProxy *points)
+{ BEGIN_WRAP obj->getPoints(OutProxy(*points)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_getNormals(
+    KinFu *obj, const interop::InputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getNormals(InProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_reset(KinFu *obj)
+{ BEGIN_WRAP obj->reset(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_getPose(KinFu *obj, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f m = obj->getPose().matrix;
+    cv::Mat(m).copyTo(OutProxy(*pose));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_kinfu_KinFu_update(KinFu *obj, const interop::InputArrayProxy *depth, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->update(InProxy(*depth)) ? 1 : 0; END_WRAP }
+
+#undef BEGIN_WRAP
+#undef END_WRAP
+#endif

--- a/src/OpenCvSharpExtern/rgbd_large_kinfu.h
+++ b/src/OpenCvSharpExtern/rgbd_large_kinfu.h
@@ -23,7 +23,7 @@ struct CvLargeKinfuVolumeParams
     int32_t ResolutionY;
     int32_t ResolutionZ;
     int32_t UnitResolution;
-    float   VolumSize;
+    float   VolumeSize;
     float   VoxelSize;
     float   TsdfTruncDist;
     int32_t MaxWeight;
@@ -60,7 +60,7 @@ static void ReadLargeKinfuVolumeParams(
     pod->ResolutionY = v.resolutionY;
     pod->ResolutionZ = v.resolutionZ;
     pod->UnitResolution = v.unitResolution;
-    pod->VolumSize = v.volumSize;
+    pod->VolumeSize = v.volumSize;
     pod->VoxelSize = v.voxelSize;
     pod->TsdfTruncDist = v.tsdfTruncDist;
     pod->MaxWeight = v.maxWeight;
@@ -78,7 +78,7 @@ static LargeKinfuVolumeParams BuildLargeKinfuVolumeParams(
     v.resolutionY = pod->ResolutionY;
     v.resolutionZ = pod->ResolutionZ;
     v.unitResolution = pod->UnitResolution;
-    v.volumSize = pod->VolumSize;
+    v.volumSize = pod->VolumeSize;
     v.pose = cv::Matx44f(getMatFromProxy(*pose));
     v.voxelSize = pod->VoxelSize;
     v.tsdfTruncDist = pod->TsdfTruncDist;

--- a/src/OpenCvSharpExtern/rgbd_large_kinfu.h
+++ b/src/OpenCvSharpExtern/rgbd_large_kinfu.h
@@ -1,0 +1,250 @@
+#pragma once
+#ifndef NO_CONTRIB
+#include "include_opencv.h"
+#include "rgbd_kinfu.h" // toCv/toInterop Vec3i/Vec3f helpers
+
+// Keep the exported functions compact while using the repository's cvTry exception boundary.
+#define BEGIN_WRAP return cvTry([&] {
+#define END_WRAP });
+
+using cv::large_kinfu::LargeKinfu;
+using LargeKinfuParams = cv::large_kinfu::Params;
+using LargeKinfuVolumeParams = cv::large_kinfu::VolumeParams;
+
+/// <summary>
+/// Plain-C struct for marshaling the scalar fields of large_kinfu::VolumeParams across the P/Invoke
+/// boundary. The Matx44f pose field is marshaled as a separate argument.
+/// Layout must stay in sync with OpenCvSharp.Rgbd.LargeKinfuVolumeParams in C#.
+/// </summary>
+struct CvLargeKinfuVolumeParams
+{
+    int32_t Kind;
+    int32_t ResolutionX;
+    int32_t ResolutionY;
+    int32_t ResolutionZ;
+    int32_t UnitResolution;
+    float   VolumSize;
+    float   VoxelSize;
+    float   TsdfTruncDist;
+    int32_t MaxWeight;
+    float   DepthTruncThreshold;
+    float   RaycastStepFactor;
+};
+
+/// <summary>
+/// Plain-C struct for marshaling the scalar/fixed-size fields of large_kinfu::Params (excluding its
+/// nested VolumeParams, which is marshaled separately as CvLargeKinfuVolumeParams). The Matx33f
+/// fields (intr, rgb_intr) and the icpIterations vector are marshaled as separate arguments.
+/// Layout must stay in sync with OpenCvSharp.Rgbd.LargeKinfuParams in C#.
+/// </summary>
+struct CvLargeKinfuParams
+{
+    interop::Size FrameSize;
+    float         DepthFactor;
+    float         BilateralSigmaDepth;
+    float         BilateralSigmaSpatial;
+    int32_t       BilateralKernelSize;
+    int32_t       PyramidLevels;
+    float         TsdfMinCameraMovement;
+    interop::Vec3f LightPose;
+    float         IcpDistThresh;
+    float         IcpAngleThresh;
+    float         TruncateThreshold;
+};
+
+static void ReadLargeKinfuVolumeParams(
+    const LargeKinfuVolumeParams &v, CvLargeKinfuVolumeParams *pod, const interop::OutputArrayProxy *pose)
+{
+    pod->Kind = static_cast<int32_t>(v.kind);
+    pod->ResolutionX = v.resolutionX;
+    pod->ResolutionY = v.resolutionY;
+    pod->ResolutionZ = v.resolutionZ;
+    pod->UnitResolution = v.unitResolution;
+    pod->VolumSize = v.volumSize;
+    pod->VoxelSize = v.voxelSize;
+    pod->TsdfTruncDist = v.tsdfTruncDist;
+    pod->MaxWeight = v.maxWeight;
+    pod->DepthTruncThreshold = v.depthTruncThreshold;
+    pod->RaycastStepFactor = v.raycastStepFactor;
+    cv::Mat(v.pose).copyTo(OutProxy(*pose));
+}
+
+static LargeKinfuVolumeParams BuildLargeKinfuVolumeParams(
+    const CvLargeKinfuVolumeParams *pod, const interop::InputArrayProxy *pose)
+{
+    LargeKinfuVolumeParams v;
+    v.kind = static_cast<cv::VolumeType>(pod->Kind);
+    v.resolutionX = pod->ResolutionX;
+    v.resolutionY = pod->ResolutionY;
+    v.resolutionZ = pod->ResolutionZ;
+    v.unitResolution = pod->UnitResolution;
+    v.volumSize = pod->VolumSize;
+    v.pose = cv::Matx44f(getMatFromProxy(*pose));
+    v.voxelSize = pod->VoxelSize;
+    v.tsdfTruncDist = pod->TsdfTruncDist;
+    v.maxWeight = pod->MaxWeight;
+    v.depthTruncThreshold = pod->DepthTruncThreshold;
+    v.raycastStepFactor = pod->RaycastStepFactor;
+    return v;
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_VolumeParams_defaultParams(
+    int volumeType, CvLargeKinfuVolumeParams *pod, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const auto v = LargeKinfuVolumeParams::defaultParams(static_cast<cv::VolumeType>(volumeType));
+    ReadLargeKinfuVolumeParams(*v, pod, pose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_VolumeParams_coarseParams(
+    int volumeType, CvLargeKinfuVolumeParams *pod, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const auto v = LargeKinfuVolumeParams::coarseParams(static_cast<cv::VolumeType>(volumeType));
+    ReadLargeKinfuVolumeParams(*v, pod, pose);
+    END_WRAP
+}
+
+static LargeKinfuParams BuildLargeKinfuParams(
+    const CvLargeKinfuParams *pod, const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const std::vector<int> *icpIterations,
+    const CvLargeKinfuVolumeParams *volumePod, const interop::InputArrayProxy *volumePose)
+{
+    LargeKinfuParams p;
+    p.frameSize = cpp(pod->FrameSize);
+    p.intr = cv::Matx33f(getMatFromProxy(*intr));
+    p.rgb_intr = cv::Matx33f(getMatFromProxy(*rgbIntr));
+    p.depthFactor = pod->DepthFactor;
+    p.bilateral_sigma_depth = pod->BilateralSigmaDepth;
+    p.bilateral_sigma_spatial = pod->BilateralSigmaSpatial;
+    p.bilateral_kernel_size = pod->BilateralKernelSize;
+    p.pyramidLevels = pod->PyramidLevels;
+    p.tsdf_min_camera_movement = pod->TsdfMinCameraMovement;
+    p.lightPose = toCv(pod->LightPose);
+    p.icpDistThresh = pod->IcpDistThresh;
+    p.icpAngleThresh = pod->IcpAngleThresh;
+    p.icpIterations = *icpIterations;
+    p.truncateThreshold = pod->TruncateThreshold;
+    p.volumeParams = BuildLargeKinfuVolumeParams(volumePod, volumePose);
+    return p;
+}
+
+static void ReadLargeKinfuParams(
+    const LargeKinfuParams &p, CvLargeKinfuParams *pod, const interop::OutputArrayProxy *intr,
+    const interop::OutputArrayProxy *rgbIntr, std::vector<int> *icpIterations,
+    CvLargeKinfuVolumeParams *volumePod, const interop::OutputArrayProxy *volumePose)
+{
+    pod->FrameSize = c(p.frameSize);
+    pod->DepthFactor = p.depthFactor;
+    pod->BilateralSigmaDepth = p.bilateral_sigma_depth;
+    pod->BilateralSigmaSpatial = p.bilateral_sigma_spatial;
+    pod->BilateralKernelSize = p.bilateral_kernel_size;
+    pod->PyramidLevels = p.pyramidLevels;
+    pod->TsdfMinCameraMovement = p.tsdf_min_camera_movement;
+    pod->LightPose = toInterop(p.lightPose);
+    pod->IcpDistThresh = p.icpDistThresh;
+    pod->IcpAngleThresh = p.icpAngleThresh;
+    pod->TruncateThreshold = p.truncateThreshold;
+    cv::Mat(p.intr).copyTo(OutProxy(*intr));
+    cv::Mat(p.rgb_intr).copyTo(OutProxy(*rgbIntr));
+    *icpIterations = p.icpIterations;
+    ReadLargeKinfuVolumeParams(p.volumeParams, volumePod, volumePose);
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_Params_defaultParams(
+    CvLargeKinfuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    std::vector<int> *icpIterations, CvLargeKinfuVolumeParams *volumePod, const interop::OutputArrayProxy *volumePose)
+{
+    BEGIN_WRAP
+    const auto p = LargeKinfuParams::defaultParams();
+    ReadLargeKinfuParams(*p, pod, intr, rgbIntr, icpIterations, volumePod, volumePose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_Params_coarseParams(
+    CvLargeKinfuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    std::vector<int> *icpIterations, CvLargeKinfuVolumeParams *volumePod, const interop::OutputArrayProxy *volumePose)
+{
+    BEGIN_WRAP
+    const auto p = LargeKinfuParams::coarseParams();
+    ReadLargeKinfuParams(*p, pod, intr, rgbIntr, icpIterations, volumePod, volumePose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_Params_hashTSDFParams(
+    int isCoarse, CvLargeKinfuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    std::vector<int> *icpIterations, CvLargeKinfuVolumeParams *volumePod, const interop::OutputArrayProxy *volumePose)
+{
+    BEGIN_WRAP
+    const auto p = LargeKinfuParams::hashTSDFParams(isCoarse != 0);
+    ReadLargeKinfuParams(*p, pod, intr, rgbIntr, icpIterations, volumePod, volumePose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_Ptr_LargeKinfu_delete(cv::Ptr<LargeKinfu> *obj)
+{ BEGIN_WRAP delete obj; END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_Ptr_LargeKinfu_get(cv::Ptr<LargeKinfu> *obj, LargeKinfu **returnValue)
+{ BEGIN_WRAP *returnValue = obj->get(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_create(
+    const CvLargeKinfuParams *pod, const interop::InputArrayProxy *intr, const interop::InputArrayProxy *rgbIntr,
+    const std::vector<int> *icpIterations, const CvLargeKinfuVolumeParams *volumePod,
+    const interop::InputArrayProxy *volumePose, cv::Ptr<LargeKinfu> **returnValue)
+{
+    BEGIN_WRAP
+    const auto p = BuildLargeKinfuParams(pod, intr, rgbIntr, icpIterations, volumePod, volumePose);
+    *returnValue = new cv::Ptr<LargeKinfu>(LargeKinfu::create(cv::makePtr<LargeKinfuParams>(p)));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_getParams(
+    LargeKinfu *obj, CvLargeKinfuParams *pod, const interop::OutputArrayProxy *intr, const interop::OutputArrayProxy *rgbIntr,
+    std::vector<int> *icpIterations, CvLargeKinfuVolumeParams *volumePod, const interop::OutputArrayProxy *volumePose)
+{
+    BEGIN_WRAP
+    ReadLargeKinfuParams(obj->getParams(), pod, intr, rgbIntr, icpIterations, volumePod, volumePose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_render(LargeKinfu *obj, const interop::OutputArrayProxy *image)
+{ BEGIN_WRAP obj->render(OutProxy(*image)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_renderWithPose(
+    LargeKinfu *obj, const interop::OutputArrayProxy *image, const interop::InputArrayProxy *cameraPose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f pose(getMatFromProxy(*cameraPose));
+    obj->render(OutProxy(*image), pose);
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_getCloud(
+    LargeKinfu *obj, const interop::OutputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getCloud(OutProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_getPoints(LargeKinfu *obj, const interop::OutputArrayProxy *points)
+{ BEGIN_WRAP obj->getPoints(OutProxy(*points)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_getNormals(
+    LargeKinfu *obj, const interop::InputArrayProxy *points, const interop::OutputArrayProxy *normals)
+{ BEGIN_WRAP obj->getNormals(InProxy(*points), OutProxy(*normals)); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_reset(LargeKinfu *obj)
+{ BEGIN_WRAP obj->reset(); END_WRAP }
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_getPose(LargeKinfu *obj, const interop::OutputArrayProxy *pose)
+{
+    BEGIN_WRAP
+    const cv::Matx44f m = obj->getPose().matrix;
+    cv::Mat(m).copyTo(OutProxy(*pose));
+    END_WRAP
+}
+
+CVAPI(ExceptionStatus) rgbd_large_kinfu_LargeKinfu_update(LargeKinfu *obj, const interop::InputArrayProxy *depth, int *returnValue)
+{ BEGIN_WRAP *returnValue = obj->update(InProxy(*depth)) ? 1 : 0; END_WRAP }
+
+#undef BEGIN_WRAP
+#undef END_WRAP
+#endif

--- a/test/OpenCvSharp.Tests/rgbd/ColoredKinFuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/ColoredKinFuTest.cs
@@ -1,0 +1,61 @@
+using OpenCvSharp.Rgbd;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Rgbd;
+
+public class ColoredKinFuTest
+{
+    private readonly ITestOutputHelper testOutputHelper;
+
+    public ColoredKinFuTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void ParamsFactoriesRoundTripFields()
+    {
+        var defaultParams = ColoredKinFuParams.DefaultParams();
+        Assert.False(defaultParams.Intr.Empty());
+
+        var coarse = ColoredKinFuParams.CoarseParams();
+        Assert.NotEmpty(coarse.IcpIterations);
+
+        var hash = ColoredKinFuParams.HashTsdfParams(true);
+        Assert.False(hash.VolumePose.Empty());
+
+        var colored = ColoredKinFuParams.ColoredTsdfParams(false);
+        Assert.Equal(VolumeType.ColorTSDF, colored.VolumeKind);
+
+        defaultParams.RgbFrameSize = new Size(32, 24);
+        Assert.Equal(new Size(32, 24), defaultParams.RgbFrameSize);
+    }
+
+    [Fact]
+    public void CreateAndUpdateWireUpCorrectly()
+    {
+        var parameters = ColoredKinFuParams.CoarseParams();
+        parameters.FrameSize = new Size(64, 48);
+        parameters.RgbFrameSize = new Size(64, 48);
+
+        using var coloredKinFu = ColoredKinFu.Create(parameters);
+        var readBack = coloredKinFu.GetParams();
+        Assert.Equal(parameters.FrameSize, readBack.FrameSize);
+
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        using var rgb = new Mat(48, 64, MatType.CV_8UC3, Scalar.All(100));
+
+        void Tolerant(string name, Action action)
+        {
+            try { action(); }
+            catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+            {
+                testOutputHelper.WriteLine($"{name} threw (wiring resolved): {ex.Message}");
+            }
+        }
+
+        Tolerant("Update", () => coloredKinFu.Update(depth, rgb));
+        Tolerant("GetPose", () => coloredKinFu.GetPose().Dispose());
+        Tolerant("Reset", coloredKinFu.Reset);
+    }
+}

--- a/test/OpenCvSharp.Tests/rgbd/DynaFuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/DynaFuTest.cs
@@ -22,7 +22,15 @@ public class DynaFuTest
         var readBack = dynaFu.GetParams();
         Assert.Equal(parameters.FrameSize, readBack.FrameSize);
 
-        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        // A perfectly flat depth Mat gives DynaFu's WarpField no real geometry to build
+        // deformation-graph nodes from; this degenerate input crashed
+        // cv::dynafu::WarpField::applyWarp natively on macOS arm64 CI (SIGSEGV), so use a
+        // depth image with real spatial variation instead (same fix shape as SuperpixelTest's
+        // SeedsNew: avoid the degenerate parameter/input that collapses the algorithm).
+        using var depth = new Mat(48, 64, MatType.CV_32FC1);
+        for (var y = 0; y < depth.Rows; y++)
+            for (var x = 0; x < depth.Cols; x++)
+                depth.Set<float>(y, x, 1.5f + 0.3f * MathF.Sin(x * 0.2f) * MathF.Cos(y * 0.2f));
 
         void Tolerant(string name, Action action)
         {

--- a/test/OpenCvSharp.Tests/rgbd/DynaFuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/DynaFuTest.cs
@@ -1,0 +1,54 @@
+using OpenCvSharp.Rgbd;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Rgbd;
+
+public class DynaFuTest
+{
+    private readonly ITestOutputHelper testOutputHelper;
+
+    public DynaFuTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void CreateUpdateAndExtrasWireUpCorrectly()
+    {
+        var parameters = KinFuParams.CoarseParams();
+        parameters.FrameSize = new Size(64, 48);
+
+        using var dynaFu = DynaFu.Create(parameters);
+        var readBack = dynaFu.GetParams();
+        Assert.Equal(parameters.FrameSize, readBack.FrameSize);
+
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+
+        void Tolerant(string name, Action action)
+        {
+            try { action(); }
+            catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+            {
+                testOutputHelper.WriteLine($"{name} threw (wiring resolved): {ex.Message}");
+            }
+        }
+
+        Tolerant("Update", () => dynaFu.Update(depth));
+        Tolerant("GetNodesPos", () => dynaFu.GetNodesPos());
+        Tolerant("MarchCubes", () =>
+        {
+            using var vertices = new Mat();
+            using var edges = new Mat();
+            dynaFu.MarchCubes(vertices, edges);
+        });
+        Tolerant("RenderSurface", () =>
+        {
+            using var depthImage = new Mat();
+            using var vertImage = new Mat();
+            using var normImage = new Mat();
+            dynaFu.RenderSurface(depthImage, vertImage, normImage);
+        });
+        Tolerant("GetPose", () => dynaFu.GetPose().Dispose());
+        Tolerant("Reset", dynaFu.Reset);
+    }
+}

--- a/test/OpenCvSharp.Tests/rgbd/KinFuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/KinFuTest.cs
@@ -17,7 +17,7 @@ public class KinFuTest
     {
         var defaultParams = KinFuParams.DefaultParams();
         Assert.False(defaultParams.Intr.Empty());
-        Assert.Equal(defaultParams.FrameSize, defaultParams.FrameSize);
+        Assert.Equal(new Size(640, 480), defaultParams.FrameSize);
 
         var coarse = KinFuParams.CoarseParams();
         Assert.NotEmpty(coarse.IcpIterations);

--- a/test/OpenCvSharp.Tests/rgbd/KinFuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/KinFuTest.cs
@@ -1,0 +1,84 @@
+using OpenCvSharp.Rgbd;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Rgbd;
+
+public class KinFuTest
+{
+    private readonly ITestOutputHelper testOutputHelper;
+
+    public KinFuTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void ParamsFactoriesRoundTripFields()
+    {
+        var defaultParams = KinFuParams.DefaultParams();
+        Assert.False(defaultParams.Intr.Empty());
+        Assert.Equal(defaultParams.FrameSize, defaultParams.FrameSize);
+
+        var coarse = KinFuParams.CoarseParams();
+        Assert.NotEmpty(coarse.IcpIterations);
+
+        var hash = KinFuParams.HashTsdfParams(true);
+        Assert.False(hash.VolumePose.Empty());
+
+        var colored = KinFuParams.ColoredTsdfParams(false);
+        Assert.Equal(VolumeType.ColorTSDF, colored.VolumeKind);
+
+        defaultParams.PyramidLevels = 5;
+        defaultParams.VoxelSize = 0.02f;
+        Assert.Equal(5, defaultParams.PyramidLevels);
+        Assert.Equal(0.02f, defaultParams.VoxelSize);
+    }
+
+    [Fact]
+    public void CreateUpdateAndGetParamsWireUpCorrectly()
+    {
+        var parameters = KinFuParams.CoarseParams();
+        parameters.FrameSize = new Size(64, 48);
+
+        using var kinFu = KinFu.Create(parameters);
+        var readBack = kinFu.GetParams();
+        Assert.Equal(parameters.FrameSize, readBack.FrameSize);
+
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+        using var cameraPose = Mat.Eye(4, 4, MatType.CV_32FC1).ToMat();
+
+        void Tolerant(string name, Action action)
+        {
+            try { action(); }
+            catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+            {
+                testOutputHelper.WriteLine($"{name} threw (wiring resolved): {ex.Message}");
+            }
+        }
+
+        Tolerant("Update", () => kinFu.Update(depth));
+        Tolerant("Render", () =>
+        {
+            using var image = new Mat();
+            kinFu.Render(image);
+        });
+        Tolerant("RenderWithPose", () =>
+        {
+            using var image = new Mat();
+            kinFu.Render(image, cameraPose);
+        });
+        Tolerant("GetCloud", () =>
+        {
+            using var points = new Mat();
+            using var normals = new Mat();
+            kinFu.GetCloud(points, normals);
+        });
+        Tolerant("GetPoints", () =>
+        {
+            using var points = new Mat();
+            kinFu.GetPoints(points);
+        });
+        Tolerant("GetPose", () => kinFu.GetPose().Dispose());
+        Tolerant("Reset", kinFu.Reset);
+    }
+}

--- a/test/OpenCvSharp.Tests/rgbd/LargeKinfuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/LargeKinfuTest.cs
@@ -42,7 +42,10 @@ public class LargeKinfuTest
     [Fact]
     public void CreateAndUpdateWireUpCorrectly()
     {
-        var parameters = LargeKinfuParams.CoarseParams();
+        // LargeKinfuImpl::paramsToSettings() always builds a HashTSDF volume regardless of
+        // volumeParams.Kind, but only HashTsdfParams() sets UnitResolution (CoarseParams()/
+        // DefaultParams() leave it at 0), so Create() needs HashTsdfParams() here.
+        var parameters = LargeKinfuParams.HashTsdfParams(true);
         parameters.FrameSize = new Size(64, 48);
 
         using var largeKinfu = LargeKinfu.Create(parameters);

--- a/test/OpenCvSharp.Tests/rgbd/LargeKinfuTest.cs
+++ b/test/OpenCvSharp.Tests/rgbd/LargeKinfuTest.cs
@@ -1,0 +1,67 @@
+using OpenCvSharp.Rgbd;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Rgbd;
+
+public class LargeKinfuTest
+{
+    private readonly ITestOutputHelper testOutputHelper;
+
+    public LargeKinfuTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void VolumeParamsFactoriesRoundTripFields()
+    {
+        var defaultVolume = LargeKinfuVolumeParams.DefaultParams(VolumeType.TSDF);
+        Assert.False(defaultVolume.Pose.Empty());
+
+        var coarseVolume = LargeKinfuVolumeParams.CoarseParams(VolumeType.HashTSDF);
+        Assert.Equal(VolumeType.HashTSDF, coarseVolume.Kind);
+
+        defaultVolume.VoxelSize = 0.01f;
+        Assert.Equal(0.01f, defaultVolume.VoxelSize);
+    }
+
+    [Fact]
+    public void ParamsFactoriesRoundTripFields()
+    {
+        var defaultParams = LargeKinfuParams.DefaultParams();
+        Assert.NotNull(defaultParams.VolumeParams);
+        Assert.False(defaultParams.Intr.Empty());
+
+        var coarse = LargeKinfuParams.CoarseParams();
+        Assert.NotEmpty(coarse.IcpIterations);
+
+        var hash = LargeKinfuParams.HashTsdfParams(true);
+        Assert.NotNull(hash.VolumeParams);
+    }
+
+    [Fact]
+    public void CreateAndUpdateWireUpCorrectly()
+    {
+        var parameters = LargeKinfuParams.CoarseParams();
+        parameters.FrameSize = new Size(64, 48);
+
+        using var largeKinfu = LargeKinfu.Create(parameters);
+        var readBack = largeKinfu.GetParams();
+        Assert.Equal(parameters.FrameSize, readBack.FrameSize);
+
+        using var depth = new Mat(48, 64, MatType.CV_32FC1, Scalar.All(2.0));
+
+        void Tolerant(string name, Action action)
+        {
+            try { action(); }
+            catch (Exception ex) when (ex is OpenCvSharpException or OpenCVException)
+            {
+                testOutputHelper.WriteLine($"{name} threw (wiring resolved): {ex.Message}");
+            }
+        }
+
+        Tolerant("Update", () => largeKinfu.Update(depth));
+        Tolerant("GetPose", () => largeKinfu.GetPose().Dispose());
+        Tolerant("Reset", largeKinfu.Reset);
+    }
+}


### PR DESCRIPTION
## Summary

- add native and managed wrappers for `cv::kinfu::KinFu`, `cv::dynafu::DynaFu`, `cv::colored_kinfu::ColoredKinFu`, and `cv::large_kinfu::LargeKinfu`
- none of these classes inherit `cv::Algorithm`, so they're wrapped as plain `CvPtrObject`-derived types with a smart-pointer `Create()` factory, following the same shape as `EdgeDrawing`
- each class's `Params` struct is marshaled as a single blittable POD (`EdgeDrawingParams`-style getAll/setAll), with the `Matx33f`/`Matx44f` fields (`intr`, `rgb_intr`, `volumePose`) and the `icpIterations` vector passed alongside it rather than embedded in the POD
- `DynaFu` shares `KinFuParams` with `KinFu` since `dynafu::Params` is a C++ alias of `kinfu::Params`
- add KinFu-family interop tests covering Params factories/round-trips, construction, and a wiring smoke test for `Update`/`Render`/`GetCloud`/etc. against synthetic depth data

This completes the KinFu-family portion of #2018; the LINEMOD portion was already implemented in #2042.

Closes #2018

## Testing

- `cmake --build src\build --config Release --target OpenCvSharpExtern`
- `dotnet build src\OpenCvSharp\OpenCvSharp.csproj -c Release --no-restore`
- `dotnet test test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~OpenCvSharp.Tests.Rgbd`
- `dotnet test test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release --no-restore` (full suite, no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB-D reconstruction managed wrappers for KinFu, ColoredKinFu, DynaFu, and LargeKinFu.
  * Added corresponding parameter classes with preset factories (default/coarse/TSDF/colored TSDF), including LargeKinfu volume parameter presets.
  * Exposed integration (depth/RGB where applicable), rendering (with optional pose), pose retrieval, and point cloud/geometry extraction APIs; includes reset and surface rendering where supported.
* **Tests**
  * Added xUnit coverage validating parameter presets and end-to-end API wiring for KinFu, ColoredKinFu, DynaFu, and LargeKinfu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->