### PR TITLE
Add a package smoke test gate before publishing to nuget.org

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -222,8 +222,63 @@ jobs:
             *.snupkg
           retention-days: 7
 
-  Publish:
+  # ---------------------------------------------------------------------------
+  # Consume the actual, about-to-be-published .nupkg files as a real PackageReference
+  # (against a local feed, not a ProjectReference against source) before anything gets
+  # pushed to nuget.org. Catches packaging mistakes - wrong RID asset placement, a missing
+  # native library, a broken dependency graph - that the source-level "test" jobs in
+  # windows.yml/manylinux.yml/macos.yml never exercise, since those only ever run against
+  # loose build output with the native binary copied in by hand.
+  # ---------------------------------------------------------------------------
+  PackageSmokeTest:
+    name: Package smoke test (${{ matrix.os }})
     needs: Prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            runtime_package: OpenCvSharp5.Windows
+          - os: ubuntu-latest
+            runtime_package: OpenCvSharp5.official.runtime.linux-x64
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download release packages
+        uses: actions/download-artifact@v8
+        with:
+          name: release-packages
+          path: release-packages
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Determine package version
+        id: version
+        shell: bash
+        run: |
+          file=$(ls release-packages/OpenCvSharp5.[0-9]*.nupkg | head -1)
+          name=$(basename "$file")
+          version=${name#OpenCvSharp5.}
+          version=${version%.nupkg}
+          echo "Package version under test: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run package smoke test
+        shell: bash
+        run: |
+          cd test/OpenCvSharp.PackageSmokeTest
+          dotnet nuget add source "${{ github.workspace }}/release-packages" --name smoke-local
+          dotnet run -c Release \
+            -p:SmokeTestPackageVersion=${{ steps.version.outputs.version }} \
+            -p:SmokeTestRuntimePackage=${{ matrix.runtime_package }}
+
+  Publish:
+    needs: [Prepare, PackageSmokeTest]
     runs-on: ubuntu-24.04
     environment: nuget-production
 

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -270,12 +270,15 @@ jobs:
 
       - name: Run package smoke test
         shell: bash
+        env:
+          SMOKE_TEST_VERSION: ${{ steps.version.outputs.version }}
+          SMOKE_TEST_RUNTIME_PACKAGE: ${{ matrix.runtime_package }}
         run: |
           cd test/OpenCvSharp.PackageSmokeTest
-          dotnet nuget add source "${{ github.workspace }}/release-packages" --name smoke-local
           dotnet run -c Release \
-            -p:SmokeTestPackageVersion=${{ steps.version.outputs.version }} \
-            -p:SmokeTestRuntimePackage=${{ matrix.runtime_package }}
+            -p:RestoreAdditionalProjectSources="$GITHUB_WORKSPACE/release-packages" \
+            -p:SmokeTestPackageVersion="$SMOKE_TEST_VERSION" \
+            -p:SmokeTestRuntimePackage="$SMOKE_TEST_RUNTIME_PACKAGE"
 
   Publish:
     needs: [Prepare, PackageSmokeTest]

--- a/test/OpenCvSharp.PackageSmokeTest/OpenCvSharp.PackageSmokeTest.csproj
+++ b/test/OpenCvSharp.PackageSmokeTest/OpenCvSharp.PackageSmokeTest.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!--
+    This project intentionally has no ProjectReference to src/OpenCvSharp: it exists to catch
+    packaging mistakes (wrong RID asset placement, missing files, a broken dependency graph) in the
+    actual .nupkg files about to be pushed to nuget.org, which a ProjectReference-based test can
+    never exercise. .github/workflows/publish_nuget.yml adds the freshly built, not-yet-published
+    packages as a local NuGet feed and passes -p:SmokeTestPackageVersion=<version> plus
+    -p:SmokeTestRuntimePackage=<runtime package id> before restoring, so this project always targets
+    whichever version and platform runtime package is actually about to be published, never a
+    hardcoded one.
+  -->
+  <PropertyGroup>
+    <SmokeTestPackageVersion Condition="'$(SmokeTestPackageVersion)' == ''">0.0.0-dev</SmokeTestPackageVersion>
+    <SmokeTestRuntimePackage Condition="'$(SmokeTestRuntimePackage)' == ''">OpenCvSharp5.official.runtime.linux-x64</SmokeTestRuntimePackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenCvSharp5" Version="$(SmokeTestPackageVersion)" />
+    <PackageReference Include="$(SmokeTestRuntimePackage)" Version="$(SmokeTestPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenCvSharp.PackageSmokeTest/Program.cs
+++ b/test/OpenCvSharp.PackageSmokeTest/Program.cs
@@ -1,0 +1,50 @@
+// Pre-publish smoke test: exercises the actual .nupkg files about to be pushed to nuget.org,
+// referenced the same way a real consumer would (PackageReference against a NuGet feed, not
+// ProjectReference against source), to catch packaging mistakes (wrong RID asset placement,
+// missing native library, broken dependency graph) that a source-level test can never see.
+// Asserts and sets the process exit code instead of using a test framework, since the point is
+// just "does a freshly `dotnet add package`-d app work at all", not exhaustive API coverage.
+using System.Globalization;
+using OpenCvSharp;
+
+try
+{
+    var version = Cv2.GetVersionString();
+
+    using var mat = new Mat(256, 256, MatType.CV_8UC1, Scalar.All(0));
+    Cv2.Rectangle(mat, new Rect(40, 40, 120, 120), Scalar.All(255), thickness: -1);
+    Cv2.Circle(mat, new Point(180, 180), 30, Scalar.All(200), thickness: -1);
+
+    using var orb = ORB.Create(500);
+    using var descriptors = new Mat();
+    orb.DetectAndCompute(mat, default, out var keypoints, descriptors);
+
+    foreach (var ext in new[] { ".jpg", ".png", ".tiff" })
+    {
+        var encoded = Cv2.ImEncode(ext, mat, out var buf);
+        if (!encoded || buf.Length == 0)
+            throw new InvalidOperationException($"ImEncode({ext}) failed or produced an empty buffer");
+
+        using var decoded = Cv2.ImDecode(buf, ImreadModes.Unchanged);
+        if (decoded.Empty() || decoded.Size() != mat.Size())
+            throw new InvalidOperationException(
+                $"ImDecode({ext}) round trip failed: empty={decoded.Empty()}, size={decoded.Size()}");
+    }
+
+    using var blob = Cv2.Dnn.BlobFromImage(mat, size: new Size(64, 64));
+    if (blob.Empty())
+        throw new InvalidOperationException("Cv2.Dnn.BlobFromImage produced an empty blob");
+
+    var blobShape = string.Join('x', Enumerable.Range(0, blob.Dims).Select(blob.Size));
+
+    Console.WriteLine(string.Format(
+        CultureInfo.InvariantCulture,
+        "ok: OpenCV {0}, ORB keypoints: {1}, dnn blob shape: {2}",
+        version, keypoints.Length, blobShape));
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine("error: " + ex);
+    return 1;
+}


### PR DESCRIPTION
## Summary

- Nothing in the release pipeline today actually restores the packed `.nupkg` files as a real consumer would before pushing to nuget.org. The existing "test" jobs in `windows.yml`/`manylinux.yml`/`macos.yml` only ever exercise loose build output with the native binary copied in by hand - never the packaging path itself (RID asset placement, missing files, dependency graph across the `OpenCvSharp5*` package family). A packaging mistake would only be noticed after users hit it in production.
- Added `test/OpenCvSharp.PackageSmokeTest`: a plain console app (same style as `test/OpenCvSharp.Tests.NativeAot`) that references `OpenCvSharp5` plus a platform runtime package via `PackageReference`, not `ProjectReference`. Since package versions are date-stamped at pack time, the version and which runtime package to pull are supplied at build time via MSBuild properties (`-p:SmokeTestPackageVersion=...` / `-p:SmokeTestRuntimePackage=...`) rather than hardcoded, so the project always targets whatever is actually about to be published.
- `publish_nuget.yml` gets a new `PackageSmokeTest` job (matrix: `windows-latest` + `ubuntu-latest`) that runs between `Prepare` and `Publish`: it adds the `Prepare` job's `release-packages` artifact as a local NuGet feed, then builds and runs the smoke test project against it. `Publish`'s `needs` now includes this job, so a broken package blocks the nuget.org push instead of only being caught after the fact.
- Scope is intentionally narrow for now: only the default "full" flavor is exercised (`OpenCvSharp5.Windows` on Windows, `OpenCvSharp5.official.runtime.linux-x64` on Linux), not slim/headless/macOS/arm64/wasm - this is meant as a cheap, low-maintenance safety net rather than exhaustive coverage.

## Testing

- Validated `.github/workflows/publish_nuget.yml` parses as well-formed YAML (`yaml.safe_load`).
- Could not exercise the new `PackageSmokeTest` job locally, since it depends on the `release-packages` artifact produced by `Prepare` (itself built from artifacts across several other workflows); this needs a `publish_nuget.yml` run (`workflow_dispatch`) to validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated NuGet package smoke test that runs during the publish flow on Windows and Ubuntu against the exact package versions being released.
* **Bug Fixes**
  * Publishing is now blocked if the packaged native assets fail validation (including image processing, encoding/decoding, ORB feature detection, and DNN blob creation).
* **Tests**
  * Introduced a dedicated smoke-test executable targeting .NET 10 to validate the end-to-end OpenCV behavior of the published runtime packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->