### PR TITLE
Fill in missing XML doc comments from native OpenCV headers

### DIFF
--- a/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorGMG.cs
+++ b/src/OpenCvSharp/Modules/bgsegm/BackgroundSubtractorGMG.cs
@@ -32,7 +32,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     #region Properties
 
     /// <summary>
-    /// 
+    /// Total number of distinct colors to maintain in histogram.
     /// </summary>
     public int MaxFeatures
     {
@@ -52,7 +52,8 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// The learning rate of the algorithm. It lies between 0.0 and 1.0. It determines how quickly
+    /// features are "forgotten" from histograms.
     /// </summary>
     public double DefaultLearningRate
     {
@@ -72,7 +73,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Number of frames used to initialize the background model.
     /// </summary>
     public int NumFrames
     {
@@ -92,7 +93,8 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// The parameter used for quantization of color-space. It is the number of discrete levels in
+    /// each channel to be used in histograms.
     /// </summary>
     public int QuantizationLevels
     {
@@ -112,7 +114,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Prior probability that each individual pixel is a background pixel.
     /// </summary>
     public double BackgroundPrior
     {
@@ -132,7 +134,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Kernel radius used for morphological operations.
     /// </summary>
     public int SmoothingRadius
     {
@@ -152,7 +154,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Value of decision threshold. Decision value is the value above which a pixel is determined to be foreground.
     /// </summary>
     public double DecisionThreshold
     {
@@ -172,7 +174,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Status of background model update.
     /// </summary>
     public bool UpdateBackgroundModel
     {
@@ -192,7 +194,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Minimum value taken on by pixels in image sequence. Usually 0.
     /// </summary>
     public double MinVal
     {
@@ -212,7 +214,7 @@ public class BackgroundSubtractorGMG : BackgroundSubtractor
     }
 
     /// <summary>
-    /// 
+    /// Maximum value taken on by pixels in image sequence, e.g. 1.0 or 255.
     /// </summary>
     public double MaxVal
     {

--- a/src/OpenCvSharp/Modules/calib/Enum/FishEyeCalibrationFlags.cs
+++ b/src/OpenCvSharp/Modules/calib/Enum/FishEyeCalibrationFlags.cs
@@ -5,18 +5,61 @@
 namespace OpenCvSharp;
 #pragma warning disable CS1591
 
+/// <summary>
+/// Different flags for the fisheye camera calibration functions (cv::fisheye::calibrate, cv::fisheye::stereoCalibrate).
+/// </summary>
 [Flags]
 public enum FishEyeCalibrationFlags
 {
     None = 0,
+
+    /// <summary>
+    /// Use user provided intrinsics as initial point for optimization.
+    /// </summary>
     UseIntrinsicGuess = 1,
+
+    /// <summary>
+    /// For fisheye model only. Recompute board position on each calibration iteration.
+    /// </summary>
     RecomputeExtrinsic = 1 << 1,
+
+    /// <summary>
+    /// For fisheye model only. Check SVD decomposition quality for each frame during extrinsics estimation.
+    /// </summary>
     CheckCond = 1 << 2,
+
+    /// <summary>
+    /// For fisheye model only. Skew coefficient (alpha) is set to zero and stay zero.
+    /// </summary>
     FixSkew = 1 << 3,
+
+    /// <summary>
+    /// The distortion coefficient k1 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
+    /// </summary>
     FixK1 = 1 << 4,
+
+    /// <summary>
+    /// The distortion coefficient k2 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
+    /// </summary>
     FixK2 = 1 << 5,
+
+    /// <summary>
+    /// The distortion coefficient k3 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
+    /// </summary>
     FixK3 = 1 << 6,
+
+    /// <summary>
+    /// The distortion coefficient k4 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
+    /// </summary>
     FixK4 = 1 << 7,
+
+    /// <summary>
+    /// For stereo and multi-camera calibration only. Do not optimize cameras intrinsics.
+    /// </summary>
     FixIntrinsic = 1 << 8,
+
+    /// <summary>
+    /// The principal point (cx, cy) stays the same as in the input camera matrix. Image center is used as principal point, if UseIntrinsicGuess is not set.
+    /// </summary>
     FixPrincipalPoint = 1 << 9
 }

--- a/src/OpenCvSharp/Modules/core/Delegate/MatForeachFunction.cs
+++ b/src/OpenCvSharp/Modules/core/Delegate/MatForeachFunction.cs
@@ -1,80 +1,229 @@
 using System.Runtime.InteropServices;
 
 namespace OpenCvSharp;
-#pragma warning disable 1591
 // ReSharper disable InconsistentNaming
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsByte"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionByte(byte* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec2b"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec2b(Vec2b* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec3b"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec3b(Vec3b* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec4b"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec4b(Vec4b* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec6b"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec6b(Vec6b* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsInt16"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionInt16(short* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec2s"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec2s(Vec2s* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec3s"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec3s(Vec3s* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec4s"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec4s(Vec4s* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec6s"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec6s(Vec6s* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsInt32"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionInt32(int* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec2i"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec2i(Vec2i* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec3i"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec3i(Vec3i* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec4i"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec4i(Vec4i* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec6i"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec6i(Vec6i* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsFloat"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionFloat(float* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec2f"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec2f(Vec2f* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec3f"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec3f(Vec3f* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec4f"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec4f(Vec4f* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec6f"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec6f(Vec6f* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsDouble"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionDouble(double* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec2d"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec2d(Vec2d* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec3d"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec3d(Vec3d* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec4d"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec4d(Vec4d* value, int* position);
 
+/// <summary>
+/// Callback invoked once per element when <see cref="Mat.ForEachAsVec6d"/> runs the given
+/// functor over all matrix elements in parallel.
+/// </summary>
+/// <param name="value">Pointer to the element value.</param>
+/// <param name="position">Pointer to the element's position (one int per matrix dimension).</param>
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public unsafe delegate void MatForeachFunctionVec6d(Vec6d* value, int* position);

--- a/src/OpenCvSharp/Modules/core/Enum/CpuFeatures.cs
+++ b/src/OpenCvSharp/Modules/core/Enum/CpuFeatures.cs
@@ -46,13 +46,40 @@ public enum CpuFeatures
     VSX             = 200,
     VSX3            = 201,
 
-    AVX512_SKX      = 256, //!< Skylake-X with AVX-512F/CD/BW/DQ/VL
-    AVX512_COMMON   = 257, //!< Common instructions AVX-512F/CD for all CPUs that support AVX-512
-    AVX512_KNL      = 258, //!< Knights Landing with AVX-512F/CD/ER/PF
-    AVX512_KNM      = 259, //!< Knights Mill with AVX-512F/CD/ER/PF/4FMAPS/4VNNIW/VPOPCNTDQ
-    AVX512_CNL      = 260, //!< Cannon Lake with AVX-512F/CD/BW/DQ/VL/IFMA/VBMI
-    AVX512_CEL      = 261, //!< Cascade Lake with AVX-512F/CD/BW/DQ/VL/IFMA/VBMI/VNNI
-    AVX512_ICL      = 262, //!< Ice Lake with AVX-512F/CD/BW/DQ/VL/IFMA/VBMI/VNNI/VBMI2/BITALG/VPOPCNTDQ
+    /// <summary>
+    /// Skylake-X with AVX-512F/CD/BW/DQ/VL
+    /// </summary>
+    AVX512_SKX      = 256,
+
+    /// <summary>
+    /// Common instructions AVX-512F/CD for all CPUs that support AVX-512
+    /// </summary>
+    AVX512_COMMON   = 257,
+
+    /// <summary>
+    /// Knights Landing with AVX-512F/CD/ER/PF
+    /// </summary>
+    AVX512_KNL      = 258,
+
+    /// <summary>
+    /// Knights Mill with AVX-512F/CD/ER/PF/4FMAPS/4VNNIW/VPOPCNTDQ
+    /// </summary>
+    AVX512_KNM      = 259,
+
+    /// <summary>
+    /// Cannon Lake with AVX-512F/CD/BW/DQ/VL/IFMA/VBMI
+    /// </summary>
+    AVX512_CNL      = 260,
+
+    /// <summary>
+    /// Cascade Lake with AVX-512F/CD/BW/DQ/VL/VNNI
+    /// </summary>
+    AVX512_CEL      = 261,
+
+    /// <summary>
+    /// Ice Lake with AVX-512F/CD/BW/DQ/VL/IFMA/VBMI/VNNI/VBMI2/BITALG/VPOPCNTDQ
+    /// </summary>
+    AVX512_ICL      = 262,
 
     MAX_FEATURE     = 512  // see CV_HARDWARE_MAX_FEATURE
 }

--- a/src/OpenCvSharp/Modules/core/Enum/ErrorCode.cs
+++ b/src/OpenCvSharp/Modules/core/Enum/ErrorCode.cs
@@ -249,13 +249,38 @@ public enum ErrorCode
     /// </summary>
     StsAssert = -215,
 
-#pragma warning disable 1591
+    /// <summary>
+    /// no CUDA support
+    /// </summary>
     GpuNotSupported = -216,
+
+    /// <summary>
+    /// GPU API call error
+    /// </summary>
     GpuApiCallError = -217,
+
+    /// <summary>
+    /// no OpenGL support
+    /// </summary>
     OpenGlNotSupported = -218,
+
+    /// <summary>
+    /// OpenGL API call error
+    /// </summary>
     OpenGlApiCallError = -219,
+
+    /// <summary>
+    /// OpenCL API call error
+    /// </summary>
     OpenCLApiCallError = -220,
+
+#pragma warning disable 1591
     OpenCLDoubleNotSupported = -221,
+
+    /// <summary>
+    /// OpenCL initialization error
+    /// </summary>
     OpenCLInitError = -222,
+
     OpenCLNoAMDBlasFft = -223
 }

--- a/src/OpenCvSharp/Modules/core/Enum/UMatUsageFlags.cs
+++ b/src/OpenCvSharp/Modules/core/Enum/UMatUsageFlags.cs
@@ -6,11 +6,26 @@ namespace OpenCvSharp;
 [Flags]
 public enum UMatUsageFlags
 {
-#pragma warning disable 1591
+    /// <summary>
+    /// Default allocation policy. Unlike the other flags, this one is not experimental.
+    /// </summary>
     None = 0,
 
     // buffer allocation policy is platform and usage specific
+
+    /// <summary>
+    /// Allocate host (CPU) memory. This flag is experimental; the buffer allocation policy is platform and usage specific.
+    /// </summary>
     HostMemory = 1 << 0,
+
+    /// <summary>
+    /// Allocate device (GPU) memory. This flag is experimental; the buffer allocation policy is platform and usage specific.
+    /// </summary>
     DeviceMemory = 1 << 1,
-    SharedMemory = 1 << 2, // It is not equal to: USAGE_ALLOCATE_HOST_MEMORY | USAGE_ALLOCATE_DEVICE_MEMORY
+
+    /// <summary>
+    /// Allocate memory shared between host and device. This flag is experimental and, for the OpenCL allocator,
+    /// depends on OpenCV's optional OpenCL SVM integration. It is not equal to HostMemory | DeviceMemory.
+    /// </summary>
+    SharedMemory = 1 << 2,
 }

--- a/src/OpenCvSharp/Modules/dnn/Backend.cs
+++ b/src/OpenCvSharp/Modules/dnn/Backend.cs
@@ -15,9 +15,9 @@ namespace OpenCvSharp.Dnn;
 /// </remarks>
 public enum Backend
 {
-    //! DNN_BACKEND_DEFAULT equals to DNN_BACKEND_INFERENCE_ENGINE if
-    //! OpenCV is built with Intel's Inference Engine library or
-    //! DNN_BACKEND_OPENCV otherwise.
+    /// <summary>
+    /// Equals to <see cref="INFERENCE_ENGINE"/> if OpenCV is built with Intel's Inference Engine library, or <see cref="OPENCV"/> otherwise.
+    /// </summary>
     // ReSharper disable once InconsistentNaming
     DEFAULT = 0,
 

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/BasicFaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/BasicFaceRecognizer.cs
@@ -15,7 +15,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
         : base(smartPtr, rawPtr, release) { }
 
     /// <summary>
-    /// 
+    /// Gets the number of components (Eigenfaces or Fisherfaces) kept by the underlying PCA/LDA computation.
     /// </summary>
     /// <returns></returns>
     public virtual int GetNumComponents()
@@ -27,7 +27,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the number of components (Eigenfaces or Fisherfaces) kept by the underlying PCA/LDA computation.
     /// </summary>
     /// <param name="val"></param>
     public virtual void SetNumComponents(int val)
@@ -38,7 +38,8 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the threshold applied in the prediction. If the distance to the nearest neighbor is
+    /// larger than the threshold, the prediction returns -1.
     /// </summary>
     /// <returns></returns>
     public new virtual double GetThreshold()
@@ -50,7 +51,8 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the threshold applied in the prediction. If the distance to the nearest neighbor is
+    /// larger than the threshold, the prediction returns -1.
     /// </summary>
     /// <param name="val"></param>
     public new virtual void SetThreshold(double val)
@@ -61,7 +63,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the projections of the training data.
     /// </summary>
     /// <returns></returns>
     public virtual Mat[] GetProjections()
@@ -74,7 +76,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the labels corresponding to the training data projections.
     /// </summary>
     /// <returns></returns>
     public virtual Mat GetLabels()
@@ -87,7 +89,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the eigenvalues computed during training, ordered descending.
     /// </summary>
     /// <returns></returns>
     public virtual Mat GetEigenValues()
@@ -100,7 +102,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the eigenvectors computed during training, ordered by their eigenvalue.
     /// </summary>
     /// <returns></returns>
     public virtual Mat GetEigenVectors()
@@ -113,7 +115,7 @@ public abstract class BasicFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the sample mean calculated from the training data.
     /// </summary>
     /// <returns></returns>
     public virtual Mat GetMean()

--- a/src/OpenCvSharp/Modules/face/FaceRecognizer/LBPHFaceRecognizer.cs
+++ b/src/OpenCvSharp/Modules/face/FaceRecognizer/LBPHFaceRecognizer.cs
@@ -47,7 +47,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the number of cells in the horizontal direction used to build the Circular Local Binary Pattern.
     /// </summary>
     /// <returns></returns>
     public virtual int GetGridX()
@@ -59,7 +59,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the number of cells in the horizontal direction used to build the Circular Local Binary Pattern.
     /// </summary>
     /// <param name="val"></param>
     public virtual void SetGridX(int val)
@@ -70,7 +70,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the number of cells in the vertical direction used to build the Circular Local Binary Pattern.
     /// </summary>
     /// <returns></returns>
     public virtual int GetGridY()
@@ -82,7 +82,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the number of cells in the vertical direction used to build the Circular Local Binary Pattern.
     /// </summary>
     /// <param name="val"></param>
     public virtual void SetGridY(int val)
@@ -93,7 +93,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the radius used for building the Circular Local Binary Pattern.
     /// </summary>
     /// <returns></returns>
     public virtual int GetRadius()
@@ -105,7 +105,8 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the radius used for building the Circular Local Binary Pattern. The greater the radius,
+    /// the smoother the image but more spatial information you can get.
     /// </summary>
     /// <param name="val"></param>
     public virtual void SetRadius(int val)
@@ -116,7 +117,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the number of sample points used to build the Circular Local Binary Pattern.
     /// </summary>
     /// <returns></returns>
     public virtual int GetNeighbors()
@@ -128,7 +129,8 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the number of sample points used to build the Circular Local Binary Pattern. An appropriate
+    /// value is 8; keep in mind that including more sample points increases the computational cost.
     /// </summary>
     /// <param name="val"></param>
     public virtual void SetNeighbors(int val)
@@ -139,7 +141,8 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the threshold applied in the prediction. If the distance to the nearest neighbor is
+    /// larger than the threshold, the prediction returns -1.
     /// </summary>
     /// <returns></returns>
     public new virtual double GetThreshold()
@@ -151,7 +154,8 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Sets the threshold applied in the prediction. If the distance to the nearest neighbor is
+    /// larger than the threshold, the prediction returns -1.
     /// </summary>
     /// <param name="val"></param>
     public new virtual void SetThreshold(double val)
@@ -162,7 +166,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the Local Binary Patterns histograms calculated from the given training data (empty if none was given).
     /// </summary>
     /// <returns></returns>
     public virtual Mat[] GetHistograms()
@@ -175,7 +179,7 @@ public class LBPHFaceRecognizer : FaceRecognizer
     }
 
     /// <summary>
-    /// 
+    /// Gets the labels corresponding to the calculated Local Binary Patterns histograms.
     /// </summary>
     /// <returns></returns>
     public virtual Mat GetLabels()

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkAAM.cs
@@ -15,7 +15,7 @@ public sealed class FacemarkAAM : FacemarkTrain
     { }
 
     /// <summary>
-    ///
+    /// Creates a FacemarkAAM model.
     /// </summary>
     /// <param name="parameters"></param>
     /// <returns></returns>

--- a/src/OpenCvSharp/Modules/features/SimpleBlobDetector.cs
+++ b/src/OpenCvSharp/Modules/features/SimpleBlobDetector.cs
@@ -50,18 +50,28 @@ public class SimpleBlobDetector : Feature2D
         }
 
 #pragma warning disable 1591
+        /// <summary>
+        /// Distance between neighboring thresholds when converting the source image to several
+        /// binary images, from MinThreshold (inclusive) to MaxThreshold (exclusive).
+        /// </summary>
         public float ThresholdStep
         {
             get => Data.thresholdStep;
             set => Data.thresholdStep = value;
         }
 
+        /// <summary>
+        /// Lower bound (inclusive) of the range of thresholds used to binarize the source image.
+        /// </summary>
         public float MinThreshold
         {
             get => Data.minThreshold;
             set => Data.minThreshold = value;
         }
 
+        /// <summary>
+        /// Upper bound (exclusive) of the range of thresholds used to binarize the source image.
+        /// </summary>
         public float MaxThreshold
         {
             get => Data.maxThreshold;
@@ -74,90 +84,145 @@ public class SimpleBlobDetector : Feature2D
             set => Data.minRepeatability = value;
         }
 
+        /// <summary>
+        /// Maximum distance between centers of two blobs for them to be merged into a single blob
+        /// group when combining results from the several binarized images.
+        /// </summary>
         public float MinDistBetweenBlobs
         {
             get => Data.minDistBetweenBlobs;
             set => Data.minDistBetweenBlobs = value;
         }
 
+        /// <summary>
+        /// If true, blobs are filtered by comparing the intensity of a binary image at the center of a
+        /// blob to <see cref="BlobColor"/>; blobs with a different intensity are filtered out.
+        /// </summary>
         public bool FilterByColor
         {
             get => Data.filterByColor != 0;
             set => Data.filterByColor = (value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Expected intensity of a blob center in the binary image, used when <see cref="FilterByColor"/>
+        /// is enabled. Use 0 to extract dark blobs and 255 to extract light blobs.
+        /// </summary>
         public byte BlobColor
         {
             get => Data.blobColor;
             set => Data.blobColor = value;
         }
 
+        /// <summary>
+        /// If true, blobs are filtered by area; only blobs with an area between
+        /// <see cref="MinArea"/> (inclusive) and <see cref="MaxArea"/> (exclusive) are extracted.
+        /// </summary>
         public bool FilterByArea
         {
             get => Data.filterByArea != 0;
             set => Data.filterByArea = (value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Lower bound (inclusive) of blob area used when <see cref="FilterByArea"/> is enabled.
+        /// </summary>
         public float MinArea
         {
             get => Data.minArea;
             set => Data.minArea = value;
         }
 
+        /// <summary>
+        /// Upper bound (exclusive) of blob area used when <see cref="FilterByArea"/> is enabled.
+        /// </summary>
         public float MaxArea
         {
             get => Data.maxArea;
             set => Data.maxArea = value;
         }
 
+        /// <summary>
+        /// If true, blobs are filtered by circularity (4*pi*area / perimeter^2); only blobs with a
+        /// circularity between <see cref="MinCircularity"/> (inclusive) and <see cref="MaxCircularity"/>
+        /// (exclusive) are extracted.
+        /// </summary>
         public bool FilterByCircularity
         {
             get => Data.filterByCircularity != 0;
             set => Data.filterByCircularity = (value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Lower bound (inclusive) of blob circularity used when <see cref="FilterByCircularity"/> is enabled.
+        /// </summary>
         public float MinCircularity
         {
             get => Data.minCircularity;
             set => Data.minCircularity = value;
         }
 
+        /// <summary>
+        /// Upper bound (exclusive) of blob circularity used when <see cref="FilterByCircularity"/> is enabled.
+        /// </summary>
         public float MaxCircularity
         {
             get => Data.maxCircularity;
             set => Data.maxCircularity = value;
         }
 
+        /// <summary>
+        /// If true, blobs are filtered by the ratio of the minimum to the maximum inertia; only blobs
+        /// with a ratio between <see cref="MinInertiaRatio"/> (inclusive) and
+        /// <see cref="MaxInertiaRatio"/> (exclusive) are extracted.
+        /// </summary>
         public bool FilterByInertia
         {
             get => Data.filterByInertia != 0;
             set => Data.filterByInertia = (value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Lower bound (inclusive) of the inertia ratio used when <see cref="FilterByInertia"/> is enabled.
+        /// </summary>
         public float MinInertiaRatio
         {
             get => Data.minInertiaRatio;
             set => Data.minInertiaRatio = value;
         }
 
+        /// <summary>
+        /// Upper bound (exclusive) of the inertia ratio used when <see cref="FilterByInertia"/> is enabled.
+        /// </summary>
         public float MaxInertiaRatio
         {
             get => Data.maxInertiaRatio;
             set => Data.maxInertiaRatio = value;
         }
 
+        /// <summary>
+        /// If true, blobs are filtered by convexity (area / area of the blob's convex hull); only blobs
+        /// with a convexity between <see cref="MinConvexity"/> (inclusive) and <see cref="MaxConvexity"/>
+        /// (exclusive) are extracted.
+        /// </summary>
         public bool FilterByConvexity
         {
             get => Data.filterByConvexity != 0;
             set => Data.filterByConvexity = (value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Lower bound (inclusive) of blob convexity used when <see cref="FilterByConvexity"/> is enabled.
+        /// </summary>
         public float MinConvexity
         {
             get => Data.minConvexity;
             set => Data.minConvexity = value;
         }
 
+        /// <summary>
+        /// Upper bound (exclusive) of blob convexity used when <see cref="FilterByConvexity"/> is enabled.
+        /// </summary>
         public float MaxConvexity
         {
             get => Data.maxConvexity;

--- a/src/OpenCvSharp/Modules/line_descriptors/LSDParam.cs
+++ b/src/OpenCvSharp/Modules/line_descriptors/LSDParam.cs
@@ -4,9 +4,21 @@ using System.Runtime.InteropServices;
 namespace OpenCvSharp.LineDescriptor;
 #pragma warning disable CA1815
 #pragma warning disable 1591
+/// <summary>
+/// Parameters used by <see cref="LSDDetector"/> to configure the underlying Line Segment Detector (LSD) algorithm.
+/// The LSD algorithm is defined using the standard values below. Only advanced users may want to edit those,
+/// as to tailor it for their own application.
+/// </summary>
+/// <param name="scale">The scale of the image that will be used to find the lines. Range (0..1].</param>
+/// <param name="sigmaScale">Sigma for the Gaussian filter. It is computed as sigma = sigmaScale/scale.</param>
+/// <param name="quant">Bound to the quantization error on the gradient norm.</param>
+/// <param name="angTh">Gradient angle tolerance in degrees.</param>
+/// <param name="logEps">Detection threshold: -log10(NFA) &gt; logEps. Used only when advanced refinement is chosen.</param>
+/// <param name="densityTh">Minimal density of aligned region points in the enclosing rectangle.</param>
+/// <param name="nBins">Number of bins in pseudo-ordering of gradient modulus.</param>
+// ReSharper disable once InconsistentNaming
 [StructLayout(LayoutKind.Sequential)]
 [SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
-// ReSharper disable once InconsistentNaming
 public readonly struct LSDParam(
     double scale = 0.8,
     double sigmaScale = 0.6,
@@ -16,11 +28,38 @@ public readonly struct LSDParam(
     double densityTh = 0.7,
     int nBins = 1024)
 {
+    /// <summary>
+    /// The scale of the image that will be used to find the lines. Range (0..1].
+    /// </summary>
     public readonly double Scale = scale;
+
+    /// <summary>
+    /// Sigma for the Gaussian filter. It is computed as sigma = SigmaScale/Scale.
+    /// </summary>
     public readonly double SigmaScale = sigmaScale;
+
+    /// <summary>
+    /// Bound to the quantization error on the gradient norm.
+    /// </summary>
     public readonly double Quant = quant;
+
+    /// <summary>
+    /// Gradient angle tolerance in degrees.
+    /// </summary>
     public readonly double AngTh = angTh;
+
+    /// <summary>
+    /// Detection threshold: -log10(NFA) &gt; LogEps. Used only when advanced refinement is chosen.
+    /// </summary>
     public readonly double LogEps = logEps;
+
+    /// <summary>
+    /// Minimal density of aligned region points in the enclosing rectangle.
+    /// </summary>
     public readonly double DensityTh = densityTh;
+
+    /// <summary>
+    /// Number of bins in pseudo-ordering of gradient modulus.
+    /// </summary>
     public readonly int NBins = nBins;
 }

--- a/src/OpenCvSharp/Modules/stereo/StereoBM.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoBM.cs
@@ -18,11 +18,16 @@ public class StereoBM : StereoMatcher
     { }
 
     /// <summary>
-    /// 
+    /// Creates StereoBM object. You can then call Compute() to compute disparity for a specific stereo pair.
     /// </summary>
-    /// <param name="numDisparities"></param>
-    /// <param name="blockSize"></param>
-    /// <returns></returns>
+    /// <param name="numDisparities">the disparity search range. For each pixel algorithm will find the best
+    /// disparity from 0 (default minimum disparity) to numDisparities. The search range can then be
+    /// shifted by changing the minimum disparity.</param>
+    /// <param name="blockSize">the linear size of the blocks compared by the algorithm. The size should be odd
+    /// (as the block is centered at the current pixel). Larger block size implies smoother, though less
+    /// accurate disparity map. Smaller block size gives more detailed disparity map, but there is higher
+    /// chance for algorithm to find a wrong correspondence.</param>
+    /// <returns>A new StereoBM instance.</returns>
     public static StereoBM Create(int numDisparities = 0, int blockSize = 21)
     {
         NativeMethods.HandleException(
@@ -76,7 +81,9 @@ public class StereoBM : StereoMatcher
     }
 
     /// <summary>
-    /// 
+    /// Truncation value for the prefiltered image pixels. The algorithm first computes x-derivative at each
+    /// pixel and clips its value by [-preFilterCap, preFilterCap] interval. The result values are passed to
+    /// the Birchfield-Tomasi pixel cost function.
     /// </summary>
     public int PreFilterCap
     {
@@ -116,7 +123,9 @@ public class StereoBM : StereoMatcher
     }
 
     /// <summary>
-    /// 
+    /// Margin in percentage by which the best (minimum) computed cost function value should "win" the
+    /// second best value to consider the found match correct. Normally, a value within the 5-15 range is
+    /// good enough.
     /// </summary>
     public int UniquenessRatio
     {

--- a/src/OpenCvSharp/Modules/stereo/StereoMatcher.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoMatcher.cs
@@ -47,7 +47,8 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// Minimum possible disparity value. Normally, it is zero but sometimes rectification algorithms can
+    /// shift images, so this parameter needs to be adjusted accordingly.
     /// </summary>
     public int MinDisparity
     {
@@ -65,7 +66,9 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// The disparity search range. For each pixel the algorithm will find the best disparity from 0
+    /// (default minimum disparity) to NumDisparities. The search range can then be shifted by changing
+    /// the minimum disparity.
     /// </summary>
     public int NumDisparities
     {
@@ -83,7 +86,10 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// The linear size of the blocks compared by the algorithm. The size should be odd (as the block is
+    /// centered at the current pixel). Larger block size implies smoother, though less accurate disparity
+    /// map. Smaller block size gives more detailed disparity map, but there is higher chance for the
+    /// algorithm to find a wrong correspondence.
     /// </summary>
     public int BlockSize
     {
@@ -101,7 +107,8 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// Maximum size of smooth disparity regions to consider their noise speckles and invalidate. Set it to
+    /// 0 to disable speckle filtering. Otherwise, set it somewhere in the 50-200 range.
     /// </summary>
     public int SpeckleWindowSize
     {
@@ -119,7 +126,9 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// Maximum disparity variation within each connected component. If you do speckle filtering, set the
+    /// parameter to a positive value; it will be implicitly multiplied by 16. Normally, 1 or 2 is good
+    /// enough.
     /// </summary>
     public int SpeckleRange
     {
@@ -137,7 +146,8 @@ public class StereoMatcher : Algorithm
     }
 
     /// <summary>
-    /// 
+    /// Maximum allowed difference (in integer pixel units) in the left-right disparity check. Set it to a
+    /// non-positive value to disable the check.
     /// </summary>
     public int Disp12MaxDiff
     {

--- a/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
+++ b/src/OpenCvSharp/Modules/stereo/StereoSGBM.cs
@@ -26,20 +26,38 @@ public class StereoSGBM : StereoMatcher
     { }
 
     /// <summary>
-    /// 
+    /// Creates StereoSGBM object. Using the default parameters, only <paramref name="numDisparities"/> needs
+    /// to be set at minimum; every other parameter can be set to a custom value as needed.
     /// </summary>
-    /// <param name="minDisparity"></param>
-    /// <param name="numDisparities"></param>
-    /// <param name="blockSize"></param>
-    /// <param name="p1"></param>
-    /// <param name="p2"></param>
-    /// <param name="disp12MaxDiff"></param>
-    /// <param name="preFilterCap"></param>
-    /// <param name="uniquenessRatio"></param>
-    /// <param name="speckleWindowSize"></param>
-    /// <param name="speckleRange"></param>
-    /// <param name="mode"></param>
-    /// <returns></returns>
+    /// <param name="minDisparity">Minimum possible disparity value. Normally, it is zero but sometimes
+    /// rectification algorithms can shift images, so this parameter needs to be adjusted accordingly.</param>
+    /// <param name="numDisparities">Maximum disparity minus minimum disparity. The value is always greater
+    /// than zero. In the current implementation, this parameter must be divisible by 16.</param>
+    /// <param name="blockSize">Matched block size. It must be an odd number &gt;=1. Normally, it should be
+    /// somewhere in the 3..11 range.</param>
+    /// <param name="p1">The first parameter controlling the disparity smoothness. See <paramref name="p2"/>.</param>
+    /// <param name="p2">The second parameter controlling the disparity smoothness. The larger the values
+    /// are, the smoother the disparity is. P1 is the penalty on the disparity change by plus or minus 1
+    /// between neighbor pixels. P2 is the penalty on the disparity change by more than 1 between neighbor
+    /// pixels. The algorithm requires P2 &gt; P1.</param>
+    /// <param name="disp12MaxDiff">Maximum allowed difference (in integer pixel units) in the left-right
+    /// disparity check. Set it to a non-positive value to disable the check.</param>
+    /// <param name="preFilterCap">Truncation value for the prefiltered image pixels. The algorithm first
+    /// computes x-derivative at each pixel and clips its value by [-preFilterCap, preFilterCap] interval.
+    /// The result values are passed to the Birchfield-Tomasi pixel cost function.</param>
+    /// <param name="uniquenessRatio">Margin in percentage by which the best (minimum) computed cost
+    /// function value should "win" the second best value to consider the found match correct. Normally, a
+    /// value within the 5-15 range is good enough.</param>
+    /// <param name="speckleWindowSize">Maximum size of smooth disparity regions to consider their noise
+    /// speckles and invalidate. Set it to 0 to disable speckle filtering. Otherwise, set it somewhere in
+    /// the 50-200 range.</param>
+    /// <param name="speckleRange">Maximum disparity variation within each connected component. If you do
+    /// speckle filtering, set the parameter to a positive value, it will be implicitly multiplied by 16.
+    /// Normally, 1 or 2 is good enough.</param>
+    /// <param name="mode">Set it to <see cref="StereoSGBMMode.HH"/> to run the full-scale two-pass dynamic
+    /// programming algorithm. It will consume a large amount of memory for large images. By default, the
+    /// single-pass 5-direction variant is used.</param>
+    /// <returns>A new StereoSGBM instance.</returns>
     public static StereoSGBM Create(
         int minDisparity, int numDisparities, int blockSize,
         int p1 = 0, int p2 = 0, int disp12MaxDiff = 0,

--- a/src/OpenCvSharp/Modules/stitching/Stitcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/Stitcher.cs
@@ -28,6 +28,9 @@ namespace OpenCvSharp
     {
             #region Enum
 
+        /// <summary>
+        /// When setting a resolution for stitching, this value is a placeholder for preserving the original resolution.
+        /// </summary>
         public const int ORIG_RESOL = -1;
 
         /// <summary>
@@ -197,6 +200,9 @@ namespace OpenCvSharp
         }
 
         // TODO this should be method?
+        /// <summary>
+        /// Returns indices of input images used in panorama stitching.
+        /// </summary>
         public IReadOnlyList<int> Component
         {
             get
@@ -253,6 +259,12 @@ namespace OpenCvSharp
 
         #region Methods
 
+        /// <summary>
+        /// Tries to match the given images and to estimate rotations of each camera.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(InputArray, OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <returns>Status code.</returns>
         public Status EstimateTransform(InputArray images)
         {
             NativeMethods.HandleException(
@@ -262,6 +274,13 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to match the given images and to estimate rotations of each camera.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(InputArray, Rect[][], OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <param name="rois">Masks for each input image specifying where to look for keypoints (optional).</param>
+        /// <returns>Status code.</returns>
         public Status EstimateTransform(InputArray images, Rect[][] rois)
         {
             ArgumentNullException.ThrowIfNull(rois);
@@ -274,6 +293,12 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to match the given images and to estimate rotations of each camera.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(IEnumerable{Mat}, OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <returns>Status code.</returns>
         public Status EstimateTransform(IEnumerable<Mat> images)
         {
             ArgumentNullException.ThrowIfNull(images);
@@ -288,6 +313,13 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to match the given images and to estimate rotations of each camera.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(IEnumerable{Mat}, Rect[][], OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <param name="rois">Masks for each input image specifying where to look for keypoints (optional).</param>
+        /// <returns>Status code.</returns>
         public Status EstimateTransform(IEnumerable<Mat> images, Rect[][] rois)
         {
             ArgumentNullException.ThrowIfNull(images);
@@ -305,6 +337,13 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to compose the images stored internally from the other function calls into the final pano,
+        /// under the assumption that the image transformations were estimated before.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(InputArray, OutputArray)"/>.
+        /// </summary>
+        /// <param name="pano">Final pano.</param>
+        /// <returns>Status code.</returns>
         public Status ComposePanorama(OutputArray pano)
         {
             NativeMethods.HandleException(
@@ -314,6 +353,14 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to compose the given images into the final pano, under the assumption that
+        /// the image transformations were estimated before.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(InputArray, OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <param name="pano">Final pano.</param>
+        /// <returns>Status code.</returns>
         public Status ComposePanorama(InputArray images, OutputArray pano)
         {
             NativeMethods.HandleException(
@@ -324,6 +371,14 @@ namespace OpenCvSharp
             return (Status)ret;
         }
 
+        /// <summary>
+        /// Tries to compose the given images into the final pano, under the assumption that
+        /// the image transformations were estimated before.
+        /// Note: Use this method only if you're aware of the stitching pipeline, otherwise use <see cref="Stitch(IEnumerable{Mat}, OutputArray)"/>.
+        /// </summary>
+        /// <param name="images">Input images.</param>
+        /// <param name="pano">Final pano.</param>
+        /// <returns>Status code.</returns>
         public Status ComposePanorama(IEnumerable<Mat> images, OutputArray pano)
         {
             ArgumentNullException.ThrowIfNull(images);

--- a/src/OpenCvSharp/Modules/superres/BroxOpticalFlow.cs
+++ b/src/OpenCvSharp/Modules/superres/BroxOpticalFlow.cs
@@ -37,7 +37,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     #region Properties
 
     /// <summary>
-    /// 
+    /// Flow smoothness
     /// </summary>
     public double Alpha
     {
@@ -57,7 +57,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     }
 
     /// <summary>
-    /// 
+    /// Gradient constancy importance
     /// </summary>
     public double Gamma
     {
@@ -77,7 +77,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     }
 
     /// <summary>
-    /// 
+    /// Pyramid scale factor
     /// </summary>
     public double ScaleFactor
     {
@@ -97,7 +97,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     }
 
     /// <summary>
-    /// 
+    /// Number of lagged non-linearity iterations (inner loop)
     /// </summary>
     public int InnerIterations
     {
@@ -117,7 +117,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     }
 
     /// <summary>
-    /// 
+    /// Number of warping iterations (number of pyramid levels)
     /// </summary>
     public int OuterIterations
     {
@@ -137,7 +137,7 @@ public class BroxOpticalFlow : DenseOpticalFlowExt
     }
 
     /// <summary>
-    /// 
+    /// Number of linear system solver iterations
     /// </summary>
     public int SolverIterations
     {

--- a/src/OpenCvSharp/Modules/superres/FrameSource.cs
+++ b/src/OpenCvSharp/Modules/superres/FrameSource.cs
@@ -85,9 +85,9 @@ public class FrameSource : CvPtrObject
     #region Methods
         
     /// <summary>
-    /// 
+    /// Process next frame from input and return output result.
     /// </summary>
-    /// <param name="frame"></param>
+    /// <param name="frame">Output result</param>
     public virtual void NextFrame(OutputArray frame)
     {
         ThrowIfDisposed();


### PR DESCRIPTION
## Summary

Some public API members had no XML doc comment at all. This fills them in using the corresponding Doxygen comment from the native opencv/opencv_contrib headers, for members where a matching native description actually exists.

- `MatForeachFunction.cs` — 25 delegate types (from `cv::Mat::forEach`'s Doxygen block)
- `CpuFeatures.cs` / `ErrorCode.cs` / `UMatUsageFlags.cs` — several enum members
- `Stitcher.cs` — `EstimateTransform`, `ComposePanorama` overloads, `Component`, `ORIG_RESOL`
- `BasicFaceRecognizer.cs` / `LBPHFaceRecognizer.cs` / `FacemarkAAM.cs` — face recognizer getters/setters and `Create`
- `SimpleBlobDetector.cs` — most `Params` properties
- `FishEyeCalibrationFlags.cs` — enum members
- `LSDParam.cs` — the struct and all its fields
- `StereoBM.cs` / `StereoMatcher.cs` / `StereoSGBM.cs` — several properties and `Create`
- `BroxOpticalFlow.cs` / `FrameSource.cs` (superres) — several properties/methods
- `BackgroundSubtractorGMG.cs` — several properties
- `Backend.cs` (dnn) — `DEFAULT`

Members without a discoverable native comment (C#-only helpers, undocumented native enum values, etc.) were intentionally left untouched rather than inventing documentation.

## Test plan

- [x] `dotnet build src/OpenCvSharp/OpenCvSharp.csproj` — 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation across background subtraction, calibration, face recognition, stereo vision, stitching, super-resolution, blob detection, and related features.
  * Added clearer descriptions for configuration parameters, method inputs, return values, enum options, and processing behavior.
  * Added documentation for an additional matrix iteration callback supporting six-dimensional vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->