### PR TITLE
Disable FFmpeg's libdrm autodetection; harden the no-GUI-deps CI check

### DIFF
--- a/.github/actions/build-manylinux-variant/action.yml
+++ b/.github/actions/build-manylinux-variant/action.yml
@@ -223,13 +223,26 @@ runs:
         cmake --build ${{ inputs.extern_build_dir }} -j
         cp ${{ inputs.extern_build_dir }}/OpenCvSharpExtern/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }}
 
-    - name: Verify no GTK3/X11 dependency (${{ inputs.variant_label }})
+    - name: Verify no GTK3/X11/DRM dependency (${{ inputs.variant_label }})
       if: inputs.verify_no_gui_deps == 'true'
       shell: bash
       run: |
-        if objdump -p ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }} | grep -qi 'libgtk\|libX11\|libdrm'; then
+        so_path=${GITHUB_WORKSPACE}/${{ inputs.output_so_name }}
+        # readelf -d (rather than objdump -p) since an `objdump -p | grep` version of
+        # this check silently "passed" in CI on a .so that does depend on libdrm.so.2
+        # (reproduced independently outside CI with the exact same artifact) - a tool
+        # producing no output looked identical to a tool finding nothing. Failing loudly
+        # when NEEDED comes back empty (every shared lib here needs at least libc) turns
+        # that failure mode into a hard error instead of a silent false pass.
+        needed=$(readelf -d "$so_path" | grep NEEDED || true)
+        echo "$needed"
+        if [ -z "$needed" ]; then
+          echo "ERROR: readelf found no NEEDED entries at all in ${{ inputs.variant_label }} .so - the check itself is broken, treat as inconclusive"
+          exit 1
+        fi
+        if echo "$needed" | grep -qi 'libgtk\|libx11\|libdrm'; then
           echo "ERROR: ${{ inputs.variant_label }} .so unexpectedly depends on GTK3/X11/DRM:"
-          objdump -p ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }} | grep -i 'NEEDED'
+          echo "$needed"
           exit 1
         fi
 

--- a/packaging/docker/manylinux/build_static_deps.sh
+++ b/packaging/docker/manylinux/build_static_deps.sh
@@ -39,6 +39,11 @@ dnf install -y nasm yasm
 # never uses hardware acceleration, but if libva happens to be present in the
 # build container, FFmpeg's configure would auto-enable vaapi and silently add
 # libdrm.so.2 as a runtime dependency of the final .so. See issue #2065.
+# libdrm itself is a separate autodetected component (not gated by the vaapi/
+# vdpau/v4l2-m2m flags above): manylinux_2_28_x86_64 ships libdrm-devel out of
+# the box, so configure enables CONFIG_LIBDRM unless disabled explicitly here,
+# which still pulls in libdrm.so.2 via hwcontext_drm even with every hwaccel
+# backend above turned off. See issue #2071.
 # ---------------------------------------------------------------------------
 curl -fL --retry 5 --retry-delay 2 \
     "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
@@ -64,7 +69,8 @@ cd "ffmpeg-${FFMPEG_VERSION}"
     --enable-swresample \
     --disable-vaapi \
     --disable-vdpau \
-    --disable-v4l2-m2m
+    --disable-v4l2-m2m \
+    --disable-libdrm
 make -j"${NPROC}"
 make install
 


### PR DESCRIPTION
## Summary

- `libdrm` is a separate FFmpeg configure autodetect from `vaapi`/`vdpau`/`v4l2-m2m` (the three flags PR #2067 disabled for #2065). `manylinux_2_28_x86_64` ships `libdrm-devel` out of the box, so FFmpeg's `./configure` was still enabling `CONFIG_LIBDRM` and building `hwcontext_drm.o` regardless of those three disables, leaving the **headless** `linux-x64` package still dependent on `libdrm.so.2` at runtime — the one thing #2065/#2067 set out to eliminate. `packaging/docker/manylinux/build_static_deps.sh` now also passes `--disable-libdrm`. Verified locally in `quay.io/pypa/manylinux_2_28_x86_64`: current flags alone leave `CONFIG_LIBDRM 1` in `config.h`; adding `--disable-libdrm` flips it to `0` (`ffbuild/config.log` shows `libdrm=no`).
- Downloaded the published `OpenCvSharp5.official.runtime.linux-x64.headless` 5.0.0.20260719 package and confirmed (`ldd`/`readelf -d`, clean `mcr.microsoft.com/dotnet/aspnet:8.0` container, no extra packages) that `libdrm.so.2` is genuinely `NEEDED` and unresolved; installing `libdrm2` alone fixes it, confirming it's the only remaining external dependency.
- While chasing why CI's `verify_no_gui_deps` check didn't catch this, found the check itself is unreliable: reproduced the exact same `objdump -p | grep -qi 'libgtk\|libX11\|libdrm'` command against the byte-identical `.so` (SHA256-verified against both the CI-uploaded artifact and the published nupkg) in a fresh `quay.io/pypa/manylinux_2_28_x86_64` pull, and it *does* match there — yet the real CI run for this exact artifact reported no error. Replaced the check with `readelf -d` and an explicit guard that fails loudly if `NEEDED` comes back empty (a shared lib here always needs at least libc, so empty output means the check tool itself broke, not that there's nothing to report) instead of silently reading the same as "no dependency found."

Fixes #2071

## Testing

- Verified the FFmpeg `--disable-libdrm` fix in isolation (fast: just `./configure`, not a full OpenCV build) inside `quay.io/pypa/manylinux_2_28_x86_64`, matching the actual build environment.
- Verified the hardened `readelf`-based check correctly flags the known-bad `.so` (downloaded from the CI artifact of PR #2067's merge run) in the same container image.
- Could not run a full `manylinux.yml` build locally (a full OpenCV compile takes over an hour); needs the `build_headless`/`build_full` CI jobs on this PR to confirm the fix holds end-to-end and that the hardened check now passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Linux builds to reliably detect unintended GTK3, X11, or DRM dependencies.
  * Added clear failure reporting when dependency checks cannot find expected metadata.
  * Prevented FFmpeg builds from introducing an unwanted `libdrm` runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->