### PR TITLE
Collect VSTest blame crash dumps on Windows/macOS CI test failures

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -348,7 +348,7 @@ jobs:
           # re-run. See "Upload crash dumps on failure" below (separate from the .ips upload above).
           DYLD_LIBRARY_PATH=/usr/local/lib:${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime osx-arm64 \
             --logger "trx;LogFileName=test-results.trx" \
-            --blame-crash --blame-crash-collect-always --blame-crash-dump-type full < /dev/null
+            --blame-crash --blame-crash-dump-type full < /dev/null
 
       - name: Test Avalonia extensions
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -342,8 +342,13 @@ jobs:
           cp ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.dylib ./
           sudo mkdir -p /usr/local/lib
           sudo cp ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.dylib /usr/local/lib/
+          # --blame-crash* collects a full memory dump and a Sequence_*.xml (listing tests executed,
+          # in order) into TestResults\ if the test host crashes, so an intermittent native crash
+          # (e.g. the dynafu::WarpField SIGSEGV) can be attributed to a specific test without a
+          # re-run. See "Upload crash dumps on failure" below (separate from the .ips upload above).
           DYLD_LIBRARY_PATH=/usr/local/lib:${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime osx-arm64 \
-            --logger "trx;LogFileName=test-results.trx" < /dev/null
+            --logger "trx;LogFileName=test-results.trx" \
+            --blame-crash --blame-crash-collect-always --blame-crash-dump-type full < /dev/null
 
       - name: Test Avalonia extensions
         run: |
@@ -376,6 +381,14 @@ jobs:
         with:
           name: macos-arm64-crash-reports
           path: ~/Library/Logs/DiagnosticReports/
+          if-no-files-found: ignore
+
+      - name: Upload crash dumps on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-arm64-crash-dumps
+          path: test/OpenCvSharp.Tests/TestResults/
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -176,7 +176,19 @@ jobs:
 
       - name: Test
         shell: cmd
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64
+        # --blame-crash* collects a full memory dump and a Sequence_*.xml (listing tests executed,
+        # in order) into test\OpenCvSharp.Tests\TestResults\ if the test host crashes, so an
+        # intermittent native access violation can be attributed to a specific test without a
+        # re-run. See "Upload crash dumps on failure" below.
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-collect-always --blame-crash-dump-type full
+
+      - name: Upload crash dumps on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-x64-crash-dumps
+          path: test/OpenCvSharp.Tests/TestResults/
+          if-no-files-found: ignore
 
       - name: Test Windows-only functions
         shell: powershell
@@ -459,7 +471,16 @@ jobs:
 
       - name: Test
         shell: cmd
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64 --filter "FullyQualifiedName!=OpenCvSharp.Tests.Core.BuildConfigurationTest.FFMPEG_IsEnabled"
+        # See the x64 job's "Test" step above for why --blame-crash* is here.
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64 --filter "FullyQualifiedName!=OpenCvSharp.Tests.Core.BuildConfigurationTest.FFMPEG_IsEnabled" --blame-crash --blame-crash-collect-always --blame-crash-dump-type full
+
+      - name: Upload crash dumps on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-crash-dumps
+          path: test/OpenCvSharp.Tests/TestResults/
+          if-no-files-found: ignore
 
       - name: Pack NuGet packages
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,7 +180,7 @@ jobs:
         # in order) into test\OpenCvSharp.Tests\TestResults\ if the test host crashes, so an
         # intermittent native access violation can be attributed to a specific test without a
         # re-run. See "Upload crash dumps on failure" below.
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-collect-always --blame-crash-dump-type full
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full
 
       - name: Upload crash dumps on failure
         if: failure()
@@ -472,7 +472,7 @@ jobs:
       - name: Test
         shell: cmd
         # See the x64 job's "Test" step above for why --blame-crash* is here.
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64 --filter "FullyQualifiedName!=OpenCvSharp.Tests.Core.BuildConfigurationTest.FFMPEG_IsEnabled" --blame-crash --blame-crash-collect-always --blame-crash-dump-type full
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-arm64 --filter "FullyQualifiedName!=OpenCvSharp.Tests.Core.BuildConfigurationTest.FFMPEG_IsEnabled" --blame-crash --blame-crash-dump-type full
 
       - name: Upload crash dumps on failure
         if: failure()


### PR DESCRIPTION
## Summary

- Intermittent native crashes during `dotnet test` (access violations on Windows, SIGSEGV on macOS) have been hard to diagnose: the test host just dies with an opaque exit code, and since passing tests produce no console output of their own (only `[SKIP]` lines appear), there's no way to tell which test was running when it crashed without a re-run under a debugger.
- Added `--blame-crash --blame-crash-collect-always --blame-crash-dump-type full` to the main "Test" step on both Windows jobs (x64, arm64) and the macOS arm64 job. On a crash, VSTest's Blame collector writes a full process dump plus a `Sequence_*.xml` (the ordered list of tests that had started) to `TestResults/`, uploaded as a build artifact on failure - mirroring the existing macOS `.ips` crash report upload (which captures the OS-level crash report but not which test was running).
- No functional change on a passing run - the flags only affect what happens when the test host actually crashes (verified locally: a normal passing run just logs an informational "no dump generated" message from the Blame collector and otherwise behaves identically).

## Context

This came out of investigating a Windows CI crash on [#2064](https://github.com/shimat/opencvsharp/pull/2064) (`Test process crashed with exit code -1073741819`, i.e. `STATUS_ACCESS_VIOLATION`). Digging through recent CI history turned up several more native crashes across Windows/macOS over the past week, some already-known (the `dynafu::WarpField` uninitialized-read SIGSEGV, since fixed with a test `Skip`) and at least one still undiagnosed (a Windows arm64 crash where the known offender was already skipped). Without dump/sequence data there's no way to make progress on the undiagnosed one(s) beyond guessing from log timestamps, hence this change.

## Testing

- `dotnet test test/OpenCvSharp.Tests -c Debug -f net10.0 --filter "FullyQualifiedName~SaturateCastTest" --blame-crash --blame-crash-collect-always --blame-crash-dump-type full` locally: flags are accepted, Blame collector attaches, test run passes normally (6/6), only an expected informational "dump collection was enabled but no dump file was generated" message since nothing crashed.
- `actionlint` (via Docker) against both modified workflow files: no errors (only pre-existing, unrelated shellcheck `SC2086` info-level nits on lines this change didn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced macOS (arm64) and Windows (x64/arm64) integration tests to automatically capture crash diagnostics and collect full crash dump artifacts when the test host crashes.
  * Preserved existing architectures, test selection behavior, and logging/filters to avoid changing test coverage.

* **Chores**
  * Added failure-only artifact uploads for crash dumps on macOS arm64 and Windows x64/arm64 to streamline debugging of failed CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->