### PR TITLE
Add OpenCV 5 face, img_hash, and line_descriptor APIs

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_img_hash.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_img_hash.cs
@@ -10,6 +10,30 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_averageHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_blockMeanHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr, int mode);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_colorMomentHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_marrHildrethHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr, float alpha, float scale);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_pHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus img_hash_radialVarianceHash(
+        in InputArrayProxy inputArr, in OutputArrayProxy outputArr, double sigma, int numOfAngleLine);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus img_hash_ImgHashBase_compute(OpenCvSafeHandle obj, in InputArrayProxy inputArr, in OutputArrayProxy outputArr);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_line_descriptor.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_line_descriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using OpenCvSharp.LineDescriptor;
 
 #pragma warning disable 1591
 #pragma warning disable CA1401 // P/Invokes should not be visible
@@ -37,4 +38,119 @@ static partial class NativeMethods
         IntPtr[] images, int imagesSize,
         IntPtr keyLines, int scale, int numOctaves,
         IntPtr[] masks, int masksSize);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_create(
+        IntPtr parameters, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_Ptr_BinaryDescriptor_get(
+        IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_Ptr_BinaryDescriptor_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_getNumOfOctaves(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_setNumOfOctaves(
+        OpenCvSafeHandle obj, int value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_getWidthOfBand(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_setWidthOfBand(
+        OpenCvSafeHandle obj, int value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_getReductionRatio(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_setReductionRatio(
+        OpenCvSafeHandle obj, int value);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_detect1(
+        OpenCvSafeHandle obj, IntPtr image, IntPtr keyLines, OpenCvSafeHandle mask);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_detect2(
+        OpenCvSafeHandle obj, IntPtr[] images, int imagesLength, IntPtr keyLines,
+        IntPtr[] masks, int masksLength);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_compute1(
+        OpenCvSafeHandle obj, IntPtr image, IntPtr keyLines, IntPtr descriptors, int returnFloatDescriptor);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_compute2(
+        OpenCvSafeHandle obj, IntPtr[] images, int imagesLength,
+        IntPtr[] keyLines, int[] keyLineSizes, int keyLinesLength,
+        IntPtr outputKeyLines, IntPtr descriptors, int returnFloatDescriptor);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_descriptorSize(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_descriptorType(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_defaultNorm(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_getAll(
+        IntPtr obj, out BinaryDescriptorParamsData data);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_setAll(
+        IntPtr obj, BinaryDescriptorParamsData data);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_read(IntPtr obj, IntPtr node);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptor_Params_write(IntPtr obj, IntPtr storage);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_create(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_Ptr_BinaryDescriptorMatcher_get(
+        IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_Ptr_BinaryDescriptorMatcher_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_match(
+        OpenCvSafeHandle obj, IntPtr query, IntPtr train, IntPtr matches, OpenCvSafeHandle mask);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_matchQuery(
+        OpenCvSafeHandle obj, IntPtr query, IntPtr matches, IntPtr[] masks, int masksLength);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_knnMatch(
+        OpenCvSafeHandle obj, IntPtr query, IntPtr train, IntPtr matches, int k,
+        OpenCvSafeHandle mask, int compactResult);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_knnMatchQuery(
+        OpenCvSafeHandle obj, IntPtr query, IntPtr matches, int k,
+        IntPtr[] masks, int masksLength, int compactResult);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_add(
+        OpenCvSafeHandle obj, IntPtr[] descriptors, int descriptorsLength);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_train(OpenCvSafeHandle obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus line_descriptor_BinaryDescriptorMatcher_clear(OpenCvSafeHandle obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial ExceptionStatus line_descriptor_drawLineMatches(
+        IntPtr image1, KeyLine* keyLines1, int keyLines1Length,
+        IntPtr image2, KeyLine* keyLines2, int keyLines2Length,
+        DMatch* matches, int matchesLength, IntPtr output,
+        Scalar matchColor, Scalar singleLineColor,
+        byte* matchesMask, int matchesMaskLength, int flags);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial ExceptionStatus line_descriptor_drawKeylines(
+        IntPtr image, KeyLine* keyLines, int keyLinesLength,
+        IntPtr output, Scalar color, int flags);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct BinaryDescriptorParamsData
+{
+    public int NumOfOctaves;
+    public int WidthOfBand;
+    public int ReductionRatio;
+    public int KSize;
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_stdvector.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenCvSharp.Detail;
+using OpenCvSharp.LineDescriptor;
 
 #pragma warning disable 1591
 #pragma warning disable CA1401 // P/Invokes should not be visible
@@ -346,6 +347,9 @@ static partial class NativeMethods
     #region cv::line_descriptor::KeyLine
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial IntPtr vector_KeyLine_new1();
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe partial IntPtr vector_KeyLine_new2(KeyLine* data, nuint length);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial nuint vector_KeyLine_getSize(OpenCvSafeHandle vector);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/FacemarkKazemiParamsData.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/FacemarkKazemiParamsData.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace OpenCvSharp.Internal;
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct FacemarkKazemiParamsData
+{
+    public ulong CascadeDepth;
+    public ulong TreeDepth;
+    public ulong NumTreesPerCascadeLevel;
+    public float LearningRate;
+    public ulong OversamplingAmount;
+    public ulong NumTestCoordinates;
+    public float Lambda;
+    public ulong NumTestSplits;
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Additional.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Additional.cs
@@ -1,0 +1,73 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401
+#pragma warning disable CA2101
+#pragma warning disable IDE1006
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_BIF_create(
+        int numBands, int numRotations, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_BIF_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_BIF_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_BIF_getNumBands(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_BIF_getNumRotations(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_BIF_compute(
+        OpenCvSafeHandle obj, in InputArrayProxy image, in OutputArrayProxy features);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_MACE_create(int imageSize, out IntPtr returnValue);
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_MACE_load(
+        string filename, string objName, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_MACE_get(IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_MACE_delete(IntPtr obj);
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_MACE_salt(OpenCvSafeHandle obj, string passphrase);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_MACE_train(
+        OpenCvSafeHandle obj, IntPtr[] images, int imagesLength);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_MACE_same(
+        OpenCvSafeHandle obj, in InputArrayProxy query, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_PredictCollector_init(
+        OpenCvSafeHandle obj, nuint size);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_PredictCollector_collect(
+        OpenCvSafeHandle obj, int label, double distance, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_StandardCollector_create(
+        double threshold, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_StandardCollector_get(
+        IntPtr obj, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_StandardCollector_delete(IntPtr obj);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_StandardCollector_getMinLabel(
+        OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_StandardCollector_getMinDist(
+        OpenCvSafeHandle obj, out double returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_StandardCollector_getResults(
+        OpenCvSafeHandle obj, int sorted, IntPtr labels, IntPtr distances);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_StandardCollector_getResultsMap(
+        OpenCvSafeHandle obj, IntPtr labels, IntPtr distances);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_FaceRecognizer.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_FaceRecognizer.cs
@@ -27,6 +27,9 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus face_FaceRecognizer_predict2(
         OpenCvSafeHandle obj, in InputArrayProxy src, out int label, out double confidence);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FaceRecognizer_predictCollect(
+        OpenCvSafeHandle obj, in InputArrayProxy src, IntPtr collector);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_FaceRecognizer_write1(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
@@ -70,10 +70,6 @@ static partial class NativeMethods
     internal static partial ExceptionStatus face_FacemarkTrain_getFaces(
         OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr faces, out int returnValue);
 
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial ExceptionStatus face_FacemarkTrain_getData(
-        OpenCvSafeHandle obj, IntPtr items, out int returnValue);
-
     [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
     internal static extern ExceptionStatus face_FacemarkTrain_setFaceDetector(
         OpenCvSafeHandle obj, FacemarkFaceDetectorNativeCallback callback,
@@ -91,6 +87,12 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_Ptr_FacemarkLBF_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus face_FacemarkLBF_write(OpenCvSafeHandle obj, IntPtr fs);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus face_FacemarkLBF_read(OpenCvSafeHandle obj, IntPtr fn);
 
     #region Params
 
@@ -132,6 +134,12 @@ static partial class NativeMethods
     public static partial ExceptionStatus face_Ptr_FacemarkAAM_delete(IntPtr obj);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus face_FacemarkAAM_write(OpenCvSafeHandle obj, IntPtr fs);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus face_FacemarkAAM_read(OpenCvSafeHandle obj, IntPtr fn);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus face_FacemarkAAM_fitConfig(
         OpenCvSafeHandle obj,
         in InputArrayProxy image,
@@ -143,6 +151,10 @@ static partial class NativeMethods
         int[] modelScaleIndexes,
         int configLength,
         out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkAAM_getData(
+        OpenCvSafeHandle obj, IntPtr s0, out int returnValue);
 
     #region Params
 
@@ -182,6 +194,12 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus face_Ptr_FacemarkKazemi_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_write(OpenCvSafeHandle obj, IntPtr fs);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_read(OpenCvSafeHandle obj, IntPtr fn);
 
     [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus face_FacemarkKazemi_training(

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using OpenCvSharp.Face;
 
 #pragma warning disable 1591
 #pragma warning disable CA1401 // P/Invokes should not be visible
@@ -12,6 +13,38 @@ namespace OpenCvSharp.Internal;
 // ReSharper disable InconsistentNaming
 static partial class NativeMethods
 {
+    #region Utilities
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_getFacesHAAR(
+        in InputArrayProxy image, in OutputArrayProxy faces, string cascadeName, out int returnValue);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_loadDatasetList(
+        string imageList, string annotationList, IntPtr images, IntPtr annotations, out int returnValue);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_loadTrainingData1(
+        string filename, IntPtr images, IntPtr facePoints, byte delim, float offset, out int returnValue);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_loadTrainingData2(
+        string imageList, string groundTruth, IntPtr images, IntPtr facePoints, float offset, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_loadTrainingData3(
+        IntPtr filenames, IntPtr landmarks, IntPtr images, out int returnValue);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_loadFacePoints(
+        string filename, IntPtr points, float offset, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_drawFacemarks(
+        in InputOutputArrayProxy image, in InputArrayProxy points, Scalar color);
+
+    #endregion
+
     #region Facemark
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -21,6 +54,30 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus face_Facemark_fit(
         OpenCvSafeHandle obj, in InputArrayProxy image, in InputArrayProxy faces, IntPtr landmarks, out int returnValue);
+
+    #endregion
+
+    #region FacemarkTrain
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkTrain_addTrainingSample(
+        OpenCvSafeHandle obj, in InputArrayProxy image, in InputArrayProxy landmarks, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkTrain_training(OpenCvSafeHandle obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkTrain_getFaces(
+        OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr faces, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkTrain_getData(
+        OpenCvSafeHandle obj, IntPtr items, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    internal static extern ExceptionStatus face_FacemarkTrain_setFaceDetector(
+        OpenCvSafeHandle obj, FacemarkFaceDetectorNativeCallback callback,
+        out IntPtr callbackData, out int returnValue);
 
     #endregion
 
@@ -74,6 +131,19 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus face_Ptr_FacemarkAAM_delete(IntPtr obj);
 
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkAAM_fitConfig(
+        OpenCvSafeHandle obj,
+        in InputArrayProxy image,
+        in InputArrayProxy roi,
+        IntPtr landmarks,
+        IntPtr[] rotations,
+        Point2f[] translations,
+        float[] scales,
+        int[] modelScaleIndexes,
+        int configLength,
+        out int returnValue);
+
     #region Params
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -97,6 +167,60 @@ static partial class NativeMethods
     public static partial ExceptionStatus face_FacemarkAAM_Params_write(IntPtr obj, IntPtr fs);
 
     #endregion
+
+    #endregion
+
+    #region FacemarkKazemi
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_create(
+        IntPtr parameters, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_FacemarkKazemi_get(
+        IntPtr obj, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_Ptr_FacemarkKazemi_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_training(
+        OpenCvSafeHandle obj,
+        IntPtr[] images,
+        int imagesLength,
+        IntPtr[] landmarks,
+        int[] landmarkSizes,
+        int landmarksLength,
+        string configFile,
+        Size scale,
+        string modelFilename,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_getFaces(
+        OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr faces, out int returnValue);
+
+    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+    internal static extern ExceptionStatus face_FacemarkKazemi_setFaceDetector(
+        OpenCvSafeHandle obj, FacemarkFaceDetectorNativeCallback callback,
+        out IntPtr callbackData, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkFaceDetectorCallbackData_delete(IntPtr callbackData);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_Params_new(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_Params_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_Params_getAll(
+        IntPtr obj, out FacemarkKazemiParamsData data, IntPtr configFile);
+
+    [LibraryImport(DllExtern, StringMarshalling = StringMarshalling.Utf8), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_Params_setAll(
+        IntPtr obj, FacemarkKazemiParamsData data, string configFile);
 
     #endregion
 }

--- a/src/OpenCvSharp/Internal/Vectors/VectorOfKeyLine.cs
+++ b/src/OpenCvSharp/Internal/Vectors/VectorOfKeyLine.cs
@@ -14,6 +14,20 @@ namespace OpenCvSharp.Internal.Vectors
             var p = NativeMethods.vector_KeyLine_new1();
             SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
         }
+
+        /// <summary>
+        /// Creates a vector populated with key lines.
+        /// </summary>
+        public unsafe VectorOfKeyLine(IEnumerable<KeyLine> keyLines)
+        {
+            ArgumentNullException.ThrowIfNull(keyLines);
+            var data = keyLines.ToArray();
+            fixed (KeyLine* pointer = data)
+            {
+                var p = NativeMethods.vector_KeyLine_new2(pointer, (nuint)data.Length);
+                SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle: false, releaseAction: null));
+            }
+        }
         
         /// <summary>
         /// Releases unmanaged resources

--- a/src/OpenCvSharp/Modules/face/BIF.cs
+++ b/src/OpenCvSharp/Modules/face/BIF.cs
@@ -1,0 +1,62 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Computes bio-inspired features used by age-estimation models.
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public sealed class BIF : Algorithm
+{
+    private BIF(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.face_Ptr_BIF_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a BIF descriptor.
+    /// </summary>
+    public static BIF Create(int numBands = 8, int numRotations = 12)
+    {
+        NativeMethods.HandleException(NativeMethods.face_BIF_create(numBands, numRotations, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.face_Ptr_BIF_get(smartPtr, out var rawPtr));
+        return new BIF(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Gets the number of filter bands.
+    /// </summary>
+    public int NumBands
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.face_BIF_getNumBands(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of image rotations.
+    /// </summary>
+    public int NumRotations
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.face_BIF_getNumRotations(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Computes a CV_32FC1 feature vector from a CV_32FC1 image.
+    /// </summary>
+    public void Compute(InputArray image, OutputArray features)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.face_BIF_compute(Handle, image.Proxy, features.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(features.Source);
+    }
+}

--- a/src/OpenCvSharp/Modules/face/Cv2.Face.cs
+++ b/src/OpenCvSharp/Modules/face/Cv2.Face.cs
@@ -1,0 +1,149 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp;
+
+public static partial class Cv2
+{
+    /// <summary>
+    /// cv::face utility functions.
+    /// </summary>
+    public static partial class Face
+    {
+        /// <summary>
+        /// Creates a Kazemi facemark detector.
+        /// </summary>
+        public static OpenCvSharp.Face.FacemarkKazemi CreateFacemarkKazemi()
+        {
+            return OpenCvSharp.Face.FacemarkKazemi.Create();
+        }
+
+        /// <summary>
+        /// Detects faces with a Haar cascade.
+        /// </summary>
+        public static bool GetFacesHAAR(InputArray image, OutputArray faces, string faceCascadeName)
+        {
+            ArgumentNullException.ThrowIfNull(faceCascadeName);
+            NativeMethods.HandleException(
+                NativeMethods.face_getFacesHAAR(
+                    image.Proxy, faces.Proxy, faceCascadeName, out var result));
+            GC.KeepAlive(image.Source);
+            GC.KeepAlive(faces.Source);
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Loads paired image and annotation paths from list files.
+        /// </summary>
+        public static bool LoadDatasetList(
+            string imageList,
+            string annotationList,
+            out string[] images,
+            out string[] annotations)
+        {
+            ArgumentNullException.ThrowIfNull(imageList);
+            ArgumentNullException.ThrowIfNull(annotationList);
+            using var imageVector = new VectorOfString();
+            using var annotationVector = new VectorOfString();
+            NativeMethods.HandleException(
+                NativeMethods.face_loadDatasetList(
+                    imageList, annotationList, imageVector.CvPtr, annotationVector.CvPtr, out var result));
+            images = imageVector.ToArray();
+            annotations = annotationVector.ToArray();
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Loads a facial landmark dataset from a single file.
+        /// </summary>
+        public static bool LoadTrainingData(
+            string filename,
+            out string[] images,
+            out Point2f[][] facePoints,
+            char delimiter = ' ',
+            float offset = 0)
+        {
+            ArgumentNullException.ThrowIfNull(filename);
+            if (delimiter > byte.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(delimiter));
+            using var imageVector = new VectorOfString();
+            using var pointVector = new VectorOfVectorPoint2f();
+            NativeMethods.HandleException(
+                NativeMethods.face_loadTrainingData1(
+                    filename, imageVector.CvPtr, pointVector.CvPtr, (byte)delimiter, offset, out var result));
+            images = imageVector.ToArray();
+            facePoints = pointVector.ToArray();
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Loads a facial landmark dataset from image and ground-truth list files.
+        /// </summary>
+        public static bool LoadTrainingData(
+            string imageList,
+            string groundTruth,
+            out string[] images,
+            out Point2f[][] facePoints,
+            float offset = 0)
+        {
+            ArgumentNullException.ThrowIfNull(imageList);
+            ArgumentNullException.ThrowIfNull(groundTruth);
+            using var imageVector = new VectorOfString();
+            using var pointVector = new VectorOfVectorPoint2f();
+            NativeMethods.HandleException(
+                NativeMethods.face_loadTrainingData2(
+                    imageList, groundTruth, imageVector.CvPtr, pointVector.CvPtr, offset, out var result));
+            images = imageVector.ToArray();
+            facePoints = pointVector.ToArray();
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Loads training landmarks from a collection of annotation files.
+        /// </summary>
+        public static bool LoadTrainingData(
+            IEnumerable<string> filenames,
+            out Point2f[][] landmarks,
+            out string[] images)
+        {
+            ArgumentNullException.ThrowIfNull(filenames);
+            using var filenameVector = new VectorOfString(filenames);
+            using var landmarkVector = new VectorOfVectorPoint2f();
+            using var imageVector = new VectorOfString();
+            NativeMethods.HandleException(
+                NativeMethods.face_loadTrainingData3(
+                    filenameVector.CvPtr, landmarkVector.CvPtr, imageVector.CvPtr, out var result));
+            landmarks = landmarkVector.ToArray();
+            images = imageVector.ToArray();
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Loads landmark points from a standard .pts file.
+        /// </summary>
+        public static bool LoadFacePoints(string filename, out Point2f[] points, float offset = 0)
+        {
+            ArgumentNullException.ThrowIfNull(filename);
+            using var pointVector = new StdVector<Point2f>();
+            NativeMethods.HandleException(
+                NativeMethods.face_loadFacePoints(filename, pointVector.CvPtr, offset, out var result));
+            points = pointVector.ToArray();
+            return result != 0;
+        }
+
+        /// <summary>
+        /// Draws facial landmark points on an image.
+        /// </summary>
+        public static void DrawFacemarks(
+            InputOutputArray image,
+            InputArray points,
+            Scalar? color = null)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_drawFacemarks(
+                    image.Proxy, points.Proxy, color ?? new Scalar(255, 0, 0)));
+            GC.KeepAlive(image.Source);
+            GC.KeepAlive(points.Source);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/FaceRecognizer.cs
@@ -86,6 +86,21 @@ public abstract class FaceRecognizer : Algorithm
     }
 
     /// <summary>
+    /// Runs prediction and forwards every evaluated result to a collector.
+    /// </summary>
+    public virtual void Predict(InputArray src, PredictCollector collector)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(collector);
+        collector.ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.face_FaceRecognizer_predictCollect(Handle, src.Proxy, collector.SmartPtr));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(collector);
+    }
+
+    /// <summary>
     /// Serializes this object to a given filename.
     /// </summary>
     /// <param name="fileName"></param>

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/PredictCollector.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/PredictCollector.cs
@@ -107,7 +107,7 @@ public sealed class StandardCollector : PredictCollector
         NativeMethods.HandleException(
             NativeMethods.face_StandardCollector_getResultsMap(
                 Handle, labels.CvPtr, distances.CvPtr));
-        return labels.ToArray().Zip(distances.ToArray()).ToDictionary(x => x.First, x => x.Second);
+        return Combine(labels.ToArray(), distances.ToArray()).ToDictionary(x => x.Label, x => x.Distance);
     }
 
     private static PredictResult[] Combine(int[] labels, double[] distances)

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/PredictCollector.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/PredictCollector.cs
@@ -1,0 +1,119 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Base class for face-recognition prediction result collectors.
+/// </summary>
+public abstract class PredictCollector : CvPtrObject
+{
+    /// <summary>
+    /// Initializes a collector backed by a native smart pointer.
+    /// </summary>
+    protected PredictCollector(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> release)
+        : base(smartPtr, rawPtr, release)
+    {
+    }
+
+    /// <summary>Resets the collector for an expected number of prediction results.</summary>
+    public void Init(int size)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(size);
+        NativeMethods.HandleException(NativeMethods.face_PredictCollector_init(Handle, (nuint)size));
+    }
+
+    /// <summary>Adds a prediction result and returns whether collection should continue.</summary>
+    public bool Collect(int label, double distance)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.face_PredictCollector_collect(Handle, label, distance, out var result));
+        return result != 0;
+    }
+}
+
+/// <summary>
+/// A collected face-recognition label and distance.
+/// </summary>
+public readonly record struct PredictResult(int Label, double Distance);
+
+/// <summary>
+/// Default collector that tracks the minimum distance subject to a threshold.
+/// </summary>
+public sealed class StandardCollector : PredictCollector
+{
+    private StandardCollector(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p =>
+            NativeMethods.HandleException(NativeMethods.face_Ptr_StandardCollector_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a standard collector.
+    /// </summary>
+    public static StandardCollector Create(double threshold = double.MaxValue)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.face_StandardCollector_create(threshold, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.face_Ptr_StandardCollector_get(smartPtr, out var rawPtr));
+        return new StandardCollector(smartPtr, rawPtr);
+    }
+
+    /// <summary>Gets the label with the minimum distance.</summary>
+    public int MinLabel
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.face_StandardCollector_getMinLabel(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>Gets the minimum collected distance.</summary>
+    public double MinDistance
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.face_StandardCollector_getMinDist(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>Gets all collected results, optionally sorted by distance.</summary>
+    public PredictResult[] GetResults(bool sorted = false)
+    {
+        ThrowIfDisposed();
+        using var labels = new StdVector<int>();
+        using var distances = new StdVector<double>();
+        NativeMethods.HandleException(
+            NativeMethods.face_StandardCollector_getResults(
+                Handle, sorted ? 1 : 0, labels.CvPtr, distances.CvPtr));
+        return Combine(labels.ToArray(), distances.ToArray());
+    }
+
+    /// <summary>Gets the minimum distance collected for each label.</summary>
+    public IReadOnlyDictionary<int, double> GetResultsMap()
+    {
+        ThrowIfDisposed();
+        using var labels = new StdVector<int>();
+        using var distances = new StdVector<double>();
+        NativeMethods.HandleException(
+            NativeMethods.face_StandardCollector_getResultsMap(
+                Handle, labels.CvPtr, distances.CvPtr));
+        return labels.ToArray().Zip(distances.ToArray()).ToDictionary(x => x.First, x => x.Second);
+    }
+
+    private static PredictResult[] Combine(int[] labels, double[] distances)
+    {
+        if (labels.Length != distances.Length)
+            throw new OpenCvSharpException("The native collector returned inconsistent result arrays.");
+        return labels.Zip(distances, static (label, distance) => new PredictResult(label, distance)).ToArray();
+    }
+}

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -48,6 +48,41 @@ public sealed class FacemarkAAM : FacemarkTrain
     }
 
     /// <summary>
+    /// Stores algorithm parameters in a file storage.
+    /// </summary>
+    /// <remarks>
+    /// Overrides the generic Algorithm.Write, which passes a cv::Algorithm* to the native side.
+    /// cv::face::Facemark inherits Algorithm virtually, so a raw pointer obtained as FacemarkAAM*
+    /// cannot be safely reinterpreted as Algorithm* on the managed side; this override calls
+    /// write() with the pointer kept at its concrete native type instead.
+    /// </remarks>
+    /// <param name="fs"></param>
+    public override void Write(FileStorage fs)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fs);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_write(Handle, fs.CvPtr));
+        GC.KeepAlive(fs);
+    }
+
+    /// <summary>
+    /// Reads algorithm parameters from a file storage.
+    /// </summary>
+    /// <remarks>
+    /// See the remarks on <see cref="Write"/> for why this override is needed.
+    /// </remarks>
+    /// <param name="fn"></param>
+    public override void Read(FileNode fn)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fn);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_read(Handle, fn.CvPtr));
+        GC.KeepAlive(fn);
+    }
+
+    /// <summary>
     /// Runtime pose and scale configuration for fitting one face.
     /// </summary>
     public readonly struct Config
@@ -127,6 +162,21 @@ public sealed class FacemarkAAM : FacemarkTrain
         GC.KeepAlive(image.Source);
         GC.KeepAlive(roi.Source);
         GC.KeepAlive(configs);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Retrieves the mean shape (s0) of the trained AAM model.
+    /// </summary>
+    /// <param name="s0">The mean shape points, or an empty array if the model has no data yet.</param>
+    /// <returns>true if the model had data to return.</returns>
+    public bool GetData(out Point2f[] s0)
+    {
+        ThrowIfDisposed();
+        using var s0Vector = new StdVector<Point2f>();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkAAM_getData(Handle, s0Vector.CvPtr, out var result));
+        s0 = s0Vector.ToArray();
         return result != 0;
     }
 

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -8,7 +8,7 @@ namespace OpenCvSharp.Face;
 ///
 /// </summary>
 // ReSharper disable once InconsistentNaming
-public sealed class FacemarkAAM : Facemark
+public sealed class FacemarkAAM : FacemarkTrain
 {
     private FacemarkAAM(IntPtr smartPtr, IntPtr rawPtr)
         : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkAAM_delete(p)))
@@ -45,6 +45,89 @@ public sealed class FacemarkAAM : Facemark
             throw new OpenCvSharpException($"Invalid cv::Ptr<{nameof(FacemarkAAM)}> pointer");
         NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkAAM_get(smartPtr, out var rawPtr));
         return new FacemarkAAM(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Runtime pose and scale configuration for fitting one face.
+    /// </summary>
+    public readonly struct Config
+    {
+        /// <summary>
+        /// Creates a configuration with OpenCV's defaults.
+        /// </summary>
+        public Config()
+            : this(null, default, 1.0f, 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a runtime fitting configuration.
+        /// </summary>
+        public Config(Mat? rotation, Point2f translation, float scale, int modelScaleIndex)
+        {
+            Rotation = rotation;
+            Translation = translation;
+            Scale = scale;
+            ModelScaleIndex = modelScaleIndex;
+        }
+
+        /// <summary>
+        /// Optional 2x2 CV_32F rotation matrix. Null uses the identity matrix.
+        /// </summary>
+        public Mat? Rotation { get; }
+
+        /// <summary>
+        /// Translation applied during fitting.
+        /// </summary>
+        public Point2f Translation { get; }
+
+        /// <summary>
+        /// Scale applied during fitting.
+        /// </summary>
+        public float Scale { get; }
+
+        /// <summary>
+        /// Index of the model scale to use.
+        /// </summary>
+        public int ModelScaleIndex { get; }
+    }
+
+    /// <summary>
+    /// Fits landmarks using a per-face runtime configuration.
+    /// </summary>
+    public bool FitConfig(
+        InputArray image,
+        InputArray roi,
+        IEnumerable<Config> runtimeParameters,
+        out Point2f[][] landmarks)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(runtimeParameters);
+
+        var configs = runtimeParameters.ToArray();
+        var rotations = new IntPtr[configs.Length];
+        var translations = new Point2f[configs.Length];
+        var scales = new float[configs.Length];
+        var modelScaleIndexes = new int[configs.Length];
+        for (var i = 0; i < configs.Length; i++)
+        {
+            configs[i].Rotation?.ThrowIfDisposed();
+            rotations[i] = configs[i].Rotation?.CvPtr ?? IntPtr.Zero;
+            translations[i] = configs[i].Translation;
+            scales[i] = configs[i].Scale;
+            modelScaleIndexes[i] = configs[i].ModelScaleIndex;
+        }
+
+        using var landmarkVector = new VectorOfVectorPoint2f();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkAAM_fitConfig(
+                Handle, image.Proxy, roi.Proxy, landmarkVector.CvPtr,
+                rotations, translations, scales, modelScaleIndexes, configs.Length, out var result));
+        landmarks = landmarkVector.ToArray();
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(roi.Source);
+        GC.KeepAlive(configs);
+        return result != 0;
     }
 
 #pragma warning disable CA1034

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -61,6 +61,7 @@ public sealed class FacemarkAAM : FacemarkTrain
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fs);
+        fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_write(Handle, fs.CvPtr));
         GC.KeepAlive(fs);
@@ -77,6 +78,7 @@ public sealed class FacemarkAAM : FacemarkTrain
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fn);
+        fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkAAM_read(Handle, fn.CvPtr));
         GC.KeepAlive(fn);
@@ -264,6 +266,7 @@ public sealed class FacemarkAAM : FacemarkTrain
         public void Read(FileNode fn)
         {
             ArgumentNullException.ThrowIfNull(fn);
+            fn.ThrowIfDisposed();
             var p = ToNative();
             try
             {
@@ -285,6 +288,7 @@ public sealed class FacemarkAAM : FacemarkTrain
         public void Write(FileStorage fs)
         {
             ArgumentNullException.ThrowIfNull(fs);
+            fs.ThrowIfDisposed();
             var p = ToNative();
             try
             {

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Detects face rectangles from an image for a facemark model.
+/// </summary>
+public delegate Rect[] FacemarkFaceDetector(Mat image);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal unsafe delegate int FacemarkFaceDetectorNativeCallback(
+    IntPtr image, Rect* faces, int capacity);
+
+internal sealed unsafe class FacemarkFaceDetectorBridge : IDisposable
+{
+    internal delegate ExceptionStatus NativeSetter(
+        OpenCvSafeHandle obj,
+        FacemarkFaceDetectorNativeCallback callback,
+        out IntPtr callbackData,
+        out int returnValue);
+
+    private readonly FacemarkFaceDetector detector;
+    private readonly FacemarkFaceDetectorNativeCallback nativeCallback;
+    private readonly ConcurrentDictionary<int, Rect[]> pendingResults = new();
+    private OpenCvPtrSafeHandle? callbackDataHandle;
+
+    public FacemarkFaceDetectorBridge(
+        OpenCvSafeHandle obj,
+        FacemarkFaceDetector detector,
+        NativeSetter setter)
+    {
+        this.detector = detector;
+        nativeCallback = Invoke;
+        NativeMethods.HandleException(setter(obj, nativeCallback, out var callbackData, out var result));
+        if (result == 0 || callbackData == IntPtr.Zero)
+            throw new OpenCvSharpException("OpenCV rejected the custom facemark face detector.");
+        callbackDataHandle = new OpenCvPtrSafeHandle(
+            callbackData, ownsHandle: true,
+            releaseAction: p => NativeMethods.HandleException(
+                NativeMethods.face_FacemarkFaceDetectorCallbackData_delete(p)));
+    }
+
+    private unsafe int Invoke(IntPtr imagePointer, Rect* faces, int capacity)
+    {
+        try
+        {
+            var threadId = Environment.CurrentManagedThreadId;
+            if (faces == null)
+            {
+                using var image = new Mat(imagePointer, ownsHandle: false);
+                var result = detector(image) ?? [];
+                pendingResults[threadId] = result;
+                return result.Length;
+            }
+
+            if (!pendingResults.TryRemove(threadId, out var pending) || pending.Length != capacity)
+                return -1;
+            pending.AsSpan().CopyTo(new Span<Rect>(faces, capacity));
+            return pending.Length;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+
+    public void Dispose()
+    {
+        callbackDataHandle?.Dispose();
+        callbackDataHandle = null;
+        pendingResults.Clear();
+    }
+}

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
@@ -113,6 +113,7 @@ public sealed class FacemarkKazemi : Facemark
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fs);
+        fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_write(Handle, fs.CvPtr));
         GC.KeepAlive(fs);
@@ -129,6 +130,7 @@ public sealed class FacemarkKazemi : Facemark
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fn);
+        fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_read(Handle, fn.CvPtr));
         GC.KeepAlive(fn);

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
@@ -99,6 +99,41 @@ public sealed class FacemarkKazemi : Facemark
         faceDetectorBridge = newBridge;
     }
 
+    /// <summary>
+    /// Stores algorithm parameters in a file storage.
+    /// </summary>
+    /// <remarks>
+    /// Overrides the generic Algorithm.Write, which passes a cv::Algorithm* to the native side.
+    /// cv::face::Facemark inherits Algorithm virtually, so a raw pointer obtained as FacemarkKazemi*
+    /// cannot be safely reinterpreted as Algorithm* on the managed side; this override calls
+    /// write() with the pointer kept at its concrete native type instead.
+    /// </remarks>
+    /// <param name="fs"></param>
+    public override void Write(FileStorage fs)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fs);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_write(Handle, fs.CvPtr));
+        GC.KeepAlive(fs);
+    }
+
+    /// <summary>
+    /// Reads algorithm parameters from a file storage.
+    /// </summary>
+    /// <remarks>
+    /// See the remarks on <see cref="Write"/> for why this override is needed.
+    /// </remarks>
+    /// <param name="fn"></param>
+    public override void Read(FileNode fn)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fn);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_read(Handle, fn.CvPtr));
+        GC.KeepAlive(fn);
+    }
+
     /// <inheritdoc />
     protected override void DisposeManaged()
     {

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkKazemi.cs
@@ -1,0 +1,191 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Ensemble-of-regression-trees facemark implementation.
+/// </summary>
+public sealed class FacemarkKazemi : Facemark
+{
+    private FacemarkFaceDetectorBridge? faceDetectorBridge;
+    private FacemarkKazemi(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p =>
+            NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkKazemi_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a FacemarkKazemi model.
+    /// </summary>
+    public static FacemarkKazemi Create(Params? parameters = null)
+    {
+        var nativeParams = parameters?.ToNative() ?? IntPtr.Zero;
+        try
+        {
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkKazemi_create(nativeParams, out var smartPtr));
+            NativeMethods.HandleException(
+                NativeMethods.face_Ptr_FacemarkKazemi_get(smartPtr, out var rawPtr));
+            return new FacemarkKazemi(smartPtr, rawPtr);
+        }
+        finally
+        {
+            if (nativeParams != IntPtr.Zero)
+                NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_Params_delete(nativeParams));
+        }
+    }
+
+    /// <summary>
+    /// Trains and writes a Kazemi model.
+    /// </summary>
+    public bool Training(
+        IEnumerable<Mat> images,
+        Point2f[][] landmarks,
+        string configFile,
+        Size scale,
+        string modelFilename = "face_landmarks.dat")
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(landmarks);
+        ArgumentNullException.ThrowIfNull(configFile);
+        ArgumentNullException.ThrowIfNull(modelFilename);
+        var imageArray = images.ToArray();
+        if (imageArray.Length != landmarks.Length)
+            throw new ArgumentException("Images and landmarks must have the same length.", nameof(landmarks));
+        foreach (var image in imageArray)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+            image.ThrowIfDisposed();
+        }
+
+        using var landmarkPointers = new ArrayAddress2<Point2f>(landmarks);
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkKazemi_training(
+                Handle, imageArray.Select(x => x.CvPtr).ToArray(), imageArray.Length,
+                landmarkPointers.GetPointer(), landmarkPointers.GetDim2Lengths(), landmarks.Length,
+                configFile, scale, modelFilename, out var result));
+        GC.KeepAlive(imageArray);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Detects faces with the configured detector.
+    /// </summary>
+    public bool GetFaces(InputArray image, out Rect[] faces)
+    {
+        ThrowIfDisposed();
+        using var faceVector = new StdVector<Rect>();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkKazemi_getFaces(
+                Handle, image.Proxy, faceVector.CvPtr, out var result));
+        faces = faceVector.ToArray();
+        GC.KeepAlive(image.Source);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Installs a managed face detector used by the model.
+    /// </summary>
+    public void SetFaceDetector(FacemarkFaceDetector detector)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(detector);
+        var newBridge = new FacemarkFaceDetectorBridge(
+            Handle, detector, NativeMethods.face_FacemarkKazemi_setFaceDetector);
+        faceDetectorBridge?.Dispose();
+        faceDetectorBridge = newBridge;
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeManaged()
+    {
+        faceDetectorBridge?.Dispose();
+        faceDetectorBridge = null;
+        base.DisposeManaged();
+    }
+
+#pragma warning disable CA1034
+    /// <summary>
+    /// Parameters controlling Kazemi model training.
+    /// </summary>
+    public sealed class Params
+    {
+        /// <summary>Creates a parameter set initialized with OpenCV defaults.</summary>
+        public Params()
+        {
+            NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_Params_new(out var native));
+            try
+            {
+                LoadFrom(native);
+            }
+            finally
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_Params_delete(native));
+            }
+        }
+
+        /// <summary>Gets or sets the cascade depth used for training.</summary>
+        public ulong CascadeDepth { get; set; }
+        /// <summary>Gets or sets the maximum regression-tree depth.</summary>
+        public ulong TreeDepth { get; set; }
+        /// <summary>Gets or sets the number of trees per cascade level.</summary>
+        public ulong NumTreesPerCascadeLevel { get; set; }
+        /// <summary>Gets or sets the gradient-boosting learning rate.</summary>
+        public float LearningRate { get; set; }
+        /// <summary>Gets or sets the number of initializations per training sample.</summary>
+        public ulong OversamplingAmount { get; set; }
+        /// <summary>Gets or sets the number of candidate test coordinates.</summary>
+        public ulong NumTestCoordinates { get; set; }
+        /// <summary>Gets or sets the coordinate-closeness probability parameter.</summary>
+        public float Lambda { get; set; }
+        /// <summary>Gets or sets the number of random test splits.</summary>
+        public ulong NumTestSplits { get; set; }
+        /// <summary>Gets or sets the training configuration filename.</summary>
+        public string ConfigFile { get; set; } = "";
+
+        private void LoadFrom(IntPtr native)
+        {
+            using var configFile = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.face_FacemarkKazemi_Params_getAll(native, out var data, configFile.CvPtr));
+            CascadeDepth = data.CascadeDepth;
+            TreeDepth = data.TreeDepth;
+            NumTreesPerCascadeLevel = data.NumTreesPerCascadeLevel;
+            LearningRate = data.LearningRate;
+            OversamplingAmount = data.OversamplingAmount;
+            NumTestCoordinates = data.NumTestCoordinates;
+            Lambda = data.Lambda;
+            NumTestSplits = data.NumTestSplits;
+            ConfigFile = configFile.ToString();
+        }
+
+        internal IntPtr ToNative()
+        {
+            NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_Params_new(out var native));
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.face_FacemarkKazemi_Params_setAll(native, new FacemarkKazemiParamsData
+                    {
+                        CascadeDepth = CascadeDepth,
+                        TreeDepth = TreeDepth,
+                        NumTreesPerCascadeLevel = NumTreesPerCascadeLevel,
+                        LearningRate = LearningRate,
+                        OversamplingAmount = OversamplingAmount,
+                        NumTestCoordinates = NumTestCoordinates,
+                        Lambda = Lambda,
+                        NumTestSplits = NumTestSplits,
+                    }, ConfigFile));
+                return native;
+            }
+            catch
+            {
+                NativeMethods.HandleException(NativeMethods.face_FacemarkKazemi_Params_delete(native));
+                throw;
+            }
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -61,6 +61,7 @@ public sealed class FacemarkLBF : FacemarkTrain
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fs);
+        fs.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_write(Handle, fs.CvPtr));
         GC.KeepAlive(fs);
@@ -77,6 +78,7 @@ public sealed class FacemarkLBF : FacemarkTrain
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(fn);
+        fn.ThrowIfDisposed();
 
         NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_read(Handle, fn.CvPtr));
         GC.KeepAlive(fn);
@@ -202,6 +204,7 @@ public sealed class FacemarkLBF : FacemarkTrain
         public void Read(FileNode fn)
         {
             ArgumentNullException.ThrowIfNull(fn);
+            fn.ThrowIfDisposed();
             var p = ToNative();
             try
             {
@@ -223,6 +226,7 @@ public sealed class FacemarkLBF : FacemarkTrain
         public void Write(FileStorage fs)
         {
             ArgumentNullException.ThrowIfNull(fs);
+            fs.ThrowIfDisposed();
             var p = ToNative();
             try
             {

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -47,6 +47,41 @@ public sealed class FacemarkLBF : FacemarkTrain
         return new FacemarkLBF(smartPtr, rawPtr);
     }
 
+    /// <summary>
+    /// Stores algorithm parameters in a file storage.
+    /// </summary>
+    /// <remarks>
+    /// Overrides the generic Algorithm.Write, which passes a cv::Algorithm* to the native side.
+    /// cv::face::Facemark inherits Algorithm virtually, so a raw pointer obtained as FacemarkLBF*
+    /// cannot be safely reinterpreted as Algorithm* on the managed side; this override calls
+    /// write() with the pointer kept at its concrete native type instead.
+    /// </remarks>
+    /// <param name="fs"></param>
+    public override void Write(FileStorage fs)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fs);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_write(Handle, fs.CvPtr));
+        GC.KeepAlive(fs);
+    }
+
+    /// <summary>
+    /// Reads algorithm parameters from a file storage.
+    /// </summary>
+    /// <remarks>
+    /// See the remarks on <see cref="Write"/> for why this override is needed.
+    /// </remarks>
+    /// <param name="fn"></param>
+    public override void Read(FileNode fn)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(fn);
+
+        NativeMethods.HandleException(NativeMethods.face_FacemarkLBF_read(Handle, fn.CvPtr));
+        GC.KeepAlive(fn);
+    }
+
 #pragma warning disable CA1034
     /// <summary>
     /// Parameters for the FacemarkLBF model.

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkLBF.cs
@@ -8,7 +8,7 @@ namespace OpenCvSharp.Face;
 ///
 /// </summary>
 // ReSharper disable once InconsistentNaming
-public sealed class FacemarkLBF : Facemark
+public sealed class FacemarkLBF : FacemarkTrain
 {
     private FacemarkLBF(IntPtr smartPtr, IntPtr rawPtr)
         : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.face_Ptr_FacemarkLBF_delete(p)))

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkTrain.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkTrain.cs
@@ -1,0 +1,89 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Base class for trainable facemark models.
+/// </summary>
+public abstract class FacemarkTrain : Facemark
+{
+    private FacemarkFaceDetectorBridge? faceDetectorBridge;
+    /// <summary>
+    /// Initializes a trainable facemark wrapper.
+    /// </summary>
+    protected FacemarkTrain(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> release)
+        : base(smartPtr, rawPtr, release)
+    {
+    }
+
+    /// <summary>
+    /// Adds one training image and its landmark points.
+    /// </summary>
+    public bool AddTrainingSample(InputArray image, InputArray landmarks)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkTrain_addTrainingSample(
+                Handle, image.Proxy, landmarks.Proxy, out var result));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(landmarks.Source);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Trains the model from samples previously added with <see cref="AddTrainingSample"/>.
+    /// </summary>
+    public void Training()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.face_FacemarkTrain_training(Handle));
+    }
+
+    /// <summary>
+    /// Detects faces using the detector configured by the algorithm.
+    /// </summary>
+    public bool GetFaces(InputArray image, out Rect[] faces)
+    {
+        ThrowIfDisposed();
+        using var faceVector = new StdVector<Rect>();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkTrain_getFaces(
+                Handle, image.Proxy, faceVector.CvPtr, out var result));
+        faces = faceVector.ToArray();
+        GC.KeepAlive(image.Source);
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Retrieves algorithm-specific data into a native structure.
+    /// </summary>
+    public bool GetData(IntPtr items)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.face_FacemarkTrain_getData(Handle, items, out var result));
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Installs a managed face detector used by the facemark algorithm.
+    /// </summary>
+    public void SetFaceDetector(FacemarkFaceDetector detector)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(detector);
+        var newBridge = new FacemarkFaceDetectorBridge(
+            Handle, detector, NativeMethods.face_FacemarkTrain_setFaceDetector);
+        faceDetectorBridge?.Dispose();
+        faceDetectorBridge = newBridge;
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeManaged()
+    {
+        faceDetectorBridge?.Dispose();
+        faceDetectorBridge = null;
+        base.DisposeManaged();
+    }
+}

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkTrain.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkTrain.cs
@@ -56,17 +56,6 @@ public abstract class FacemarkTrain : Facemark
     }
 
     /// <summary>
-    /// Retrieves algorithm-specific data into a native structure.
-    /// </summary>
-    public bool GetData(IntPtr items)
-    {
-        ThrowIfDisposed();
-        NativeMethods.HandleException(
-            NativeMethods.face_FacemarkTrain_getData(Handle, items, out var result));
-        return result != 0;
-    }
-
-    /// <summary>
     /// Installs a managed face detector used by the facemark algorithm.
     /// </summary>
     public void SetFaceDetector(FacemarkFaceDetector detector)

--- a/src/OpenCvSharp/Modules/face/MACE.cs
+++ b/src/OpenCvSharp/Modules/face/MACE.cs
@@ -1,0 +1,78 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Face;
+
+/// <summary>
+/// Minimum Average Correlation Energy filter for face verification.
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public sealed class MACE : Algorithm
+{
+    private MACE(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p => NativeMethods.HandleException(NativeMethods.face_Ptr_MACE_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a MACE filter.
+    /// </summary>
+    public static MACE Create(int imageSize = 64)
+    {
+        NativeMethods.HandleException(NativeMethods.face_MACE_create(imageSize, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.face_Ptr_MACE_get(smartPtr, out var rawPtr));
+        return new MACE(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Loads a serialized MACE filter.
+    /// </summary>
+    public static MACE Load(string filename, string objName = "")
+    {
+        ArgumentNullException.ThrowIfNull(filename);
+        ArgumentNullException.ThrowIfNull(objName);
+        NativeMethods.HandleException(NativeMethods.face_MACE_load(filename, objName, out var smartPtr));
+        NativeMethods.HandleException(NativeMethods.face_Ptr_MACE_get(smartPtr, out var rawPtr));
+        return new MACE(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Salts the filter with a passphrase.
+    /// </summary>
+    public void Salt(string passphrase)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(passphrase);
+        NativeMethods.HandleException(NativeMethods.face_MACE_salt(Handle, passphrase));
+    }
+
+    /// <summary>
+    /// Trains the filter on positive images.
+    /// </summary>
+    public void Train(IEnumerable<Mat> images)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(images);
+        var imageArray = images.ToArray();
+        foreach (var image in imageArray)
+        {
+            if (image is null)
+                throw new ArgumentException("The collection contains null.", nameof(images));
+            image.ThrowIfDisposed();
+        }
+        NativeMethods.HandleException(
+            NativeMethods.face_MACE_train(
+                Handle, imageArray.Select(x => x.CvPtr).ToArray(), imageArray.Length));
+        GC.KeepAlive(imageArray);
+    }
+
+    /// <summary>
+    /// Tests whether the query belongs to the trained class.
+    /// </summary>
+    public bool Same(InputArray query)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.face_MACE_same(Handle, query.Proxy, out var result));
+        GC.KeepAlive(query.Source);
+        return result != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/img_hash/Cv2.ImgHash.cs
+++ b/src/OpenCvSharp/Modules/img_hash/Cv2.ImgHash.cs
@@ -1,0 +1,80 @@
+using OpenCvSharp.ImgHash;
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+public static partial class Cv2
+{
+    /// <summary>
+    /// cv::img_hash functions.
+    /// </summary>
+    public static partial class ImgHash
+    {
+        /// <summary>
+        /// Computes the average hash of an image.
+        /// </summary>
+        public static void AverageHash(InputArray input, OutputArray output)
+        {
+            NativeMethods.HandleException(NativeMethods.img_hash_averageHash(input.Proxy, output.Proxy));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+
+        /// <summary>
+        /// Computes the block mean hash of an image.
+        /// </summary>
+        public static void BlockMeanHash(
+            InputArray input, OutputArray output, BlockMeanHashMode mode = BlockMeanHashMode.Mode0)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.img_hash_blockMeanHash(input.Proxy, output.Proxy, (int)mode));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+
+        /// <summary>
+        /// Computes the color moment hash of an image.
+        /// </summary>
+        public static void ColorMomentHash(InputArray input, OutputArray output)
+        {
+            NativeMethods.HandleException(NativeMethods.img_hash_colorMomentHash(input.Proxy, output.Proxy));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+
+        /// <summary>
+        /// Computes the Marr-Hildreth hash of an image.
+        /// </summary>
+        public static void MarrHildrethHash(
+            InputArray input, OutputArray output, float alpha = 2.0f, float scale = 1.0f)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.img_hash_marrHildrethHash(input.Proxy, output.Proxy, alpha, scale));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+
+        /// <summary>
+        /// Computes the perceptual hash of an image.
+        /// </summary>
+        public static void PHash(InputArray input, OutputArray output)
+        {
+            NativeMethods.HandleException(NativeMethods.img_hash_pHash(input.Proxy, output.Proxy));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+
+        /// <summary>
+        /// Computes the radial variance hash of an image.
+        /// </summary>
+        public static void RadialVarianceHash(
+            InputArray input, OutputArray output, double sigma = 1, int numOfAngleLine = 180)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.img_hash_radialVarianceHash(
+                    input.Proxy, output.Proxy, sigma, numOfAngleLine));
+            GC.KeepAlive(input.Source);
+            GC.KeepAlive(output.Source);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/line_descriptors/BinaryDescriptor.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/BinaryDescriptor.cs
@@ -1,0 +1,331 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.LineDescriptor;
+
+/// <summary>
+/// Detects line segments and computes binary line descriptors.
+/// </summary>
+public sealed class BinaryDescriptor : Algorithm
+{
+    private BinaryDescriptor(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p =>
+            NativeMethods.HandleException(NativeMethods.line_descriptor_Ptr_BinaryDescriptor_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a binary descriptor.
+    /// </summary>
+    public static BinaryDescriptor Create(Params? parameters = null)
+    {
+        var nativeParams = parameters?.ToNative() ?? IntPtr.Zero;
+        try
+        {
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_create(nativeParams, out var smartPtr));
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_Ptr_BinaryDescriptor_get(smartPtr, out var rawPtr));
+            return new BinaryDescriptor(smartPtr, rawPtr);
+        }
+        finally
+        {
+            if (nativeParams != IntPtr.Zero)
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_delete(nativeParams));
+        }
+    }
+
+    /// <summary>Gets or sets the number of image octaves.</summary>
+    public int NumOfOctaves
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_getNumOfOctaves(Handle, out var value));
+            return value;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_setNumOfOctaves(Handle, value));
+        }
+    }
+
+    /// <summary>Gets or sets the descriptor band width.</summary>
+    public int WidthOfBand
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_getWidthOfBand(Handle, out var value));
+            return value;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_setWidthOfBand(Handle, value));
+        }
+    }
+
+    /// <summary>Gets or sets the Gaussian-pyramid reduction ratio.</summary>
+    public int ReductionRatio
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_getReductionRatio(Handle, out var value));
+            return value;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_setReductionRatio(Handle, value));
+        }
+    }
+
+    /// <summary>Gets the descriptor size in bits.</summary>
+    public int DescriptorSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_descriptorSize(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>Gets the OpenCV matrix type used by binary descriptors.</summary>
+    public int DescriptorType
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_descriptorType(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>Gets the default norm used to compare descriptors.</summary>
+    public int DefaultNorm
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_defaultNorm(Handle, out var value));
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Detects line segments in an image.
+    /// </summary>
+    public KeyLine[] Detect(Mat image, Mat? mask = null)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(image);
+        image.ThrowIfDisposed();
+        mask?.ThrowIfDisposed();
+        using var keyLines = new VectorOfKeyLine();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptor_detect1(
+                Handle, image.CvPtr, keyLines.CvPtr, mask?.Handle ?? OpenCvSafeHandle.Null));
+        GC.KeepAlive(image);
+        GC.KeepAlive(mask);
+        return keyLines.ToArray();
+    }
+
+    /// <summary>
+    /// Detects line segments in multiple images.
+    /// </summary>
+    public KeyLine[][] Detect(IEnumerable<Mat> images, IEnumerable<Mat>? masks = null)
+    {
+        ThrowIfDisposed();
+        var imageArray = MaterializeMats(images, nameof(images));
+        var maskArray = masks is null ? [] : MaterializeMats(masks, nameof(masks));
+        if (maskArray.Length != 0 && maskArray.Length != imageArray.Length)
+            throw new ArgumentException("Masks must be empty or have one entry per image.", nameof(masks));
+        using var keyLines = new VectorOfVectorKeyLine();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptor_detect2(
+                Handle, imageArray.Select(x => x.CvPtr).ToArray(), imageArray.Length, keyLines.CvPtr,
+                maskArray.Select(x => x.CvPtr).ToArray(), maskArray.Length));
+        GC.KeepAlive(imageArray);
+        GC.KeepAlive(maskArray);
+        return keyLines.ToArray();
+    }
+
+    /// <summary>
+    /// Computes descriptors for the supplied lines. The native algorithm may update the lines.
+    /// </summary>
+    public void Compute(Mat image, ref KeyLine[] keyLines, Mat descriptors, bool returnFloatDescriptor = false)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(image);
+        ArgumentNullException.ThrowIfNull(keyLines);
+        ArgumentNullException.ThrowIfNull(descriptors);
+        image.ThrowIfDisposed();
+        descriptors.ThrowIfDisposed();
+        using var keyLineVector = new VectorOfKeyLine(keyLines);
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptor_compute1(
+                Handle, image.CvPtr, keyLineVector.CvPtr, descriptors.CvPtr,
+                returnFloatDescriptor ? 1 : 0));
+        keyLines = keyLineVector.ToArray();
+        GC.KeepAlive(image);
+        GC.KeepAlive(descriptors);
+    }
+
+    /// <summary>
+    /// Computes descriptors for lines from multiple images.
+    /// </summary>
+    public void Compute(
+        IEnumerable<Mat> images,
+        ref KeyLine[][] keyLines,
+        out Mat[] descriptors,
+        bool returnFloatDescriptor = false)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(keyLines);
+        var imageArray = MaterializeMats(images, nameof(images));
+        if (imageArray.Length != keyLines.Length)
+            throw new ArgumentException("Images and key lines must have the same length.", nameof(keyLines));
+        using var keyLinePointers = new ArrayAddress2<KeyLine>(keyLines);
+        using var outputKeyLines = new VectorOfVectorKeyLine();
+        using var descriptorVector = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptor_compute2(
+                Handle, imageArray.Select(x => x.CvPtr).ToArray(), imageArray.Length,
+                keyLinePointers.GetPointer(), keyLinePointers.GetDim2Lengths(), keyLines.Length,
+                outputKeyLines.CvPtr, descriptorVector.CvPtr, returnFloatDescriptor ? 1 : 0));
+        keyLines = outputKeyLines.ToArray();
+        descriptors = descriptorVector.ToArray();
+        GC.KeepAlive(imageArray);
+    }
+
+    private static Mat[] MaterializeMats(IEnumerable<Mat> mats, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(mats, parameterName);
+        var result = mats.ToArray();
+        foreach (var mat in result)
+        {
+            if (mat is null)
+                throw new ArgumentException("The collection contains null.", parameterName);
+            mat.ThrowIfDisposed();
+        }
+        return result;
+    }
+
+#pragma warning disable CA1034
+    /// <summary>
+    /// Binary descriptor configuration.
+    /// </summary>
+    public sealed class Params
+    {
+        /// <summary>Creates a parameter set initialized with OpenCV defaults.</summary>
+        public Params()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_Params_new(out var native));
+            try
+            {
+                LoadFrom(native);
+            }
+            finally
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_delete(native));
+            }
+        }
+
+        /// <summary>Gets or sets the number of octaves.</summary>
+        public int NumOfOctaves { get; set; }
+        /// <summary>Gets or sets the descriptor band width.</summary>
+        public int WidthOfBand { get; set; }
+        /// <summary>Gets or sets the pyramid reduction ratio.</summary>
+        public int ReductionRatio { get; set; }
+        /// <summary>Gets or sets the smoothing kernel size.</summary>
+        public int KSize { get; set; }
+
+        /// <summary>Reads parameter values from a file node.</summary>
+        public void Read(FileNode node)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+            var native = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_read(native, node.CvPtr));
+                LoadFrom(native);
+                GC.KeepAlive(node);
+            }
+            finally
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_delete(native));
+            }
+        }
+
+        /// <summary>Writes parameter values to a file storage.</summary>
+        public void Write(FileStorage storage)
+        {
+            ArgumentNullException.ThrowIfNull(storage);
+            var native = ToNative();
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_write(native, storage.CvPtr));
+                GC.KeepAlive(storage);
+            }
+            finally
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_delete(native));
+            }
+        }
+
+        private void LoadFrom(IntPtr native)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_Params_getAll(native, out var data));
+            NumOfOctaves = data.NumOfOctaves;
+            WidthOfBand = data.WidthOfBand;
+            ReductionRatio = data.ReductionRatio;
+            KSize = data.KSize;
+        }
+
+        internal IntPtr ToNative()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.line_descriptor_BinaryDescriptor_Params_new(out var native));
+            try
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_setAll(native, new BinaryDescriptorParamsData
+                    {
+                        NumOfOctaves = NumOfOctaves,
+                        WidthOfBand = WidthOfBand,
+                        ReductionRatio = ReductionRatio,
+                        KSize = KSize,
+                    }));
+                return native;
+            }
+            catch
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_BinaryDescriptor_Params_delete(native));
+                throw;
+            }
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/line_descriptors/BinaryDescriptorMatcher.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/BinaryDescriptorMatcher.cs
@@ -1,0 +1,147 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.LineDescriptor;
+
+/// <summary>
+/// Matches binary line descriptors using multi-index hashing.
+/// </summary>
+public sealed class BinaryDescriptorMatcher : Algorithm
+{
+    private BinaryDescriptorMatcher(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr, p =>
+            NativeMethods.HandleException(NativeMethods.line_descriptor_Ptr_BinaryDescriptorMatcher_delete(p)))
+    {
+    }
+
+    /// <summary>Creates a binary line descriptor matcher.</summary>
+    public static BinaryDescriptorMatcher Create()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_create(out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_Ptr_BinaryDescriptorMatcher_get(smartPtr, out var rawPtr));
+        return new BinaryDescriptorMatcher(smartPtr, rawPtr);
+    }
+
+    /// <summary>Finds the best train descriptor for every query descriptor.</summary>
+    public DMatch[] Match(Mat queryDescriptors, Mat trainDescriptors, Mat? mask = null)
+    {
+        Validate(queryDescriptors, nameof(queryDescriptors));
+        Validate(trainDescriptors, nameof(trainDescriptors));
+        mask?.ThrowIfDisposed();
+        using var matches = new StdVector<DMatch>();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_match(
+                Handle, queryDescriptors.CvPtr, trainDescriptors.CvPtr, matches.CvPtr,
+                mask?.Handle ?? OpenCvSafeHandle.Null));
+        GC.KeepAlive(queryDescriptors);
+        GC.KeepAlive(trainDescriptors);
+        GC.KeepAlive(mask);
+        return matches.ToArray();
+    }
+
+    /// <summary>Matches query descriptors against the matcher's trained dataset.</summary>
+    public DMatch[] MatchQuery(Mat queryDescriptors, IEnumerable<Mat>? masks = null)
+    {
+        Validate(queryDescriptors, nameof(queryDescriptors));
+        var maskArray = Materialize(masks);
+        using var matches = new StdVector<DMatch>();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_matchQuery(
+                Handle, queryDescriptors.CvPtr, matches.CvPtr,
+                maskArray.Select(x => x.CvPtr).ToArray(), maskArray.Length));
+        GC.KeepAlive(queryDescriptors);
+        GC.KeepAlive(maskArray);
+        return matches.ToArray();
+    }
+
+    /// <summary>Finds the k nearest train descriptors for every query descriptor.</summary>
+    public DMatch[][] KnnMatch(
+        Mat queryDescriptors,
+        Mat trainDescriptors,
+        int k,
+        Mat? mask = null,
+        bool compactResult = false)
+    {
+        Validate(queryDescriptors, nameof(queryDescriptors));
+        Validate(trainDescriptors, nameof(trainDescriptors));
+        mask?.ThrowIfDisposed();
+        using var matches = new VectorOfVectorDMatch();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_knnMatch(
+                Handle, queryDescriptors.CvPtr, trainDescriptors.CvPtr, matches.CvPtr, k,
+                mask?.Handle ?? OpenCvSafeHandle.Null, compactResult ? 1 : 0));
+        GC.KeepAlive(queryDescriptors);
+        GC.KeepAlive(trainDescriptors);
+        GC.KeepAlive(mask);
+        return matches.ToArray();
+    }
+
+    /// <summary>Finds k nearest matches in the matcher's trained dataset.</summary>
+    public DMatch[][] KnnMatchQuery(
+        Mat queryDescriptors,
+        int k,
+        IEnumerable<Mat>? masks = null,
+        bool compactResult = false)
+    {
+        Validate(queryDescriptors, nameof(queryDescriptors));
+        var maskArray = Materialize(masks);
+        using var matches = new VectorOfVectorDMatch();
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_knnMatchQuery(
+                Handle, queryDescriptors.CvPtr, matches.CvPtr, k,
+                maskArray.Select(x => x.CvPtr).ToArray(), maskArray.Length,
+                compactResult ? 1 : 0));
+        GC.KeepAlive(queryDescriptors);
+        GC.KeepAlive(maskArray);
+        return matches.ToArray();
+    }
+
+    /// <summary>Adds descriptor matrices to the matcher's pending dataset.</summary>
+    public void Add(IEnumerable<Mat> descriptors)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(descriptors);
+        var descriptorArray = Materialize(descriptors);
+        NativeMethods.HandleException(
+            NativeMethods.line_descriptor_BinaryDescriptorMatcher_add(
+                Handle, descriptorArray.Select(x => x.CvPtr).ToArray(), descriptorArray.Length));
+        GC.KeepAlive(descriptorArray);
+    }
+
+    /// <summary>Builds the search dataset from descriptors added to the matcher.</summary>
+    public void Train()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.line_descriptor_BinaryDescriptorMatcher_train(Handle));
+    }
+
+    /// <summary>Clears the dataset and all internal matcher state.</summary>
+    public void Clear()
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.line_descriptor_BinaryDescriptorMatcher_clear(Handle));
+    }
+
+    private void Validate(Mat mat, string parameterName)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(mat, parameterName);
+        mat.ThrowIfDisposed();
+    }
+
+    private static Mat[] Materialize(IEnumerable<Mat>? mats)
+    {
+        if (mats is null)
+            return [];
+        var result = mats.ToArray();
+        foreach (var mat in result)
+        {
+            if (mat is null)
+                throw new ArgumentException("The collection contains null.", nameof(mats));
+            mat.ThrowIfDisposed();
+        }
+        return result;
+    }
+}

--- a/src/OpenCvSharp/Modules/line_descriptors/Cv2.LineDescriptor.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/Cv2.LineDescriptor.cs
@@ -1,0 +1,79 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.LineDescriptor;
+
+namespace OpenCvSharp;
+
+public static partial class Cv2
+{
+    /// <summary>
+    /// cv::line_descriptor functions.
+    /// </summary>
+    public static partial class LineDescriptor
+    {
+        /// <summary>
+        /// Draws matched key lines from two images.
+        /// </summary>
+        public static unsafe void DrawLineMatches(
+            Mat image1,
+            KeyLine[] keyLines1,
+            Mat image2,
+            KeyLine[] keyLines2,
+            DMatch[] matches,
+            Mat output,
+            Scalar? matchColor = null,
+            Scalar? singleLineColor = null,
+            byte[]? matchesMask = null,
+            DrawLinesMatchesFlags flags = DrawLinesMatchesFlags.Default)
+        {
+            ArgumentNullException.ThrowIfNull(image1);
+            ArgumentNullException.ThrowIfNull(keyLines1);
+            ArgumentNullException.ThrowIfNull(image2);
+            ArgumentNullException.ThrowIfNull(keyLines2);
+            ArgumentNullException.ThrowIfNull(matches);
+            ArgumentNullException.ThrowIfNull(output);
+            matchesMask ??= [];
+            if (matchesMask.Length != 0 && matchesMask.Length != matches.Length)
+                throw new ArgumentException("The match mask must be empty or have one entry per match.", nameof(matchesMask));
+            fixed (KeyLine* keyLines1Pointer = keyLines1)
+            fixed (KeyLine* keyLines2Pointer = keyLines2)
+            fixed (DMatch* matchesPointer = matches)
+            fixed (byte* maskPointer = matchesMask)
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_drawLineMatches(
+                        image1.CvPtr, keyLines1Pointer, keyLines1.Length,
+                        image2.CvPtr, keyLines2Pointer, keyLines2.Length,
+                        matchesPointer, matches.Length, output.CvPtr,
+                        matchColor ?? Scalar.All(-1), singleLineColor ?? Scalar.All(-1),
+                        maskPointer, matchesMask.Length, (int)flags));
+            }
+            GC.KeepAlive(image1);
+            GC.KeepAlive(image2);
+            GC.KeepAlive(output);
+        }
+
+        /// <summary>
+        /// Draws key lines on an image.
+        /// </summary>
+        public static unsafe void DrawKeylines(
+            Mat image,
+            KeyLine[] keyLines,
+            Mat output,
+            Scalar? color = null,
+            DrawLinesMatchesFlags flags = DrawLinesMatchesFlags.Default)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+            ArgumentNullException.ThrowIfNull(keyLines);
+            ArgumentNullException.ThrowIfNull(output);
+            fixed (KeyLine* keyLinePointer = keyLines)
+            {
+                NativeMethods.HandleException(
+                    NativeMethods.line_descriptor_drawKeylines(
+                        image.CvPtr, keyLinePointer, keyLines.Length, output.CvPtr,
+                        color ?? Scalar.All(-1), (int)flags));
+            }
+            GC.KeepAlive(image);
+            GC.KeepAlive(output);
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/line_descriptors/DrawLinesMatchesFlags.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/DrawLinesMatchesFlags.cs
@@ -1,0 +1,15 @@
+namespace OpenCvSharp.LineDescriptor;
+
+/// <summary>
+/// Options for drawing key lines and line matches.
+/// </summary>
+[Flags]
+public enum DrawLinesMatchesFlags
+{
+    /// <summary>Creates the output and draws matches and unmatched lines.</summary>
+    Default = 0,
+    /// <summary>Draws over the existing output image.</summary>
+    DrawOverOutImg = 1,
+    /// <summary>Does not draw unmatched lines.</summary>
+    NotDrawSingleLines = 2,
+}

--- a/src/OpenCvSharpExtern/face.cpp
+++ b/src/OpenCvSharpExtern/face.cpp
@@ -1,3 +1,4 @@
 // ReSharper disable CppUnusedIncludeDirective
 #include "face_FaceRecognizer.h"
 #include "face_Facemark.h"
+#include "face_Additional.h"

--- a/src/OpenCvSharpExtern/face_Additional.h
+++ b/src/OpenCvSharpExtern/face_Additional.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#ifndef NO_CONTRIB
+
+#include "include_opencv.h"
+#include <opencv2/face/bif.hpp>
+
+#ifndef _WINRT_DLL
+
+#pragma region BIF
+
+CVAPI(ExceptionStatus) face_BIF_create(
+    const int numBands, const int numRotations, cv::Ptr<cv::face::BIF> **returnValue)
+{
+    return cvTry([&] { *returnValue = clone(cv::face::BIF::create(numBands, numRotations)); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_BIF_get(
+    cv::Ptr<cv::face::BIF> *obj, cv::face::BIF **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_BIF_delete(cv::Ptr<cv::face::BIF> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) face_BIF_getNumBands(cv::face::BIF *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNumBands(); });
+}
+
+CVAPI(ExceptionStatus) face_BIF_getNumRotations(cv::face::BIF *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNumRotations(); });
+}
+
+CVAPI(ExceptionStatus) face_BIF_compute(
+    cv::face::BIF *obj,
+    const interop::InputArrayProxy *image,
+    const interop::OutputArrayProxy *features)
+{
+    return cvTry([&] { obj->compute(InProxy(*image), OutProxy(*features)); });
+}
+
+#pragma endregion
+
+#pragma region MACE
+
+CVAPI(ExceptionStatus) face_MACE_create(const int imageSize, cv::Ptr<cv::face::MACE> **returnValue)
+{
+    return cvTry([&] { *returnValue = clone(cv::face::MACE::create(imageSize)); });
+}
+
+CVAPI(ExceptionStatus) face_MACE_load(
+    const char *filename, const char *objName, cv::Ptr<cv::face::MACE> **returnValue)
+{
+    return cvTry([&] { *returnValue = clone(cv::face::MACE::load(filename, objName)); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_MACE_get(
+    cv::Ptr<cv::face::MACE> *obj, cv::face::MACE **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_MACE_delete(cv::Ptr<cv::face::MACE> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) face_MACE_salt(cv::face::MACE *obj, const char *passphrase)
+{
+    return cvTry([&] { obj->salt(passphrase); });
+}
+
+CVAPI(ExceptionStatus) face_MACE_train(
+    cv::face::MACE *obj, cv::Mat **images, const int imagesLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imageVector(imagesLength);
+        for (auto i = 0; i < imagesLength; i++)
+            imageVector[i] = *images[i];
+        obj->train(imageVector);
+    });
+}
+
+CVAPI(ExceptionStatus) face_MACE_same(
+    cv::face::MACE *obj, const interop::InputArrayProxy *query, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->same(InProxy(*query)) ? 1 : 0; });
+}
+
+#pragma endregion
+
+#pragma region PredictCollector
+
+CVAPI(ExceptionStatus) face_PredictCollector_init(
+    cv::face::PredictCollector *obj, const size_t size)
+{
+    return cvTry([&] { obj->init(size); });
+}
+
+CVAPI(ExceptionStatus) face_PredictCollector_collect(
+    cv::face::PredictCollector *obj, const int label, const double distance, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->collect(label, distance) ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) face_StandardCollector_create(
+    const double threshold, cv::Ptr<cv::face::StandardCollector> **returnValue)
+{
+    return cvTry([&] { *returnValue = clone(cv::face::StandardCollector::create(threshold)); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_StandardCollector_get(
+    cv::Ptr<cv::face::StandardCollector> *obj, cv::face::StandardCollector **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_StandardCollector_delete(
+    cv::Ptr<cv::face::StandardCollector> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) face_StandardCollector_getMinLabel(
+    cv::face::StandardCollector *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMinLabel(); });
+}
+
+CVAPI(ExceptionStatus) face_StandardCollector_getMinDist(
+    cv::face::StandardCollector *obj, double *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getMinDist(); });
+}
+
+CVAPI(ExceptionStatus) face_StandardCollector_getResults(
+    cv::face::StandardCollector *obj,
+    const int sorted,
+    std::vector<int> *labels,
+    std::vector<double> *distances)
+{
+    return cvTry([&] {
+        const auto results = obj->getResults(sorted != 0);
+        labels->clear();
+        distances->clear();
+        labels->reserve(results.size());
+        distances->reserve(results.size());
+        for (const auto &result : results)
+        {
+            labels->push_back(result.first);
+            distances->push_back(result.second);
+        }
+    });
+}
+
+CVAPI(ExceptionStatus) face_StandardCollector_getResultsMap(
+    cv::face::StandardCollector *obj,
+    std::vector<int> *labels,
+    std::vector<double> *distances)
+{
+    return cvTry([&] {
+        const auto results = obj->getResultsMap();
+        labels->clear();
+        distances->clear();
+        labels->reserve(results.size());
+        distances->reserve(results.size());
+        for (const auto &result : results)
+        {
+            labels->push_back(result.first);
+            distances->push_back(result.second);
+        }
+    });
+}
+
+#pragma endregion
+
+#endif // !_WINRT_DLL
+#endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/face_FaceRecognizer.h
+++ b/src/OpenCvSharpExtern/face_FaceRecognizer.h
@@ -62,6 +62,16 @@ CVAPI(ExceptionStatus) face_FaceRecognizer_predict2(
     });
 }
 
+CVAPI(ExceptionStatus) face_FaceRecognizer_predictCollect(
+    cv::face::FaceRecognizer *obj,
+    const interop::InputArrayProxy* src,
+    cv::Ptr<cv::face::PredictCollector> *collector)
+{
+    return cvTry([&] {
+        obj->predict(InProxy(*src), *collector);
+    });
+}
+
 CVAPI(ExceptionStatus) face_FaceRecognizer_write1(cv::face::FaceRecognizer *obj, const char *filename)
 {
     return cvTry([&] {

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -228,12 +228,6 @@ CVAPI(ExceptionStatus) face_FacemarkTrain_getFaces(
     });
 }
 
-CVAPI(ExceptionStatus) face_FacemarkTrain_getData(
-    cv::face::FacemarkTrain *obj, void *items, int *returnValue)
-{
-    return cvTry([&] { *returnValue = obj->getData(items) ? 1 : 0; });
-}
-
 CVAPI(ExceptionStatus) face_FacemarkTrain_setFaceDetector(
     cv::face::FacemarkTrain *obj,
     const FacemarkFaceDetectorCallback callback,
@@ -279,6 +273,24 @@ CVAPI(ExceptionStatus) face_Ptr_FacemarkLBF_delete(cv::Ptr<cv::face::FacemarkLBF
 {
     return cvTry([&] {
         delete obj;
+    });
+}
+
+// write/read are called directly on the concrete type here (rather than going through the generic
+// core_Algorithm_write/read, which take a cv::Algorithm*): cv::face::Facemark inherits Algorithm
+// virtually, so a raw pointer obtained as FacemarkLBF* cannot be safely reinterpreted as Algorithm*
+// on the managed side without the compiler-generated virtual-base offset adjustment.
+CVAPI(ExceptionStatus) face_FacemarkLBF_write(cv::face::FacemarkLBF *obj, cv::FileStorage *fs)
+{
+    return cvTry([&] {
+        obj->write(*fs);
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkLBF_read(cv::face::FacemarkLBF *obj, cv::FileNode *fn)
+{
+    return cvTry([&] {
+        obj->read(*fn);
     });
 }
 
@@ -404,6 +416,24 @@ CVAPI(ExceptionStatus) face_Ptr_FacemarkAAM_delete(cv::Ptr<cv::face::FacemarkAAM
     });
 }
 
+// write/read are called directly on the concrete type here (rather than going through the generic
+// core_Algorithm_write/read, which take a cv::Algorithm*): cv::face::Facemark inherits Algorithm
+// virtually, so a raw pointer obtained as FacemarkAAM* cannot be safely reinterpreted as Algorithm*
+// on the managed side without the compiler-generated virtual-base offset adjustment.
+CVAPI(ExceptionStatus) face_FacemarkAAM_write(cv::face::FacemarkAAM *obj, cv::FileStorage *fs)
+{
+    return cvTry([&] {
+        obj->write(*fs);
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkAAM_read(cv::face::FacemarkAAM *obj, cv::FileNode *fn)
+{
+    return cvTry([&] {
+        obj->read(*fn);
+    });
+}
+
 CVAPI(ExceptionStatus) face_FacemarkAAM_fitConfig(
     cv::face::FacemarkAAM *obj,
     const interop::InputArrayProxy *image,
@@ -427,6 +457,20 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_fitConfig(
             configs.emplace_back(rotation, cpp(translations[i]), scales[i], modelScaleIndexes[i]);
         }
         *returnValue = obj->fitConfig(InProxy(*image), InProxy(*roi), *landmarks, configs) ? 1 : 0;
+    });
+}
+
+// Typed wrapper around FacemarkTrain::getData(void*): FacemarkAAM is the only algorithm that
+// populates anything through it (FacemarkAAM::Data{ s0 }); FacemarkLBF's override ignores the
+// pointer entirely and always returns false. Building and reading the Data struct natively here
+// avoids handing callers a raw void* to poke at.
+CVAPI(ExceptionStatus) face_FacemarkAAM_getData(cv::face::FacemarkAAM *obj, std::vector<cv::Point2f> *s0, int *returnValue)
+{
+    return cvTry([&] {
+        cv::face::FacemarkAAM::Data data;
+        *returnValue = obj->getData(&data) ? 1 : 0;
+        if (*returnValue != 0)
+            *s0 = data.s0;
     });
 }
 
@@ -528,6 +572,24 @@ CVAPI(ExceptionStatus) face_Ptr_FacemarkKazemi_delete(
     cv::Ptr<cv::face::FacemarkKazemi> *obj)
 {
     return cvTry([&] { delete obj; });
+}
+
+// write/read are called directly on the concrete type here (rather than going through the generic
+// core_Algorithm_write/read, which take a cv::Algorithm*): cv::face::Facemark inherits Algorithm
+// virtually, so a raw pointer obtained as FacemarkKazemi* cannot be safely reinterpreted as
+// Algorithm* on the managed side without the compiler-generated virtual-base offset adjustment.
+CVAPI(ExceptionStatus) face_FacemarkKazemi_write(cv::face::FacemarkKazemi *obj, cv::FileStorage *fs)
+{
+    return cvTry([&] {
+        obj->write(*fs);
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_read(cv::face::FacemarkKazemi *obj, cv::FileNode *fn)
+{
+    return cvTry([&] {
+        obj->read(*fn);
+    });
 }
 
 CVAPI(ExceptionStatus) face_FacemarkKazemi_training(

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -40,6 +40,142 @@ struct FacemarkAAMParamsData
     int texture_max_m;
 };
 
+struct FacemarkKazemiParamsData
+{
+    uint64_t cascade_depth;
+    uint64_t tree_depth;
+    uint64_t num_trees_per_cascade_level;
+    float learning_rate;
+    uint64_t oversampling_amount;
+    uint64_t num_test_coordinates;
+    float lambda;
+    uint64_t num_test_splits;
+};
+
+typedef int (*FacemarkFaceDetectorCallback)(cv::Mat *image, interop::Rect *faces, int capacity);
+
+struct FacemarkFaceDetectorCallbackData
+{
+    FacemarkFaceDetectorCallback callback;
+};
+
+static bool face_Facemark_faceDetectorThunk(
+    cv::InputArray image, cv::OutputArray faces, void *userData)
+{
+    const auto data = static_cast<FacemarkFaceDetectorCallbackData *>(userData);
+    if (data == nullptr || data->callback == nullptr)
+        return false;
+    auto imageMat = image.getMat();
+    const auto count = data->callback(&imageMat, nullptr, 0);
+    if (count < 0)
+        return false;
+    if (count == 0)
+    {
+        faces.release();
+        return true;
+    }
+    std::vector<interop::Rect> interopFaces(count);
+    const auto written = data->callback(&imageMat, interopFaces.data(), count);
+    if (written != count)
+        return false;
+    std::vector<cv::Rect> nativeFaces(count);
+    for (auto i = 0; i < count; i++)
+        nativeFaces[i] = cpp(interopFaces[i]);
+    cv::Mat(nativeFaces).copyTo(faces);
+    return true;
+}
+
+CVAPI(ExceptionStatus) face_FacemarkFaceDetectorCallbackData_delete(
+    FacemarkFaceDetectorCallbackData *data)
+{
+    return cvTry([&] { delete data; });
+}
+
+#pragma region Utilities
+
+CVAPI(ExceptionStatus) face_getFacesHAAR(
+    const interop::InputArrayProxy *image,
+    const interop::OutputArrayProxy *faces,
+    const char *cascadeName,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::getFacesHAAR(InProxy(*image), OutProxy(*faces), cascadeName) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_loadDatasetList(
+    const char *imageList,
+    const char *annotationList,
+    std::vector<std::string> *images,
+    std::vector<std::string> *annotations,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::loadDatasetList(imageList, annotationList, *images, *annotations) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_loadTrainingData1(
+    const char *filename,
+    std::vector<std::string> *images,
+    std::vector<std::vector<cv::Point2f>> *facePoints,
+    const char delim,
+    const float offset,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::loadTrainingData(filename, *images, *facePoints, delim, offset) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_loadTrainingData2(
+    const char *imageList,
+    const char *groundTruth,
+    std::vector<std::string> *images,
+    std::vector<std::vector<cv::Point2f>> *facePoints,
+    const float offset,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::loadTrainingData(imageList, groundTruth, *images, *facePoints, offset) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_loadTrainingData3(
+    std::vector<std::string> *filenames,
+    std::vector<std::vector<cv::Point2f>> *landmarks,
+    std::vector<std::string> *images,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::loadTrainingData(*filenames, *landmarks, *images) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_loadFacePoints(
+    const char *filename,
+    std::vector<cv::Point2f> *points,
+    const float offset,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::face::loadFacePoints(filename, *points, offset) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_drawFacemarks(
+    const interop::InputOutputArrayProxy *image,
+    const interop::InputArrayProxy *points,
+    const interop::Scalar color)
+{
+    return cvTry([&] {
+        cv::face::drawFacemarks(IoProxy(*image), InProxy(*points), cpp(color));
+    });
+}
+
+#pragma endregion
+
 #pragma region Facemark
 
 CVAPI(ExceptionStatus) face_Facemark_loadModel(cv::face::Facemark *obj, const char *model)
@@ -58,6 +194,63 @@ CVAPI(ExceptionStatus) face_Facemark_fit(
 {
     return cvTry([&] {
         *returnValue = obj->fit(InProxy(*image), InProxy(*faces), *landmarks) ? 1 : 0;
+    });
+}
+
+#pragma endregion
+
+#pragma region FacemarkTrain
+
+CVAPI(ExceptionStatus) face_FacemarkTrain_addTrainingSample(
+    cv::face::FacemarkTrain *obj,
+    const interop::InputArrayProxy *image,
+    const interop::InputArrayProxy *landmarks,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->addTrainingSample(InProxy(*image), InProxy(*landmarks)) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkTrain_training(cv::face::FacemarkTrain *obj)
+{
+    return cvTry([&] { obj->training(); });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkTrain_getFaces(
+    cv::face::FacemarkTrain *obj,
+    const interop::InputArrayProxy *image,
+    std::vector<cv::Rect> *faces,
+    int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getFaces(InProxy(*image), *faces) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkTrain_getData(
+    cv::face::FacemarkTrain *obj, void *items, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getData(items) ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkTrain_setFaceDetector(
+    cv::face::FacemarkTrain *obj,
+    const FacemarkFaceDetectorCallback callback,
+    FacemarkFaceDetectorCallbackData **callbackData,
+    int *returnValue)
+{
+    return cvTry([&] {
+        const auto data = new FacemarkFaceDetectorCallbackData { callback };
+        if (!obj->setFaceDetector(face_Facemark_faceDetectorThunk, data))
+        {
+            delete data;
+            *callbackData = nullptr;
+            *returnValue = 0;
+            return;
+        }
+        *callbackData = data;
+        *returnValue = 1;
     });
 }
 
@@ -211,6 +404,32 @@ CVAPI(ExceptionStatus) face_Ptr_FacemarkAAM_delete(cv::Ptr<cv::face::FacemarkAAM
     });
 }
 
+CVAPI(ExceptionStatus) face_FacemarkAAM_fitConfig(
+    cv::face::FacemarkAAM *obj,
+    const interop::InputArrayProxy *image,
+    const interop::InputArrayProxy *roi,
+    std::vector<std::vector<cv::Point2f>> *landmarks,
+    cv::Mat **rotations,
+    const interop::Point2f *translations,
+    const float *scales,
+    const int *modelScaleIndexes,
+    const int configLength,
+    int *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::face::FacemarkAAM::Config> configs;
+        configs.reserve(configLength);
+        for (auto i = 0; i < configLength; i++)
+        {
+            const auto rotation = rotations[i] == nullptr
+                ? cv::Mat::eye(2, 2, CV_32F)
+                : *rotations[i];
+            configs.emplace_back(rotation, cpp(translations[i]), scales[i], modelScaleIndexes[i]);
+        }
+        *returnValue = obj->fitConfig(InProxy(*image), InProxy(*roi), *landmarks, configs) ? 1 : 0;
+    });
+}
+
 #pragma region Params
 
 CVAPI(ExceptionStatus) face_FacemarkAAM_Params_new(cv::face::FacemarkAAM::Params **returnValue)
@@ -283,6 +502,138 @@ CVAPI(ExceptionStatus) face_FacemarkAAM_Params_write(cv::face::FacemarkAAM::Para
 }
 
 #pragma endregion
+#pragma endregion
+
+#pragma region FacemarkKazemi
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_create(
+    cv::face::FacemarkKazemi::Params *params,
+    cv::Ptr<cv::face::FacemarkKazemi> **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = clone(params == nullptr
+            ? cv::face::FacemarkKazemi::create()
+            : cv::face::FacemarkKazemi::create(*params));
+    });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_FacemarkKazemi_get(
+    cv::Ptr<cv::face::FacemarkKazemi> *obj,
+    cv::face::FacemarkKazemi **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) face_Ptr_FacemarkKazemi_delete(
+    cv::Ptr<cv::face::FacemarkKazemi> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_training(
+    cv::face::FacemarkKazemi *obj,
+    cv::Mat **images,
+    const int imagesLength,
+    cv::Point2f **landmarks,
+    const int *landmarkSizes,
+    const int landmarksLength,
+    const char *configFile,
+    const interop::Size scale,
+    const char *modelFilename,
+    int *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imageVector(imagesLength);
+        for (auto i = 0; i < imagesLength; i++)
+            imageVector[i] = *images[i];
+        std::vector<std::vector<cv::Point2f>> landmarkVector(landmarksLength);
+        for (auto i = 0; i < landmarksLength; i++)
+        {
+            if (landmarkSizes[i] > 0)
+                landmarkVector[i].assign(landmarks[i], landmarks[i] + landmarkSizes[i]);
+        }
+        *returnValue = obj->training(
+            imageVector, landmarkVector, configFile, cpp(scale), modelFilename) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_getFaces(
+    cv::face::FacemarkKazemi *obj,
+    const interop::InputArrayProxy *image,
+    std::vector<cv::Rect> *faces,
+    int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getFaces(InProxy(*image), *faces) ? 1 : 0; });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_setFaceDetector(
+    cv::face::FacemarkKazemi *obj,
+    const FacemarkFaceDetectorCallback callback,
+    FacemarkFaceDetectorCallbackData **callbackData,
+    int *returnValue)
+{
+    return cvTry([&] {
+        const auto data = new FacemarkFaceDetectorCallbackData { callback };
+        if (!obj->setFaceDetector(face_Facemark_faceDetectorThunk, data))
+        {
+            delete data;
+            *callbackData = nullptr;
+            *returnValue = 0;
+            return;
+        }
+        *callbackData = data;
+        *returnValue = 1;
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_Params_new(
+    cv::face::FacemarkKazemi::Params **returnValue)
+{
+    return cvTry([&] { *returnValue = new cv::face::FacemarkKazemi::Params; });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_Params_delete(
+    cv::face::FacemarkKazemi::Params *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_Params_getAll(
+    cv::face::FacemarkKazemi::Params *obj,
+    FacemarkKazemiParamsData *data,
+    std::string *configFile)
+{
+    return cvTry([&] {
+        data->cascade_depth = obj->cascade_depth;
+        data->tree_depth = obj->tree_depth;
+        data->num_trees_per_cascade_level = obj->num_trees_per_cascade_level;
+        data->learning_rate = obj->learning_rate;
+        data->oversampling_amount = obj->oversampling_amount;
+        data->num_test_coordinates = obj->num_test_coordinates;
+        data->lambda = obj->lambda;
+        data->num_test_splits = obj->num_test_splits;
+        configFile->assign(obj->configfile);
+    });
+}
+
+CVAPI(ExceptionStatus) face_FacemarkKazemi_Params_setAll(
+    cv::face::FacemarkKazemi::Params *obj,
+    const FacemarkKazemiParamsData data,
+    const char *configFile)
+{
+    return cvTry([&] {
+        obj->cascade_depth = static_cast<unsigned long>(data.cascade_depth);
+        obj->tree_depth = static_cast<unsigned long>(data.tree_depth);
+        obj->num_trees_per_cascade_level = static_cast<unsigned long>(data.num_trees_per_cascade_level);
+        obj->learning_rate = data.learning_rate;
+        obj->oversampling_amount = static_cast<unsigned long>(data.oversampling_amount);
+        obj->num_test_coordinates = static_cast<unsigned long>(data.num_test_coordinates);
+        obj->lambda = data.lambda;
+        obj->num_test_splits = static_cast<unsigned long>(data.num_test_splits);
+        obj->configfile = configFile;
+    });
+}
+
 #pragma endregion
 
 #endif // !_WINRT_DLL

--- a/src/OpenCvSharpExtern/img_hash.h
+++ b/src/OpenCvSharpExtern/img_hash.h
@@ -31,6 +31,68 @@ CVAPI(ExceptionStatus) img_hash_ImgHashBase_compare(
 }
 
 
+// One-shot convenience functions
+
+CVAPI(ExceptionStatus) img_hash_averageHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr)
+{
+    return cvTry([&] {
+        cv::img_hash::averageHash(InProxy(*inputArr), OutProxy(*outputArr));
+    });
+}
+
+CVAPI(ExceptionStatus) img_hash_blockMeanHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr,
+    const int mode)
+{
+    return cvTry([&] {
+        cv::img_hash::blockMeanHash(InProxy(*inputArr), OutProxy(*outputArr), mode);
+    });
+}
+
+CVAPI(ExceptionStatus) img_hash_colorMomentHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr)
+{
+    return cvTry([&] {
+        cv::img_hash::colorMomentHash(InProxy(*inputArr), OutProxy(*outputArr));
+    });
+}
+
+CVAPI(ExceptionStatus) img_hash_marrHildrethHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr,
+    const float alpha,
+    const float scale)
+{
+    return cvTry([&] {
+        cv::img_hash::marrHildrethHash(InProxy(*inputArr), OutProxy(*outputArr), alpha, scale);
+    });
+}
+
+CVAPI(ExceptionStatus) img_hash_pHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr)
+{
+    return cvTry([&] {
+        cv::img_hash::pHash(InProxy(*inputArr), OutProxy(*outputArr));
+    });
+}
+
+CVAPI(ExceptionStatus) img_hash_radialVarianceHash(
+    const interop::InputArrayProxy* inputArr,
+    const interop::OutputArrayProxy* outputArr,
+    const double sigma,
+    const int numOfAngleLine)
+{
+    return cvTry([&] {
+        cv::img_hash::radialVarianceHash(InProxy(*inputArr), OutProxy(*outputArr), sigma, numOfAngleLine);
+    });
+}
+
+
 // AverageHash
 
 CVAPI(ExceptionStatus) img_hash_AverageHash_create(cv::Ptr<cv::img_hash::AverageHash> **returnValue)

--- a/src/OpenCvSharpExtern/line_descriptor.h
+++ b/src/OpenCvSharpExtern/line_descriptor.h
@@ -8,6 +8,18 @@
 
 #include "include_opencv.h"
 
+struct BinaryDescriptorParamsData
+{
+    int numOfOctaves;
+    int widthOfBand;
+    int reductionRatio;
+    int ksize;
+};
+
+// BinaryDescriptor::EDLineDetector and EDLineParam are private nested implementation details in
+// OpenCV's descriptor.hpp. They cannot be named by C++ callers and therefore are intentionally not
+// part of the public OpenCvSharp surface.
+
 
 CVAPI(ExceptionStatus) line_descriptor_LSDDetector_new1(
     cv::line_descriptor::LSDDetector** returnValue)
@@ -82,5 +94,364 @@ CVAPI(ExceptionStatus) line_descriptor_LSDDetector_detect2(
 
     });
 }
+
+#pragma region BinaryDescriptor
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_create(
+    cv::line_descriptor::BinaryDescriptor::Params *params,
+    cv::Ptr<cv::line_descriptor::BinaryDescriptor> **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = clone(params == nullptr
+            ? cv::line_descriptor::BinaryDescriptor::createBinaryDescriptor()
+            : cv::line_descriptor::BinaryDescriptor::createBinaryDescriptor(*params));
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_Ptr_BinaryDescriptor_get(
+    cv::Ptr<cv::line_descriptor::BinaryDescriptor> *obj,
+    cv::line_descriptor::BinaryDescriptor **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_Ptr_BinaryDescriptor_delete(
+    cv::Ptr<cv::line_descriptor::BinaryDescriptor> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_getNumOfOctaves(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getNumOfOctaves(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_setNumOfOctaves(
+    cv::line_descriptor::BinaryDescriptor *obj, const int value)
+{
+    return cvTry([&] { obj->setNumOfOctaves(value); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_getWidthOfBand(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getWidthOfBand(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_setWidthOfBand(
+    cv::line_descriptor::BinaryDescriptor *obj, const int value)
+{
+    return cvTry([&] { obj->setWidthOfBand(value); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_getReductionRatio(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->getReductionRatio(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_setReductionRatio(
+    cv::line_descriptor::BinaryDescriptor *obj, const int value)
+{
+    return cvTry([&] { obj->setReductionRatio(value); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_detect1(
+    cv::line_descriptor::BinaryDescriptor *obj,
+    cv::Mat *image,
+    std::vector<cv::line_descriptor::KeyLine> *keyLines,
+    cv::Mat *mask)
+{
+    return cvTry([&] { obj->detect(*image, *keyLines, entity(mask)); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_detect2(
+    cv::line_descriptor::BinaryDescriptor *obj,
+    cv::Mat **images,
+    const int imagesLength,
+    std::vector<std::vector<cv::line_descriptor::KeyLine>> *keyLines,
+    cv::Mat **masks,
+    const int masksLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imageVector(imagesLength);
+        for (auto i = 0; i < imagesLength; i++)
+            imageVector[i] = *images[i];
+        std::vector<cv::Mat> maskVector(imagesLength);
+        for (auto i = 0; i < masksLength; i++)
+            maskVector[i] = *masks[i];
+        keyLines->resize(imagesLength);
+        obj->detect(imageVector, *keyLines, maskVector);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_compute1(
+    cv::line_descriptor::BinaryDescriptor *obj,
+    cv::Mat *image,
+    std::vector<cv::line_descriptor::KeyLine> *keyLines,
+    cv::Mat *descriptors,
+    const int returnFloatDescriptor)
+{
+    return cvTry([&] {
+        obj->compute(*image, *keyLines, *descriptors, returnFloatDescriptor != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_compute2(
+    cv::line_descriptor::BinaryDescriptor *obj,
+    cv::Mat **images,
+    const int imagesLength,
+    cv::line_descriptor::KeyLine **keyLines,
+    const int *keyLineSizes,
+    const int keyLinesLength,
+    std::vector<std::vector<cv::line_descriptor::KeyLine>> *outputKeyLines,
+    std::vector<cv::Mat> *descriptors,
+    const int returnFloatDescriptor)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> imageVector(imagesLength);
+        for (auto i = 0; i < imagesLength; i++)
+            imageVector[i] = *images[i];
+        std::vector<std::vector<cv::line_descriptor::KeyLine>> keyLineVector(keyLinesLength);
+        for (auto i = 0; i < keyLinesLength; i++)
+        {
+            if (keyLineSizes[i] > 0)
+                keyLineVector[i].assign(keyLines[i], keyLines[i] + keyLineSizes[i]);
+        }
+        descriptors->resize(imagesLength);
+        obj->compute(imageVector, keyLineVector, *descriptors, returnFloatDescriptor != 0);
+        *outputKeyLines = std::move(keyLineVector);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_descriptorSize(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->descriptorSize(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_descriptorType(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->descriptorType(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_defaultNorm(
+    cv::line_descriptor::BinaryDescriptor *obj, int *returnValue)
+{
+    return cvTry([&] { *returnValue = obj->defaultNorm(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_new(
+    cv::line_descriptor::BinaryDescriptor::Params **returnValue)
+{
+    return cvTry([&] { *returnValue = new cv::line_descriptor::BinaryDescriptor::Params; });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_delete(
+    cv::line_descriptor::BinaryDescriptor::Params *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_getAll(
+    cv::line_descriptor::BinaryDescriptor::Params *obj,
+    BinaryDescriptorParamsData *data)
+{
+    return cvTry([&] {
+        data->numOfOctaves = obj->numOfOctave_;
+        data->widthOfBand = obj->widthOfBand_;
+        data->reductionRatio = obj->reductionRatio;
+        data->ksize = obj->ksize_;
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_setAll(
+    cv::line_descriptor::BinaryDescriptor::Params *obj,
+    const BinaryDescriptorParamsData data)
+{
+    return cvTry([&] {
+        obj->numOfOctave_ = data.numOfOctaves;
+        obj->widthOfBand_ = data.widthOfBand;
+        obj->reductionRatio = data.reductionRatio;
+        obj->ksize_ = data.ksize;
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_read(
+    cv::line_descriptor::BinaryDescriptor::Params *obj, cv::FileNode *node)
+{
+    return cvTry([&] { obj->read(*node); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptor_Params_write(
+    cv::line_descriptor::BinaryDescriptor::Params *obj, cv::FileStorage *storage)
+{
+    return cvTry([&] { obj->write(*storage); });
+}
+
+#pragma endregion
+
+#pragma region BinaryDescriptorMatcher
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_create(
+    cv::Ptr<cv::line_descriptor::BinaryDescriptorMatcher> **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = clone(cv::line_descriptor::BinaryDescriptorMatcher::createBinaryDescriptorMatcher());
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_Ptr_BinaryDescriptorMatcher_get(
+    cv::Ptr<cv::line_descriptor::BinaryDescriptorMatcher> *obj,
+    cv::line_descriptor::BinaryDescriptorMatcher **returnValue)
+{
+    return cvTry([&] { *returnValue = obj->get(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_Ptr_BinaryDescriptorMatcher_delete(
+    cv::Ptr<cv::line_descriptor::BinaryDescriptorMatcher> *obj)
+{
+    return cvTry([&] { delete obj; });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_match(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj,
+    cv::Mat *query,
+    cv::Mat *train,
+    std::vector<cv::DMatch> *matches,
+    cv::Mat *mask)
+{
+    return cvTry([&] { obj->match(*query, *train, *matches, entity(mask)); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_matchQuery(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj,
+    cv::Mat *query,
+    std::vector<cv::DMatch> *matches,
+    cv::Mat **masks,
+    const int masksLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> maskVector(masksLength);
+        for (auto i = 0; i < masksLength; i++)
+            maskVector[i] = *masks[i];
+        obj->match(*query, *matches, maskVector);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_knnMatch(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj,
+    cv::Mat *query,
+    cv::Mat *train,
+    std::vector<std::vector<cv::DMatch>> *matches,
+    const int k,
+    cv::Mat *mask,
+    const int compactResult)
+{
+    return cvTry([&] {
+        obj->knnMatch(*query, *train, *matches, k, entity(mask), compactResult != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_knnMatchQuery(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj,
+    cv::Mat *query,
+    std::vector<std::vector<cv::DMatch>> *matches,
+    const int k,
+    cv::Mat **masks,
+    const int masksLength,
+    const int compactResult)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> maskVector(masksLength);
+        for (auto i = 0; i < masksLength; i++)
+            maskVector[i] = *masks[i];
+        obj->knnMatch(*query, *matches, k, maskVector, compactResult != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_add(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj,
+    cv::Mat **descriptors,
+    const int descriptorsLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> descriptorVector(descriptorsLength);
+        for (auto i = 0; i < descriptorsLength; i++)
+            descriptorVector[i] = *descriptors[i];
+        obj->add(descriptorVector);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_train(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj)
+{
+    return cvTry([&] { obj->train(); });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_BinaryDescriptorMatcher_clear(
+    cv::line_descriptor::BinaryDescriptorMatcher *obj)
+{
+    return cvTry([&] { obj->clear(); });
+}
+
+#pragma endregion
+
+#pragma region Drawing
+
+CVAPI(ExceptionStatus) line_descriptor_drawLineMatches(
+    cv::Mat *image1,
+    cv::line_descriptor::KeyLine *keyLines1,
+    const int keyLines1Length,
+    cv::Mat *image2,
+    cv::line_descriptor::KeyLine *keyLines2,
+    const int keyLines2Length,
+    cv::DMatch *matches,
+    const int matchesLength,
+    cv::Mat *output,
+    const interop::Scalar matchColor,
+    const interop::Scalar singleLineColor,
+    char *matchesMask,
+    const int matchesMaskLength,
+    const int flags)
+{
+    return cvTry([&] {
+        std::vector<cv::line_descriptor::KeyLine> keyLineVector1;
+        std::vector<cv::line_descriptor::KeyLine> keyLineVector2;
+        std::vector<cv::DMatch> matchVector;
+        std::vector<char> maskVector;
+        if (keyLines1Length > 0)
+            keyLineVector1.assign(keyLines1, keyLines1 + keyLines1Length);
+        if (keyLines2Length > 0)
+            keyLineVector2.assign(keyLines2, keyLines2 + keyLines2Length);
+        if (matchesLength > 0)
+            matchVector.assign(matches, matches + matchesLength);
+        if (matchesMaskLength > 0)
+            maskVector.assign(matchesMask, matchesMask + matchesMaskLength);
+        cv::line_descriptor::drawLineMatches(
+            *image1, keyLineVector1, *image2, keyLineVector2, matchVector, *output,
+            cpp(matchColor), cpp(singleLineColor), maskVector, flags);
+    });
+}
+
+CVAPI(ExceptionStatus) line_descriptor_drawKeylines(
+    cv::Mat *image,
+    cv::line_descriptor::KeyLine *keyLines,
+    const int keyLinesLength,
+    cv::Mat *output,
+    const interop::Scalar color,
+    const int flags)
+{
+    return cvTry([&] {
+        std::vector<cv::line_descriptor::KeyLine> keyLineVector;
+        if (keyLinesLength > 0)
+            keyLineVector.assign(keyLines, keyLines + keyLinesLength);
+        cv::line_descriptor::drawKeylines(*image, keyLineVector, *output, cpp(color), flags);
+    });
+}
+
+#pragma endregion
 
 #endif // NO_CONTRIB

--- a/src/OpenCvSharpExtern/std_vector.h
+++ b/src/OpenCvSharpExtern/std_vector.h
@@ -285,6 +285,14 @@ CVAPI(std::vector<cv::line_descriptor::KeyLine>*) vector_KeyLine_new1()
     return new std::vector<cv::line_descriptor::KeyLine>;
 }
 
+CVAPI(std::vector<cv::line_descriptor::KeyLine>*) vector_KeyLine_new2(
+    cv::line_descriptor::KeyLine* data, size_t length)
+{
+    if (length == 0)
+        return new std::vector<cv::line_descriptor::KeyLine>;
+    return new std::vector<cv::line_descriptor::KeyLine>(data, data + length);
+}
+
 CVAPI(size_t) vector_KeyLine_getSize(std::vector<cv::line_descriptor::KeyLine>* vector)
 {
     return vector->size();

--- a/test/OpenCvSharp.Tests/face/BIFTest.cs
+++ b/test/OpenCvSharp.Tests/face/BIFTest.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Face;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Face;
+
+// ReSharper disable once InconsistentNaming
+public class BIFTest
+{
+    [Fact]
+    public void CreateAndCompute()
+    {
+        using var bif = BIF.Create(4, 6);
+        using var image = new Mat(64, 64, MatType.CV_32FC1, Scalar.All(0.5));
+        using var features = new Mat();
+
+        bif.Compute(image, features);
+
+        Assert.Equal(4, bif.NumBands);
+        Assert.Equal(6, bif.NumRotations);
+        Assert.False(features.Empty());
+        Assert.Equal(MatType.CV_32FC1, features.Type());
+    }
+}

--- a/test/OpenCvSharp.Tests/face/FaceUtilitiesTest.cs
+++ b/test/OpenCvSharp.Tests/face/FaceUtilitiesTest.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Face;
+
+public class FaceUtilitiesTest : TestBase
+{
+    [Fact]
+    public void LoadFacePointsAndDrawFacemarks()
+    {
+        var file = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(file, "version: 1\nn_points: 2\n{\n10 12\n20 24\n}\n");
+
+            var loaded = Cv2.Face.LoadFacePoints(file, out var points);
+
+            Assert.True(loaded);
+            Assert.Equal([new Point2f(10, 12), new Point2f(20, 24)], points);
+            using var image = new Mat(40, 40, MatType.CV_8UC3, Scalar.Black);
+            using var pointsMat = Mat.FromPixelData(points.Length, 1, MatType.CV_32FC2, points);
+            Cv2.Face.DrawFacemarks(image, pointsMat, Scalar.Red);
+            Assert.NotEqual(0, Cv2.CountNonZero(image.Reshape(1)));
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void LoadDatasetList()
+    {
+        var imagesFile = Path.GetTempFileName();
+        var annotationsFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllLines(imagesFile, ["image-a.png", "image-b.png"]);
+            File.WriteAllLines(annotationsFile, ["face-a.pts", "face-b.pts"]);
+
+            var loaded = Cv2.Face.LoadDatasetList(
+                imagesFile, annotationsFile, out var images, out var annotations);
+
+            Assert.True(loaded);
+            Assert.Equal(["image-a.png", "image-b.png"], images);
+            Assert.Equal(["face-a.pts", "face-b.pts"], annotations);
+        }
+        finally
+        {
+            File.Delete(imagesFile);
+            File.Delete(annotationsFile);
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
@@ -191,7 +191,7 @@ public class FacemarkAAMTest : TestBase
         // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
         using var facemark = FacemarkAAM.Create();
 
-        var fileName = Path.Combine(Path.GetTempPath(), "facemark_aam_test.yml");
+        var fileName = Path.Combine(Path.GetTempPath(), $"facemark_aam_test_{Guid.NewGuid():N}.yml");
         try
         {
             using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))

--- a/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using OpenCvSharp.Face;
 using Xunit;
 
@@ -167,6 +168,47 @@ public class FacemarkAAMTest : TestBase
             Assert.True(parameter.Verbose);
             parameter.Verbose = false;
             Assert.False(parameter.Verbose);
+        }
+    }
+
+    [Fact]
+    public void GetData_ReturnsMeanShape()
+    {
+        // FacemarkAAMImpl::getData() unconditionally returns true and copies whatever mean shape
+        // the model currently holds (empty before training) - this proves the typed
+        // FacemarkAAM::Data(&data) marshaling reaches native and copies s0 back without crashing.
+        using var facemark = FacemarkAAM.Create();
+        var result = facemark.GetData(out var s0);
+        Assert.True(result);
+        Assert.NotNull(s0);
+    }
+
+    [Fact]
+    public void ReadWrite()
+    {
+        // cv::face::Facemark inherits Algorithm virtually; this exercises the P/Invoke plumbing
+        // that keeps the native pointer at its concrete type across the write/read call, rather
+        // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
+        using var facemark = FacemarkAAM.Create();
+
+        var fileName = Path.Combine(Path.GetTempPath(), "facemark_aam_test.yml");
+        try
+        {
+            using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+            {
+                fs.Write("marker", 1);
+                facemark.Write(fs);
+            }
+
+            using var fs2 = new FileStorage(fileName, FileStorage.Modes.Read);
+            var root = fs2.Root();
+            Assert.NotNull(root);
+            facemark.Read(root);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+                File.Delete(fileName);
         }
     }
 }

--- a/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkAAMTest.cs
@@ -44,6 +44,17 @@ public class FacemarkAAMTest : TestBase
         Assert.NotEmpty(parameter.Scales);
     }
 
+    [Fact]
+    public void FitConfigDefaults()
+    {
+        var config = new FacemarkAAM.Config();
+
+        Assert.Null(config.Rotation);
+        Assert.Equal(default, config.Translation);
+        Assert.Equal(1.0f, config.Scale);
+        Assert.Equal(0, config.ModelScaleIndex);
+    }
+
     /*
     /// <summary>
     /// https://docs.opencv.org/trunk/d5/dd8/tutorial_facemark_aam.html

--- a/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
@@ -26,7 +26,7 @@ public class FacemarkKazemiTest
         // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
         using var model = FacemarkKazemi.Create();
 
-        var fileName = Path.Combine(Path.GetTempPath(), "facemark_kazemi_test.yml");
+        var fileName = Path.Combine(Path.GetTempPath(), $"facemark_kazemi_test_{Guid.NewGuid():N}.yml");
         try
         {
             using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))

--- a/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
@@ -1,0 +1,33 @@
+using OpenCvSharp.Face;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Face;
+
+public class FacemarkKazemiTest
+{
+    [Fact]
+    public void CreateWithDefaultAndCustomParameters()
+    {
+        var parameters = new FacemarkKazemi.Params();
+        Assert.True(parameters.CascadeDepth > 0);
+        Assert.True(parameters.TreeDepth > 0);
+        Assert.True(parameters.NumTreesPerCascadeLevel > 0);
+
+        using var defaultModel = FacemarkKazemi.Create();
+        using var customModel = FacemarkKazemi.Create(parameters);
+    }
+
+    [Fact]
+    public void CustomFaceDetectorIsInvoked()
+    {
+        using var model = FacemarkKazemi.Create();
+        using var image = new Mat(32, 32, MatType.CV_8UC1, Scalar.Black);
+        Rect expected = new(4, 5, 20, 18);
+        model.SetFaceDetector(_ => [expected]);
+
+        var result = model.GetFaces(image, out var faces);
+
+        Assert.True(result);
+        Assert.Equal([expected], faces);
+    }
+}

--- a/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkKazemiTest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using OpenCvSharp.Face;
 using Xunit;
 
@@ -15,6 +16,35 @@ public class FacemarkKazemiTest
 
         using var defaultModel = FacemarkKazemi.Create();
         using var customModel = FacemarkKazemi.Create(parameters);
+    }
+
+    [Fact]
+    public void ReadWrite()
+    {
+        // cv::face::Facemark inherits Algorithm virtually; this exercises the P/Invoke plumbing
+        // that keeps the native pointer at its concrete type across the write/read call, rather
+        // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
+        using var model = FacemarkKazemi.Create();
+
+        var fileName = Path.Combine(Path.GetTempPath(), "facemark_kazemi_test.yml");
+        try
+        {
+            using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+            {
+                fs.Write("marker", 1);
+                model.Write(fs);
+            }
+
+            using var fs2 = new FileStorage(fileName, FileStorage.Modes.Read);
+            var root = fs2.Root();
+            Assert.NotNull(root);
+            model.Read(root);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+        }
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using OpenCvSharp.Face;
 using Xunit;
 
@@ -14,6 +15,35 @@ public class FacemarkLBFTest : TestBase
         using (var facemark = FacemarkLBF.Create())
         {
             GC.KeepAlive(facemark);
+        }
+    }
+
+    [Fact]
+    public void ReadWrite()
+    {
+        // cv::face::Facemark inherits Algorithm virtually; this exercises the P/Invoke plumbing
+        // that keeps the native pointer at its concrete type across the write/read call, rather
+        // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
+        using var facemark = FacemarkLBF.Create();
+
+        var fileName = Path.Combine(Path.GetTempPath(), "facemark_lbf_test.yml");
+        try
+        {
+            using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))
+            {
+                fs.Write("marker", 1);
+                facemark.Write(fs);
+            }
+
+            using var fs2 = new FileStorage(fileName, FileStorage.Modes.Read);
+            var root = fs2.Root();
+            Assert.NotNull(root);
+            facemark.Read(root);
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+                File.Delete(fileName);
         }
     }
 

--- a/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
+++ b/test/OpenCvSharp.Tests/face/FacemarkLBFTest.cs
@@ -26,7 +26,7 @@ public class FacemarkLBFTest : TestBase
         // than reinterpreting it as cv::Algorithm* (which would corrupt memory).
         using var facemark = FacemarkLBF.Create();
 
-        var fileName = Path.Combine(Path.GetTempPath(), "facemark_lbf_test.yml");
+        var fileName = Path.Combine(Path.GetTempPath(), $"facemark_lbf_test_{Guid.NewGuid():N}.yml");
         try
         {
             using (var fs = new FileStorage(fileName, FileStorage.Modes.Write))

--- a/test/OpenCvSharp.Tests/face/LBPHFaceRecognizerTest.cs
+++ b/test/OpenCvSharp.Tests/face/LBPHFaceRecognizerTest.cs
@@ -46,6 +46,11 @@ public class LBPHFaceRecognizerTest : TestBase
                 Assert.NotEqual(0, confidence, 9);
 
                 Assert.Equal(1, model.Predict(face));
+
+                using var collector = StandardCollector.Create();
+                model.Predict(face, collector);
+                Assert.Equal(1, collector.MinLabel);
+                Assert.NotEmpty(collector.GetResults());
             }
         }
     }

--- a/test/OpenCvSharp.Tests/face/MACETest.cs
+++ b/test/OpenCvSharp.Tests/face/MACETest.cs
@@ -1,0 +1,29 @@
+using OpenCvSharp.Face;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Face;
+
+// ReSharper disable once InconsistentNaming
+public class MACETest
+{
+    [Fact]
+    public void TrainAndRecognizeTrainingImage()
+    {
+        using var first = CreateImage(10);
+        using var second = CreateImage(20);
+        using var model = MACE.Create(64);
+        model.Salt("test-passphrase");
+
+        model.Train([first, second]);
+
+        Assert.True(model.Same(first));
+    }
+
+    private static Mat CreateImage(int offset)
+    {
+        var image = new Mat(64, 64, MatType.CV_8UC1, Scalar.Black);
+        Cv2.Circle(image, new Point(32 + offset / 10, 32), 16, Scalar.White, -1);
+        Cv2.Line(image, new Point(12, 12 + offset), new Point(52, 52), Scalar.Gray, 2);
+        return image;
+    }
+}

--- a/test/OpenCvSharp.Tests/face/StandardCollectorTest.cs
+++ b/test/OpenCvSharp.Tests/face/StandardCollectorTest.cs
@@ -1,0 +1,31 @@
+using OpenCvSharp.Face;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Face;
+
+public class StandardCollectorTest
+{
+    [Fact]
+    public void CreateHasEmptyResult()
+    {
+        using var collector = StandardCollector.Create();
+
+        Assert.Equal(-1, collector.MinLabel);
+        Assert.Equal(double.MaxValue, collector.MinDistance);
+        Assert.Empty(collector.GetResults());
+        Assert.Empty(collector.GetResultsMap());
+    }
+
+    [Fact]
+    public void InitAndCollectAreExposed()
+    {
+        using var collector = StandardCollector.Create();
+
+        collector.Init(2);
+        Assert.True(collector.Collect(4, 2.5));
+        Assert.True(collector.Collect(8, 1.25));
+
+        Assert.Equal(8, collector.MinLabel);
+        Assert.Equal(1.25, collector.MinDistance);
+    }
+}

--- a/test/OpenCvSharp.Tests/img_hash/ImgHashFunctionsTest.cs
+++ b/test/OpenCvSharp.Tests/img_hash/ImgHashFunctionsTest.cs
@@ -1,0 +1,54 @@
+using OpenCvSharp.ImgHash;
+using Xunit;
+
+namespace OpenCvSharp.Tests.ImgHash;
+
+public class ImgHashFunctionsTest : TestBase
+{
+    [Theory]
+    [InlineData("average")]
+    [InlineData("blockMean")]
+    [InlineData("colorMoment")]
+    [InlineData("marrHildreth")]
+    [InlineData("pHash")]
+    [InlineData("radialVariance")]
+    public void MatchesAlgorithmCompute(string algorithmName)
+    {
+        using var image = LoadImage("lenna.png");
+        using var expected = new Mat();
+        using var actual = new Mat();
+        using var algorithm = CreateAlgorithm(algorithmName);
+
+        algorithm.Compute(image, expected);
+        ComputeOneShot(algorithmName, image, actual);
+
+        using var mismatch = new Mat();
+        Cv2.Compare(expected, actual, mismatch, CmpTypes.NE);
+        Assert.Equal(0, Cv2.CountNonZero(mismatch.Reshape(1)));
+    }
+
+    private static ImgHashBase CreateAlgorithm(string name) => name switch
+    {
+        "average" => AverageHash.Create(),
+        "blockMean" => BlockMeanHash.Create(),
+        "colorMoment" => ColorMomentHash.Create(),
+        "marrHildreth" => MarrHildrethHash.Create(),
+        "pHash" => PHash.Create(),
+        "radialVariance" => RadialVarianceHash.Create(),
+        _ => throw new ArgumentOutOfRangeException(nameof(name)),
+    };
+
+    private static void ComputeOneShot(string name, Mat image, Mat output)
+    {
+        switch (name)
+        {
+            case "average": Cv2.ImgHash.AverageHash(image, output); break;
+            case "blockMean": Cv2.ImgHash.BlockMeanHash(image, output); break;
+            case "colorMoment": Cv2.ImgHash.ColorMomentHash(image, output); break;
+            case "marrHildreth": Cv2.ImgHash.MarrHildrethHash(image, output); break;
+            case "pHash": Cv2.ImgHash.PHash(image, output); break;
+            case "radialVariance": Cv2.ImgHash.RadialVarianceHash(image, output); break;
+            default: throw new ArgumentOutOfRangeException(nameof(name));
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/line_descriptor/BinaryDescriptorTest.cs
+++ b/test/OpenCvSharp.Tests/line_descriptor/BinaryDescriptorTest.cs
@@ -1,0 +1,71 @@
+using OpenCvSharp.LineDescriptor;
+using Xunit;
+
+namespace OpenCvSharp.Tests.LineDescriptor;
+
+public class BinaryDescriptorTest
+{
+    [Fact]
+    public void DetectComputeMatchAndDraw()
+    {
+        using var image = Mat.Zeros(200, 200, MatType.CV_8UC1).ToMat();
+        Cv2.Line(image, new Point(20, 20), new Point(180, 20), Scalar.White, 2);
+        Cv2.Line(image, new Point(20, 60), new Point(180, 160), Scalar.White, 2);
+        using var descriptor = BinaryDescriptor.Create();
+
+        var keyLines = descriptor.Detect(image);
+        using var descriptors = new Mat();
+        descriptor.Compute(image, ref keyLines, descriptors);
+
+        Assert.NotEmpty(keyLines);
+        Assert.Equal(keyLines.Length, descriptors.Rows);
+        Assert.Equal(descriptor.DescriptorSize / 8, descriptors.Cols);
+
+        using var matcher = BinaryDescriptorMatcher.Create();
+        var matches = matcher.Match(descriptors, descriptors);
+        Assert.Equal(keyLines.Length, matches.Length);
+        var nearest = matcher.KnnMatch(descriptors, descriptors, 1);
+        Assert.Equal(keyLines.Length, nearest.Length);
+
+        matcher.Add([descriptors]);
+        matcher.Train();
+        Assert.Equal(keyLines.Length, matcher.MatchQuery(descriptors).Length);
+        Assert.Equal(keyLines.Length, matcher.KnnMatchQuery(descriptors, 1).Length);
+        matcher.Clear();
+
+        using var drawn = new Mat();
+        Cv2.LineDescriptor.DrawKeylines(image, keyLines, drawn);
+        Assert.False(drawn.Empty());
+
+        using var matchesDrawn = new Mat();
+        Cv2.LineDescriptor.DrawLineMatches(
+            image, keyLines, image, keyLines, matches, matchesDrawn,
+            matchesMask: Enumerable.Repeat((byte)1, matches.Length).ToArray());
+        Assert.False(matchesDrawn.Empty());
+    }
+
+    [Fact]
+    public void DetectAndComputeMultipleImages()
+    {
+        using var image1 = Mat.Zeros(200, 200, MatType.CV_8UC1).ToMat();
+        using var image2 = Mat.Zeros(200, 200, MatType.CV_8UC1).ToMat();
+        Cv2.Line(image1, new Point(20, 20), new Point(180, 20), Scalar.White, 2);
+        Cv2.Line(image2, new Point(20, 80), new Point(180, 160), Scalar.White, 2);
+        using var descriptor = BinaryDescriptor.Create();
+
+        var keyLines = descriptor.Detect([image1, image2]);
+        descriptor.Compute([image1, image2], ref keyLines, out var descriptors);
+        try
+        {
+            Assert.Equal(2, keyLines.Length);
+            Assert.Equal(2, descriptors.Length);
+            Assert.Equal(keyLines[0].Length, descriptors[0].Rows);
+            Assert.Equal(keyLines[1].Length, descriptors[1].Rows);
+        }
+        finally
+        {
+            foreach (var value in descriptors)
+                value.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add OpenCV 5 wrappers for the missing `face` APIs, including BIF, MACE, prediction collectors, trainable facemarks, FacemarkKazemi, AAM runtime configuration, and dataset utilities
- add the six `img_hash` one-shot functions under `Cv2.ImgHash`
- add BinaryDescriptor, BinaryDescriptorMatcher, multi-image operations, and drawing helpers for `line_descriptor`
- add managed/native boundary validation and regression tests for the new APIs

OpenCV declares `BinaryDescriptor::EDLineDetector` and `EDLineParam` inside the class's private section, so they cannot be referenced by external C++ callers and are intentionally not exposed.

## Testing

- `cmake --build src\build --config Release --target OpenCvSharpExtern`
- `dotnet build src\OpenCvSharp\OpenCvSharp.csproj -c Release --no-restore` (0 warnings, 0 errors)
- `dotnet test test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release --no-build` (1,514 passed, 26 skipped, 0 failed)
- `git diff --check`

Closes #2014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Cv2.ImgHash` hashing helpers (average, block-mean, color-moment, Marr-Hildreth, pHash, radial-variance).
  * Introduced face-analysis and facemark training APIs: `BIF`, `MACE`, `FacemarkTrain` workflow, Kazemi, LBF/AAM model read/write, AAM config fitting/data access, plus `Cv2.Face` dataset/landmark utilities.
  * Added face-recognition prediction collection via `PredictCollector`/`StandardCollector`, including a `Predict` overload.
  * Added binary line-descriptor support: `BinaryDescriptor`, `BinaryDescriptorMatcher`, and `Cv2.LineDescriptor` drawing helpers.
* **Tests**
  * Expanded coverage for image hashing, face utilities/training/serialization, collectors, and binary line-descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->