### PR TITLE
Add stitching::detail:: pipeline coverage (warpers, blenders, exposure compensators, seam finders, estimators/bundle adjusters, matchers)

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching.cs
@@ -94,4 +94,35 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stitching_Stitcher_workScale(OpenCvSafeHandle obj, out double returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_cameras(
+        OpenCvSafeHandle obj,
+        IntPtr focals, IntPtr aspects, IntPtr ppxs, IntPtr ppys, IntPtr rs, IntPtr ts);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setFeaturesFinder(OpenCvSafeHandle obj, IntPtr featuresFinder);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setFeaturesMatcher(OpenCvSafeHandle obj, IntPtr featuresMatcher);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_matchingMask(OpenCvSafeHandle obj, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setMatchingMask(OpenCvSafeHandle obj, IntPtr mask);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setBundleAdjuster(OpenCvSafeHandle obj, IntPtr bundleAdjuster);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setWarper(OpenCvSafeHandle obj, IntPtr warper);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setExposureCompensator(OpenCvSafeHandle obj, IntPtr exposureCompensator);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setSeamFinder(OpenCvSafeHandle obj, IntPtr seamFinder);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Stitcher_setBlender(OpenCvSafeHandle obj, IntPtr blender);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Blenders.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Blenders.cs
@@ -1,0 +1,88 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // Blender
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Blender_createDefault(int type, int tryGpu, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_Blender_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_Blender_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Blender_prepare1(
+        OpenCvSafeHandle obj, Point[] corners, int cornersLength, Size[] sizes, int sizesLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Blender_prepare2(OpenCvSafeHandle obj, Rect dstRoi);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_Blender_feed(
+        OpenCvSafeHandle obj, in InputArrayProxy img, in InputArrayProxy mask, Point tl);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_Blender_blend(
+        OpenCvSafeHandle obj, in InputOutputArrayProxy dst, in InputOutputArrayProxy dstMask);
+
+
+    // FeatherBlender
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FeatherBlender_new(float sharpness, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FeatherBlender_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FeatherBlender_getSharpness(OpenCvSafeHandle obj, out float returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FeatherBlender_setSharpness(OpenCvSafeHandle obj, float val);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FeatherBlender_createWeightMaps(
+        OpenCvSafeHandle obj,
+        IntPtr[] masks, int masksLength,
+        Point[] corners, int cornersLength,
+        IntPtr[] weightMaps, int weightMapsLength,
+        out Rect returnValue);
+
+
+    // MultiBandBlender
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MultiBandBlender_new(int tryGpu, int numBands, int weightType, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MultiBandBlender_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MultiBandBlender_getNumBands(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MultiBandBlender_setNumBands(OpenCvSafeHandle obj, int val);
+
+
+    // Auxiliary functions
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_normalizeUsingWeightMap(in InputArrayProxy weight, in InputOutputArrayProxy src);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_createWeightMap(in InputArrayProxy mask, float sharpness, in InputOutputArrayProxy weight);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_createLaplacePyr(in InputArrayProxy img, int numLevels, IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_restoreImageFromLaplacePyr(IntPtr[] pyr, int pyrLength, IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_ExposureCompensators.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_ExposureCompensators.cs
@@ -1,0 +1,125 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // ExposureCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_createDefault(int type, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_ExposureCompensator_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_ExposureCompensator_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_feed(
+        OpenCvSafeHandle obj,
+        Point[] corners, int cornersLength,
+        IntPtr[] images, int imagesLength,
+        IntPtr[] masks, int masksLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_ExposureCompensator_apply(
+        OpenCvSafeHandle obj, int index, Point corner, in InputOutputArrayProxy image, in InputArrayProxy mask);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_getMatGains(OpenCvSafeHandle obj, IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_setMatGains(OpenCvSafeHandle obj, IntPtr[] gains, int gainsLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_getUpdateGain(OpenCvSafeHandle obj, out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ExposureCompensator_setUpdateGain(OpenCvSafeHandle obj, int b);
+
+
+    // NoExposureCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_NoExposureCompensator_new(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_NoExposureCompensator_delete(IntPtr obj);
+
+
+    // GainCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_new(int nrFeeds, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_getNrFeeds(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_setNrFeeds(OpenCvSafeHandle obj, int nrFeeds);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_getSimilarityThreshold(OpenCvSafeHandle obj, out double returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GainCompensator_setSimilarityThreshold(OpenCvSafeHandle obj, double thresh);
+
+
+    // ChannelsCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_new(int nrFeeds, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_getNrFeeds(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_setNrFeeds(OpenCvSafeHandle obj, int nrFeeds);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_getSimilarityThreshold(OpenCvSafeHandle obj, out double returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_ChannelsCompensator_setSimilarityThreshold(OpenCvSafeHandle obj, double thresh);
+
+
+    // BlocksCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_getNrFeeds(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_setNrFeeds(OpenCvSafeHandle obj, int nrFeeds);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_getSimilarityThreshold(OpenCvSafeHandle obj, out double returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_setSimilarityThreshold(OpenCvSafeHandle obj, double thresh);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_getBlockSize(OpenCvSafeHandle obj, out Size returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_setBlockSize(OpenCvSafeHandle obj, int width, int height);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_getNrGainsFilteringIterations(OpenCvSafeHandle obj, out int returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksCompensator_setNrGainsFilteringIterations(OpenCvSafeHandle obj, int nrIterations);
+
+
+    // BlocksGainCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksGainCompensator_new(int blWidth, int blHeight, int nrFeeds, out IntPtr returnValue);
+
+
+    // BlocksChannelsCompensator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BlocksChannelsCompensator_new(int blWidth, int blHeight, int nrFeeds, out IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Matchers.cs
@@ -87,4 +87,32 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus stitching_AffineBestOf2NearestMatcher_delete(
         IntPtr obj);
+
+
+    // BestOf2NearestRangeMatcher
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BestOf2NearestRangeMatcher_new(
+        int rangeWidth, int tryUseGpu, float matchConf, int numMatchesThresh1, int numMatchesThresh2,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BestOf2NearestRangeMatcher_delete(
+        IntPtr obj);
+
+
+    // LightGlueFeaturesMatcher
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_LightGlueFeaturesMatcher_new(
+        IntPtr lgMatcherSmartPtr, int numMatchesThresh1, int numMatchesThresh2, double matchesConfidenceThresh,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_LightGlueFeaturesMatcher_delete(
+        IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_LightGlueFeaturesMatcher_setScoreThreshold(
+        OpenCvSafeHandle obj, float thresh);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_MotionEstimators.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_MotionEstimators.cs
@@ -1,0 +1,106 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using OpenCvSharp.Detail;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // Estimator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Estimator_apply(
+        OpenCvSafeHandle obj,
+        WImageFeatures[] features, int featuresSize,
+        WMatchesInfo[] pairwiseMatches, int pairwiseMatchesSize,
+        WCameraParams[] cameras, int camerasSize,
+        out int returnValue);
+
+
+    // HomographyBasedEstimator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_HomographyBasedEstimator_new(int isFocalsEstimated, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_HomographyBasedEstimator_delete(IntPtr obj);
+
+
+    // AffineBasedEstimator
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_AffineBasedEstimator_new(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_AffineBasedEstimator_delete(IntPtr obj);
+
+
+    // BundleAdjusterBase
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_refinementMask(OpenCvSafeHandle obj, IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_setRefinementMask(OpenCvSafeHandle obj, IntPtr mask);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_confThresh(OpenCvSafeHandle obj, out double returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_setConfThresh(OpenCvSafeHandle obj, double confThresh);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_termCriteria(OpenCvSafeHandle obj, out TermCriteria returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterBase_setTermCriteria(OpenCvSafeHandle obj, TermCriteria termCriteria);
+
+
+    // NoBundleAdjuster
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_NoBundleAdjuster_new(out IntPtr returnValue);
+
+
+    // BundleAdjusterReproj
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterReproj_new(out IntPtr returnValue);
+
+
+    // BundleAdjusterRay
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterRay_new(out IntPtr returnValue);
+
+
+    // BundleAdjusterAffine
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterAffine_new(out IntPtr returnValue);
+
+
+    // BundleAdjusterAffinePartial
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_BundleAdjusterAffinePartial_new(out IntPtr returnValue);
+
+
+    // Auxiliary functions
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_waveCorrect(IntPtr[] rmats, int rmatsLength, int kind);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_matchesGraphAsString(
+        int numImages, WMatchesInfo[] pairwiseMatches, int pairwiseMatchesSize, float confThreshold, IntPtr buf);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_leaveBiggestComponent(
+        WImageFeatures[] features, int featuresSize,
+        WMatchesInfo[] pairwiseMatches, int pairwiseMatchesSize,
+        float confThreshold,
+        IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_SeamFinders.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_SeamFinders.cs
@@ -1,0 +1,100 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // SeamFinder
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_SeamFinder_createDefault(int type, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_SeamFinder_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_SeamFinder_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_SeamFinder_find(
+        OpenCvSafeHandle obj,
+        IntPtr[] src, int srcLength,
+        Point[] corners, int cornersLength,
+        IntPtr[] masks, int masksLength);
+
+
+    // NoSeamFinder
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_NoSeamFinder_new(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_NoSeamFinder_delete(IntPtr obj);
+
+
+    // VoronoiSeamFinder
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_VoronoiSeamFinder_new(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_VoronoiSeamFinder_delete(IntPtr obj);
+
+
+    // DpSeamFinder
+
+    [LibraryImport(DllExtern, EntryPoint = "stitching_DpSeamFinder_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_DpSeamFinder_new_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string costFunc, out IntPtr returnValue);
+    [LibraryImport(DllExtern, EntryPoint = "stitching_DpSeamFinder_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_DpSeamFinder_new_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string costFunc, out IntPtr returnValue);
+    public static ExceptionStatus stitching_DpSeamFinder_new(string costFunc, out IntPtr returnValue)
+        => IsWindows()
+            ? stitching_DpSeamFinder_new_Windows(costFunc, out returnValue)
+            : stitching_DpSeamFinder_new_NotWindows(costFunc, out returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_DpSeamFinder_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern, EntryPoint = "stitching_DpSeamFinder_setCostFunction"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_DpSeamFinder_setCostFunction_Windows(
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeWindows)] string val);
+    [LibraryImport(DllExtern, EntryPoint = "stitching_DpSeamFinder_setCostFunction"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_DpSeamFinder_setCostFunction_NotWindows(
+        OpenCvSafeHandle obj, [MarshalAs(StringUnmanagedTypeNotWindows)] string val);
+    public static ExceptionStatus stitching_DpSeamFinder_setCostFunction(OpenCvSafeHandle obj, string val)
+        => IsWindows()
+            ? stitching_DpSeamFinder_setCostFunction_Windows(obj, val)
+            : stitching_DpSeamFinder_setCostFunction_NotWindows(obj, val);
+
+
+    // GraphCutSeamFinder
+
+    [LibraryImport(DllExtern, EntryPoint = "stitching_GraphCutSeamFinder_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_GraphCutSeamFinder_new_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string costType, float terminalCost, float badRegionPenalty, out IntPtr returnValue);
+    [LibraryImport(DllExtern, EntryPoint = "stitching_GraphCutSeamFinder_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_GraphCutSeamFinder_new_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string costType, float terminalCost, float badRegionPenalty, out IntPtr returnValue);
+    public static ExceptionStatus stitching_GraphCutSeamFinder_new(
+        string costType, float terminalCost, float badRegionPenalty, out IntPtr returnValue)
+        => IsWindows()
+            ? stitching_GraphCutSeamFinder_new_Windows(costType, terminalCost, badRegionPenalty, out returnValue)
+            : stitching_GraphCutSeamFinder_new_NotWindows(costType, terminalCost, badRegionPenalty, out returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GraphCutSeamFinder_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_GraphCutSeamFinder_find(
+        OpenCvSafeHandle obj,
+        IntPtr[] src, int srcLength,
+        Point[] corners, int cornersLength,
+        IntPtr[] masks, int masksLength);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Timelapsers.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Timelapsers.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Timelapser_createDefault(int type, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_Timelapser_get(IntPtr ptr, out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Ptr_Timelapser_delete(IntPtr ptr);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Timelapser_initialize(
+        OpenCvSafeHandle obj,
+        Point[] corners, int cornersLength,
+        Size[] sizes, int sizesLength);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_Timelapser_process(
+        OpenCvSafeHandle obj, in InputArrayProxy img, in InputArrayProxy mask, Point tl);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_Timelapser_getDst(OpenCvSafeHandle obj, IntPtr returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Warpers.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/stitching/NativeMethods_stitching_Warpers.cs
@@ -1,0 +1,122 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    // PyRotationWarper
+
+    [LibraryImport(DllExtern, EntryPoint = "stitching_PyRotationWarper_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_PyRotationWarper_new_Windows(
+        [MarshalAs(StringUnmanagedTypeWindows)] string type, float scale, out IntPtr returnValue);
+    [LibraryImport(DllExtern, EntryPoint = "stitching_PyRotationWarper_new"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial ExceptionStatus stitching_PyRotationWarper_new_NotWindows(
+        [MarshalAs(StringUnmanagedTypeNotWindows)] string type, float scale, out IntPtr returnValue);
+    public static ExceptionStatus stitching_PyRotationWarper_new(string type, float scale, out IntPtr returnValue)
+        => IsWindows()
+            ? stitching_PyRotationWarper_new_Windows(type, scale, out returnValue)
+            : stitching_PyRotationWarper_new_NotWindows(type, scale, out returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PyRotationWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_warpPoint(
+        OpenCvSafeHandle obj, Point2f pt, in InputArrayProxy k, in InputArrayProxy r, out Point2f returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_warpPointBackward(
+        OpenCvSafeHandle obj, Point2f pt, in InputArrayProxy k, in InputArrayProxy r, out Point2f returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_buildMaps(
+        OpenCvSafeHandle obj, Size srcSize, in InputArrayProxy k, in InputArrayProxy r,
+        in OutputArrayProxy xmap, in OutputArrayProxy ymap, out Rect returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_warp(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in InputArrayProxy k, in InputArrayProxy r,
+        int interpMode, int borderMode, in OutputArrayProxy dst, out Point returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_warpBackward(
+        OpenCvSafeHandle obj, in InputArrayProxy src, in InputArrayProxy k, in InputArrayProxy r,
+        int interpMode, int borderMode, Size dstSize, in OutputArrayProxy dst);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus stitching_PyRotationWarper_warpRoi(
+        OpenCvSafeHandle obj, Size srcSize, in InputArrayProxy k, in InputArrayProxy r, out Rect returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PyRotationWarper_getScale(OpenCvSafeHandle obj, out float returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PyRotationWarper_setScale(OpenCvSafeHandle obj, float val);
+
+
+    // WarperCreator concrete factories
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PlaneWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PlaneWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_AffineWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_AffineWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CylindricalWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CylindricalWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_SphericalWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_SphericalWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FisheyeWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_FisheyeWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_StereographicWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_StereographicWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MercatorWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_MercatorWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_TransverseMercatorWarper_new(out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_TransverseMercatorWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CompressedRectilinearWarper_new(float a, float b, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CompressedRectilinearWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CompressedRectilinearPortraitWarper_new(float a, float b, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_CompressedRectilinearPortraitWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PaniniWarper_new(float a, float b, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PaniniWarper_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PaniniPortraitWarper_new(float a, float b, out IntPtr returnValue);
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus stitching_PaniniPortraitWarper_delete(IntPtr obj);
+}

--- a/src/OpenCvSharp/Modules/stitching/AffineBasedEstimator.cs
+++ b/src/OpenCvSharp/Modules/stitching/AffineBasedEstimator.cs
@@ -1,0 +1,30 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Affine transformation based estimator. This estimator uses pairwise transformations estimated by
+/// the matcher to estimate the final transformation for each camera.
+/// </summary>
+public class AffineBasedEstimator : Estimator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public AffineBasedEstimator() : base(Create())
+    {
+        InitSafeHandle(CvPtr);
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_AffineBasedEstimator_new(out var ptr));
+        return ptr;
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_AffineBasedEstimator_delete(h))));
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/AffineWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/AffineWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Affine warper factory class.
+/// </summary>
+public class AffineWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public AffineWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_AffineWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_AffineWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BestOf2NearestRangeMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/BestOf2NearestRangeMatcher.cs
@@ -1,0 +1,59 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Features matcher similar to cv::detail::BestOf2NearestMatcher which finds two best matches for each
+/// feature and leaves the best one only if the ratio between descriptor distances is greater than the
+/// threshold match_conf.
+///
+/// Unlike cv::detail::BestOf2NearestMatcher, this matcher only matches images that are no more than
+/// range_width apart in the source sequence.
+/// </summary>
+public class BestOf2NearestRangeMatcher : BestOf2NearestMatcher
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="rangeWidth">Number of images from each side in the sequence that are to be matched</param>
+    /// <param name="tryUseGpu">Should try to use GPU or not</param>
+    /// <param name="matchConf">Match distances ration threshold</param>
+    /// <param name="numMatchesThresh1">Minimum number of matches required for the 2D projective transform
+    /// estimation used in the inliers classification step</param>
+    /// <param name="numMatchesThresh2">Minimum number of matches required for the 2D projective transform
+    /// re-estimation on inliers</param>
+    public BestOf2NearestRangeMatcher(
+        int rangeWidth = 5,
+        bool tryUseGpu = false,
+        float matchConf = 0.3f,
+        int numMatchesThresh1 = 6,
+        int numMatchesThresh2 = 6)
+        : base(Create(rangeWidth, tryUseGpu, matchConf, numMatchesThresh1, numMatchesThresh2))
+    {
+        InitSafeHandle(CvPtr);
+    }
+
+    private static IntPtr Create(
+        int rangeWidth,
+        bool tryUseGpu,
+        float matchConf,
+        int numMatchesThresh1,
+        int numMatchesThresh2)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_BestOf2NearestRangeMatcher_new(
+                rangeWidth,
+                tryUseGpu ? 1 : 0,
+                matchConf,
+                numMatchesThresh1,
+                numMatchesThresh2,
+                out var ptr));
+        return ptr;
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_BestOf2NearestRangeMatcher_delete(h))));
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/Blender.cs
+++ b/src/OpenCvSharp/Modules/stitching/Blender.cs
@@ -1,0 +1,106 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Kind of blender to build (see <see cref="Blender.CreateDefault"/>).
+/// </summary>
+public enum BlenderType
+{
+#pragma warning disable 1591
+    No,
+    Feather,
+    MultiBand,
+#pragma warning restore 1591
+}
+
+/// <summary>
+/// Base class for all blenders. Simple blender which puts one image over another.
+/// </summary>
+public class Blender : CvPtrObject
+{
+    /// <summary>
+    /// Constructor for the factory pattern (used by <see cref="CreateDefault"/>).
+    /// </summary>
+    private Blender(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr,
+            p => NativeMethods.HandleException(NativeMethods.stitching_Ptr_Blender_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Constructor for the direct-allocation pattern (used by concrete subclasses with a public constructor).
+    /// </summary>
+    protected Blender(IntPtr rawPtr, Action<IntPtr> release)
+        : base(rawPtr, release)
+    {
+    }
+
+    /// <summary>
+    /// Creates a blender of the given kind.
+    /// </summary>
+    /// <param name="type">Kind of blender to build</param>
+    /// <param name="tryGpu">Should try to use GPU or not</param>
+    public static Blender CreateDefault(BlenderType type, bool tryGpu = false)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Blender_createDefault((int)type, tryGpu ? 1 : 0, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Ptr_Blender_get(smartPtr, out var rawPtr));
+        return new Blender(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Prepares the blender for blending.
+    /// </summary>
+    /// <param name="corners">Source images top-left corners</param>
+    /// <param name="sizes">Source image sizes</param>
+    public void Prepare(IReadOnlyList<Point> corners, IReadOnlyList<Size> sizes)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(sizes);
+
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var sizesArray = sizes as Size[] ?? [.. sizes];
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Blender_prepare1(Handle, cornersArray, cornersArray.Length, sizesArray, sizesArray.Length));
+    }
+
+    /// <summary>
+    /// Prepares the blender for blending.
+    /// </summary>
+    /// <param name="dstRoi">Final pano region of interest</param>
+    public void Prepare(Rect dstRoi)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.stitching_Blender_prepare2(Handle, dstRoi));
+    }
+
+    /// <summary>
+    /// Processes the image.
+    /// </summary>
+    /// <param name="img">Source image</param>
+    /// <param name="mask">Source image mask</param>
+    /// <param name="tl">Source image top-left corner</param>
+    public void Feed(InputArray img, InputArray mask, Point tl)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.stitching_Blender_feed(Handle, img.Proxy, mask.Proxy, tl));
+        GC.KeepAlive(img.Source);
+        GC.KeepAlive(mask.Source);
+    }
+
+    /// <summary>
+    /// Blends and returns the final pano.
+    /// </summary>
+    /// <param name="dst">Final pano</param>
+    /// <param name="dstMask">Final pano mask</param>
+    public void Blend(InputOutputArray dst, InputOutputArray dstMask)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(NativeMethods.stitching_Blender_blend(Handle, dst.Proxy, dstMask.Proxy));
+        GC.KeepAlive(dst.Source);
+        GC.KeepAlive(dstMask.Source);
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BlocksChannelsCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/BlocksChannelsCompensator.cs
@@ -1,0 +1,28 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Exposure compensator which tries to remove exposure related artifacts by adjusting image blocks on each
+/// channel independently.
+/// </summary>
+public class BlocksChannelsCompensator : BlocksCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="blockWidth"></param>
+    /// <param name="blockHeight"></param>
+    /// <param name="nrFeeds"></param>
+    public BlocksChannelsCompensator(int blockWidth = 32, int blockHeight = 32, int nrFeeds = 1)
+        : base(Create(blockWidth, blockHeight, nrFeeds))
+    {
+    }
+
+    private static IntPtr Create(int blockWidth, int blockHeight, int nrFeeds)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_BlocksChannelsCompensator_new(blockWidth, blockHeight, nrFeeds, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BlocksCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/BlocksCompensator.cs
@@ -1,0 +1,92 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Exposure compensator which tries to remove exposure related artifacts by adjusting image blocks.
+/// Shared base for <see cref="BlocksGainCompensator"/> and <see cref="BlocksChannelsCompensator"/>;
+/// it has no public constructor of its own (matching upstream OpenCV, which does not expose one either).
+/// </summary>
+public abstract class BlocksCompensator : ExposureCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="rawPtr"></param>
+    private protected BlocksCompensator(IntPtr rawPtr) : base(rawPtr, static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_delete(h)))
+    {
+    }
+
+    /// <summary>
+    /// Number of images fed to this compensator.
+    /// </summary>
+    public int NrFeeds
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_getNrFeeds(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_setNrFeeds(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Similarity threshold used for masking similar image regions in the exposure compensation gain computation.
+    /// </summary>
+    public double SimilarityThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_getSimilarityThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_setSimilarityThreshold(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Size, in pixels, of each block used for exposure compensation.
+    /// </summary>
+    public Size BlockSize
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_getBlockSize(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_setBlockSize(Handle, value.Width, value.Height));
+        }
+    }
+
+    /// <summary>
+    /// Number of filtering iterations applied to the gain map.
+    /// </summary>
+    public int NrGainsFilteringIterations
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_getNrGainsFilteringIterations(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BlocksCompensator_setNrGainsFilteringIterations(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BlocksGainCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/BlocksGainCompensator.cs
@@ -1,0 +1,27 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Exposure compensator which tries to remove exposure related artifacts by adjusting image block intensities.
+/// </summary>
+public class BlocksGainCompensator : BlocksCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="blockWidth"></param>
+    /// <param name="blockHeight"></param>
+    /// <param name="nrFeeds"></param>
+    public BlocksGainCompensator(int blockWidth = 32, int blockHeight = 32, int nrFeeds = 1)
+        : base(Create(blockWidth, blockHeight, nrFeeds))
+    {
+    }
+
+    private static IntPtr Create(int blockWidth, int blockHeight, int nrFeeds)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_BlocksGainCompensator_new(blockWidth, blockHeight, nrFeeds, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BundleAdjusterAffine.cs
+++ b/src/OpenCvSharp/Modules/stitching/BundleAdjusterAffine.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Bundle adjuster that expects an affine transformation represented in homogeneous coordinates in R
+/// for each camera parameter. Estimates all transformation parameters; the refinement mask is ignored.
+/// </summary>
+public class BundleAdjusterAffine : BundleAdjusterBase
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public BundleAdjusterAffine() : base(Create())
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterAffine_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BundleAdjusterAffinePartial.cs
+++ b/src/OpenCvSharp/Modules/stitching/BundleAdjusterAffinePartial.cs
@@ -1,0 +1,24 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Bundle adjuster that expects an affine transformation with 4 degrees of freedom, represented in
+/// homogeneous coordinates in R for each camera parameter. Estimates all transformation parameters;
+/// the refinement mask is ignored.
+/// </summary>
+public class BundleAdjusterAffinePartial : BundleAdjusterBase
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public BundleAdjusterAffinePartial() : base(Create())
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterAffinePartial_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BundleAdjusterBase.cs
+++ b/src/OpenCvSharp/Modules/stitching/BundleAdjusterBase.cs
@@ -1,0 +1,81 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Base class for all camera parameters refinement methods.
+/// </summary>
+public abstract class BundleAdjusterBase : Estimator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="ptr"></param>
+    private protected BundleAdjusterBase(IntPtr ptr) : base(ptr)
+    {
+        InitSafeHandle(ptr);
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_delete(h))));
+    }
+
+    /// <summary>
+    /// 3x3 8U mask, where 0 means don't refine the respective parameter, non-zero means refine it.
+    /// </summary>
+    public Mat RefinementMask
+    {
+        get
+        {
+            ThrowIfDisposed();
+            var mask = new Mat();
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_refinementMask(Handle, mask.CvPtr));
+            return mask;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            ArgumentNullException.ThrowIfNull(value);
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_setRefinementMask(Handle, value.CvPtr));
+            GC.KeepAlive(value);
+        }
+    }
+
+    /// <summary>
+    /// Threshold to filter out poorly matched image pairs.
+    /// </summary>
+    public double ConfThresh
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_confThresh(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_setConfThresh(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Levenberg-Marquardt algorithm termination criteria.
+    /// </summary>
+    public TermCriteria TermCriteria
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_termCriteria(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterBase_setTermCriteria(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BundleAdjusterRay.cs
+++ b/src/OpenCvSharp/Modules/stitching/BundleAdjusterRay.cs
@@ -1,0 +1,24 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Implementation of the camera parameters refinement algorithm which minimizes the sum of the
+/// distances between the rays passing through the camera center and a feature. It can estimate
+/// focal length; it ignores the refinement mask.
+/// </summary>
+public class BundleAdjusterRay : BundleAdjusterBase
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public BundleAdjusterRay() : base(Create())
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterRay_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/BundleAdjusterReproj.cs
+++ b/src/OpenCvSharp/Modules/stitching/BundleAdjusterReproj.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Implementation of the camera parameters refinement algorithm which minimizes the sum of the
+/// reprojection error squares. It can estimate focal length, aspect ratio and principal point.
+/// </summary>
+public class BundleAdjusterReproj : BundleAdjusterBase
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public BundleAdjusterReproj() : base(Create())
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_BundleAdjusterReproj_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/CameraParams.cs
+++ b/src/OpenCvSharp/Modules/stitching/CameraParams.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Describes camera parameters. Translation is assumed to be zero during the whole stitching pipeline.
+/// </summary>
+public sealed class CameraParams : IDisposable
+{
+    /// <summary>
+    /// Focal length
+    /// </summary>
+    public double Focal { get; set; }
+
+    /// <summary>
+    /// Aspect ratio
+    /// </summary>
+    public double Aspect { get; set; } = 1.0;
+
+    /// <summary>
+    /// Principal point X
+    /// </summary>
+    public double Ppx { get; set; }
+
+    /// <summary>
+    /// Principal point Y
+    /// </summary>
+    public double Ppy { get; set; }
+
+    /// <summary>
+    /// Rotation
+    /// </summary>
+    public Mat R { get; }
+
+    /// <summary>
+    /// Translation
+    /// </summary>
+    public Mat T { get; }
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public CameraParams()
+        : this(0, 1.0, 0, 0, new Mat(3, 3, MatType.CV_64F, Scalar.All(0)), new Mat(3, 1, MatType.CV_64F, Scalar.All(0)))
+    {
+    }
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public CameraParams(double focal, double aspect, double ppx, double ppy, Mat r, Mat t)
+    {
+        Focal = focal;
+        Aspect = aspect;
+        Ppx = ppx;
+        Ppy = ppy;
+        R = r;
+        T = t;
+    }
+
+    /// <summary>
+    /// Computes the intrinsic camera matrix from the focal length, aspect ratio and principal point.
+    /// </summary>
+    public Mat K()
+    {
+        var k = new Mat(3, 3, MatType.CV_64F, Scalar.All(0));
+        k.Set(0, 0, Focal);
+        k.Set(0, 2, Ppx);
+        k.Set(1, 1, Focal * Aspect);
+        k.Set(1, 2, Ppy);
+        k.Set(2, 2, 1.0);
+        return k;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        R.Dispose();
+        T.Dispose();
+    }
+}
+
+#pragma warning disable 1591
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
+[SuppressMessage("Microsoft.Design", "CA1815: Override equals and operator equals on value types")]
+public struct WCameraParams
+{
+    public double Focal;
+    public double Aspect;
+    public double Ppx;
+    public double Ppy;
+    public IntPtr R;
+    public IntPtr T;
+}
+#pragma warning restore 1591

--- a/src/OpenCvSharp/Modules/stitching/ChannelsCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/ChannelsCompensator.cs
@@ -1,0 +1,61 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Exposure compensator which tries to remove exposure related artifacts by adjusting image intensities
+/// on each channel independently.
+/// </summary>
+public class ChannelsCompensator : ExposureCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="nrFeeds"></param>
+    public ChannelsCompensator(int nrFeeds = 1) : base(Create(nrFeeds), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(int nrFeeds)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_new(nrFeeds, out var ptr));
+        return ptr;
+    }
+
+    /// <summary>
+    /// Number of images fed to this compensator.
+    /// </summary>
+    public int NrFeeds
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_getNrFeeds(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_setNrFeeds(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Similarity threshold used for masking similar image regions in the exposure compensation gain computation.
+    /// </summary>
+    public double SimilarityThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_getSimilarityThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_ChannelsCompensator_setSimilarityThreshold(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/CompressedRectilinearPortraitWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/CompressedRectilinearPortraitWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Compressed rectilinear portrait warper factory class.
+/// </summary>
+public class CompressedRectilinearPortraitWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public CompressedRectilinearPortraitWarper(float a = 1, float b = 1) : base(Create(a, b), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_CompressedRectilinearPortraitWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(float a, float b)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_CompressedRectilinearPortraitWarper_new(a, b, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/CompressedRectilinearWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/CompressedRectilinearWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Compressed rectilinear warper factory class.
+/// </summary>
+public class CompressedRectilinearWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public CompressedRectilinearWarper(float a = 1, float b = 1) : base(Create(a, b), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_CompressedRectilinearWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(float a, float b)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_CompressedRectilinearWarper_new(a, b, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
+++ b/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
@@ -1,5 +1,6 @@
 using OpenCvSharp.Detail;
 using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
 using OpenCvSharp.Internal.Vectors;
 
 // ReSharper disable UnusedMember.Global
@@ -92,6 +93,188 @@ public static partial class Cv2
                 wImageFeatures.ImgSize,
                 keypointsVec.ToArray(),
                 descriptorsMat);
+        }
+
+        /// <summary>
+        /// Normalizes the given image using a weight map.
+        /// </summary>
+        /// <param name="weight">Weight map</param>
+        /// <param name="src">Image to normalize, in place</param>
+        public static void NormalizeUsingWeightMap(InputArray weight, InputOutputArray src)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.stitching_normalizeUsingWeightMap(weight.Proxy, src.Proxy));
+            GC.KeepAlive(weight.Source);
+            GC.KeepAlive(src.Source);
+        }
+
+        /// <summary>
+        /// Creates a weight map from the given mask.
+        /// </summary>
+        /// <param name="mask">Source mask</param>
+        /// <param name="sharpness">Sharpness of the weight map border</param>
+        /// <param name="weight">Resulting weight map</param>
+        public static void CreateWeightMap(InputArray mask, float sharpness, InputOutputArray weight)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.stitching_createWeightMap(mask.Proxy, sharpness, weight.Proxy));
+            GC.KeepAlive(mask.Source);
+            GC.KeepAlive(weight.Source);
+        }
+
+        /// <summary>
+        /// Builds a Laplacian pyramid for the given image.
+        /// </summary>
+        /// <param name="img">Source image</param>
+        /// <param name="numLevels">Number of pyramid levels</param>
+        public static Mat[] CreateLaplacePyr(InputArray img, int numLevels)
+        {
+            using var pyr = new VectorOfMat();
+            NativeMethods.HandleException(
+                NativeMethods.stitching_createLaplacePyr(img.Proxy, numLevels, pyr.CvPtr));
+            GC.KeepAlive(img.Source);
+            return pyr.ToArray();
+        }
+
+        /// <summary>
+        /// Restores the source image from its Laplacian pyramid.
+        /// </summary>
+        /// <param name="pyr">Laplacian pyramid, as produced by <see cref="CreateLaplacePyr"/></param>
+        public static Mat RestoreImageFromLaplacePyr(IEnumerable<Mat> pyr)
+        {
+            ArgumentNullException.ThrowIfNull(pyr);
+
+            var pyrArray = pyr as Mat[] ?? [.. pyr];
+            var pyrPtrs = pyrArray.Select(m => m.CvPtr).ToArray();
+            var dst = new Mat();
+            NativeMethods.HandleException(
+                NativeMethods.stitching_restoreImageFromLaplacePyr(pyrPtrs, pyrPtrs.Length, dst.CvPtr));
+            GC.KeepAlive(pyrArray);
+            return dst;
+        }
+
+        /// <summary>
+        /// Tries to make the panorama more horizontal (or vertical).
+        /// </summary>
+        /// <param name="rmats">Camera rotation matrices, refined in place</param>
+        /// <param name="kind">Correction kind</param>
+        public static void WaveCorrect(IEnumerable<Mat> rmats, WaveCorrectKind kind)
+        {
+            ArgumentNullException.ThrowIfNull(rmats);
+
+            var rmatsArray = rmats as Mat[] ?? [.. rmats];
+            var ptrs = rmatsArray.Select(m => m.CvPtr).ToArray();
+            NativeMethods.HandleException(NativeMethods.stitching_waveCorrect(ptrs, ptrs.Length, (int)kind));
+            GC.KeepAlive(rmatsArray);
+        }
+
+        /// <summary>
+        /// Returns a matches graph representation in DOT language.
+        /// </summary>
+        /// <param name="numImages">Number of images</param>
+        /// <param name="pairwiseMatches">Pairwise matches of images</param>
+        /// <param name="confThreshold">Confidence threshold</param>
+        public static string MatchesGraphAsString(int numImages, IReadOnlyList<MatchesInfo> pairwiseMatches, float confThreshold)
+        {
+            ArgumentNullException.ThrowIfNull(pairwiseMatches);
+
+            var (wMatches, matchesVecs, inliersMaskVecs) = ToWMatchesInfoArray(pairwiseMatches);
+            try
+            {
+                using var buf = new StdString();
+                NativeMethods.HandleException(
+                    NativeMethods.stitching_matchesGraphAsString(numImages, wMatches, wMatches.Length, confThreshold, buf.CvPtr));
+                return buf.ToString();
+            }
+            finally
+            {
+                DisposeAll(matchesVecs);
+                DisposeAll(inliersMaskVecs);
+            }
+        }
+
+        /// <summary>
+        /// Finds the indices, within <paramref name="features"/>, of the images belonging to the
+        /// largest connected component of the pairwise-matches graph.
+        /// </summary>
+        /// <param name="features">Features of the source images</param>
+        /// <param name="pairwiseMatches">Pairwise matches of images</param>
+        /// <param name="confThreshold">Confidence threshold</param>
+        public static int[] LeaveBiggestComponent(
+            IReadOnlyList<ImageFeatures> features, IReadOnlyList<MatchesInfo> pairwiseMatches, float confThreshold)
+        {
+            ArgumentNullException.ThrowIfNull(features);
+            ArgumentNullException.ThrowIfNull(pairwiseMatches);
+
+            var (wFeatures, keypointVecs) = ToWImageFeaturesArray(features);
+            var (wMatches, matchesVecs, inliersMaskVecs) = ToWMatchesInfoArray(pairwiseMatches);
+            try
+            {
+                using var indices = new StdVector<int>();
+                NativeMethods.HandleException(
+                    NativeMethods.stitching_leaveBiggestComponent(
+                        wFeatures, wFeatures.Length, wMatches, wMatches.Length, confThreshold, indices.CvPtr));
+                return indices.ToArray();
+            }
+            finally
+            {
+                DisposeAll(keypointVecs);
+                DisposeAll(matchesVecs);
+                DisposeAll(inliersMaskVecs);
+            }
+        }
+
+        private static void DisposeAll<T>(IEnumerable<StdVector<T>?> vecs)
+            where T : unmanaged
+        {
+            foreach (var vec in vecs)
+                vec?.Dispose();
+        }
+
+        private static (WImageFeatures[] wFeatures, StdVector<KeyPoint>?[] keypointVecs) ToWImageFeaturesArray(
+            IReadOnlyList<ImageFeatures> features)
+        {
+            var featuresArray = features.CastOrToArray();
+            var keypointVecs = new StdVector<KeyPoint>?[featuresArray.Length];
+            var wFeatures = new WImageFeatures[featuresArray.Length];
+            for (var i = 0; i < featuresArray.Length; i++)
+            {
+                ArgumentNullException.ThrowIfNull(featuresArray[i].Descriptors, $"{nameof(features)}[{i}].Descriptors");
+                keypointVecs[i] = new StdVector<KeyPoint>(featuresArray[i].Keypoints);
+                wFeatures[i] = new WImageFeatures
+                {
+                    ImgIdx = featuresArray[i].ImgIdx,
+                    ImgSize = featuresArray[i].ImgSize,
+                    Keypoints = keypointVecs[i]!.CvPtr,
+                    Descriptors = featuresArray[i].Descriptors.CvPtr,
+                };
+            }
+            return (wFeatures, keypointVecs);
+        }
+
+        private static (WMatchesInfo[] wMatches, StdVector<DMatch>?[] matchesVecs, StdVector<byte>?[] inliersMaskVecs) ToWMatchesInfoArray(
+            IReadOnlyList<MatchesInfo> pairwiseMatches)
+        {
+            var matchesArray = pairwiseMatches.CastOrToArray();
+            var matchesVecs = new StdVector<DMatch>?[matchesArray.Length];
+            var inliersMaskVecs = new StdVector<byte>?[matchesArray.Length];
+            var wMatches = new WMatchesInfo[matchesArray.Length];
+            for (var i = 0; i < matchesArray.Length; i++)
+            {
+                matchesVecs[i] = new StdVector<DMatch>(matchesArray[i].Matches);
+                inliersMaskVecs[i] = new StdVector<byte>(matchesArray[i].InliersMask);
+                wMatches[i] = new WMatchesInfo
+                {
+                    SrcImgIdx = matchesArray[i].SrcImgIdx,
+                    DstImgIdx = matchesArray[i].DstImgIdx,
+                    Matches = matchesVecs[i]!.CvPtr,
+                    InliersMask = inliersMaskVecs[i]!.CvPtr,
+                    NumInliers = matchesArray[i].NumInliers,
+                    H = matchesArray[i].H.CvPtr,
+                    Confidence = matchesArray[i].Confidence,
+                };
+            }
+            return (wMatches, matchesVecs, inliersMaskVecs);
         }
     }
 }

--- a/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
+++ b/src/OpenCvSharp/Modules/stitching/Cv2.Detail.cs
@@ -190,6 +190,7 @@ public static partial class Cv2
             {
                 DisposeAll(matchesVecs);
                 DisposeAll(inliersMaskVecs);
+                GC.KeepAlive(pairwiseMatches);
             }
         }
 
@@ -221,6 +222,8 @@ public static partial class Cv2
                 DisposeAll(keypointVecs);
                 DisposeAll(matchesVecs);
                 DisposeAll(inliersMaskVecs);
+                GC.KeepAlive(features);
+                GC.KeepAlive(pairwiseMatches);
             }
         }
 

--- a/src/OpenCvSharp/Modules/stitching/CylindricalWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/CylindricalWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Cylindrical warper factory class.
+/// </summary>
+public class CylindricalWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public CylindricalWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_CylindricalWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_CylindricalWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/DpSeamFinder.cs
+++ b/src/OpenCvSharp/Modules/stitching/DpSeamFinder.cs
@@ -1,0 +1,57 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Cost function used by <see cref="DpSeamFinder"/> and <see cref="GraphCutSeamFinder"/>.
+/// </summary>
+public enum SeamFinderCostFunction
+{
+#pragma warning disable 1591
+    Color,
+    ColorGrad,
+#pragma warning restore 1591
+}
+
+internal static class SeamFinderCostFunctionExtensions
+{
+    public static string ToNativeString(this SeamFinderCostFunction costFunction) => costFunction switch
+    {
+        SeamFinderCostFunction.Color => "COLOR",
+        SeamFinderCostFunction.ColorGrad => "COLOR_GRAD",
+        _ => throw new ArgumentOutOfRangeException(nameof(costFunction), costFunction, null),
+    };
+}
+
+/// <summary>
+/// Seam estimator based on dynamic programming.
+/// </summary>
+public class DpSeamFinder : SeamFinder
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="costFunction"></param>
+    public DpSeamFinder(SeamFinderCostFunction costFunction = SeamFinderCostFunction.Color)
+        : base(Create(costFunction), static h =>
+            NativeMethods.HandleException(NativeMethods.stitching_DpSeamFinder_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(SeamFinderCostFunction costFunction)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_DpSeamFinder_new(costFunction.ToNativeString(), out var ptr));
+        return ptr;
+    }
+
+    /// <summary>
+    /// Sets the cost function used to estimate seams.
+    /// </summary>
+    public void SetCostFunction(SeamFinderCostFunction costFunction)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_DpSeamFinder_setCostFunction(Handle, costFunction.ToNativeString()));
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/Estimator.cs
+++ b/src/OpenCvSharp/Modules/stitching/Estimator.cs
@@ -102,6 +102,9 @@ public abstract class Estimator : CvObject
                 cameras[i].Ppy = wCameras[i].Ppy;
             }
 
+            GC.KeepAlive(featuresArray);
+            GC.KeepAlive(matchesArray);
+
             return ret != 0;
         }
         finally

--- a/src/OpenCvSharp/Modules/stitching/Estimator.cs
+++ b/src/OpenCvSharp/Modules/stitching/Estimator.cs
@@ -1,0 +1,117 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Rotation estimator base class. It takes features of all images, pairwise matches between all images
+/// and estimates rotations of all cameras.
+/// </summary>
+public abstract class Estimator : CvObject
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    protected Estimator(IntPtr ptr) : base(ptr)
+    {
+    }
+
+    /// <summary>
+    /// Estimates camera parameters.
+    /// </summary>
+    /// <param name="features">Features of images</param>
+    /// <param name="pairwiseMatches">Pairwise matches of images</param>
+    /// <param name="cameras">Initial camera parameters to refine, one per image; refined in place</param>
+    /// <returns>True in case of success, false otherwise</returns>
+    public bool Apply(IReadOnlyList<ImageFeatures> features, IReadOnlyList<MatchesInfo> pairwiseMatches, CameraParams[] cameras)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(features);
+        ArgumentNullException.ThrowIfNull(pairwiseMatches);
+        ArgumentNullException.ThrowIfNull(cameras);
+        if (cameras.Length != features.Count)
+            throw new ArgumentException($"{nameof(cameras)}.Length must equal {nameof(features)}.Count", nameof(cameras));
+
+        var featuresArray = features.CastOrToArray();
+        var matchesArray = pairwiseMatches.CastOrToArray();
+
+        var keypointVecs = new StdVector<KeyPoint>?[featuresArray.Length];
+        var wFeatures = new WImageFeatures[featuresArray.Length];
+        var wMatches = new WMatchesInfo[matchesArray.Length];
+        var matchesVecs = new StdVector<DMatch>?[matchesArray.Length];
+        var inliersMaskVecs = new StdVector<byte>?[matchesArray.Length];
+        var wCameras = new WCameraParams[cameras.Length];
+        try
+        {
+            for (var i = 0; i < featuresArray.Length; i++)
+            {
+                ArgumentNullException.ThrowIfNull(featuresArray[i].Descriptors, $"{nameof(features)}[{i}].Descriptors");
+                keypointVecs[i] = new StdVector<KeyPoint>(featuresArray[i].Keypoints);
+                wFeatures[i] = new WImageFeatures
+                {
+                    ImgIdx = featuresArray[i].ImgIdx,
+                    ImgSize = featuresArray[i].ImgSize,
+                    Keypoints = keypointVecs[i]!.CvPtr,
+                    Descriptors = featuresArray[i].Descriptors.CvPtr,
+                };
+            }
+
+            for (var i = 0; i < matchesArray.Length; i++)
+            {
+                matchesVecs[i] = new StdVector<DMatch>(matchesArray[i].Matches);
+                inliersMaskVecs[i] = new StdVector<byte>(matchesArray[i].InliersMask);
+                wMatches[i] = new WMatchesInfo
+                {
+                    SrcImgIdx = matchesArray[i].SrcImgIdx,
+                    DstImgIdx = matchesArray[i].DstImgIdx,
+                    Matches = matchesVecs[i]!.CvPtr,
+                    InliersMask = inliersMaskVecs[i]!.CvPtr,
+                    NumInliers = matchesArray[i].NumInliers,
+                    H = matchesArray[i].H.CvPtr,
+                    Confidence = matchesArray[i].Confidence,
+                };
+            }
+
+            for (var i = 0; i < cameras.Length; i++)
+            {
+                wCameras[i] = new WCameraParams
+                {
+                    Focal = cameras[i].Focal,
+                    Aspect = cameras[i].Aspect,
+                    Ppx = cameras[i].Ppx,
+                    Ppy = cameras[i].Ppy,
+                    R = cameras[i].R.CvPtr,
+                    T = cameras[i].T.CvPtr,
+                };
+            }
+
+            NativeMethods.HandleException(
+                NativeMethods.stitching_Estimator_apply(
+                    Handle,
+                    wFeatures, wFeatures.Length,
+                    wMatches, wMatches.Length,
+                    wCameras, wCameras.Length,
+                    out var ret));
+
+            for (var i = 0; i < cameras.Length; i++)
+            {
+                cameras[i].Focal = wCameras[i].Focal;
+                cameras[i].Aspect = wCameras[i].Aspect;
+                cameras[i].Ppx = wCameras[i].Ppx;
+                cameras[i].Ppy = wCameras[i].Ppy;
+            }
+
+            return ret != 0;
+        }
+        finally
+        {
+            foreach (var vec in keypointVecs)
+                vec?.Dispose();
+            foreach (var vec in matchesVecs)
+                vec?.Dispose();
+            foreach (var vec in inliersMaskVecs)
+                vec?.Dispose();
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/ExposureCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/ExposureCompensator.cs
@@ -1,0 +1,150 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Kind of exposure compensator to build (see <see cref="ExposureCompensator.CreateDefault"/>).
+/// </summary>
+public enum ExposureCompensatorType
+{
+#pragma warning disable 1591
+    No,
+    Gain,
+    GainBlocks,
+    Channels,
+    ChannelsBlocks,
+#pragma warning restore 1591
+}
+
+/// <summary>
+/// Base class for all exposure compensators.
+/// </summary>
+public class ExposureCompensator : CvPtrObject
+{
+    /// <summary>
+    /// Constructor for the factory pattern (used by <see cref="CreateDefault"/>).
+    /// </summary>
+    private ExposureCompensator(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr,
+            p => NativeMethods.HandleException(NativeMethods.stitching_Ptr_ExposureCompensator_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Constructor for the direct-allocation pattern (used by concrete subclasses with a public constructor).
+    /// </summary>
+    /// <param name="rawPtr"></param>
+    /// <param name="release"></param>
+    protected ExposureCompensator(IntPtr rawPtr, Action<IntPtr> release)
+        : base(rawPtr, release)
+    {
+    }
+
+    /// <summary>
+    /// Creates an exposure compensator of the given kind.
+    /// </summary>
+    /// <param name="type">Kind of exposure compensator to build</param>
+    public static ExposureCompensator CreateDefault(ExposureCompensatorType type)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_ExposureCompensator_createDefault((int)type, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Ptr_ExposureCompensator_get(smartPtr, out var rawPtr));
+        return new ExposureCompensator(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Updates image masks and computes gains to prepare for exposure compensation.
+    /// </summary>
+    /// <param name="corners">Source image top-left corners</param>
+    /// <param name="images">Source images</param>
+    /// <param name="masks">Image masks to update</param>
+    public void Feed(IReadOnlyList<Point> corners, IEnumerable<Mat> images, IEnumerable<Mat> masks)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(images);
+        ArgumentNullException.ThrowIfNull(masks);
+
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var imagesArray = images.CastOrToArray();
+        var masksArray = masks.CastOrToArray();
+        var imagesPtrs = imagesArray.Select(m => m.CvPtr).ToArray();
+        var masksPtrs = masksArray.Select(m => m.CvPtr).ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_ExposureCompensator_feed(
+                Handle, cornersArray, cornersArray.Length,
+                imagesPtrs, imagesPtrs.Length,
+                masksPtrs, masksPtrs.Length));
+
+        GC.KeepAlive(imagesArray);
+        GC.KeepAlive(masksArray);
+    }
+
+    /// <summary>
+    /// Compensates exposure in the specified image.
+    /// </summary>
+    /// <param name="index">Image index</param>
+    /// <param name="corner">Image top-left corner</param>
+    /// <param name="image">Image to process</param>
+    /// <param name="mask">Image mask</param>
+    public virtual void Apply(int index, Point corner, InputOutputArray image, InputArray mask)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_ExposureCompensator_apply(Handle, index, corner, image.Proxy, mask.Proxy));
+        GC.KeepAlive(image.Source);
+        GC.KeepAlive(mask.Source);
+    }
+
+    /// <summary>
+    /// Gets the gains computed for each fed image.
+    /// </summary>
+    public Mat[] GetMatGains()
+    {
+        ThrowIfDisposed();
+        using var gains = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_ExposureCompensator_getMatGains(Handle, gains.CvPtr));
+        return gains.ToArray();
+    }
+
+    /// <summary>
+    /// Sets the gains for each image, in lieu of computing them via <see cref="Feed"/>.
+    /// </summary>
+    public void SetMatGains(IEnumerable<Mat> gains)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(gains);
+
+        var gainsArray = gains.CastOrToArray();
+        var gainsPtrs = gainsArray.Select(m => m.CvPtr).ToArray();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_ExposureCompensator_setMatGains(Handle, gainsPtrs, gainsPtrs.Length));
+        GC.KeepAlive(gainsArray);
+    }
+
+    /// <summary>
+    /// Whether gains are recomputed on each <see cref="Feed"/> call.
+    /// </summary>
+    public bool UpdateGain
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.stitching_ExposureCompensator_getUpdateGain(Handle, out var ret));
+            return ret != 0;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(
+                NativeMethods.stitching_ExposureCompensator_setUpdateGain(Handle, value ? 1 : 0));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/FeatherBlender.cs
+++ b/src/OpenCvSharp/Modules/stitching/FeatherBlender.cs
@@ -1,0 +1,76 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Simple blender which mixes images at its borders.
+/// </summary>
+public class FeatherBlender : Blender
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="sharpness"></param>
+    public FeatherBlender(float sharpness = 0.02f) : base(Create(sharpness), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_FeatherBlender_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(float sharpness)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_FeatherBlender_new(sharpness, out var ptr));
+        return ptr;
+    }
+
+    /// <summary>
+    /// Sharpness of the blending border.
+    /// </summary>
+    public float Sharpness
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_FeatherBlender_getSharpness(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_FeatherBlender_setSharpness(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Creates weight maps for a fixed set of source images by their masks and top-left corners.
+    /// The final image can be obtained by simple weighting of the source images.
+    /// </summary>
+    /// <param name="masks">Source image masks</param>
+    /// <param name="corners">Source image top-left corners</param>
+    /// <param name="weightMaps">Weight maps, one per source image</param>
+    /// <returns>The region of interest covered by the weight maps</returns>
+    public Rect CreateWeightMaps(IEnumerable<Mat> masks, IReadOnlyList<Point> corners, IEnumerable<Mat> weightMaps)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(masks);
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(weightMaps);
+
+        var masksArray = masks as Mat[] ?? [.. masks];
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var weightMapsArray = weightMaps as Mat[] ?? [.. weightMaps];
+        var masksPtrs = masksArray.Select(m => m.CvPtr).ToArray();
+        var weightMapsPtrs = weightMapsArray.Select(m => m.CvPtr).ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_FeatherBlender_createWeightMaps(
+                Handle,
+                masksPtrs, masksPtrs.Length,
+                cornersArray, cornersArray.Length,
+                weightMapsPtrs, weightMapsPtrs.Length,
+                out var roi));
+
+        GC.KeepAlive(masksArray);
+        GC.KeepAlive(weightMapsArray);
+        return roi;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/FisheyeWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/FisheyeWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Fisheye warper factory class.
+/// </summary>
+public class FisheyeWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public FisheyeWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_FisheyeWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_FisheyeWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/GainCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/GainCompensator.cs
@@ -1,0 +1,60 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Exposure compensator which tries to remove exposure related artifacts by adjusting image intensities.
+/// </summary>
+public class GainCompensator : ExposureCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="nrFeeds"></param>
+    public GainCompensator(int nrFeeds = 1) : base(Create(nrFeeds), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(int nrFeeds)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_new(nrFeeds, out var ptr));
+        return ptr;
+    }
+
+    /// <summary>
+    /// Number of images fed to this compensator.
+    /// </summary>
+    public int NrFeeds
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_getNrFeeds(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_setNrFeeds(Handle, value));
+        }
+    }
+
+    /// <summary>
+    /// Similarity threshold used for masking similar image regions in the exposure compensation gain computation.
+    /// </summary>
+    public double SimilarityThreshold
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_getSimilarityThreshold(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_GainCompensator_setSimilarityThreshold(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/GraphCutSeamFinder.cs
+++ b/src/OpenCvSharp/Modules/stitching/GraphCutSeamFinder.cs
@@ -1,0 +1,62 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Minimum graph cut-based seam estimator.
+/// </summary>
+public class GraphCutSeamFinder : SeamFinder
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="costType"></param>
+    /// <param name="terminalCost"></param>
+    /// <param name="badRegionPenalty"></param>
+    public GraphCutSeamFinder(
+        SeamFinderCostFunction costType = SeamFinderCostFunction.ColorGrad,
+        float terminalCost = 10000f,
+        float badRegionPenalty = 1000f)
+        : base(Create(costType, terminalCost, badRegionPenalty), static h =>
+            NativeMethods.HandleException(NativeMethods.stitching_GraphCutSeamFinder_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(SeamFinderCostFunction costType, float terminalCost, float badRegionPenalty)
+    {
+        // GraphCutSeamFinder parses "COST_COLOR"/"COST_COLOR_GRAD" (its own GraphCutSeamFinderBase::CostType
+        // enum names), unlike DpSeamFinder's "COLOR"/"COLOR_GRAD" - see opencv/modules/stitching/src/seam_finders.cpp.
+        var nativeString = costType switch
+        {
+            SeamFinderCostFunction.Color => "COST_COLOR",
+            SeamFinderCostFunction.ColorGrad => "COST_COLOR_GRAD",
+            _ => throw new ArgumentOutOfRangeException(nameof(costType), costType, null),
+        };
+        NativeMethods.HandleException(
+            NativeMethods.stitching_GraphCutSeamFinder_new(nativeString, terminalCost, badRegionPenalty, out var ptr));
+        return ptr;
+    }
+
+    /// <inheritdoc />
+    public override void Find(IEnumerable<Mat> src, IReadOnlyList<Point> corners, IEnumerable<Mat> masks)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(masks);
+
+        var srcArray = src.CastOrToArray();
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var masksArray = masks.CastOrToArray();
+        var srcPtrs = srcArray.Select(m => m.CvPtr).ToArray();
+        var masksPtrs = masksArray.Select(m => m.CvPtr).ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_GraphCutSeamFinder_find(
+                Handle, srcPtrs, srcPtrs.Length, cornersArray, cornersArray.Length, masksPtrs, masksPtrs.Length));
+
+        GC.KeepAlive(srcArray);
+        GC.KeepAlive(masksArray);
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/HomographyBasedEstimator.cs
+++ b/src/OpenCvSharp/Modules/stitching/HomographyBasedEstimator.cs
@@ -1,0 +1,31 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Homography based rotation estimator.
+/// </summary>
+public class HomographyBasedEstimator : Estimator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="isFocalsEstimated"></param>
+    public HomographyBasedEstimator(bool isFocalsEstimated = false) : base(Create(isFocalsEstimated))
+    {
+        InitSafeHandle(CvPtr);
+    }
+
+    private static IntPtr Create(bool isFocalsEstimated)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_HomographyBasedEstimator_new(isFocalsEstimated ? 1 : 0, out var ptr));
+        return ptr;
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_HomographyBasedEstimator_delete(h))));
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/LightGlueFeaturesMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/LightGlueFeaturesMatcher.cs
@@ -1,0 +1,66 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Features matcher that adapts <see cref="OpenCvSharp.LightGlueMatcher"/> (a DNN-based descriptor matcher)
+/// to the stitching pipeline's <see cref="FeaturesMatcher"/> interface.
+/// Requires OpenCV built with the dnn module; otherwise the underlying LightGlueMatcher throws at runtime.
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public class LightGlueFeaturesMatcher : FeaturesMatcher
+{
+    /// <summary>
+    /// Constructs a LightGlue features matcher.
+    /// </summary>
+    /// <param name="lgMatcher">LightGlueMatcher instance for DNN-based matching</param>
+    /// <param name="numMatchesThresh1">Minimum number of matches required for the 2D projective transform
+    /// estimation used in the inliers classification step</param>
+    /// <param name="numMatchesThresh2">Minimum number of matches required for the 2D projective transform
+    /// re-estimation on inliers</param>
+    /// <param name="matchesConfidenceThresh">Matching confidence threshold to take the match into account</param>
+    public LightGlueFeaturesMatcher(
+        LightGlueMatcher lgMatcher,
+        int numMatchesThresh1 = 6,
+        int numMatchesThresh2 = 6,
+        double matchesConfidenceThresh = 3.0)
+        : base(Create(lgMatcher, numMatchesThresh1, numMatchesThresh2, matchesConfidenceThresh))
+    {
+        InitSafeHandle(CvPtr);
+        GC.KeepAlive(lgMatcher);
+    }
+
+    private static IntPtr Create(
+        LightGlueMatcher lgMatcher,
+        int numMatchesThresh1,
+        int numMatchesThresh2,
+        double matchesConfidenceThresh)
+    {
+        ArgumentNullException.ThrowIfNull(lgMatcher);
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_LightGlueFeaturesMatcher_new(
+                lgMatcher.SmartPtr,
+                numMatchesThresh1,
+                numMatchesThresh2,
+                matchesConfidenceThresh,
+                out var ptr));
+        return ptr;
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_LightGlueFeaturesMatcher_delete(h))));
+    }
+
+    /// <summary>
+    /// Sets the LightGlue confidence threshold for filtering matches.
+    /// </summary>
+    public void SetScoreThreshold(float thresh)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_LightGlueFeaturesMatcher_setScoreThreshold(Handle, thresh));
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/MatchesInfo.cs
+++ b/src/OpenCvSharp/Modules/stitching/MatchesInfo.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
 namespace OpenCvSharp.Detail;
 
 /// <summary>
@@ -95,3 +98,19 @@ public sealed class MatchesInfo : IDisposable
         H.Dispose();
     }
 }
+
+#pragma warning disable 1591
+[StructLayout(LayoutKind.Sequential)]
+[SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
+[SuppressMessage("Microsoft.Design", "CA1815: Override equals and operator equals on value types")]
+public struct WMatchesInfo
+{
+    public int SrcImgIdx;
+    public int DstImgIdx;
+    public IntPtr Matches;
+    public IntPtr InliersMask;
+    public int NumInliers;
+    public IntPtr H;
+    public double Confidence;
+}
+#pragma warning restore 1591

--- a/src/OpenCvSharp/Modules/stitching/MercatorWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/MercatorWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Mercator warper factory class.
+/// </summary>
+public class MercatorWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public MercatorWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_MercatorWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_MercatorWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/MultiBandBlender.cs
+++ b/src/OpenCvSharp/Modules/stitching/MultiBandBlender.cs
@@ -1,0 +1,46 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Blender which uses a multi-band blending algorithm.
+/// </summary>
+public class MultiBandBlender : Blender
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="tryGpu">Should try to use GPU or not</param>
+    /// <param name="numBands">Number of bands</param>
+    /// <param name="weightType">Type of pyramid weights (CV_32F or CV_16S)</param>
+    public MultiBandBlender(bool tryGpu = false, int numBands = 5, MatType? weightType = null)
+        : base(Create(tryGpu, numBands, weightType?.Value ?? MatType.CV_32F), static h =>
+            NativeMethods.HandleException(NativeMethods.stitching_MultiBandBlender_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(bool tryGpu, int numBands, int weightType)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_MultiBandBlender_new(tryGpu ? 1 : 0, numBands, weightType, out var ptr));
+        return ptr;
+    }
+
+    /// <summary>
+    /// Number of bands used in the multi-band blending algorithm.
+    /// </summary>
+    public int NumBands
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_MultiBandBlender_getNumBands(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_MultiBandBlender_setNumBands(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/NoBundleAdjuster.cs
+++ b/src/OpenCvSharp/Modules/stitching/NoBundleAdjuster.cs
@@ -1,0 +1,22 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Stub bundle adjuster that does nothing.
+/// </summary>
+public class NoBundleAdjuster : BundleAdjusterBase
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public NoBundleAdjuster() : base(Create())
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_NoBundleAdjuster_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/NoExposureCompensator.cs
+++ b/src/OpenCvSharp/Modules/stitching/NoExposureCompensator.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Stub exposure compensator which does nothing.
+/// </summary>
+public class NoExposureCompensator : ExposureCompensator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public NoExposureCompensator() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_NoExposureCompensator_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_NoExposureCompensator_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/NoSeamFinder.cs
+++ b/src/OpenCvSharp/Modules/stitching/NoSeamFinder.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Stub seam estimator which does nothing.
+/// </summary>
+public class NoSeamFinder : SeamFinder
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public NoSeamFinder() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_NoSeamFinder_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_NoSeamFinder_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/PaniniPortraitWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/PaniniPortraitWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Panini portrait warper factory class.
+/// </summary>
+public class PaniniPortraitWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public PaniniPortraitWarper(float a = 1, float b = 1) : base(Create(a, b), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_PaniniPortraitWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(float a, float b)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_PaniniPortraitWarper_new(a, b, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/PaniniWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/PaniniWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Panini warper factory class.
+/// </summary>
+public class PaniniWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public PaniniWarper(float a = 1, float b = 1) : base(Create(a, b), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_PaniniWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create(float a, float b)
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_PaniniWarper_new(a, b, out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/PlaneWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/PlaneWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Plane warper factory class.
+/// </summary>
+public class PlaneWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public PlaneWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_PlaneWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_PlaneWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/PyRotationWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/PyRotationWarper.cs
@@ -1,0 +1,142 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+// ReSharper disable once InconsistentNaming
+/// <summary>
+/// Rotation-based image warper, usable standalone (without a full <see cref="Stitcher"/> pipeline).
+/// </summary>
+public class PyRotationWarper : CvObject
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="type">Warper type: "plane", "affine", "cylindrical", "spherical", "fisheye",
+    /// "stereographic", "compressedPlaneA2B1", "compressedPlaneA1.5B1", "compressedPlanePortraitA2B1",
+    /// "compressedPlanePortraitA1.5B1", "paniniA2B1", "paniniA1.5B1", "paniniPortraitA2B1",
+    /// "paniniPortraitA1.5B1", "mercator", "transverseMercator"</param>
+    /// <param name="scale">Warper scale</param>
+    public PyRotationWarper(string type, float scale) : base(Create(type, scale))
+    {
+        InitSafeHandle(CvPtr);
+    }
+
+    private static IntPtr Create(string type, float scale)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        NativeMethods.HandleException(NativeMethods.stitching_PyRotationWarper_new(type, scale, out var ptr));
+        return ptr;
+    }
+
+    private void InitSafeHandle(IntPtr p, bool ownsHandle = true)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
+            static h => NativeMethods.HandleException(NativeMethods.stitching_PyRotationWarper_delete(h))));
+    }
+
+    /// <summary>
+    /// Projects the image point.
+    /// </summary>
+    public Point2f WarpPoint(Point2f pt, InputArray k, InputArray r)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_warpPoint(Handle, pt, k.Proxy, r.Proxy, out var ret));
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Projects the image point backward.
+    /// </summary>
+    public Point2f WarpPointBackward(Point2f pt, InputArray k, InputArray r)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_warpPointBackward(Handle, pt, k.Proxy, r.Proxy, out var ret));
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Builds the projection maps according to the given camera data.
+    /// </summary>
+    /// <returns>Projected image minimum bounding box</returns>
+    public Rect BuildMaps(Size srcSize, InputArray k, InputArray r, OutputArray xmap, OutputArray ymap)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_buildMaps(Handle, srcSize, k.Proxy, r.Proxy, xmap.Proxy, ymap.Proxy, out var ret));
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        GC.KeepAlive(xmap.Source);
+        GC.KeepAlive(ymap.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Projects the image.
+    /// </summary>
+    /// <returns>Projected image top-left corner</returns>
+    public Point Warp(InputArray src, InputArray k, InputArray r, InterpolationFlags interpMode, BorderTypes borderMode, OutputArray dst)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_warp(
+                Handle, src.Proxy, k.Proxy, r.Proxy, (int)interpMode, (int)borderMode, dst.Proxy, out var ret));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        GC.KeepAlive(dst.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Projects the image backward.
+    /// </summary>
+    public void WarpBackward(
+        InputArray src, InputArray k, InputArray r, InterpolationFlags interpMode, BorderTypes borderMode, Size dstSize, OutputArray dst)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_warpBackward(
+                Handle, src.Proxy, k.Proxy, r.Proxy, (int)interpMode, (int)borderMode, dstSize, dst.Proxy));
+        GC.KeepAlive(src.Source);
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        GC.KeepAlive(dst.Source);
+    }
+
+    /// <summary>
+    /// Computes the projected image minimum bounding box.
+    /// </summary>
+    public Rect WarpRoi(Size srcSize, InputArray k, InputArray r)
+    {
+        ThrowIfDisposed();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_PyRotationWarper_warpRoi(Handle, srcSize, k.Proxy, r.Proxy, out var ret));
+        GC.KeepAlive(k.Source);
+        GC.KeepAlive(r.Source);
+        return ret;
+    }
+
+    /// <summary>
+    /// Warper scale.
+    /// </summary>
+    public float Scale
+    {
+        get
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_PyRotationWarper_getScale(Handle, out var ret));
+            return ret;
+        }
+        set
+        {
+            ThrowIfDisposed();
+            NativeMethods.HandleException(NativeMethods.stitching_PyRotationWarper_setScale(Handle, value));
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/SeamFinder.cs
+++ b/src/OpenCvSharp/Modules/stitching/SeamFinder.cs
@@ -1,0 +1,79 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Kind of seam finder to build (see <see cref="SeamFinder.CreateDefault"/>).
+/// </summary>
+public enum SeamFinderType
+{
+#pragma warning disable 1591
+    No,
+    VoronoiSeam,
+    DpSeam,
+#pragma warning restore 1591
+}
+
+/// <summary>
+/// Base class for a seam estimator.
+/// </summary>
+public class SeamFinder : CvPtrObject
+{
+    /// <summary>
+    /// Constructor for the factory pattern (used by <see cref="CreateDefault"/>).
+    /// </summary>
+    private SeamFinder(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr,
+            p => NativeMethods.HandleException(NativeMethods.stitching_Ptr_SeamFinder_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Constructor for the direct-allocation pattern (used by concrete subclasses with a public constructor).
+    /// </summary>
+    protected SeamFinder(IntPtr rawPtr, Action<IntPtr> release)
+        : base(rawPtr, release)
+    {
+    }
+
+    /// <summary>
+    /// Creates a seam finder of the given kind.
+    /// </summary>
+    /// <param name="type">Kind of seam finder to build</param>
+    public static SeamFinder CreateDefault(SeamFinderType type)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_SeamFinder_createDefault((int)type, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Ptr_SeamFinder_get(smartPtr, out var rawPtr));
+        return new SeamFinder(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Estimates seams and updates the source masks in place.
+    /// </summary>
+    /// <param name="src">Source images</param>
+    /// <param name="corners">Source image top-left corners</param>
+    /// <param name="masks">Source image masks to update</param>
+    public virtual void Find(IEnumerable<Mat> src, IReadOnlyList<Point> corners, IEnumerable<Mat> masks)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(masks);
+
+        var srcArray = src.CastOrToArray();
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var masksArray = masks.CastOrToArray();
+        var srcPtrs = srcArray.Select(m => m.CvPtr).ToArray();
+        var masksPtrs = masksArray.Select(m => m.CvPtr).ToArray();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_SeamFinder_find(
+                Handle, srcPtrs, srcPtrs.Length, cornersArray, cornersArray.Length, masksPtrs, masksPtrs.Length));
+
+        GC.KeepAlive(srcArray);
+        GC.KeepAlive(masksArray);
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/SphericalWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/SphericalWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Spherical warper factory class.
+/// </summary>
+public class SphericalWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public SphericalWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_SphericalWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_SphericalWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/StereographicWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/StereographicWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Stereographic warper factory class.
+/// </summary>
+public class StereographicWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public StereographicWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_StereographicWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_StereographicWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -8,28 +8,14 @@ namespace OpenCvSharp
 #pragma warning disable 1591
     // ReSharper disable InconsistentNaming
 
-    // TODO
     namespace Detail
     {
         public enum WaveCorrectKind
         {
             Horizontal,
-            Vertical
+            Vertical,
+            Auto
         }
-        
-        public class FeaturesFinder;
-        
-        public class BundleAdjusterBase;
-
-        public class WarperCreator;
-
-        public class ExposureCompensator;
-
-        public class SeamFinder;
-
-        public class Blender;
-
-        public class CameraParams;
     }
 
     /// <summary>
@@ -191,55 +177,24 @@ namespace OpenCvSharp
             }
         }
 
-        /*
-        public FeaturesFinder FeaturesFinder
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
-        public FeaturesMatcher FeaturesMatcher
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
+        /// <summary>
+        /// Mask indicating which image pairs must be matched.
+        /// </summary>
         public Mat MatchingMask
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get
+            {
+                var mask = new Mat();
+                NativeMethods.HandleException(NativeMethods.stitching_Stitcher_matchingMask(Handle, mask.CvPtr));
+                return mask;
+            }
+            set
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setMatchingMask(Handle, value.CvPtr));
+                GC.KeepAlive(value);
+            }
         }
-
-        public BundleAdjusterBase BundleAdjuster
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
-        public WarperCreator Warper
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
-        public ExposureCompensator ExposureCompensator
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
-        public SeamFinder SeamFinder
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
-        public Blender Blender
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-        */
 
         // TODO this should be method?
         public IReadOnlyList<int> Component
@@ -253,7 +208,36 @@ namespace OpenCvSharp
             }
         }
 
-        //public CameraParams[] Cameras => throw new NotImplementedException();
+        /// <summary>
+        /// Estimated camera parameters, one per stitched image.
+        /// </summary>
+        public CameraParams[] Cameras
+        {
+            get
+            {
+                using var focals = new StdVector<double>();
+                using var aspects = new StdVector<double>();
+                using var ppxs = new StdVector<double>();
+                using var ppys = new StdVector<double>();
+                using var rs = new VectorOfMat();
+                using var ts = new VectorOfMat();
+                NativeMethods.HandleException(
+                    NativeMethods.stitching_Stitcher_cameras(
+                        Handle, focals.CvPtr, aspects.CvPtr, ppxs.CvPtr, ppys.CvPtr, rs.CvPtr, ts.CvPtr));
+
+                var focalsArr = focals.ToArray();
+                var aspectsArr = aspects.ToArray();
+                var ppxsArr = ppxs.ToArray();
+                var ppysArr = ppys.ToArray();
+                var rsArr = rs.ToArray();
+                var tsArr = ts.ToArray();
+
+                var result = new CameraParams[focalsArr.Length];
+                for (var i = 0; i < result.Length; i++)
+                    result[i] = new CameraParams(focalsArr[i], aspectsArr[i], ppxsArr[i], ppysArr[i], rsArr[i], tsArr[i]);
+                return result;
+            }
+        }
 
         public double WorkScale
         {
@@ -432,6 +416,76 @@ namespace OpenCvSharp
             GC.KeepAlive(images);
             GC.KeepAlive(pano.Source);
             return (Status)ret;
+        }
+
+        /// <summary>
+        /// Sets the features finder used to detect keypoints and compute descriptors.
+        /// </summary>
+        public void SetFeaturesFinder(Feature2D featuresFinder)
+        {
+            ArgumentNullException.ThrowIfNull(featuresFinder);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setFeaturesFinder(Handle, featuresFinder.RawPtr));
+            GC.KeepAlive(featuresFinder);
+        }
+
+        /// <summary>
+        /// Sets the features matcher used to match images pairwise.
+        /// </summary>
+        public void SetFeaturesMatcher(FeaturesMatcher featuresMatcher)
+        {
+            ArgumentNullException.ThrowIfNull(featuresMatcher);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setFeaturesMatcher(Handle, featuresMatcher.CvPtr));
+            GC.KeepAlive(featuresMatcher);
+        }
+
+        /// <summary>
+        /// Sets the bundle adjuster used to refine camera parameters.
+        /// </summary>
+        public void SetBundleAdjuster(BundleAdjusterBase bundleAdjuster)
+        {
+            ArgumentNullException.ThrowIfNull(bundleAdjuster);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setBundleAdjuster(Handle, bundleAdjuster.CvPtr));
+            GC.KeepAlive(bundleAdjuster);
+        }
+
+        /// <summary>
+        /// Sets the warper creator used to project images onto the panorama surface.
+        /// </summary>
+        public void SetWarper(WarperCreator warper)
+        {
+            ArgumentNullException.ThrowIfNull(warper);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setWarper(Handle, warper.CvPtr));
+            GC.KeepAlive(warper);
+        }
+
+        /// <summary>
+        /// Sets the exposure compensator used to remove exposure related artifacts.
+        /// </summary>
+        public void SetExposureCompensator(ExposureCompensator exposureCompensator)
+        {
+            ArgumentNullException.ThrowIfNull(exposureCompensator);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setExposureCompensator(Handle, exposureCompensator.CvPtr));
+            GC.KeepAlive(exposureCompensator);
+        }
+
+        /// <summary>
+        /// Sets the seam finder used to estimate seams between images.
+        /// </summary>
+        public void SetSeamFinder(SeamFinder seamFinder)
+        {
+            ArgumentNullException.ThrowIfNull(seamFinder);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setSeamFinder(Handle, seamFinder.CvPtr));
+            GC.KeepAlive(seamFinder);
+        }
+
+        /// <summary>
+        /// Sets the blender used to compose the final panorama.
+        /// </summary>
+        public void SetBlender(Blender blender)
+        {
+            ArgumentNullException.ThrowIfNull(blender);
+            NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setBlender(Handle, blender.CvPtr));
+            GC.KeepAlive(blender);
         }
 
         #endregion

--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -418,6 +418,18 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        // Stitcher's native setters wrap these in a non-owning cv::Ptr (no-op deleter), so the
+        // managed side is solely responsible for keeping the object alive for as long as it's
+        // attached to this Stitcher - otherwise the GC could collect it and free the native
+        // object out from under the Stitcher, causing a use-after-free.
+        private Feature2D? featuresFinderRef;
+        private FeaturesMatcher? featuresMatcherRef;
+        private BundleAdjusterBase? bundleAdjusterRef;
+        private WarperCreator? warperRef;
+        private ExposureCompensator? exposureCompensatorRef;
+        private SeamFinder? seamFinderRef;
+        private Blender? blenderRef;
+
         /// <summary>
         /// Sets the features finder used to detect keypoints and compute descriptors.
         /// </summary>
@@ -426,6 +438,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(featuresFinder);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setFeaturesFinder(Handle, featuresFinder.RawPtr));
             GC.KeepAlive(featuresFinder);
+            featuresFinderRef = featuresFinder;
         }
 
         /// <summary>
@@ -436,6 +449,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(featuresMatcher);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setFeaturesMatcher(Handle, featuresMatcher.CvPtr));
             GC.KeepAlive(featuresMatcher);
+            featuresMatcherRef = featuresMatcher;
         }
 
         /// <summary>
@@ -446,6 +460,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(bundleAdjuster);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setBundleAdjuster(Handle, bundleAdjuster.CvPtr));
             GC.KeepAlive(bundleAdjuster);
+            bundleAdjusterRef = bundleAdjuster;
         }
 
         /// <summary>
@@ -456,6 +471,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(warper);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setWarper(Handle, warper.CvPtr));
             GC.KeepAlive(warper);
+            warperRef = warper;
         }
 
         /// <summary>
@@ -466,6 +482,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(exposureCompensator);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setExposureCompensator(Handle, exposureCompensator.CvPtr));
             GC.KeepAlive(exposureCompensator);
+            exposureCompensatorRef = exposureCompensator;
         }
 
         /// <summary>
@@ -476,6 +493,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(seamFinder);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setSeamFinder(Handle, seamFinder.CvPtr));
             GC.KeepAlive(seamFinder);
+            seamFinderRef = seamFinder;
         }
 
         /// <summary>
@@ -486,6 +504,7 @@ namespace OpenCvSharp
             ArgumentNullException.ThrowIfNull(blender);
             NativeMethods.HandleException(NativeMethods.stitching_Stitcher_setBlender(Handle, blender.CvPtr));
             GC.KeepAlive(blender);
+            blenderRef = blender;
         }
 
         #endregion

--- a/src/OpenCvSharp/Modules/stitching/Timelapser.cs
+++ b/src/OpenCvSharp/Modules/stitching/Timelapser.cs
@@ -1,0 +1,97 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Kind of timelapse to build (see <see cref="Timelapser"/>).
+/// </summary>
+public enum TimelapserType
+{
+    /// <summary>
+    /// Each frame is composited as-is, without cropping to the common overlap region.
+    /// </summary>
+    AsIs = 0,
+
+    /// <summary>
+    /// Each frame is cropped to the common overlap region before compositing.
+    /// </summary>
+    Crop = 1,
+}
+
+/// <summary>
+/// Base class for timelapse composition. Takes a sequence of images, applies the appropriate shift,
+/// and stores the result.
+/// </summary>
+public class Timelapser : CvPtrObject
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="smartPtr">cv::Ptr&lt;cv::detail::Timelapser&gt;*</param>
+    /// <param name="rawPtr">cv::detail::Timelapser*</param>
+    private Timelapser(IntPtr smartPtr, IntPtr rawPtr)
+        : base(smartPtr, rawPtr,
+            p => NativeMethods.HandleException(NativeMethods.stitching_Ptr_Timelapser_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a timelapser of the given kind.
+    /// </summary>
+    /// <param name="type">Kind of timelapse to build</param>
+    public static Timelapser CreateDefault(TimelapserType type)
+    {
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Timelapser_createDefault((int)type, out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Ptr_Timelapser_get(smartPtr, out var rawPtr));
+        return new Timelapser(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Prepares the timelapser for a sequence of images with the given corners and sizes in the
+    /// destination image plane.
+    /// </summary>
+    /// <param name="corners">Top-left corners of the source images in the destination plane</param>
+    /// <param name="sizes">Sizes of the source images</param>
+    public void Initialize(IReadOnlyList<Point> corners, IReadOnlyList<Size> sizes)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(corners);
+        ArgumentNullException.ThrowIfNull(sizes);
+
+        var cornersArray = corners as Point[] ?? [.. corners];
+        var sizesArray = sizes as Size[] ?? [.. sizes];
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Timelapser_initialize(
+                Handle, cornersArray, cornersArray.Length, sizesArray, sizesArray.Length));
+    }
+
+    /// <summary>
+    /// Composites the given image into the timelapse at the given position.
+    /// </summary>
+    /// <param name="img">Source image</param>
+    /// <param name="mask">Mask indicating valid pixels of the source image</param>
+    /// <param name="tl">Top-left corner of the source image in the destination plane</param>
+    public void Process(InputArray img, InputArray mask, Point tl)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Timelapser_process(Handle, img.Proxy, mask.Proxy, tl));
+        GC.KeepAlive(img.Source);
+        GC.KeepAlive(mask.Source);
+    }
+
+    /// <summary>
+    /// Gets the composited destination image.
+    /// </summary>
+    public Mat GetDst()
+    {
+        ThrowIfDisposed();
+        var dst = new Mat();
+        NativeMethods.HandleException(
+            NativeMethods.stitching_Timelapser_getDst(Handle, dst.CvPtr));
+        return dst;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/TransverseMercatorWarper.cs
+++ b/src/OpenCvSharp/Modules/stitching/TransverseMercatorWarper.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+/// <summary>
+/// Transverse Mercator warper factory class.
+/// </summary>
+public class TransverseMercatorWarper : WarperCreator
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public TransverseMercatorWarper() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_TransverseMercatorWarper_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_TransverseMercatorWarper_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/VoronoiSeamFinder.cs
+++ b/src/OpenCvSharp/Modules/stitching/VoronoiSeamFinder.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.Detail;
+
+/// <summary>
+/// Voronoi diagram-based seam estimator.
+/// </summary>
+public class VoronoiSeamFinder : SeamFinder
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public VoronoiSeamFinder() : base(Create(), static h =>
+        NativeMethods.HandleException(NativeMethods.stitching_VoronoiSeamFinder_delete(h)))
+    {
+    }
+
+    private static IntPtr Create()
+    {
+        NativeMethods.HandleException(NativeMethods.stitching_VoronoiSeamFinder_new(out var ptr));
+        return ptr;
+    }
+}

--- a/src/OpenCvSharp/Modules/stitching/WarperCreator.cs
+++ b/src/OpenCvSharp/Modules/stitching/WarperCreator.cs
@@ -1,0 +1,19 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// Image warper factories base class. Instances of concrete subclasses are handed to
+/// <see cref="Stitcher.SetWarper"/> to select the projection used by the stitching pipeline;
+/// for standalone warping, use <see cref="PyRotationWarper"/> instead.
+/// </summary>
+public abstract class WarperCreator : CvObject
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="rawPtr"></param>
+    /// <param name="release"></param>
+    private protected WarperCreator(IntPtr rawPtr, Action<IntPtr> release) : base(rawPtr)
+    {
+        SetSafeHandle(new OpenCvPtrSafeHandle(rawPtr, ownsHandle: true, releaseAction: release));
+    }
+}

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj
@@ -167,6 +167,12 @@
     <ClInclude Include="std_vector_nesting.h" />
     <ClInclude Include="stitching.h" />
     <ClInclude Include="stitching_detail_Matchers.h" />
+    <ClInclude Include="stitching_detail_Timelapsers.h" />
+    <ClInclude Include="stitching_detail_ExposureCompensators.h" />
+    <ClInclude Include="stitching_detail_SeamFinders.h" />
+    <ClInclude Include="stitching_detail_Blenders.h" />
+    <ClInclude Include="stitching_detail_MotionEstimators.h" />
+    <ClInclude Include="stitching_detail_Warpers.h" />
     <ClInclude Include="superres.h" />
     <ClInclude Include="text.h" />
     <ClInclude Include="text_ERFilter.h" />

--- a/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
+++ b/src/OpenCvSharpExtern/OpenCvSharpExtern.vcxproj.filters
@@ -351,6 +351,24 @@
     <ClInclude Include="stitching_detail_Matchers.h">
       <Filter>Header Files\stitching</Filter>
     </ClInclude>
+    <ClInclude Include="stitching_detail_Timelapsers.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
+    <ClInclude Include="stitching_detail_ExposureCompensators.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
+    <ClInclude Include="stitching_detail_SeamFinders.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
+    <ClInclude Include="stitching_detail_Blenders.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
+    <ClInclude Include="stitching_detail_MotionEstimators.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
+    <ClInclude Include="stitching_detail_Warpers.h">
+      <Filter>Header Files\stitching</Filter>
+    </ClInclude>
     <ClInclude Include="photo_Tonemap.h">
       <Filter>Header Files\photo</Filter>
     </ClInclude>

--- a/src/OpenCvSharpExtern/my_functions.h
+++ b/src/OpenCvSharpExtern/my_functions.h
@@ -290,6 +290,17 @@ static void toVec(
     }
 }
 
+// Converts a flat array of cv::Mat* into a std::vector<cv::UMat>, copying each Mat into a UMat.
+static void toUMatVec(
+    cv::Mat **inPtr, const int size, std::vector<cv::UMat> &outVec)
+{
+    outVec.resize(size);
+    for (int i = 0; i < size; i++)
+    {
+        inPtr[i]->copyTo(outVec[i]);
+    }
+}
+
 template <typename TIn, typename TOut>
 static void toVec(
     const TIn **inPtr, const int size1, const int *size2, std::vector<std::vector<TOut> > &outVec)

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -287,6 +287,31 @@ extern "C"
         cv::Mat* descriptors;
     };
 
+    /** @brief Structure containing information about matches between two images (interop mirror of
+    cv::detail::MatchesInfo, used as an INPUT boundary type by Estimator/BundleAdjuster). */
+    struct CV_EXPORTS_W_SIMPLE detail_MatchesInfo
+    {
+        int src_img_idx;
+        int dst_img_idx;
+        std::vector<cv::DMatch>* matches;
+        std::vector<uchar>* inliers_mask;
+        int num_inliers;
+        cv::Mat* h;
+        double confidence;
+    };
+
+    /** @brief Interop mirror of cv::detail::CameraParams. R and t point to caller-owned Mat instances
+    that are filled via copyTo at the boundary (Mat is not trivially copyable). */
+    struct CV_EXPORTS_W_SIMPLE detail_CameraParams
+    {
+        double focal;
+        double aspect;
+        double ppx;
+        double ppy;
+        cv::Mat* r;
+        cv::Mat* t;
+    };
+
 }
 
 // bit_cast-based converter pair for layout-identical POD <-> cv:: types.

--- a/src/OpenCvSharpExtern/stitching.cpp
+++ b/src/OpenCvSharpExtern/stitching.cpp
@@ -1,3 +1,9 @@
 // ReSharper disable CppUnusedIncludeDirective
 #include "stitching.h"
 #include "stitching_detail_Matchers.h"
+#include "stitching_detail_Timelapsers.h"
+#include "stitching_detail_ExposureCompensators.h"
+#include "stitching_detail_SeamFinders.h"
+#include "stitching_detail_Blenders.h"
+#include "stitching_detail_MotionEstimators.h"
+#include "stitching_detail_Warpers.h"

--- a/src/OpenCvSharpExtern/stitching.h
+++ b/src/OpenCvSharpExtern/stitching.h
@@ -287,4 +287,106 @@ CVAPI(ExceptionStatus) stitching_Stitcher_workScale(cv::Stitcher *obj, double *r
     });
 }
 
+CVAPI(ExceptionStatus) stitching_Stitcher_cameras(
+    cv::Stitcher *obj,
+    std::vector<double> *focals, std::vector<double> *aspects,
+    std::vector<double> *ppxs, std::vector<double> *ppys,
+    std::vector<cv::Mat> *rs, std::vector<cv::Mat> *ts)
+{
+    return cvTry([&] {
+        const auto cameras = obj->cameras();
+        for (const auto &cam : cameras)
+        {
+            focals->push_back(cam.focal);
+            aspects->push_back(cam.aspect);
+            ppxs->push_back(cam.ppx);
+            ppys->push_back(cam.ppy);
+            rs->push_back(cam.R.clone());
+            ts->push_back(cam.t.clone());
+        }
+    });
+}
+
+#pragma region pipeline component setters
+// Getters are intentionally not exposed: Stitcher stores these as cv::Ptr<T> to a *polymorphic*
+// base (FeaturesMatcher/WarperCreator/ExposureCompensator/SeamFinder/Blender/BundleAdjusterBase),
+// and there is no RTTI-free way to hand a raw pointer back to C# as the correct concrete managed
+// subclass. Callers that need the object back should keep their own reference to what they set.
+// Each setter wraps the caller-owned raw pointer in a non-owning cv::Ptr<T> (no-op deleter): the
+// managed wrapper object retains true ownership, and Stitcher merely holds a reference to it, so
+// the caller must keep that managed object alive for as long as it's attached to the Stitcher.
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setFeaturesFinder(cv::Stitcher *obj, cv::Feature2D *featuresFinder)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::Feature2D> nonOwning(featuresFinder, [](cv::Feature2D*) {});
+        obj->setFeaturesFinder(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setFeaturesMatcher(cv::Stitcher *obj, cv::detail::FeaturesMatcher *featuresMatcher)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::detail::FeaturesMatcher> nonOwning(featuresMatcher, [](cv::detail::FeaturesMatcher*) {});
+        obj->setFeaturesMatcher(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_matchingMask(cv::Stitcher *obj, cv::Mat *returnValue)
+{
+    return cvTry([&] {
+        obj->matchingMask().copyTo(*returnValue);
+    });
+}
+CVAPI(ExceptionStatus) stitching_Stitcher_setMatchingMask(cv::Stitcher *obj, cv::Mat *mask)
+{
+    return cvTry([&] {
+        cv::UMat maskU;
+        mask->copyTo(maskU);
+        obj->setMatchingMask(maskU);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setBundleAdjuster(cv::Stitcher *obj, cv::detail::BundleAdjusterBase *bundleAdjuster)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::detail::BundleAdjusterBase> nonOwning(bundleAdjuster, [](cv::detail::BundleAdjusterBase*) {});
+        obj->setBundleAdjuster(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setWarper(cv::Stitcher *obj, cv::WarperCreator *warper)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::WarperCreator> nonOwning(warper, [](cv::WarperCreator*) {});
+        obj->setWarper(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setExposureCompensator(cv::Stitcher *obj, cv::detail::ExposureCompensator *exposureCompensator)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::detail::ExposureCompensator> nonOwning(exposureCompensator, [](cv::detail::ExposureCompensator*) {});
+        obj->setExposureCompensator(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setSeamFinder(cv::Stitcher *obj, cv::detail::SeamFinder *seamFinder)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::detail::SeamFinder> nonOwning(seamFinder, [](cv::detail::SeamFinder*) {});
+        obj->setSeamFinder(nonOwning);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Stitcher_setBlender(cv::Stitcher *obj, cv::detail::Blender *blender)
+{
+    return cvTry([&] {
+        const cv::Ptr<cv::detail::Blender> nonOwning(blender, [](cv::detail::Blender*) {});
+        obj->setBlender(nonOwning);
+    });
+}
+
+#pragma endregion
+
 #endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_Blenders.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Blenders.h
@@ -1,0 +1,224 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+
+// Blender
+
+CVAPI(ExceptionStatus) stitching_Blender_createDefault(
+    int type, int tryGpu, cv::Ptr<cv::detail::Blender> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::detail::Blender::createDefault(type, tryGpu != 0);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_Blender_get(
+    cv::Ptr<cv::detail::Blender> *ptr, cv::detail::Blender **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_Blender_delete(cv::Ptr<cv::detail::Blender> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Blender_prepare1(
+    cv::detail::Blender *obj,
+    const interop::Point *corners, int cornersLength,
+    const interop::Size *sizes, int sizesLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::Size> sizesVec;
+        sizesVec.reserve(sizesLength);
+        for (int i = 0; i < sizesLength; i++)
+            sizesVec.push_back(cpp(sizes[i]));
+
+        obj->prepare(cornersVec, sizesVec);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Blender_prepare2(cv::detail::Blender *obj, interop::Rect dstRoi)
+{
+    return cvTry([&] {
+        obj->prepare(cpp(dstRoi));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Blender_feed(
+    cv::detail::Blender *obj,
+    const interop::InputArrayProxy *img,
+    const interop::InputArrayProxy *mask,
+    interop::Point tl)
+{
+    return cvTry([&] {
+        obj->feed(InProxy(*img), InProxy(*mask), cpp(tl));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Blender_blend(
+    cv::detail::Blender *obj,
+    const interop::InputOutputArrayProxy *dst,
+    const interop::InputOutputArrayProxy *dstMask)
+{
+    return cvTry([&] {
+        obj->blend(IoProxy(*dst), IoProxy(*dstMask));
+    });
+}
+
+
+// FeatherBlender
+
+CVAPI(ExceptionStatus) stitching_FeatherBlender_new(float sharpness, cv::detail::FeatherBlender **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::FeatherBlender(sharpness);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_FeatherBlender_delete(cv::detail::FeatherBlender *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_FeatherBlender_getSharpness(cv::detail::FeatherBlender *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->sharpness();
+    });
+}
+CVAPI(ExceptionStatus) stitching_FeatherBlender_setSharpness(cv::detail::FeatherBlender *obj, float val)
+{
+    return cvTry([&] {
+        obj->setSharpness(val);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_FeatherBlender_createWeightMaps(
+    cv::detail::FeatherBlender *obj,
+    cv::Mat **masks, int masksLength,
+    const interop::Point *corners, int cornersLength,
+    cv::Mat **weightMaps, int weightMapsLength,
+    interop::Rect *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::UMat> masksVec;
+        toUMatVec(masks, masksLength, masksVec);
+
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::UMat> weightMapsVec;
+        toUMatVec(weightMaps, weightMapsLength, weightMapsVec);
+
+        const auto roi = obj->createWeightMaps(masksVec, cornersVec, weightMapsVec);
+        *returnValue = c(roi);
+
+        for (int i = 0; i < weightMapsLength && i < static_cast<int>(weightMapsVec.size()); i++)
+            weightMapsVec[static_cast<size_t>(i)].copyTo(*weightMaps[i]);
+    });
+}
+
+
+// MultiBandBlender
+
+CVAPI(ExceptionStatus) stitching_MultiBandBlender_new(
+    int tryGpu, int numBands, int weightType, cv::detail::MultiBandBlender **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::MultiBandBlender(tryGpu != 0, numBands, weightType);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_MultiBandBlender_delete(cv::detail::MultiBandBlender *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_MultiBandBlender_getNumBands(cv::detail::MultiBandBlender *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->numBands();
+    });
+}
+CVAPI(ExceptionStatus) stitching_MultiBandBlender_setNumBands(cv::detail::MultiBandBlender *obj, int val)
+{
+    return cvTry([&] {
+        obj->setNumBands(val);
+    });
+}
+
+
+// Auxiliary functions
+
+CVAPI(ExceptionStatus) stitching_normalizeUsingWeightMap(
+    const interop::InputArrayProxy *weight, const interop::InputOutputArrayProxy *src)
+{
+    return cvTry([&] {
+        cv::detail::normalizeUsingWeightMap(InProxy(*weight), IoProxy(*src));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_createWeightMap(
+    const interop::InputArrayProxy *mask, float sharpness, const interop::InputOutputArrayProxy *weight)
+{
+    return cvTry([&] {
+        cv::detail::createWeightMap(InProxy(*mask), sharpness, IoProxy(*weight));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_createLaplacePyr(
+    const interop::InputArrayProxy *img, int numLevels, std::vector<cv::Mat> *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::UMat> pyr;
+        cv::detail::createLaplacePyr(InProxy(*img), numLevels, pyr);
+
+        returnValue->reserve(pyr.size());
+        for (const auto &level : pyr)
+        {
+            cv::Mat m;
+            level.copyTo(m);
+            returnValue->push_back(m);
+        }
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_restoreImageFromLaplacePyr(
+    cv::Mat **pyr, int pyrLength, cv::Mat *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::UMat> pyrVec;
+        toUMatVec(pyr, pyrLength, pyrVec);
+
+        cv::detail::restoreImageFromLaplacePyr(pyrVec);
+
+        if (!pyrVec.empty())
+            pyrVec[0].copyTo(*returnValue);
+    });
+}
+
+#endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_ExposureCompensators.h
+++ b/src/OpenCvSharpExtern/stitching_detail_ExposureCompensators.h
@@ -1,0 +1,288 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+// ExposureCompensator
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_createDefault(
+    int type, cv::Ptr<cv::detail::ExposureCompensator> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::detail::ExposureCompensator::createDefault(type);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_ExposureCompensator_get(
+    cv::Ptr<cv::detail::ExposureCompensator> *ptr, cv::detail::ExposureCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_ExposureCompensator_delete(cv::Ptr<cv::detail::ExposureCompensator> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_feed(
+    cv::detail::ExposureCompensator *obj,
+    const interop::Point *corners, int cornersLength,
+    cv::Mat **images, int imagesLength,
+    cv::Mat **masks, int masksLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::UMat> imagesVec;
+        toUMatVec(images, imagesLength, imagesVec);
+        std::vector<cv::UMat> masksVec;
+        toUMatVec(masks, masksLength, masksVec);
+
+        obj->feed(cornersVec, imagesVec, masksVec);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_apply(
+    cv::detail::ExposureCompensator *obj,
+    int index,
+    interop::Point corner,
+    const interop::InputOutputArrayProxy *image,
+    const interop::InputArrayProxy *mask)
+{
+    return cvTry([&] {
+        obj->apply(index, cpp(corner), IoProxy(*image), InProxy(*mask));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_getMatGains(
+    cv::detail::ExposureCompensator *obj, std::vector<cv::Mat> *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> gains;
+        obj->getMatGains(gains);
+        std::copy(gains.begin(), gains.end(), std::back_inserter(*returnValue));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_setMatGains(
+    cv::detail::ExposureCompensator *obj, cv::Mat **gains, int gainsLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> gainsVec;
+        toVec(gains, gainsLength, gainsVec);
+        obj->setMatGains(gainsVec);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_getUpdateGain(
+    cv::detail::ExposureCompensator *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getUpdateGain() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ExposureCompensator_setUpdateGain(
+    cv::detail::ExposureCompensator *obj, int b)
+{
+    return cvTry([&] {
+        obj->setUpdateGain(b != 0);
+    });
+}
+
+
+// NoExposureCompensator
+
+CVAPI(ExceptionStatus) stitching_NoExposureCompensator_new(cv::detail::NoExposureCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::NoExposureCompensator();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_NoExposureCompensator_delete(cv::detail::NoExposureCompensator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// GainCompensator
+
+CVAPI(ExceptionStatus) stitching_GainCompensator_new(int nr_feeds, cv::detail::GainCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::GainCompensator(nr_feeds);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_GainCompensator_delete(cv::detail::GainCompensator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_GainCompensator_getNrFeeds(cv::detail::GainCompensator *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNrFeeds();
+    });
+}
+CVAPI(ExceptionStatus) stitching_GainCompensator_setNrFeeds(cv::detail::GainCompensator *obj, int nrFeeds)
+{
+    return cvTry([&] {
+        obj->setNrFeeds(nrFeeds);
+    });
+}
+CVAPI(ExceptionStatus) stitching_GainCompensator_getSimilarityThreshold(cv::detail::GainCompensator *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSimilarityThreshold();
+    });
+}
+CVAPI(ExceptionStatus) stitching_GainCompensator_setSimilarityThreshold(cv::detail::GainCompensator *obj, double thresh)
+{
+    return cvTry([&] {
+        obj->setSimilarityThreshold(thresh);
+    });
+}
+
+
+// ChannelsCompensator
+
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_new(int nr_feeds, cv::detail::ChannelsCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::ChannelsCompensator(nr_feeds);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_delete(cv::detail::ChannelsCompensator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_getNrFeeds(cv::detail::ChannelsCompensator *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNrFeeds();
+    });
+}
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_setNrFeeds(cv::detail::ChannelsCompensator *obj, int nrFeeds)
+{
+    return cvTry([&] {
+        obj->setNrFeeds(nrFeeds);
+    });
+}
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_getSimilarityThreshold(cv::detail::ChannelsCompensator *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSimilarityThreshold();
+    });
+}
+CVAPI(ExceptionStatus) stitching_ChannelsCompensator_setSimilarityThreshold(cv::detail::ChannelsCompensator *obj, double thresh)
+{
+    return cvTry([&] {
+        obj->setSimilarityThreshold(thresh);
+    });
+}
+
+
+// BlocksCompensator (shared implementation for BlocksGainCompensator / BlocksChannelsCompensator)
+
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_delete(cv::detail::BlocksCompensator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_getNrFeeds(cv::detail::BlocksCompensator *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNrFeeds();
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_setNrFeeds(cv::detail::BlocksCompensator *obj, int nrFeeds)
+{
+    return cvTry([&] {
+        obj->setNrFeeds(nrFeeds);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_getSimilarityThreshold(cv::detail::BlocksCompensator *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getSimilarityThreshold();
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_setSimilarityThreshold(cv::detail::BlocksCompensator *obj, double thresh)
+{
+    return cvTry([&] {
+        obj->setSimilarityThreshold(thresh);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_getBlockSize(cv::detail::BlocksCompensator *obj, interop::Size *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->getBlockSize());
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_setBlockSize(cv::detail::BlocksCompensator *obj, int width, int height)
+{
+    return cvTry([&] {
+        obj->setBlockSize(width, height);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_getNrGainsFilteringIterations(cv::detail::BlocksCompensator *obj, int *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getNrGainsFilteringIterations();
+    });
+}
+CVAPI(ExceptionStatus) stitching_BlocksCompensator_setNrGainsFilteringIterations(cv::detail::BlocksCompensator *obj, int nrIterations)
+{
+    return cvTry([&] {
+        obj->setNrGainsFilteringIterations(nrIterations);
+    });
+}
+
+
+// BlocksGainCompensator
+
+CVAPI(ExceptionStatus) stitching_BlocksGainCompensator_new(
+    int bl_width, int bl_height, int nr_feeds, cv::detail::BlocksGainCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BlocksGainCompensator(bl_width, bl_height, nr_feeds);
+    });
+}
+
+
+// BlocksChannelsCompensator
+
+CVAPI(ExceptionStatus) stitching_BlocksChannelsCompensator_new(
+    int bl_width, int bl_height, int nr_feeds, cv::detail::BlocksChannelsCompensator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BlocksChannelsCompensator(bl_width, bl_height, nr_feeds);
+    });
+}
+
+#endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_Matchers.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Matchers.h
@@ -238,4 +238,61 @@ CVAPI(ExceptionStatus) stitching_AffineBestOf2NearestMatcher_delete(
     });
 }
 
+
+// BestOf2NearestRangeMatcher
+
+CVAPI(ExceptionStatus) stitching_BestOf2NearestRangeMatcher_new(
+    int range_width,
+    int try_use_gpu,
+    float match_conf,
+    int num_matches_thresh1,
+    int num_matches_thresh2,
+    cv::detail::BestOf2NearestRangeMatcher** returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BestOf2NearestRangeMatcher(
+            range_width, try_use_gpu != 0, match_conf, num_matches_thresh1, num_matches_thresh2);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_BestOf2NearestRangeMatcher_delete(
+    cv::detail::BestOf2NearestRangeMatcher* obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// LightGlueFeaturesMatcher
+
+CVAPI(ExceptionStatus) stitching_LightGlueFeaturesMatcher_new(
+    cv::Ptr<cv::LightGlueMatcher> *lgMatcher,
+    int num_matches_thresh1,
+    int num_matches_thresh2,
+    double matches_confidence_thresh,
+    cv::detail::LightGlueFeaturesMatcher** returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::LightGlueFeaturesMatcher(
+            *lgMatcher, num_matches_thresh1, num_matches_thresh2, matches_confidence_thresh);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_LightGlueFeaturesMatcher_delete(
+    cv::detail::LightGlueFeaturesMatcher* obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_LightGlueFeaturesMatcher_setScoreThreshold(
+    cv::detail::LightGlueFeaturesMatcher* obj, float thresh)
+{
+    return cvTry([&] {
+        obj->setScoreThreshold(thresh);
+    });
+}
+
 #endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_MotionEstimators.h
+++ b/src/OpenCvSharpExtern/stitching_detail_MotionEstimators.h
@@ -1,0 +1,275 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+static void toImageFeaturesVec(
+    detail_ImageFeatures *features, int size, std::vector<cv::detail::ImageFeatures> &outVec)
+{
+    outVec.reserve(size);
+    for (int i = 0; i < size; i++)
+    {
+        cv::detail::ImageFeatures f{
+            features[i].img_idx,
+            cpp(features[i].img_size),
+            *features[i].keypoints,
+            cv::UMat() };
+        features[i].descriptors->copyTo(f.descriptors);
+        outVec.push_back(f);
+    }
+}
+
+static void toMatchesInfoVec(
+    detail_MatchesInfo *matches, int size, std::vector<cv::detail::MatchesInfo> &outVec)
+{
+    outVec.reserve(size);
+    for (int i = 0; i < size; i++)
+    {
+        cv::detail::MatchesInfo m;
+        m.src_img_idx = matches[i].src_img_idx;
+        m.dst_img_idx = matches[i].dst_img_idx;
+        m.matches = *matches[i].matches;
+        m.inliers_mask = *matches[i].inliers_mask;
+        m.num_inliers = matches[i].num_inliers;
+        matches[i].h->copyTo(m.H);
+        m.confidence = matches[i].confidence;
+        outVec.push_back(m);
+    }
+}
+
+
+// Estimator
+
+CVAPI(ExceptionStatus) stitching_Estimator_apply(
+    cv::detail::Estimator *obj,
+    detail_ImageFeatures *features, int featuresSize,
+    detail_MatchesInfo *pairwiseMatches, int pairwiseMatchesSize,
+    detail_CameraParams *cameras, int camerasSize,
+    int *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::detail::ImageFeatures> featuresVec;
+        toImageFeaturesVec(features, featuresSize, featuresVec);
+
+        std::vector<cv::detail::MatchesInfo> matchesVec;
+        toMatchesInfoVec(pairwiseMatches, pairwiseMatchesSize, matchesVec);
+
+        std::vector<cv::detail::CameraParams> camerasVec(static_cast<size_t>(camerasSize));
+        for (int i = 0; i < camerasSize; i++)
+        {
+            camerasVec[static_cast<size_t>(i)].focal = cameras[i].focal;
+            camerasVec[static_cast<size_t>(i)].aspect = cameras[i].aspect;
+            camerasVec[static_cast<size_t>(i)].ppx = cameras[i].ppx;
+            camerasVec[static_cast<size_t>(i)].ppy = cameras[i].ppy;
+            cameras[i].r->copyTo(camerasVec[static_cast<size_t>(i)].R);
+            cameras[i].t->copyTo(camerasVec[static_cast<size_t>(i)].t);
+        }
+
+        const bool ok = (*obj)(featuresVec, matchesVec, camerasVec);
+        *returnValue = ok ? 1 : 0;
+
+        for (int i = 0; i < camerasSize && i < static_cast<int>(camerasVec.size()); i++)
+        {
+            const auto &c = camerasVec[static_cast<size_t>(i)];
+            cameras[i].focal = c.focal;
+            cameras[i].aspect = c.aspect;
+            cameras[i].ppx = c.ppx;
+            cameras[i].ppy = c.ppy;
+            c.R.copyTo(*cameras[i].r);
+            c.t.copyTo(*cameras[i].t);
+        }
+    });
+}
+
+
+// HomographyBasedEstimator
+
+CVAPI(ExceptionStatus) stitching_HomographyBasedEstimator_new(
+    int isFocalsEstimated, cv::detail::HomographyBasedEstimator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::HomographyBasedEstimator(isFocalsEstimated != 0);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_HomographyBasedEstimator_delete(cv::detail::HomographyBasedEstimator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// AffineBasedEstimator
+
+CVAPI(ExceptionStatus) stitching_AffineBasedEstimator_new(cv::detail::AffineBasedEstimator **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::AffineBasedEstimator();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_AffineBasedEstimator_delete(cv::detail::AffineBasedEstimator *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// BundleAdjusterBase
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_delete(cv::detail::BundleAdjusterBase *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_refinementMask(cv::detail::BundleAdjusterBase *obj, cv::Mat *returnValue)
+{
+    return cvTry([&] {
+        obj->refinementMask().copyTo(*returnValue);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_setRefinementMask(cv::detail::BundleAdjusterBase *obj, cv::Mat *mask)
+{
+    return cvTry([&] {
+        obj->setRefinementMask(*mask);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_confThresh(cv::detail::BundleAdjusterBase *obj, double *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->confThresh();
+    });
+}
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_setConfThresh(cv::detail::BundleAdjusterBase *obj, double confThresh)
+{
+    return cvTry([&] {
+        obj->setConfThresh(confThresh);
+    });
+}
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_termCriteria(cv::detail::BundleAdjusterBase *obj, interop::TermCriteria *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->termCriteria());
+    });
+}
+CVAPI(ExceptionStatus) stitching_BundleAdjusterBase_setTermCriteria(cv::detail::BundleAdjusterBase *obj, interop::TermCriteria termCriteria)
+{
+    return cvTry([&] {
+        obj->setTermCriteria(cpp(termCriteria));
+    });
+}
+
+
+// NoBundleAdjuster
+
+CVAPI(ExceptionStatus) stitching_NoBundleAdjuster_new(cv::detail::NoBundleAdjuster **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::NoBundleAdjuster();
+    });
+}
+
+
+// BundleAdjusterReproj
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterReproj_new(cv::detail::BundleAdjusterReproj **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BundleAdjusterReproj();
+    });
+}
+
+
+// BundleAdjusterRay
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterRay_new(cv::detail::BundleAdjusterRay **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BundleAdjusterRay();
+    });
+}
+
+
+// BundleAdjusterAffine
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterAffine_new(cv::detail::BundleAdjusterAffine **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BundleAdjusterAffine();
+    });
+}
+
+
+// BundleAdjusterAffinePartial
+
+CVAPI(ExceptionStatus) stitching_BundleAdjusterAffinePartial_new(cv::detail::BundleAdjusterAffinePartial **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::BundleAdjusterAffinePartial();
+    });
+}
+
+
+// Auxiliary functions
+
+CVAPI(ExceptionStatus) stitching_waveCorrect(cv::Mat **rmats, int rmatsLength, int kind)
+{
+    return cvTry([&] {
+        std::vector<cv::Mat> rmatsVec;
+        toVec(rmats, rmatsLength, rmatsVec);
+
+        cv::detail::waveCorrect(rmatsVec, static_cast<cv::detail::WaveCorrectKind>(kind));
+
+        for (int i = 0; i < rmatsLength && i < static_cast<int>(rmatsVec.size()); i++)
+            rmatsVec[static_cast<size_t>(i)].copyTo(*rmats[i]);
+    });
+}
+
+// Note: upstream matchesGraphAsString() takes a `paths` label per image, but there's no established
+// cross-platform-safe convention in this codebase for marshaling string arrays across the P/Invoke
+// boundary (individual strings need the Windows-LPStr/non-Windows-LPUTF8Str split used elsewhere).
+// Since the labels are cosmetic (DOT graph node text), numImages is used to generate empty placeholders.
+CVAPI(ExceptionStatus) stitching_matchesGraphAsString(
+    int numImages,
+    detail_MatchesInfo *pairwiseMatches, int pairwiseMatchesSize,
+    float confThreshold,
+    std::string *buf)
+{
+    return cvTry([&] {
+        std::vector<cv::String> pathsVec(static_cast<size_t>(numImages));
+
+        std::vector<cv::detail::MatchesInfo> matchesVec;
+        toMatchesInfoVec(pairwiseMatches, pairwiseMatchesSize, matchesVec);
+
+        buf->assign(cv::detail::matchesGraphAsString(pathsVec, matchesVec, confThreshold));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_leaveBiggestComponent(
+    detail_ImageFeatures *features, int featuresSize,
+    detail_MatchesInfo *pairwiseMatches, int pairwiseMatchesSize,
+    float confThreshold,
+    std::vector<int> *returnValue)
+{
+    return cvTry([&] {
+        std::vector<cv::detail::ImageFeatures> featuresVec;
+        toImageFeaturesVec(features, featuresSize, featuresVec);
+
+        std::vector<cv::detail::MatchesInfo> matchesVec;
+        toMatchesInfoVec(pairwiseMatches, pairwiseMatchesSize, matchesVec);
+
+        const auto indices = cv::detail::leaveBiggestComponent(featuresVec, matchesVec, confThreshold);
+        std::copy(indices.begin(), indices.end(), std::back_inserter(*returnValue));
+    });
+}
+
+#endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_SeamFinders.h
+++ b/src/OpenCvSharpExtern/stitching_detail_SeamFinders.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+
+// SeamFinder
+
+CVAPI(ExceptionStatus) stitching_SeamFinder_createDefault(
+    int type, cv::Ptr<cv::detail::SeamFinder> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::detail::SeamFinder::createDefault(type);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_SeamFinder_get(
+    cv::Ptr<cv::detail::SeamFinder> *ptr, cv::detail::SeamFinder **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_SeamFinder_delete(cv::Ptr<cv::detail::SeamFinder> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_SeamFinder_find(
+    cv::detail::SeamFinder *obj,
+    cv::Mat **src, int srcLength,
+    const interop::Point *corners, int cornersLength,
+    cv::Mat **masks, int masksLength)
+{
+    return cvTry([&] {
+        std::vector<cv::UMat> srcVec;
+        toUMatVec(src, srcLength, srcVec);
+
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::UMat> masksVec;
+        toUMatVec(masks, masksLength, masksVec);
+
+        obj->find(srcVec, cornersVec, masksVec);
+
+        for (int i = 0; i < masksLength && i < static_cast<int>(masksVec.size()); i++)
+            masksVec[static_cast<size_t>(i)].copyTo(*masks[i]);
+    });
+}
+
+
+// NoSeamFinder
+
+CVAPI(ExceptionStatus) stitching_NoSeamFinder_new(cv::detail::NoSeamFinder **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::NoSeamFinder();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_NoSeamFinder_delete(cv::detail::NoSeamFinder *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// VoronoiSeamFinder
+
+CVAPI(ExceptionStatus) stitching_VoronoiSeamFinder_new(cv::detail::VoronoiSeamFinder **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::VoronoiSeamFinder();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_VoronoiSeamFinder_delete(cv::detail::VoronoiSeamFinder *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+
+// DpSeamFinder
+
+CVAPI(ExceptionStatus) stitching_DpSeamFinder_new(const char *costFunc, cv::detail::DpSeamFinder **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::DpSeamFinder(cv::String(costFunc));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_DpSeamFinder_delete(cv::detail::DpSeamFinder *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_DpSeamFinder_setCostFunction(cv::detail::DpSeamFinder *obj, const char *val)
+{
+    return cvTry([&] {
+        obj->setCostFunction(cv::String(val));
+    });
+}
+
+
+// GraphCutSeamFinder
+
+CVAPI(ExceptionStatus) stitching_GraphCutSeamFinder_new(
+    const char *costType, float terminalCost, float badRegionPenalty, cv::detail::GraphCutSeamFinder **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::detail::GraphCutSeamFinder(cv::String(costType), terminalCost, badRegionPenalty);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_GraphCutSeamFinder_delete(cv::detail::GraphCutSeamFinder *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_GraphCutSeamFinder_find(
+    cv::detail::GraphCutSeamFinder *obj,
+    cv::Mat **src, int srcLength,
+    const interop::Point *corners, int cornersLength,
+    cv::Mat **masks, int masksLength)
+{
+    return cvTry([&] {
+        std::vector<cv::UMat> srcVec;
+        toUMatVec(src, srcLength, srcVec);
+
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::UMat> masksVec;
+        toUMatVec(masks, masksLength, masksVec);
+
+        obj->find(srcVec, cornersVec, masksVec);
+
+        for (int i = 0; i < masksLength && i < static_cast<int>(masksVec.size()); i++)
+            masksVec[static_cast<size_t>(i)].copyTo(*masks[i]);
+    });
+}
+
+#endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_Timelapsers.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Timelapsers.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+#include "opencv2/stitching/detail/timelapsers.hpp"
+
+
+// Timelapser
+
+CVAPI(ExceptionStatus) stitching_Timelapser_createDefault(
+    int type, cv::Ptr<cv::detail::Timelapser> **returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::detail::Timelapser::createDefault(type);
+        *returnValue = clone(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_Timelapser_get(
+    cv::Ptr<cv::detail::Timelapser> *ptr, cv::detail::Timelapser **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Ptr_Timelapser_delete(cv::Ptr<cv::detail::Timelapser> *ptr)
+{
+    return cvTry([&] {
+        delete ptr;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Timelapser_initialize(
+    cv::detail::Timelapser *obj,
+    const interop::Point *corners, int cornersLength,
+    const interop::Size *sizes, int sizesLength)
+{
+    return cvTry([&] {
+        std::vector<cv::Point> cornersVec;
+        cornersVec.reserve(cornersLength);
+        for (int i = 0; i < cornersLength; i++)
+            cornersVec.push_back(cpp(corners[i]));
+
+        std::vector<cv::Size> sizesVec;
+        sizesVec.reserve(sizesLength);
+        for (int i = 0; i < sizesLength; i++)
+            sizesVec.push_back(cpp(sizes[i]));
+
+        obj->initialize(cornersVec, sizesVec);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Timelapser_process(
+    cv::detail::Timelapser *obj,
+    const interop::InputArrayProxy *img,
+    const interop::InputArrayProxy *mask,
+    interop::Point tl)
+{
+    return cvTry([&] {
+        obj->process(InProxy(*img), InProxy(*mask), cpp(tl));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_Timelapser_getDst(
+    cv::detail::Timelapser *obj, cv::Mat *returnValue)
+{
+    return cvTry([&] {
+        obj->getDst().copyTo(*returnValue);
+    });
+}
+
+#endif // NO_STITCHING

--- a/src/OpenCvSharpExtern/stitching_detail_Warpers.h
+++ b/src/OpenCvSharpExtern/stitching_detail_Warpers.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#ifndef NO_STITCHING
+
+// ReSharper disable IdentifierTypo
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+#include "include_opencv.h"
+
+
+// PyRotationWarper
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_new(const char *type, float scale, cv::PyRotationWarper **returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::PyRotationWarper(cv::String(type), scale);
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_delete(cv::PyRotationWarper *obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_warpPoint(
+    cv::PyRotationWarper *obj, interop::Point2f pt,
+    const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    interop::Point2f *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->warpPoint(cpp(pt), InProxy(*k), InProxy(*r)));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_warpPointBackward(
+    cv::PyRotationWarper *obj, interop::Point2f pt,
+    const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    interop::Point2f *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->warpPointBackward(cpp(pt), InProxy(*k), InProxy(*r)));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_buildMaps(
+    cv::PyRotationWarper *obj, interop::Size srcSize,
+    const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    const interop::OutputArrayProxy *xmap, const interop::OutputArrayProxy *ymap,
+    interop::Rect *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->buildMaps(cpp(srcSize), InProxy(*k), InProxy(*r), OutProxy(*xmap), OutProxy(*ymap)));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_warp(
+    cv::PyRotationWarper *obj,
+    const interop::InputArrayProxy *src, const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    int interpMode, int borderMode,
+    const interop::OutputArrayProxy *dst,
+    interop::Point *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->warp(InProxy(*src), InProxy(*k), InProxy(*r), interpMode, borderMode, OutProxy(*dst)));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_warpBackward(
+    cv::PyRotationWarper *obj,
+    const interop::InputArrayProxy *src, const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    int interpMode, int borderMode, interop::Size dstSize,
+    const interop::OutputArrayProxy *dst)
+{
+    return cvTry([&] {
+        obj->warpBackward(InProxy(*src), InProxy(*k), InProxy(*r), interpMode, borderMode, cpp(dstSize), OutProxy(*dst));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_warpRoi(
+    cv::PyRotationWarper *obj, interop::Size srcSize,
+    const interop::InputArrayProxy *k, const interop::InputArrayProxy *r,
+    interop::Rect *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = c(obj->warpRoi(cpp(srcSize), InProxy(*k), InProxy(*r)));
+    });
+}
+
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_getScale(cv::PyRotationWarper *obj, float *returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->getScale();
+    });
+}
+CVAPI(ExceptionStatus) stitching_PyRotationWarper_setScale(cv::PyRotationWarper *obj, float val)
+{
+    return cvTry([&] {
+        obj->setScale(val);
+    });
+}
+
+
+// WarperCreator concrete factories: constructor + destructor only.
+// (WarperCreator::create() is intentionally not exposed - cv::PyRotationWarper already covers
+// standalone warping, and these types exist only to be handed to Stitcher::setWarper().)
+
+#define OCS_WARPER_CREATOR_CTOR_DTOR(NAME)                                                    \
+    CVAPI(ExceptionStatus) stitching_##NAME##_new(cv::NAME **returnValue)                     \
+    {                                                                                         \
+        return cvTry([&] {                                                                    \
+            *returnValue = new cv::NAME();                                                     \
+        });                                                                                    \
+    }                                                                                          \
+    CVAPI(ExceptionStatus) stitching_##NAME##_delete(cv::NAME *obj)                           \
+    {                                                                                         \
+        return cvTry([&] {                                                                    \
+            delete obj;                                                                        \
+        });                                                                                    \
+    }
+
+OCS_WARPER_CREATOR_CTOR_DTOR(PlaneWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(AffineWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(CylindricalWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(SphericalWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(FisheyeWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(StereographicWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(MercatorWarper)
+OCS_WARPER_CREATOR_CTOR_DTOR(TransverseMercatorWarper)
+
+#undef OCS_WARPER_CREATOR_CTOR_DTOR
+
+#define OCS_WARPER_CREATOR_AB_CTOR_DTOR(NAME)                                                 \
+    CVAPI(ExceptionStatus) stitching_##NAME##_new(float a, float b, cv::NAME **returnValue)   \
+    {                                                                                         \
+        return cvTry([&] {                                                                    \
+            *returnValue = new cv::NAME(a, b);                                                 \
+        });                                                                                    \
+    }                                                                                          \
+    CVAPI(ExceptionStatus) stitching_##NAME##_delete(cv::NAME *obj)                           \
+    {                                                                                         \
+        return cvTry([&] {                                                                    \
+            delete obj;                                                                        \
+        });                                                                                    \
+    }
+
+OCS_WARPER_CREATOR_AB_CTOR_DTOR(CompressedRectilinearWarper)
+OCS_WARPER_CREATOR_AB_CTOR_DTOR(CompressedRectilinearPortraitWarper)
+OCS_WARPER_CREATOR_AB_CTOR_DTOR(PaniniWarper)
+OCS_WARPER_CREATOR_AB_CTOR_DTOR(PaniniPortraitWarper)
+
+#undef OCS_WARPER_CREATOR_AB_CTOR_DTOR
+
+#endif // NO_STITCHING

--- a/test/OpenCvSharp.Tests/stitching/BlenderTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/BlenderTest.cs
@@ -1,0 +1,83 @@
+using OpenCvSharp.Detail;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class BlenderTest : TestBase
+{
+    private static (Mat image, Mat mask) MakeImageAndMask()
+    {
+        var image = new Mat(new Size(60, 60), MatType.CV_16SC3, Scalar.All(128));
+        var mask = new Mat(new Size(60, 60), MatType.CV_8UC1, Scalar.All(255));
+        return (image, mask);
+    }
+
+    private static void RunBlend(Blender blender)
+    {
+        var (image1, mask1) = MakeImageAndMask();
+        var (image2, mask2) = MakeImageAndMask();
+        using var dst = new Mat();
+        using var dstMask = new Mat();
+        try
+        {
+            blender.Prepare([new Point(0, 0), new Point(30, 0)], [image1.Size(), image2.Size()]);
+            blender.Feed(image1, mask1, new Point(0, 0));
+            blender.Feed(image2, mask2, new Point(30, 0));
+            blender.Blend(dst, dstMask);
+            Assert.False(dst.Empty());
+        }
+        finally
+        {
+            image1.Dispose();
+            mask1.Dispose();
+            image2.Dispose();
+            mask2.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData(BlenderType.No)]
+    [InlineData(BlenderType.Feather)]
+    [InlineData(BlenderType.MultiBand)]
+    public void CreateDefaultBlend(BlenderType type)
+    {
+        using var blender = Blender.CreateDefault(type);
+        RunBlend(blender);
+    }
+
+    [Fact]
+    public void FeatherBlenderProperties()
+    {
+        using var blender = new FeatherBlender(0.05f);
+        Assert.Equal(0.05f, blender.Sharpness, 3);
+        blender.Sharpness = 0.1f;
+        Assert.Equal(0.1f, blender.Sharpness, 3);
+        RunBlend(blender);
+    }
+
+    [Fact]
+    public void MultiBandBlenderProperties()
+    {
+        using var blender = new MultiBandBlender(numBands: 3);
+        Assert.Equal(3, blender.NumBands);
+        RunBlend(blender);
+    }
+
+    [Fact]
+    public void LaplacePyrRoundTrip()
+    {
+        using var img = new Mat(new Size(64, 64), MatType.CV_32FC3, Scalar.All(100));
+        var pyr = Cv2.Detail.CreateLaplacePyr(img, 3);
+        try
+        {
+            Assert.NotEmpty(pyr);
+            using var restored = Cv2.Detail.RestoreImageFromLaplacePyr(pyr);
+            Assert.False(restored.Empty());
+        }
+        finally
+        {
+            foreach (var p in pyr)
+                p.Dispose();
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/stitching/EstimatorTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/EstimatorTest.cs
@@ -1,0 +1,146 @@
+using OpenCvSharp.Detail;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class EstimatorTest : TestBase
+{
+    private static (ImageFeatures[] features, MatchesInfo[] matches, Mat[] images) ComputeFeaturesAndMatches()
+    {
+        using var source = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var images = new[]
+        {
+            source[new Rect(0, 0, 200, 200)].Clone(),
+            source[new Rect(100, 100, 200, 200)].Clone(),
+        };
+        using var orb = ORB.Create(500);
+        var features = Cv2.Detail.ComputeImageFeatures(orb, images);
+        using var matcher = new BestOf2NearestMatcher();
+        var matches = matcher.Apply(features);
+        return (features, matches, images);
+    }
+
+    [Fact]
+    public void HomographyBasedEstimatorApply()
+    {
+        var (features, matches, images) = ComputeFeaturesAndMatches();
+        try
+        {
+            using var estimator = new HomographyBasedEstimator();
+            var cameras = new CameraParams[features.Length];
+            for (var i = 0; i < cameras.Length; i++)
+                cameras[i] = new CameraParams();
+            try
+            {
+                estimator.Apply(features, matches, cameras);
+                Assert.All(cameras, c => Assert.False(c.R.Empty()));
+            }
+            finally
+            {
+                foreach (var c in cameras)
+                    c.Dispose();
+            }
+        }
+        finally
+        {
+            foreach (var f in features) f.Dispose();
+            foreach (var m in matches) m.Dispose();
+            foreach (var img in images) img.Dispose();
+        }
+    }
+
+    [Fact]
+    public void CameraParamsK()
+    {
+        using var cam = new CameraParams { Focal = 100, Aspect = 1.0, Ppx = 50, Ppy = 60 };
+        using var k = cam.K();
+        Assert.Equal(100.0, k.At<double>(0, 0));
+        Assert.Equal(50.0, k.At<double>(0, 2));
+        Assert.Equal(60.0, k.At<double>(1, 2));
+        Assert.Equal(1.0, k.At<double>(2, 2));
+    }
+
+    [Fact]
+    public void BundleAdjusterReprojProperties()
+    {
+        using var adjuster = new BundleAdjusterReproj();
+        Assert.False(adjuster.RefinementMask.Empty());
+        adjuster.ConfThresh = 0.5;
+        Assert.Equal(0.5, adjuster.ConfThresh);
+        var criteria = new TermCriteria(CriteriaTypes.Count | CriteriaTypes.Eps, 100, 1e-6);
+        adjuster.TermCriteria = criteria;
+        Assert.Equal(criteria.Type, adjuster.TermCriteria.Type);
+    }
+
+    [Fact]
+    public void NoBundleAdjusterApply()
+    {
+        var (features, matches, images) = ComputeFeaturesAndMatches();
+        try
+        {
+            using var adjuster = new NoBundleAdjuster();
+            var cameras = new CameraParams[features.Length];
+            for (var i = 0; i < cameras.Length; i++)
+                cameras[i] = new CameraParams();
+            try
+            {
+                var ok = adjuster.Apply(features, matches, cameras);
+                Assert.True(ok);
+            }
+            finally
+            {
+                foreach (var c in cameras)
+                    c.Dispose();
+            }
+        }
+        finally
+        {
+            foreach (var f in features) f.Dispose();
+            foreach (var m in matches) m.Dispose();
+            foreach (var img in images) img.Dispose();
+        }
+    }
+
+    [Fact]
+    public void WaveCorrectRuns()
+    {
+        using var r1 = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+        using var r2 = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+        Cv2.Detail.WaveCorrect([r1, r2], WaveCorrectKind.Horizontal);
+        Assert.False(r1.Empty());
+    }
+
+    [Fact]
+    public void MatchesGraphAsStringRuns()
+    {
+        var (features, matches, images) = ComputeFeaturesAndMatches();
+        try
+        {
+            var dot = Cv2.Detail.MatchesGraphAsString(images.Length, matches, 1.0f);
+            Assert.NotNull(dot);
+        }
+        finally
+        {
+            foreach (var f in features) f.Dispose();
+            foreach (var m in matches) m.Dispose();
+            foreach (var img in images) img.Dispose();
+        }
+    }
+
+    [Fact]
+    public void LeaveBiggestComponentRuns()
+    {
+        var (features, matches, images) = ComputeFeaturesAndMatches();
+        try
+        {
+            var indices = Cv2.Detail.LeaveBiggestComponent(features, matches, 1.0f);
+            Assert.NotEmpty(indices);
+        }
+        finally
+        {
+            foreach (var f in features) f.Dispose();
+            foreach (var m in matches) m.Dispose();
+            foreach (var img in images) img.Dispose();
+        }
+    }
+}

--- a/test/OpenCvSharp.Tests/stitching/ExposureCompensatorTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/ExposureCompensatorTest.cs
@@ -1,0 +1,87 @@
+using OpenCvSharp.Detail;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class ExposureCompensatorTest : TestBase
+{
+    private static (Mat image, Mat mask) MakeImageAndMask()
+    {
+        var image = new Mat(new Size(50, 50), MatType.CV_8UC3, Scalar.All(128));
+        var mask = new Mat(new Size(50, 50), MatType.CV_8UC1, Scalar.All(255));
+        return (image, mask);
+    }
+
+    [Theory]
+    [InlineData(ExposureCompensatorType.No)]
+    [InlineData(ExposureCompensatorType.Gain)]
+    [InlineData(ExposureCompensatorType.GainBlocks)]
+    [InlineData(ExposureCompensatorType.Channels)]
+    [InlineData(ExposureCompensatorType.ChannelsBlocks)]
+    public void CreateDefaultFeedApply(ExposureCompensatorType type)
+    {
+        using var compensator = ExposureCompensator.CreateDefault(type);
+        var (image1, mask1) = MakeImageAndMask();
+        var (image2, mask2) = MakeImageAndMask();
+        try
+        {
+            compensator.Feed([new Point(0, 0), new Point(30, 0)], [image1, image2], [mask1, mask2]);
+            compensator.Apply(0, new Point(0, 0), image1, mask1);
+        }
+        finally
+        {
+            image1.Dispose();
+            mask1.Dispose();
+            image2.Dispose();
+            mask2.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GainCompensatorProperties()
+    {
+        using var compensator = new GainCompensator(nrFeeds: 2);
+        Assert.Equal(2, compensator.NrFeeds);
+        compensator.NrFeeds = 3;
+        Assert.Equal(3, compensator.NrFeeds);
+        compensator.SimilarityThreshold = 0.5;
+        Assert.Equal(0.5, compensator.SimilarityThreshold);
+    }
+
+    [Fact]
+    public void ChannelsCompensatorProperties()
+    {
+        using var compensator = new ChannelsCompensator(nrFeeds: 2);
+        Assert.Equal(2, compensator.NrFeeds);
+        compensator.SimilarityThreshold = 0.7;
+        Assert.Equal(0.7, compensator.SimilarityThreshold);
+    }
+
+    [Fact]
+    public void BlocksGainCompensatorProperties()
+    {
+        using var compensator = new BlocksGainCompensator(16, 16, 1);
+        Assert.Equal(new Size(16, 16), compensator.BlockSize);
+        compensator.BlockSize = new Size(8, 8);
+        Assert.Equal(new Size(8, 8), compensator.BlockSize);
+        compensator.NrGainsFilteringIterations = 3;
+        Assert.Equal(3, compensator.NrGainsFilteringIterations);
+    }
+
+    [Fact]
+    public void BlocksChannelsCompensatorProperties()
+    {
+        using var compensator = new BlocksChannelsCompensator(16, 16, 1);
+        Assert.Equal(new Size(16, 16), compensator.BlockSize);
+    }
+
+    [Fact]
+    public void UpdateGainProperty()
+    {
+        using var compensator = new GainCompensator();
+        compensator.UpdateGain = false;
+        Assert.False(compensator.UpdateGain);
+        compensator.UpdateGain = true;
+        Assert.True(compensator.UpdateGain);
+    }
+}

--- a/test/OpenCvSharp.Tests/stitching/FeaturesMatcherTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/FeaturesMatcherTest.cs
@@ -6,6 +6,41 @@ namespace OpenCvSharp.Tests.Stitching;
 public class FeaturesMatcherTest : TestBase
 {
     [Fact]
+    public void BestOf2NearestRangeMatcherApply()
+    {
+        using var source = LoadImage("lenna.png", ImreadModes.Grayscale);
+        var images = new[]
+        {
+            source[new Rect(0, 0, 200, 200)].Clone(),
+            source[new Rect(100, 100, 200, 200)].Clone(),
+            source[new Rect(200, 0, 200, 200)].Clone(),
+        };
+        try
+        {
+            using var orb = ORB.Create(500);
+            var features = Cv2.Detail.ComputeImageFeatures(orb, images);
+            try
+            {
+                using var matcher = new BestOf2NearestRangeMatcher(rangeWidth: 1);
+                var matches = matcher.Apply(features);
+                Assert.Equal(images.Length * images.Length, matches.Length);
+                foreach (var m in matches)
+                    m.Dispose();
+            }
+            finally
+            {
+                foreach (var f in features)
+                    f.Dispose();
+            }
+        }
+        finally
+        {
+            foreach (var image in images)
+                image.Dispose();
+        }
+    }
+
+    [Fact]
     public void ApplyMultipleImageFeatures()
     {
         using var source = LoadImage("lenna.png", ImreadModes.Grayscale);

--- a/test/OpenCvSharp.Tests/stitching/PyRotationWarperTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/PyRotationWarperTest.cs
@@ -1,0 +1,71 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class PyRotationWarperTest : TestBase
+{
+    [Theory]
+    [InlineData("plane")]
+    [InlineData("cylindrical")]
+    [InlineData("spherical")]
+    [InlineData("fisheye")]
+    [InlineData("stereographic")]
+    [InlineData("mercator")]
+    [InlineData("transverseMercator")]
+    public void WarpImage(string type)
+    {
+        using var warper = new PyRotationWarper(type, 300f);
+        using var src = new Mat(new Size(64, 64), MatType.CV_8UC3, Scalar.All(128));
+        using var k = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+        using var r = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+        using var dst = new Mat();
+
+        var corner = warper.Warp(src, k, r, InterpolationFlags.Linear, BorderTypes.Reflect, dst);
+        Assert.False(dst.Empty());
+        _ = corner;
+
+        var roi = warper.WarpRoi(src.Size(), k, r);
+        Assert.True(roi.Width > 0 && roi.Height > 0);
+    }
+
+    [Fact]
+    public void WarpPointRoundTrip()
+    {
+        using var warper = new PyRotationWarper("plane", 300f);
+        using var k = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+        using var r = Mat.Eye(3, 3, MatType.CV_32F).ToMat();
+
+        var projected = warper.WarpPoint(new Point2f(10, 10), k, r);
+        var back = warper.WarpPointBackward(projected, k, r);
+        Assert.InRange(back.X, 5, 15);
+        Assert.InRange(back.Y, 5, 15);
+    }
+
+    [Theory]
+    [InlineData(typeof(PlaneWarper))]
+    [InlineData(typeof(AffineWarper))]
+    [InlineData(typeof(CylindricalWarper))]
+    [InlineData(typeof(SphericalWarper))]
+    [InlineData(typeof(FisheyeWarper))]
+    [InlineData(typeof(StereographicWarper))]
+    [InlineData(typeof(MercatorWarper))]
+    [InlineData(typeof(TransverseMercatorWarper))]
+    public void ConstructWarperCreator(Type type)
+    {
+        using var creator = (WarperCreator)Activator.CreateInstance(type)!;
+        Assert.NotNull(creator);
+    }
+
+    [Fact]
+    public void ConstructCompressedAndPaniniWarperCreators()
+    {
+        using var w1 = new CompressedRectilinearWarper();
+        using var w2 = new CompressedRectilinearPortraitWarper();
+        using var w3 = new PaniniWarper();
+        using var w4 = new PaniniPortraitWarper();
+        Assert.NotNull(w1);
+        Assert.NotNull(w2);
+        Assert.NotNull(w3);
+        Assert.NotNull(w4);
+    }
+}

--- a/test/OpenCvSharp.Tests/stitching/SeamFinderTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/SeamFinderTest.cs
@@ -1,0 +1,70 @@
+using OpenCvSharp.Detail;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class SeamFinderTest : TestBase
+{
+    private static (Mat, Mat) MakeImageAndMask(Scalar color)
+    {
+        var image = new Mat(new Size(60, 60), MatType.CV_32FC3, color);
+        var mask = new Mat(new Size(60, 60), MatType.CV_8UC1, Scalar.All(255));
+        return (image, mask);
+    }
+
+    private static void RunFind(SeamFinder finder)
+    {
+        var (image1, mask1) = MakeImageAndMask(Scalar.All(50));
+        var (image2, mask2) = MakeImageAndMask(Scalar.All(200));
+        try
+        {
+            finder.Find([image1, image2], [new Point(0, 0), new Point(30, 0)], [mask1, mask2]);
+        }
+        finally
+        {
+            image1.Dispose();
+            mask1.Dispose();
+            image2.Dispose();
+            mask2.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData(SeamFinderType.No)]
+    [InlineData(SeamFinderType.VoronoiSeam)]
+    [InlineData(SeamFinderType.DpSeam)]
+    public void CreateDefaultFind(SeamFinderType type)
+    {
+        using var finder = SeamFinder.CreateDefault(type);
+        RunFind(finder);
+    }
+
+    [Fact]
+    public void NoSeamFinderFind()
+    {
+        using var finder = new NoSeamFinder();
+        RunFind(finder);
+    }
+
+    [Fact]
+    public void VoronoiSeamFinderFind()
+    {
+        using var finder = new VoronoiSeamFinder();
+        RunFind(finder);
+    }
+
+    [Fact]
+    public void DpSeamFinderFind()
+    {
+        using var finder = new DpSeamFinder(SeamFinderCostFunction.ColorGrad);
+        finder.SetCostFunction(SeamFinderCostFunction.Color);
+        RunFind(finder);
+    }
+
+    [Fact]
+    public void GraphCutSeamFinderFind()
+    {
+        using var finder = new GraphCutSeamFinder(SeamFinderCostFunction.Color);
+        RunFind(finder);
+    }
+}

--- a/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/StitchingTest.cs
@@ -139,4 +139,49 @@ public class StitchingTest : TestBase
         stitcher.WaveCorrectKind = value;
         Assert.Equal(value, stitcher.WaveCorrectKind);
     }
+
+    [Fact]
+    public void MatchingMaskProperty()
+    {
+        using var stitcher = Stitcher.Create();
+        using var mask = new Mat(3, 3, MatType.CV_8U, Scalar.All(1));
+        stitcher.MatchingMask = mask;
+        using var roundTripped = stitcher.MatchingMask;
+        Assert.Equal(mask.Size(), roundTripped.Size());
+    }
+
+    [Fact]
+    public void CustomPipelineComponentsStitch()
+    {
+        Mat[] images = SelectStitchingImages(200, 200, 6);
+        try
+        {
+            using var stitcher = Stitcher.Create(Stitcher.Mode.Scans);
+            using var warper = new PlaneWarper();
+            using var exposureCompensator = new GainCompensator();
+            using var seamFinder = new VoronoiSeamFinder();
+            using var blender = new FeatherBlender();
+            using var bundleAdjuster = new BundleAdjusterRay();
+
+            stitcher.SetWarper(warper);
+            stitcher.SetExposureCompensator(exposureCompensator);
+            stitcher.SetSeamFinder(seamFinder);
+            stitcher.SetBlender(blender);
+            stitcher.SetBundleAdjuster(bundleAdjuster);
+
+            using var pano = new Mat();
+            var status = stitcher.Stitch(images, pano);
+            Assert.Equal(Stitcher.Status.OK, status);
+
+            var cameras = stitcher.Cameras;
+            Assert.NotEmpty(cameras);
+            foreach (var cam in cameras)
+                cam.Dispose();
+        }
+        finally
+        {
+            foreach (Mat image in images)
+                image.Dispose();
+        }
+    }
 }

--- a/test/OpenCvSharp.Tests/stitching/TimelapserTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/TimelapserTest.cs
@@ -1,0 +1,23 @@
+using OpenCvSharp.Detail;
+using Xunit;
+
+namespace OpenCvSharp.Tests.Stitching;
+
+public class TimelapserTest : TestBase
+{
+    [Theory]
+    [InlineData(TimelapserType.AsIs)]
+    [InlineData(TimelapserType.Crop)]
+    public void InitializeProcessGetDst(TimelapserType type)
+    {
+        using var timelapser = Timelapser.CreateDefault(type);
+        using var image = new Mat(new Size(50, 50), MatType.CV_16SC3, Scalar.All(255));
+        using var mask = new Mat(new Size(50, 50), MatType.CV_8UC1, Scalar.All(255));
+
+        timelapser.Initialize([new Point(0, 0)], [new Size(50, 50)]);
+        timelapser.Process(image, mask, new Point(0, 0));
+
+        using var dst = timelapser.GetDst();
+        Assert.False(dst.Empty());
+    }
+}


### PR DESCRIPTION
## Summary

- add native and managed wrappers for the six `stitching::detail::` gaps identified in #2016: the `Warper`/`WarperCreator` family (`PyRotationWarper` plus 12 concrete creators: `PlaneWarper`, `AffineWarper`, `CylindricalWarper`, `SphericalWarper`, `FisheyeWarper`, `StereographicWarper`, `CompressedRectilinearWarper`(`Portrait`), `PaniniWarper`(`Portrait`), `MercatorWarper`, `TransverseMercatorWarper`), the `Blender` family (`Blender`/`FeatherBlender`/`MultiBandBlender`) with its `NormalizeUsingWeightMap`/`CreateWeightMap`/`CreateLaplacePyr`/`RestoreImageFromLaplacePyr` free functions, the `ExposureCompensator` family (7 classes), the `SeamFinder` family (`SeamFinder`/`NoSeamFinder`/`VoronoiSeamFinder`/`DpSeamFinder`/`GraphCutSeamFinder`), the `Estimator`/`BundleAdjuster` family (9 classes) plus a new `CameraParams` type and `WaveCorrect`/`MatchesGraphAsString`/`LeaveBiggestComponent` free functions, and `BestOf2NearestRangeMatcher`/`LightGlueFeaturesMatcher`/`Timelapser`
- `Stitcher.cs` already had empty stub classes and a fully commented-out property block for these types (`FeaturesFinder`/`BundleAdjusterBase`/`WarperCreator`/`ExposureCompensator`/`SeamFinder`/`Blender`/`CameraParams`), so this PR also replaces those stubs with real `SetWarper`/`SetExposureCompensator`/`SetSeamFinder`/`SetBlender`/`SetBundleAdjuster`/`SetFeaturesFinder`/`SetFeaturesMatcher` methods and `MatchingMask`/`Cameras` properties, wired to new native getters/setters on `cv::Stitcher`. Setters wrap the caller-owned raw pointer in a non-owning `cv::Ptr<T>` (no-op deleter); getters for the polymorphic component types aren't exposed since there's no RTTI-free way to hand the raw pointer back as the correct concrete managed subclass
- fixes `Detail.WaveCorrectKind`, which only had `Horizontal`/`Vertical` and was missing the `Auto` value present in the real `cv::detail::WaveCorrectKind` enum
- new/existing pattern split: base classes that are only constructible via a `createDefault(type)` factory (`Blender`, `ExposureCompensator`, `SeamFinder`, `Timelapser`) use the `Ptr<T>`-owning `CvPtrObject` dual-constructor pattern (mirroring `Stitcher` itself); concrete classes with a real public C++ constructor use the plain raw `new`/`delete` pattern already established by `FeaturesMatcher`/`BestOf2NearestMatcher`

Closes #2016

## Testing

- `cmake src/build` (reconfigure - picks up the six new `stitching_detail_*.h` headers referenced from `stitching.cpp`)
- `cmake --build src/build --config Release --target OpenCvSharpExtern`
- `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release`
- `dotnet test test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release --filter "FullyQualifiedName~Stitching"` (64 passed)
- `dotnet test test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release` (full suite: 1599 passed, 26 skipped, 0 failed - no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded image-stitching pipeline with additional configurable components: new matchers, estimators, seam finders, exposure compensators, blenders, and warpers, plus timelapse support.
  * Enhanced Stitcher customization with access to camera results and the matching mask, and added setters for pipeline components.
  * Added stitching utilities for weight maps, Laplacian pyramid workflows, wave correction, and match-graph inspection.
* **Tests**
  * Added/extended automated coverage for blending, warping, estimation, compensation, seam finding, timelapse, and the Stitcher custom-pipeline flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->