### PR TITLE
Fix linux-x64 libatomic/libdrm over-link; add a headless native package flavor

### DIFF
--- a/.github/actions/build-manylinux-variant/action.yml
+++ b/.github/actions/build-manylinux-variant/action.yml
@@ -118,7 +118,7 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ${{ github.workspace }}/${{ inputs.artifacts_dir }}
-        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
+        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh', '.github/actions/build-manylinux-variant/action.yml') }}-${{ inputs.extra_opencv_cmake_args }}
 
     - name: Configure OpenCV (${{ inputs.variant_label }})
       if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -200,7 +200,7 @@ runs:
       uses: actions/cache/save@v6
       with:
         path: ${{ github.workspace }}/${{ inputs.artifacts_dir }}
-        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
+        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh', '.github/actions/build-manylinux-variant/action.yml') }}-${{ inputs.extra_opencv_cmake_args }}
 
     # -- OpenCvSharpExtern --------------------------------------------------------
     - name: Build OpenCvSharpExtern (${{ inputs.variant_label }})

--- a/.github/actions/build-manylinux-variant/action.yml
+++ b/.github/actions/build-manylinux-variant/action.yml
@@ -1,0 +1,239 @@
+name: Build manylinux OpenCvSharpExtern variant
+description: >-
+  Builds OpenCV + libOpenCvSharpExtern.so for one "full-module-set" flavor (full or headless)
+  inside a manylinux_2_28 container. Not used by the "slim" flavor, which has a
+  structurally different build (no vcpkg/FFmpeg, reduced OpenCV module list).
+
+inputs:
+  opencv_version:
+    description: OpenCV version being built (e.g. 5.0.0), used in the OpenCV cache key
+    required: true
+  variant_label:
+    description: Short label for this variant, used in cache keys and log file names (e.g. full, headless)
+    required: true
+  install_gtk3_devel:
+    description: Whether to dnf install gtk3-devel before configuring OpenCV
+    required: true
+  artifacts_dir:
+    description: Directory name (relative to the workspace) OpenCV gets installed into
+    required: true
+  opencv_build_dir:
+    description: CMake build directory for OpenCV (relative to the workspace)
+    required: true
+  extern_build_dir:
+    description: CMake build directory for OpenCvSharpExtern (relative to the workspace)
+    required: true
+  extra_opencv_cmake_args:
+    description: Extra -D flags appended to the OpenCV configure command
+    required: false
+    default: ''
+  extra_extern_cmake_args:
+    description: Extra -D flags appended to the OpenCvSharpExtern configure command
+    required: false
+    default: ''
+  verify_gtk_off:
+    description: Also assert GTK+ is disabled when verifying the OpenCV cmake feature summary
+    required: false
+    default: 'false'
+  verify_no_gui_deps:
+    description: Assert the built .so has no GTK3/X11/DRM NEEDED entries
+    required: false
+    default: 'false'
+  save_shared_caches:
+    description: Save the vcpkg/FFmpeg caches shared across variants (only one variant job should do this)
+    required: false
+    default: 'false'
+  output_so_name:
+    description: Final .so filename copied to the workspace root
+    required: true
+  artifact_name:
+    description: upload-artifact name for the built .so
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # -- System tools ---------------------------------------------------------
+    - name: Install system tools (${{ inputs.variant_label }})
+      shell: bash
+      run: |
+        pkgs="git zip unzip nasm yasm pkg-config ninja-build kernel-headers perl-IPC-Cmd perl-Time-Piece"
+        if [ "${{ inputs.install_gtk3_devel }}" = "true" ]; then
+          pkgs="$pkgs gtk3-devel"
+        fi
+        dnf install -y $pkgs
+
+    # -- vcpkg (image libs + Tesseract + Leptonica) ----------------------------
+    - name: Bootstrap vcpkg (${{ inputs.variant_label }})
+      shell: bash
+      run: |
+        git clone --filter=blob:none https://github.com/microsoft/vcpkg.git /opt/vcpkg
+        /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+    - name: Restore vcpkg package cache (${{ inputs.variant_label }})
+      id: vcpkg-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ github.workspace }}/vcpkg_installed
+        key: vcpkg-x64-linux-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-linux-static.cmake') }}
+
+    - name: Install packages via vcpkg (${{ inputs.variant_label }})
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        /opt/vcpkg/vcpkg install \
+          --triplet x64-linux-static \
+          --overlay-triplets=${GITHUB_WORKSPACE}/cmake/triplets
+
+    - name: Save vcpkg package cache (${{ inputs.variant_label }})
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true' && inputs.save_shared_caches == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ github.workspace }}/vcpkg_installed
+        key: vcpkg-x64-linux-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-linux-static.cmake') }}
+
+    # -- FFmpeg cache -----------------------------------------------------------
+    - name: Restore FFmpeg cache (${{ inputs.variant_label }})
+      id: ffmpeg-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: /opt/ffmpeg
+        key: manylinux2_28-ffmpeg-${{ hashFiles('packaging/docker/manylinux/build_static_deps.sh') }}
+
+    - name: Build FFmpeg (${{ inputs.variant_label }})
+      if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: bash packaging/docker/manylinux/build_static_deps.sh
+
+    - name: Save FFmpeg cache (${{ inputs.variant_label }})
+      if: steps.ffmpeg-cache.outputs.cache-hit != 'true' && inputs.save_shared_caches == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v6
+      with:
+        path: /opt/ffmpeg
+        key: manylinux2_28-ffmpeg-${{ hashFiles('packaging/docker/manylinux/build_static_deps.sh') }}
+
+    # -- OpenCV cache -------------------------------------------------------------
+    - name: Restore OpenCV cache (${{ inputs.variant_label }})
+      id: opencv-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ github.workspace }}/${{ inputs.artifacts_dir }}
+        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
+
+    - name: Configure OpenCV (${{ inputs.variant_label }})
+      if: steps.opencv-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cmake \
+          -G Ninja \
+          -C cmake/opencv_build_options.cmake \
+          -S opencv \
+          -B ${{ inputs.opencv_build_dir }} \
+          -D OPENCV_EXTRA_MODULES_PATH=${GITHUB_WORKSPACE}/opencv_contrib/modules \
+          -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }} \
+          -D CMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          -D VCPKG_TARGET_TRIPLET=x64-linux-static \
+          -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
+          -D CMAKE_PREFIX_PATH=/opt/ffmpeg \
+          -D BUILD_JPEG=OFF \
+          -D BUILD_PNG=OFF \
+          -D BUILD_TIFF=OFF \
+          -D BUILD_WEBP=OFF \
+          -D BUILD_ZLIB=ON \
+          -D WITH_TBB=OFF \
+          -D WITH_OPENEXR=OFF \
+          -D WITH_JASPER=OFF \
+          -D WITH_OPENGL=OFF \
+          -D WITH_VA=OFF \
+          -D WITH_VA_INTEL=OFF \
+          ${{ inputs.extra_opencv_cmake_args }} \
+          2>&1 | tee /tmp/opencv-configure-${{ inputs.variant_label }}.log
+
+    - name: Verify OpenCV cmake features (${{ inputs.variant_label }})
+      if: steps.opencv-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        log=/tmp/opencv-configure-${{ inputs.variant_label }}.log
+        fail=0
+        for feature in Tesseract FFMPEG JPEG PNG TIFF WEBP; do
+          val=$(grep -E "^--\s+${feature}:\s+" "$log" | tail -1 | sed -E "s/^.*${feature}:[[:space:]]+//")
+          if [[ -n "$val" ]] && [[ "$val" != NO* ]]; then
+            echo "OK: $feature = $val"
+          else
+            echo "MISSING or DISABLED: $feature"
+            grep -iE "${feature}" "$log" | tail -3 || true
+            fail=1
+          fi
+        done
+        if [ "${{ inputs.verify_gtk_off }}" = "true" ]; then
+          gtk=$(grep -E "^--\s+GTK\+:" "$log" | tail -1 || true)
+          if [[ -n "$gtk" ]] && [[ "$gtk" != *NO* ]]; then
+            echo "GTK3 unexpectedly enabled in ${{ inputs.variant_label }} build: $gtk"
+            fail=1
+          fi
+        fi
+        [ "$fail" -eq 0 ]
+
+    - name: Build OpenCV (${{ inputs.variant_label }})
+      if: steps.opencv-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cmake --build ${{ inputs.opencv_build_dir }} -j 3
+        cmake --install ${{ inputs.opencv_build_dir }}
+        echo "=== ${{ inputs.artifacts_dir }} layout ==="
+        find ${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }} -name 'OpenCVConfig.cmake' -o -name '*.pc' | head -20
+        du -sh ${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }}/*/
+
+    - name: Validate OpenCV install (${{ inputs.variant_label }})
+      if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      shell: bash
+      run: |
+        config=$(find ${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }} -name 'OpenCVConfig.cmake' | head -1)
+        if [ -z "$config" ]; then
+          echo "ERROR: OpenCVConfig.cmake not found under ${{ inputs.artifacts_dir }} - install is incomplete."
+          exit 1
+        fi
+        echo "Found: $config"
+
+    - name: Save OpenCV cache (${{ inputs.variant_label }})
+      if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ github.workspace }}/${{ inputs.artifacts_dir }}
+        key: opencv-${{ inputs.opencv_version }}-manylinux2_28-${{ inputs.variant_label }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
+
+    # -- OpenCvSharpExtern --------------------------------------------------------
+    - name: Build OpenCvSharpExtern (${{ inputs.variant_label }})
+      shell: bash
+      run: |
+        cmake \
+          -G Ninja \
+          -S src \
+          -B ${{ inputs.extern_build_dir }} \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          -D VCPKG_TARGET_TRIPLET=x64-linux-static \
+          -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
+          -D OpenCV_DIR=${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }}/lib64/cmake/opencv4 \
+          -D CMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/${{ inputs.artifacts_dir }};/opt/ffmpeg;${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static" \
+          -D ZLIB_LIBRARY="${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/lib/libz.a" \
+          -D ZLIB_INCLUDE_DIR="${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/include" \
+          -D CMAKE_SHARED_LINKER_FLAGS="-L${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/lib" \
+          ${{ inputs.extra_extern_cmake_args }}
+        cmake --build ${{ inputs.extern_build_dir }} -j
+        cp ${{ inputs.extern_build_dir }}/OpenCvSharpExtern/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }}
+
+    - name: Verify no GTK3/X11 dependency (${{ inputs.variant_label }})
+      if: inputs.verify_no_gui_deps == 'true'
+      shell: bash
+      run: |
+        if objdump -p ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }} | grep -qi 'libgtk\|libX11\|libdrm'; then
+          echo "ERROR: ${{ inputs.variant_label }} .so unexpectedly depends on GTK3/X11/DRM:"
+          objdump -p ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }} | grep -i 'NEEDED'
+          exit 1
+        fi
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.output_so_name }}

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -30,169 +30,52 @@ jobs:
         with:
           submodules: true
 
-      # -- System tools --------------------------------------------------------
-      - name: Install system tools
-        run: |
-          dnf install -y \
-            git \
-            zip \
-            unzip \
-            nasm \
-            yasm \
-            pkg-config \
-            ninja-build \
-            kernel-headers \
-            perl-IPC-Cmd \
-            perl-Time-Piece \
-            gtk3-devel
-
-      # -- vcpkg (image libs + Tesseract + Leptonica) --------------------------
-      - name: Bootstrap vcpkg
-        run: |
-          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git /opt/vcpkg
-          /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics
-
-      - name: Restore vcpkg package cache
-        id: vcpkg-cache
-        uses: actions/cache/restore@v6
+      - uses: ./.github/actions/build-manylinux-variant
         with:
-          path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-x64-linux-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-linux-static.cmake') }}
+          opencv_version: ${{ env.OPENCV_VERSION }}
+          variant_label: full
+          install_gtk3_devel: 'true'
+          artifacts_dir: opencv_artifacts
+          opencv_build_dir: opencv/build
+          extern_build_dir: src/build
+          save_shared_caches: 'true'
+          output_so_name: libOpenCvSharpExtern.so
+          artifact_name: libOpenCvSharpExtern-full
 
-      - name: Install packages via vcpkg
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
-        run: |
-          /opt/vcpkg/vcpkg install \
-            --triplet x64-linux-static \
-            --overlay-triplets=${GITHUB_WORKSPACE}/cmake/triplets
+  # ---------------------------------------------------------------------------
+  # Build headless libOpenCvSharpExtern.so inside manylinux_2_28.
+  # Same module set as "full" (videoio, dnn, ml, contrib, stitching, barcode, ...)
+  # but highgui is disabled, so GTK3/X11/Mesa are never linked. Targets
+  # containerized/headless consumers that need more than the "slim" module set
+  # but don't want the GTK3 runtime dependency of "full". See issue #2065.
+  # ---------------------------------------------------------------------------
+  build_headless:
+    name: Linux (x64, headless)
+    runs-on: ubuntu-24.04
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64
+      options: --user root
 
-      - name: Save vcpkg package cache
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v6
+    steps:
+      - uses: actions/checkout@v7
         with:
-          path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-x64-linux-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-linux-static.cmake') }}
+          submodules: true
 
-      # -- FFmpeg cache --------------------------------------------------------
-      - name: Restore FFmpeg cache
-        id: ffmpeg-cache
-        uses: actions/cache/restore@v6
+      - uses: ./.github/actions/build-manylinux-variant
         with:
-          path: /opt/ffmpeg
-          key: manylinux2_28-ffmpeg-${{ hashFiles('packaging/docker/manylinux/build_static_deps.sh') }}
-
-      - name: Build FFmpeg
-        if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
-        run: bash packaging/docker/manylinux/build_static_deps.sh
-
-      - name: Save FFmpeg cache
-        if: steps.ffmpeg-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v6
-        with:
-          path: /opt/ffmpeg
-          key: manylinux2_28-ffmpeg-${{ hashFiles('packaging/docker/manylinux/build_static_deps.sh') }}
-
-      # -- OpenCV cache --------------------------------------------------------
-      - name: Restore OpenCV cache (full)
-        id: opencv-cache
-        uses: actions/cache/restore@v6
-        with:
-          path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-manylinux2_28-full-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
-
-      - name: Configure OpenCV (full)
-        if: steps.opencv-cache.outputs.cache-hit != 'true'
-        run: |
-          cmake \
-            -G Ninja \
-            -C cmake/opencv_build_options.cmake \
-            -S opencv \
-            -B opencv/build \
-            -D OPENCV_EXTRA_MODULES_PATH=${GITHUB_WORKSPACE}/opencv_contrib/modules \
-            -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/opencv_artifacts \
-            -D CMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
-            -D VCPKG_TARGET_TRIPLET=x64-linux-static \
-            -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
-            -D CMAKE_PREFIX_PATH=/opt/ffmpeg \
-            -D BUILD_JPEG=OFF \
-            -D BUILD_PNG=OFF \
-            -D BUILD_TIFF=OFF \
-            -D BUILD_WEBP=OFF \
-            -D BUILD_ZLIB=ON \
-            -D WITH_TBB=OFF \
-            -D WITH_OPENEXR=OFF \
-            -D WITH_JASPER=OFF \
-            -D WITH_OPENGL=OFF \
-            -D WITH_VA=OFF \
-            -D WITH_VA_INTEL=OFF \
-            2>&1 | tee /tmp/opencv-configure-full.log
-
-      - name: Verify OpenCV cmake features (full)
-        if: steps.opencv-cache.outputs.cache-hit != 'true'
-        run: |
-          log=/tmp/opencv-configure-full.log
-          fail=0
-          for feature in Tesseract FFMPEG JPEG PNG TIFF WEBP; do
-            val=$(grep -E "^--\s+${feature}:\s+" "$log" | tail -1 | sed -E "s/^.*${feature}:[[:space:]]+//")
-            if [[ -n "$val" ]] && [[ "$val" != NO* ]]; then
-              echo "OK: $feature = $val"
-            else
-              echo "MISSING or DISABLED: $feature"
-              grep -iE "${feature}" "$log" | tail -3 || true
-              fail=1
-            fi
-          done
-          [ "$fail" -eq 0 ]
-
-      - name: Build OpenCV (full)
-        if: steps.opencv-cache.outputs.cache-hit != 'true'
-        run: |
-          cmake --build opencv/build -j 3
-          cmake --install opencv/build
-          echo "=== opencv_artifacts layout ==="
-          find ${GITHUB_WORKSPACE}/opencv_artifacts -name 'OpenCVConfig.cmake' -o -name '*.pc' | head -20
-          du -sh ${GITHUB_WORKSPACE}/opencv_artifacts/*/
-
-      - name: Validate OpenCV install (full)
-        if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          config=$(find ${GITHUB_WORKSPACE}/opencv_artifacts -name 'OpenCVConfig.cmake' | head -1)
-          if [ -z "$config" ]; then
-            echo "ERROR: OpenCVConfig.cmake not found under opencv_artifacts - install is incomplete."
-            exit 1
-          fi
-          echo "Found: $config"
-        shell: bash
-      - name: Save OpenCV cache (full)
-        if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v6
-        with:
-          path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-manylinux2_28-full-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'packaging/docker/manylinux/build_static_deps.sh') }}
-
-      # -- OpenCvSharpExtern ---------------------------------------------------
-      - name: Build OpenCvSharpExtern (full)
-        run: |
-          cmake \
-            -G Ninja \
-            -S src \
-            -B src/build \
-            -D CMAKE_BUILD_TYPE=Release \
-            -D CMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
-            -D VCPKG_TARGET_TRIPLET=x64-linux-static \
-            -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
-            -D OpenCV_DIR=${GITHUB_WORKSPACE}/opencv_artifacts/lib64/cmake/opencv4 \
-            -D CMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/opencv_artifacts;/opt/ffmpeg;${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static" \
-            -D ZLIB_LIBRARY="${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/lib/libz.a" \
-            -D ZLIB_INCLUDE_DIR="${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/include" \
-            -D CMAKE_SHARED_LINKER_FLAGS="-L${GITHUB_WORKSPACE}/vcpkg_installed/x64-linux-static/lib"
-          cmake --build src/build -j
-          cp src/build/OpenCvSharpExtern/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/libOpenCvSharpExtern.so
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: libOpenCvSharpExtern-full
-          path: libOpenCvSharpExtern.so
+          opencv_version: ${{ env.OPENCV_VERSION }}
+          variant_label: headless
+          install_gtk3_devel: 'false'
+          artifacts_dir: opencv_artifacts_headless
+          opencv_build_dir: opencv/build-headless
+          extern_build_dir: src/build-headless
+          extra_opencv_cmake_args: -D WITH_GTK=OFF
+          extra_extern_cmake_args: -D NO_HIGHGUI=ON
+          verify_gtk_off: 'true'
+          verify_no_gui_deps: 'true'
+          save_shared_caches: 'false'
+          output_so_name: libOpenCvSharpExtern-headless.so
+          artifact_name: libOpenCvSharpExtern-headless
 
   # ---------------------------------------------------------------------------
   # Build slim libOpenCvSharpExtern.so inside manylinux_2_28.
@@ -289,7 +172,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     name: Linux (test)
-    needs: [build_full, build_slim]
+    needs: [build_full, build_headless, build_slim]
     runs-on: ubuntu-24.04
 
     steps:
@@ -302,6 +185,12 @@ jobs:
         with:
           name: libOpenCvSharpExtern-full
           path: packaging/nuget/
+
+      - name: Download headless artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: libOpenCvSharpExtern-headless
+          path: nuget-headless/
 
       - name: Download slim artifact
         uses: actions/download-artifact@v8
@@ -331,6 +220,18 @@ jobs:
           cp ${GITHUB_WORKSPACE}/packaging/nuget/libOpenCvSharpExtern.so bin/Release/net10.0/
           LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.Avalonia.csproj -c Release -f net10.0 --runtime linux-x64 < /dev/null
 
+      # Headless has the same module set as full except highgui, so it runs the same xunit
+      # suite minus the one test class that calls into highgui (WaitKey/PollKey/...).
+      - name: Test (headless)
+        run: |
+          cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
+          cp ${GITHUB_WORKSPACE}/nuget-headless/libOpenCvSharpExtern-headless.so bin/Release/net10.0/libOpenCvSharpExtern.so
+          cp ${GITHUB_WORKSPACE}/nuget-headless/libOpenCvSharpExtern-headless.so ./libOpenCvSharpExtern.so
+          sudo cp ${GITHUB_WORKSPACE}/nuget-headless/libOpenCvSharpExtern-headless.so /usr/lib/libOpenCvSharpExtern.so
+          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-x64 --no-build \
+            --filter "FullyQualifiedName!~OpenCvSharp.Tests.HighGui.HighGuiTest" \
+            --logger "trx;LogFileName=test-results-headless.trx" < /dev/null
+
       - name: Smoke test (slim)
         run: |
           cd ${GITHUB_WORKSPACE}/nuget-slim/
@@ -342,7 +243,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: test-results-manylinux
-          path: test/OpenCvSharp.Tests/bin/Release/net10.0/test-results.trx
+          path: test/OpenCvSharp.Tests/bin/Release/net10.0/test-results*.trx
 
   # ---------------------------------------------------------------------------
   # Create NuGet packages from the manylinux-built binaries.
@@ -362,6 +263,12 @@ jobs:
         with:
           name: libOpenCvSharpExtern-full
           path: /tmp/so-full/
+
+      - name: Download headless artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: libOpenCvSharpExtern-headless
+          path: /tmp/so-headless/
 
       - name: Download slim artifact
         uses: actions/download-artifact@v8
@@ -385,6 +292,11 @@ jobs:
           # Full package
           cp /tmp/so-full/libOpenCvSharpExtern.so packaging/nuget/libOpenCvSharpExtern.so
           dotnet pack packaging/nuget/OpenCvSharp5.official.runtime.linux-x64.csproj \
+            -o ${GITHUB_WORKSPACE}/artifacts -p:Version=$version
+
+          # Headless package (overwrite .so in packaging/nuget/ with headless binary)
+          cp /tmp/so-headless/libOpenCvSharpExtern-headless.so packaging/nuget/libOpenCvSharpExtern.so
+          dotnet pack packaging/nuget/OpenCvSharp5.official.runtime.linux-x64.headless.csproj \
             -o ${GITHUB_WORKSPACE}/artifacts -p:Version=$version
 
           # Slim package (overwrite .so in packaging/nuget/ with slim binary)

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          persist-credentials: false
 
       - uses: ./.github/actions/build-manylinux-variant
         with:

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -128,6 +128,7 @@ jobs:
             echo "skip_platforms: skipping manylinux package checks"
           else
             check_package "OpenCvSharp5.official.runtime.linux-x64.[0-9]*.nupkg"
+            check_package "OpenCvSharp5.official.runtime.linux-x64.headless.*.nupkg"
             check_package "OpenCvSharp5.official.runtime.linux-x64.slim.*.nupkg"
           fi
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ dotnet add package OpenCvSharp5.runtime.win-arm64
 ```bash
 dotnet add package OpenCvSharp5
 dotnet add package OpenCvSharp5.official.runtime.linux-x64
+# optional headless profile (full module set, no GTK3/X11 dependency)
+# dotnet add package OpenCvSharp5.official.runtime.linux-x64.headless
 # optional slim profile (smaller native dependency surface)
 # dotnet add package OpenCvSharp5.official.runtime.linux-x64.slim
 ```
@@ -71,8 +73,9 @@ For more installation options, see the [Installation](#installation) section bel
 PS1> Install-WindowsFeature Server-Media-Foundation
 ```
 * (Linux) The official `OpenCvSharp5.official.runtime.linux-x64` package is built on manylinux_2_28 and works on Ubuntu 20.04+, Debian 10+, RHEL/AlmaLinux 8+, and other Linux distributions with glibc 2.28+. The full package includes FFmpeg (LGPL v2.1) and Tesseract statically linked.
-  * The **full** package uses GTK3 for `highgui` support (`Cv2.ImShow`, `Cv2.WaitKey`, etc.). GTK3 is pre-installed on standard Ubuntu/Debian/RHEL environments. In minimal or container environments where it is absent, install it manually (`apt-get install libgtk-3-0` or `dnf install gtk3`), or use the **slim** profile instead.
-  * The **slim** package (`OpenCvSharp5.official.runtime.linux-x64.slim`) disables `highgui` and has no GUI dependencies — suitable for headless and container use.
+  * The **full** package uses GTK3 for `highgui` support (`Cv2.ImShow`, `Cv2.WaitKey`, etc.). GTK3 is pre-installed on standard Ubuntu/Debian/RHEL environments. In minimal or container environments where it is absent, install it manually (`apt-get install libgtk-3-0` or `dnf install gtk3`), or use the **headless** or **slim** profile instead.
+  * The **headless** package (`OpenCvSharp5.official.runtime.linux-x64.headless`) keeps the full module set (`videoio`, `dnn`, `ml`, `contrib`, `stitching`, `barcode`, ...) but disables `highgui`, so it has no GTK3/X11 dependency — suitable for containerized services that need more than the slim module set below.
+  * The **slim** package (`OpenCvSharp5.official.runtime.linux-x64.slim`) disables `highgui` and reduces the module set — also has no GUI dependencies.
 
 
 **OpenCvSharp won't work on Unity and Xamarin platforms.** For Unity, please consider using [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088) or some other solutions.
@@ -98,6 +101,8 @@ dotnet new console -n ConsoleApp01
 cd ConsoleApp01
 dotnet add package OpenCvSharp5
 dotnet add package OpenCvSharp5.official.runtime.linux-x64
+# or headless profile (full module set, no GTK3/X11 dependency):
+# dotnet add package OpenCvSharp5.official.runtime.linux-x64.headless
 # or slim profile:
 # dotnet add package OpenCvSharp5.official.runtime.linux-x64.slim
 # -- edit Program.cs --- # 
@@ -120,6 +125,10 @@ dotnet run
 
 > **Note:** The macOS packages include FFmpeg, Tesseract, Freetype, and all standard OpenCV modules, statically linked.
 
+
+### Headless profile (Linux only)
+
+`OpenCvSharp5.official.runtime.linux-x64.headless` keeps the same module set as the full Linux package (`videoio`, `dnn`, `ml`, `contrib`, `stitching`, `barcode`, ...); only `highgui` is disabled, so the package has no GTK3/X11 dependency. Use it instead of the full package for containerized/headless services that need more than the slim module set below (e.g. `VideoCapture`) but never call `highgui`.
 
 ### Slim profile module coverage
 
@@ -210,6 +219,7 @@ http://shimat.github.io/opencvsharp/api/OpenCvSharp.html
 |**[OpenCvSharp5.runtime.win-arm64](https://www.nuget.org/packages/OpenCvSharp5.runtime.win-arm64/)**| Native bindings for Windows ARM64 (Snapdragon X and other arm64 devices). FFmpeg not included. |
 |**[OpenCvSharp5.runtime.win-arm64.slim](https://www.nuget.org/packages/OpenCvSharp5.runtime.win-arm64.slim/)**| Slim native bindings for Windows ARM64, with `core,imgproc,imgcodecs,calib3d,features2d,flann,objdetect,photo,ml,video,barcode` enabled |
 |**[OpenCvSharp5.official.runtime.linux-x64](https://www.nuget.org/packages/OpenCvSharp5.official.runtime.linux-x64/)**| Native bindings for Linux x64 (portable RID, recommended). Built on manylinux_2_28. Includes FFmpeg and Tesseract statically linked. Requires GTK3 runtime (`libgtk-3.so.0`) for highgui (`Cv2.ImShow` etc.). |
+|**[OpenCvSharp5.official.runtime.linux-x64.headless](https://www.nuget.org/packages/OpenCvSharp5.official.runtime.linux-x64.headless/)**| Headless native bindings for Linux x64 (portable RID). Same module set as the full package, but `highgui` is disabled, so it has no GTK3/X11 dependency. |
 |**[OpenCvSharp5.official.runtime.linux-x64.slim](https://www.nuget.org/packages/OpenCvSharp5.official.runtime.linux-x64.slim/)**| Slim native bindings for Linux x64 (portable RID), with `core,imgproc,imgcodecs,calib3d,features2d,flann,objdetect,photo,ml,video,barcode` enabled. No external runtime dependencies. |
 |**[OpenCvSharp5.runtime.linux-arm64](https://www.nuget.org/packages/OpenCvSharp5.runtime.linux-arm64/)**| Native bindings for Linux ARM64 (AArch64) |
 |**[OpenCvSharp5.runtime.wasm](https://www.nuget.org/packages/OpenCvSharp5.runtime.wasm/)**| Native bindings for WebAssembly |

--- a/packaging/docker/manylinux/build_static_deps.sh
+++ b/packaging/docker/manylinux/build_static_deps.sh
@@ -35,6 +35,10 @@ dnf install -y nasm yasm
 # ---------------------------------------------------------------------------
 # FFmpeg (LGPL v2.1+ — statically linked, no patented external codecs)
 # Internal decoders cover H.264, H.265, VP8, VP9, MPEG-4, MPEG-2, and many others.
+# Hwaccel autodetection (vaapi/vdpau/v4l2-m2m) is disabled explicitly: this build
+# never uses hardware acceleration, but if libva happens to be present in the
+# build container, FFmpeg's configure would auto-enable vaapi and silently add
+# libdrm.so.2 as a runtime dependency of the final .so. See issue #2065.
 # ---------------------------------------------------------------------------
 curl -fL --retry 5 --retry-delay 2 \
     "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
@@ -57,7 +61,10 @@ cd "ffmpeg-${FFMPEG_VERSION}"
     --enable-avformat \
     --enable-avutil \
     --enable-swscale \
-    --enable-swresample
+    --enable-swresample \
+    --disable-vaapi \
+    --disable-vdpau \
+    --disable-v4l2-m2m
 make -j"${NPROC}"
 make install
 

--- a/packaging/nuget/OpenCvSharp5.official.runtime.linux-x64.headless.csproj
+++ b/packaging/nuget/OpenCvSharp5.official.runtime.linux-x64.headless.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <PackageId>OpenCvSharp5.official.runtime.linux-x64.headless</PackageId>
+    <Title>OpenCvSharp native bindings for Linux x64 (Headless)</Title>
+    <Authors>shimat</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/shimat/opencvsharp</PackageProjectUrl>
+    <PackageIcon>opencvsharp.png</PackageIcon>
+    <Description>Headless native bindings package for OpenCvSharp on Linux x64 (portable RID). Same module set as the full package (videoio, dnn, ml, contrib, stitching, barcode, ...) with highgui disabled, so it has no GTK3/X11 GUI dependency.</Description>
+    <PackageTags>Image Processing OpenCV Wrapper FFI opencvsharp linux headless</PackageTags>
+    <Copyright>Copyright 2008-2026</Copyright>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/shimat/opencvsharp.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReadmeFile>README.runtime.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="libOpenCvSharpExtern.so" Pack="true" PackagePath="runtimes/linux-x64/native/" />
+    <None Include="icon/opencvsharp.png" Pack="true" PackagePath="" />
+    <None Include="README.runtime.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+</Project>

--- a/packaging/nuget/README.managed.md
+++ b/packaging/nuget/README.managed.md
@@ -53,8 +53,9 @@ For more installation options, see [Installation on GitHub](https://github.com/s
 ### Linux (Ubuntu and other distributions)
 The official `OpenCvSharp5.official.runtime.linux-x64` package is built on manylinux_2_28 (glibc 2.28) and works on Ubuntu 20.04+, Debian 10+, RHEL/AlmaLinux 8+, and other Linux distributions.
 
-- **Full package**: uses GTK3 for `highgui` support (`Cv2.ImShow`, `Cv2.WaitKey`, etc.). GTK3 (`libgtk-3.so.0`) is pre-installed on standard Ubuntu/Debian/RHEL environments and typically requires no action. In minimal or container environments where GTK3 is absent, install it manually: Ubuntu/Debian: `apt-get install libgtk-3-0`; RHEL/AlmaLinux: `dnf install gtk3`. Alternatively, use the **slim** package which has no GUI dependencies.
-- **Slim package** (`OpenCvSharp5.official.runtime.linux-x64.slim`): `highgui` is disabled; no GTK3 or other GUI dependencies. Suitable for headless and container environments.
+- **Full package**: uses GTK3 for `highgui` support (`Cv2.ImShow`, `Cv2.WaitKey`, etc.). GTK3 (`libgtk-3.so.0`) is pre-installed on standard Ubuntu/Debian/RHEL environments and typically requires no action. In minimal or container environments where GTK3 is absent, install it manually: Ubuntu/Debian: `apt-get install libgtk-3-0`; RHEL/AlmaLinux: `dnf install gtk3`. Alternatively, use the **headless** or **slim** package below, neither of which has GUI dependencies.
+- **Headless package** (`OpenCvSharp5.official.runtime.linux-x64.headless`): same module set as full (`videoio`, `dnn`, `ml`, `contrib`, `stitching`, `barcode`, ...) but `highgui` is disabled, so it has no GTK3/X11 dependency. Suitable for containerized services that need more than the slim module set (e.g. `VideoCapture`) but never call `highgui`.
+- **Slim package** (`OpenCvSharp5.official.runtime.linux-x64.slim`): `highgui` is disabled and the module set is reduced; no GTK3 or other GUI dependencies. Suitable for headless and container environments.
 
 ### macOS (Intel and Apple Silicon)
 The `OpenCvSharp5.runtime.osx.x64` and `OpenCvSharp5.runtime.osx.arm64` packages provide native bindings for macOS. FFmpeg, Tesseract, Freetype, and all standard OpenCV modules are statically linked.

--- a/packaging/nuget/README.runtime.md
+++ b/packaging/nuget/README.runtime.md
@@ -16,7 +16,7 @@ The Linux `linux-x64` packages are built on **manylinux_2_28** (glibc 2.28) and 
 > - Ubuntu/Debian: `apt-get install libgtk-3-0`
 > - RHEL/AlmaLinux: `dnf install gtk3`
 >
-> For headless servers or minimal containers, use the **slim** package (`OpenCvSharp5.official.runtime.linux-x64.slim`) instead, which disables `highgui` and has no GUI dependencies.
+> For headless servers or minimal containers that still need `videoio`, `dnn`, `ml`, `contrib`, `stitching`, etc., use the **headless** package (`OpenCvSharp5.official.runtime.linux-x64.headless`) instead: same module set as full, `highgui` disabled, no GTK3/X11 dependency. If the reduced **slim** module set (see below) is enough, that has no GUI dependencies either.
 
 > **macOS:** The `osx.x64` and `osx.arm64` packages include FFmpeg, Tesseract, Freetype, and all standard OpenCV modules, statically linked.
 
@@ -29,6 +29,7 @@ The Linux `linux-x64` packages are built on **manylinux_2_28** (glibc 2.28) and 
 | `OpenCvSharp5.runtime.win-arm64` | Windows ARM64 (Snapdragon X and other arm64 devices). FFmpeg not included. |
 | `OpenCvSharp5.runtime.win-arm64.slim` | Windows ARM64 (slim) |
 | `OpenCvSharp5.official.runtime.linux-x64` | Linux x64 (portable, manylinux_2_28) |
+| `OpenCvSharp5.official.runtime.linux-x64.headless` | Linux x64 (portable, manylinux_2_28, headless — full module set minus `highgui`) |
 | `OpenCvSharp5.official.runtime.linux-x64.slim` | Linux x64 (portable, manylinux_2_28, slim) |
 | `OpenCvSharp5.runtime.linux-arm64` | Linux ARM64 (AArch64) |
 | `OpenCvSharp5.runtime.linux-arm` | Linux ARM64 — **deprecated**, use `linux-arm64` |
@@ -36,6 +37,10 @@ The Linux `linux-x64` packages are built on **manylinux_2_28** (glibc 2.28) and 
 | `OpenCvSharp5.runtime.osx.arm64` | macOS 11.0+ arm64 (Apple Silicon) |
 
 > **Note:** `OpenCvSharp5.runtime.linux-arm` has been renamed to `OpenCvSharp5.runtime.linux-arm64` to correctly reflect the ARM64 (AArch64) RID. The old package is kept as a compatibility shim that automatically pulls in the renamed package, but new projects should reference `OpenCvSharp5.runtime.linux-arm64` directly.
+
+## Headless Profile (Linux only)
+
+The `OpenCvSharp5.official.runtime.linux-x64.headless` package has the same module set as the full `linux-x64` package (`videoio`, `dnn`, `ml`, `contrib`, `stitching`, `barcode`, ...) but `highgui` is disabled at build time, so it never links GTK3/X11 and needs no GUI dependency to be installed. Use it for containerized/headless services (e.g. an ASP.NET Core service using `VideoCapture`/`imgcodecs`) that need more than the `slim` module set below but never call `highgui`.
 
 ## Slim Profile
 

--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -58,6 +58,13 @@ if(OpenCV_FOUND)
 	else()
 		add_library(OpenCvSharpExtern SHARED ${OPENCVSHARP_FILES})
 		target_link_libraries(OpenCvSharpExtern ${OpenCV_LIBRARIES})
+
+		if(UNIX AND NOT APPLE)
+			# Drop NEEDED entries for libraries that are passed on the link line by some static
+			# 3rd-party dependency (e.g. libatomic.so.1) but whose symbols are never actually
+			# referenced by the resulting binary. See issue #2065.
+			target_link_options(OpenCvSharpExtern PRIVATE -Wl,--as-needed)
+		endif()
 	endif()
 
 	if(Iconv_FOUND)


### PR DESCRIPTION
## Summary

- `libOpenCvSharpExtern.so` on linux-x64 pulls in `libatomic.so.1` and `libdrm.so.2` beyond the documented GTK3 dependency, so a minimal container still fails to load the library even after following the README's `apt-get install libgtk-3-0` advice. `libatomic.so.1` has zero referenced symbols in the binary (a pure over-link, likely forced unconditionally by some static dependency), fixed by adding `-Wl,--as-needed` to the final link step. `libdrm.so.2` comes from FFmpeg's VA-API hwaccel autodetection picking up libva if it happens to be present in the build container; fixed by disabling `vaapi`/`vdpau`/`v4l2-m2m` explicitly in `build_static_deps.sh`'s FFmpeg `./configure`, since this build never uses hardware acceleration.
- Added a new **headless** `linux-x64` package (`OpenCvSharp5.official.runtime.linux-x64.headless`): same module set as the full package (`videoio`, `dnn`, `ml`, `contrib`, `stitching`, `barcode`, ...) but built with `highgui` disabled (`NO_HIGHGUI=ON` + OpenCV's `WITH_GTK=OFF`), so it never links GTK3/X11/Mesa at all. This targets containerized services (ECS/EKS, chiseled/distroless base images with no package manager at all) that need more than the `slim` module set but never call `highgui` - mirroring `opencv-python` vs. `opencv-python-headless`. New CI job (`build_headless`) verifies via `objdump` that the built `.so` has no GTK3/X11/DRM `NEEDED` entries, and the `test` job runs the same xunit suite against it minus the one highgui-only test class.
- The `full`/`headless` CI jobs share ~180 lines of near-identical build steps (vcpkg/FFmpeg/OpenCV/OpenCvSharpExtern) that would otherwise be duplicated a third time; factored them into a new local composite action (`.github/actions/build-manylinux-variant`) parameterized by the handful of flags that actually differ (GTK3 install, extra cmake flags, cache paths, artifact names). `manylinux.yml` itself ends up shorter (312 lines) than before this PR (400 lines) despite gaining a third build flavor.
- Updated `README.md`, `packaging/nuget/README.managed.md`, and `packaging/nuget/README.runtime.md` to document the new headless package alongside full/slim, and added `OpenCvSharp5.official.runtime.linux-x64.headless.*.nupkg` to `publish_nuget.yml`'s expected-package check.

Fixes #2065

## Testing

- Validated `.github/workflows/manylinux.yml` and `.github/actions/build-manylinux-variant/action.yml` parse as well-formed YAML (`yaml.safe_load`).
- Could not exercise an actual manylinux container build locally (a full OpenCV compile takes well over an hour and needs the manylinux_2_28 container); this needs to be validated by the `manylinux` CI workflow running on this PR (`build_full`, `build_headless`, `build_slim`, `test`, `nuget` jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Linux **headless** runtime package with the **full module set** while keeping **GUI/highgui disabled**.
  - Published the headless native binary and packaged it for NuGet consumption.
- **Documentation**
  - Updated installation docs and profile comparisons to include the new headless option and usage guidance.
- **Bug Fixes**
  - Reduced unnecessary Linux native runtime dependencies (including unused link-time NEEDED entries).
  - Disabled FFmpeg hardware-acceleration autodetection to avoid introducing extra graphics dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->