### PR TITLE
Eliminate the remaining classic DllImport entries and dead DllImport comments

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_highgui.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_highgui.cs
@@ -104,8 +104,4 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus highgui_setTrackbarMin([MarshalAs(UnmanagedType.LPStr)] string trackbarName, [MarshalAs(UnmanagedType.LPStr)] string winName, int minVal);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true, ExactSpelling = true)]
-    //public static extern ExceptionStatus highgui_createButton(
-    //    [MarshalAs(UnmanagedType.LPStr)] string barName, IntPtr onChange, IntPtr userData, int type, int initialButtonState, out int returnValue);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods_videoio.cs
@@ -71,10 +71,12 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus videoio_VideoCapture_new5(int device, int apiPreference, [In] int[] @params, int paramsLength, out IntPtr returnValue);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus videoio_VideoCapture_new6(
-        [MarshalAs(UnmanagedType.FunctionPtr)] StreamReaderReadCallback readCallback,
-        [MarshalAs(UnmanagedType.FunctionPtr)] StreamReaderSeekCallback seekCallback,
+    // readCallback/seekCallback are function pointers to static, [UnmanagedCallersOnly] trampolines
+    // (see StreamReaderBridge); userData is a GCHandle to the context rooting the real IStreamReader,
+    // not a caller-supplied value.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus videoio_VideoCapture_new6(
+        IntPtr readCallback, IntPtr seekCallback,
         IntPtr userData, int apiPreference, [In] int[] @params, int paramsLength, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -87,11 +89,13 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus videoio_VideoCapture_open2(OpenCvSafeHandle obj, int device, int apiPreference, out int returnValue);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus videoio_VideoCapture_open3(
+    // readCallback/seekCallback are function pointers to static, [UnmanagedCallersOnly] trampolines
+    // (see StreamReaderBridge); userData is a GCHandle to the context rooting the real IStreamReader,
+    // not a caller-supplied value.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus videoio_VideoCapture_open3(
         OpenCvSafeHandle obj,
-        [MarshalAs(UnmanagedType.FunctionPtr)] StreamReaderReadCallback readCallback,
-        [MarshalAs(UnmanagedType.FunctionPtr)] StreamReaderSeekCallback seekCallback,
+        IntPtr readCallback, IntPtr seekCallback,
         IntPtr userData, int apiPreference, [In] int[] @params, int paramsLength, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -115,9 +119,6 @@ static partial class NativeMethods
         
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus videoio_VideoCapture_operatorRightShift_Mat(OpenCvSafeHandle obj, IntPtr image);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus videoio_VideoCapture_operatorRightShift_UMat(IntPtr obj, IntPtr image);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus videoio_VideoCapture_read_OutputArray(OpenCvSafeHandle obj, in OutputArrayProxy image, out int returnValue);
@@ -193,9 +194,6 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus videoio_VideoWriter_release(OpenCvSafeHandle obj);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus videoio_VideoWriter_OperatorLeftShift(IntPtr obj, IntPtr image);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus videoio_VideoWriter_write(OpenCvSafeHandle obj, in InputArrayProxy image, out int returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_FileStorage.cs
@@ -31,9 +31,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_isOpened(OpenCvSafeHandle obj, out int returnValue);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_FileStorage_release(IntPtr obj);
-
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_FileStorage_releaseAndGetString(
         OpenCvSafeHandle obj, IntPtr outString);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_InputArray.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_InputArray.cs
@@ -40,16 +40,12 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_InputArray_getMat(OpenCvSafeHandle ia, int idx, out IntPtr returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_InputArray_getMat_(IntPtr ia, int idx, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_InputArray_getUMat(OpenCvSafeHandle ia, int idx, out IntPtr returnValue);
-        
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_InputArray_getMatVector(OpenCvSafeHandle ia, IntPtr mv);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern void core_InputArray_getUMatVector(IntPtr ia, IntPtr umv);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_InputArray_getFlags(OpenCvSafeHandle ia, out int returnValue);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Mat.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Mat.cs
@@ -64,8 +64,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_Mat_new12(IntPtr mat, out IntPtr returnValue);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_Mat_release(IntPtr mat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_Mat_delete(IntPtr mat);
 
@@ -259,12 +257,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_Mat_stepAt(OpenCvSafeHandle self, int i, out IntPtr returnValue);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_Mat_assignment_FromMat(IntPtr self, IntPtr newMat);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_Mat_assignment_FromScalar(IntPtr self, Scalar scalar);
-        
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_abs_Mat(IntPtr e, out IntPtr returnValue);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_OutputArray.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_OutputArray.cs
@@ -12,8 +12,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_OutputArray_new_byMat(IntPtr mat, out IntPtr returnValue);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_OutputArray_new_byGpuMat(IntPtr mat, out IntPtr returnValue);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_OutputArray_new_byUMat(IntPtr mat, out IntPtr returnValue);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_UMat.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_UMat.cs
@@ -39,10 +39,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_UMat_new9(IntPtr umat, Range[] ranges, out IntPtr returnValue);
 
-
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus core_UMat_release(IntPtr mat);
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_UMat_delete(IntPtr umat);
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/face/NativeMethods_face_Facemark.cs
@@ -70,9 +70,12 @@ static partial class NativeMethods
     internal static partial ExceptionStatus face_FacemarkTrain_getFaces(
         OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr faces, out int returnValue);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    internal static extern ExceptionStatus face_FacemarkTrain_setFaceDetector(
-        OpenCvSafeHandle obj, FacemarkFaceDetectorNativeCallback callback,
+    // callback is a function pointer to a static, [UnmanagedCallersOnly] trampoline (see
+    // FacemarkFaceDetectorBridge); userData is a GCHandle to the context rooting the real managed
+    // detector, round-tripped opaquely through callbackData/face_Facemark_faceDetectorThunk.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkTrain_setFaceDetector(
+        OpenCvSafeHandle obj, IntPtr callback, IntPtr userData,
         out IntPtr callbackData, out int returnValue);
 
     #endregion
@@ -218,9 +221,12 @@ static partial class NativeMethods
     internal static partial ExceptionStatus face_FacemarkKazemi_getFaces(
         OpenCvSafeHandle obj, in InputArrayProxy image, IntPtr faces, out int returnValue);
 
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    internal static extern ExceptionStatus face_FacemarkKazemi_setFaceDetector(
-        OpenCvSafeHandle obj, FacemarkFaceDetectorNativeCallback callback,
+    // callback is a function pointer to a static, [UnmanagedCallersOnly] trampoline (see
+    // FacemarkFaceDetectorBridge); userData is a GCHandle to the context rooting the real managed
+    // detector, round-tripped opaquely through callbackData/face_Facemark_faceDetectorThunk.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus face_FacemarkKazemi_setFaceDetector(
+        OpenCvSafeHandle obj, IntPtr callback, IntPtr userData,
         out IntPtr callbackData, out int returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/geometry/NativeMethods_geometry.cs
@@ -688,10 +688,12 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus geometry_SACSegmentation_getRandomGeneratorState(OpenCvSafeHandle obj, out ulong returnValue);
 
-    // LibraryImport does not support marshaling delegate parameters, so this one uses classic DllImport.
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus geometry_SACSegmentation_setCustomModelConstraints(
-        OpenCvSafeHandle obj, SacModelConstraintNativeCallback? callback);
+    // callback is a function pointer to a static, [UnmanagedCallersOnly] trampoline (see
+    // SACSegmentation.SetCustomModelConstraints), or IntPtr.Zero to clear the constraint; userData
+    // is a GCHandle to the context rooting the real managed delegate, not a caller-supplied value.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus geometry_SACSegmentation_setCustomModelConstraints(
+        OpenCvSafeHandle obj, IntPtr callback, IntPtr userData);
 
     // RegionGrowing3D
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc.cs
@@ -301,9 +301,6 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_demosaicing(in InputArrayProxy src, in OutputArrayProxy dst, int code, int dstCn);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_HuMoments(ref Moments.NativeStruct moments, [MarshalAs(UnmanagedType.LPArray)] double[] hu);
-
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial ExceptionStatus imgproc_matchTemplate(
         in InputArrayProxy image, in InputArrayProxy templ, in OutputArrayProxy result, int method, in InputArrayProxy mask);

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_LineIterator.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/imgproc/NativeMethods_imgproc_LineIterator.cs
@@ -21,60 +21,33 @@ static partial class NativeMethods
     public static partial ExceptionStatus imgproc_LineIterator_getValuePosAndShiftToNext(
         OpenCvSafeHandle obj, out IntPtr returnValue, out Point returnPos);
 
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_operatorEntity(IntPtr obj, out IntPtr returnValue);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_operatorPP(IntPtr obj);
-
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_pos(IntPtr obj, out Point returnValue);
-
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_ptr_get(OpenCvSafeHandle obj, out IntPtr returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_ptr_set(IntPtr obj, IntPtr val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_ptr0_get(OpenCvSafeHandle obj, out IntPtr returnValue);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_step_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_step_set(IntPtr obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_elemSize_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_elemSize_set(IntPtr obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_err_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_err_set(IntPtr obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_count_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_count_set(IntPtr obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_minusDelta_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_minusDelta_set(IntPtr obj, int val);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_plusDelta_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_plusDelta_set(IntPtr obj, int val);
-        
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_minusStep_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_minusStep_set(IntPtr obj, int val);
-        
+
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus imgproc_LineIterator_plusStep_get(OpenCvSafeHandle obj, out int returnValue);
-    //[DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    //public static extern ExceptionStatus imgproc_LineIterator_plusStep_set(IntPtr obj, int val);
 }

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/traking/NativeMethods_tracking.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/traking/NativeMethods_tracking.cs
@@ -28,12 +28,13 @@ static partial class NativeMethods
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus tracking_Ptr_TrackerKCF_get(IntPtr ptr, out IntPtr returnValue);
 
-    // Delegate marshaling to a native function pointer isn't supported by the LibraryImport source
-    // generator, so this one entry point keeps the classic DllImport/extern shape (same as
-    // highgui_setMouseCallback).
-    [DllImport(DllExtern, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-    public static extern ExceptionStatus tracking_TrackerKCF_setFeatureExtractor(
-        IntPtr tracker, [MarshalAs(UnmanagedType.FunctionPtr)] TrackerKCF.NativeFeatureExtractorCallback callback, int pcaFunc);
+    // callback is a function pointer to a static, [UnmanagedCallersOnly] trampoline (see
+    // TrackerKCF.SetFeatureExtractor); cv::TrackerKCF::FeatureExtractorCallbackFN has no
+    // per-instance user-data slot, so unlike the other callback entry points there is no context
+    // handle to thread through here.
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus tracking_TrackerKCF_setFeatureExtractor(
+        IntPtr tracker, IntPtr callback, int pcaFunc);
 
 
     // TrackerCSRT

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenCvSharp.Internal;
 
@@ -9,21 +10,21 @@ namespace OpenCvSharp.Face;
 /// </summary>
 public delegate Rect[] FacemarkFaceDetector(Mat image);
 
-[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal unsafe delegate int FacemarkFaceDetectorNativeCallback(
-    IntPtr image, Rect* faces, int capacity);
-
 internal sealed unsafe class FacemarkFaceDetectorBridge : IDisposable
 {
+    // callback is a function pointer to the static, [UnmanagedCallersOnly] trampoline below;
+    // userData is a GCHandle to the FacemarkFaceDetectorBridge instance it should dispatch to,
+    // round-tripped opaquely by the native side (see face_Facemark.h).
     internal delegate ExceptionStatus NativeSetter(
         OpenCvSafeHandle obj,
-        FacemarkFaceDetectorNativeCallback callback,
+        IntPtr callback,
+        IntPtr userData,
         out IntPtr callbackData,
         out int returnValue);
 
     private readonly FacemarkFaceDetector detector;
-    private readonly FacemarkFaceDetectorNativeCallback nativeCallback;
     private readonly ConcurrentDictionary<int, Rect[]> pendingResults = new();
+    private GCHandle contextHandle;
     private OpenCvPtrSafeHandle? callbackDataHandle;
 
     public FacemarkFaceDetectorBridge(
@@ -32,10 +33,14 @@ internal sealed unsafe class FacemarkFaceDetectorBridge : IDisposable
         NativeSetter setter)
     {
         this.detector = detector;
-        nativeCallback = Invoke;
-        NativeMethods.HandleException(setter(obj, nativeCallback, out var callbackData, out var result));
+        contextHandle = GCHandle.Alloc(this);
+        NativeMethods.HandleException(
+            setter(obj, GetTrampolinePointer(), GCHandle.ToIntPtr(contextHandle), out var callbackData, out var result));
         if (result == 0 || callbackData == IntPtr.Zero)
+        {
+            contextHandle.Free();
             throw new OpenCvSharpException("OpenCV rejected the custom facemark face detector.");
+        }
         callbackDataHandle = new OpenCvPtrSafeHandle(
             callbackData, ownsHandle: true,
             releaseAction: p => NativeMethods.HandleException(
@@ -66,10 +71,30 @@ internal sealed unsafe class FacemarkFaceDetectorBridge : IDisposable
         }
     }
 
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static int Trampoline(IntPtr userData, IntPtr image, Rect* faces, int capacity)
+    {
+        try
+        {
+            var bridge = (FacemarkFaceDetectorBridge)GCHandle.FromIntPtr(userData).Target!;
+            return bridge.Invoke(image, faces, capacity);
+        }
+        catch
+        {
+            // Exceptions must never unwind into native code from an UnmanagedCallersOnly method.
+            return -1;
+        }
+    }
+
+    private static IntPtr GetTrampolinePointer() =>
+        (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, Rect*, int, int>)&Trampoline;
+
     public void Dispose()
     {
         callbackDataHandle?.Dispose();
         callbackDataHandle = null;
+        if (contextHandle.IsAllocated)
+            contextHandle.Free();
         pendingResults.Clear();
     }
 }

--- a/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
+++ b/src/OpenCvSharp/Modules/face/Facemark/FacemarkFaceDetector.cs
@@ -34,8 +34,18 @@ internal sealed unsafe class FacemarkFaceDetectorBridge : IDisposable
     {
         this.detector = detector;
         contextHandle = GCHandle.Alloc(this);
-        NativeMethods.HandleException(
-            setter(obj, GetTrampolinePointer(), GCHandle.ToIntPtr(contextHandle), out var callbackData, out var result));
+        IntPtr callbackData;
+        int result;
+        try
+        {
+            NativeMethods.HandleException(
+                setter(obj, GetTrampolinePointer(), GCHandle.ToIntPtr(contextHandle), out callbackData, out result));
+        }
+        catch
+        {
+            contextHandle.Free();
+            throw;
+        }
         if (result == 0 || callbackData == IntPtr.Zero)
         {
             contextHandle.Free();

--- a/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
+++ b/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenCvSharp.Internal;
 
@@ -5,13 +6,6 @@ using OpenCvSharp.Internal;
 // ReSharper disable IdentifierTypo
 
 namespace OpenCvSharp;
-
-/// <summary>
-/// The native-shaped (double*, length) form of <see cref="SACSegmentation.ModelConstraintFunction"/>,
-/// used to marshal the callback across the P/Invoke boundary.
-/// </summary>
-[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate int SacModelConstraintNativeCallback(IntPtr coefficients, int length);
 
 /// <summary>
 /// Sample Consensus algorithm segmentation of 3D point cloud model.
@@ -29,9 +23,10 @@ public class SACSegmentation : Algorithm
     /// </param>
     public delegate bool ModelConstraintFunction(double[] modelCoefficients);
 
-    // Roots the native-shaped delegate for the lifetime of this instance so the GC does not collect it
-    // while native code may still invoke the callback during Segment().
-    private SacModelConstraintNativeCallback? customModelConstraintsNative;
+    // Roots the context (and thus the delegate) for the lifetime of this instance, or until replaced,
+    // so the GC does not collect it while native code may still invoke the callback during Segment().
+    // The native-facing function pointer passed alongside it is always the fixed trampoline below.
+    private GCHandle constraintContextHandle;
     private ModelConstraintFunction? customModelConstraints;
 
     private SACSegmentation(IntPtr smartPtr, IntPtr rawPtr)
@@ -270,17 +265,22 @@ public class SACSegmentation : Algorithm
         ThrowIfDisposed();
 
         this.customModelConstraints = customModelConstraints;
-        customModelConstraintsNative = customModelConstraints is null
-            ? null
-            : (coefficients, length) =>
-            {
-                var managedCoefficients = new double[length];
-                Marshal.Copy(coefficients, managedCoefficients, 0, length);
-                return customModelConstraints(managedCoefficients) ? 1 : 0;
-            };
+
+        var oldHandle = constraintContextHandle;
+        var callbackPtr = IntPtr.Zero;
+        var userData = IntPtr.Zero;
+        if (customModelConstraints is not null)
+        {
+            constraintContextHandle = GCHandle.Alloc(customModelConstraints);
+            callbackPtr = GetConstraintTrampolinePointer();
+            userData = GCHandle.ToIntPtr(constraintContextHandle);
+        }
 
         NativeMethods.HandleException(
-            NativeMethods.geometry_SACSegmentation_setCustomModelConstraints(Handle, customModelConstraintsNative));
+            NativeMethods.geometry_SACSegmentation_setCustomModelConstraints(Handle, callbackPtr, userData));
+
+        if (oldHandle.IsAllocated)
+            oldHandle.Free();
     }
 
     /// <summary>
@@ -291,5 +291,34 @@ public class SACSegmentation : Algorithm
     {
         ThrowIfDisposed();
         return customModelConstraints;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static int ModelConstraintTrampoline(IntPtr userData, IntPtr coefficients, int length)
+    {
+        try
+        {
+            var constraint = (ModelConstraintFunction)GCHandle.FromIntPtr(userData).Target!;
+            var managedCoefficients = new double[length];
+            Marshal.Copy(coefficients, managedCoefficients, 0, length);
+            return constraint(managedCoefficients) ? 1 : 0;
+        }
+        catch
+        {
+            // Exceptions must never unwind into native code from an UnmanagedCallersOnly method;
+            // fail safe by rejecting the model.
+            return 0;
+        }
+    }
+
+    private static unsafe IntPtr GetConstraintTrampolinePointer() =>
+        (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int, int>)&ModelConstraintTrampoline;
+
+    /// <inheritdoc />
+    protected override void DisposeManaged()
+    {
+        if (constraintContextHandle.IsAllocated)
+            constraintContextHandle.Free();
+        base.DisposeManaged();
     }
 }

--- a/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
+++ b/src/OpenCvSharp/Modules/geometry/SACSegmentation.cs
@@ -275,6 +275,10 @@ public class SACSegmentation : Algorithm
             callbackPtr = GetConstraintTrampolinePointer();
             userData = GCHandle.ToIntPtr(constraintContextHandle);
         }
+        else
+        {
+            constraintContextHandle = default;
+        }
 
         NativeMethods.HandleException(
             NativeMethods.geometry_SACSegmentation_setCustomModelConstraints(Handle, callbackPtr, userData));

--- a/src/OpenCvSharp/Modules/tracking/TrackerKCF.cs
+++ b/src/OpenCvSharp/Modules/tracking/TrackerKCF.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenCvSharp.Internal;
 
@@ -45,13 +46,15 @@ public class TrackerKCF : Tracker
         return new TrackerKCF(smartPtr, rawPtr);
     }
 
-    // Roots the marshaled native trampoline process-wide (not on the instance): the native side
+    // Roots the managed callback process-wide (not on the instance): the native side
     // (cv::TrackerKCF::FeatureExtractorCallbackFN) is a plain C function pointer with no per-instance
     // user-data slot, so the callback stays reachable through this shared field for as long as any
     // tracker might still invoke it, even after the TrackerKCF instance that registered it is
     // collected. Replacing it is guarded by a lock since registrations race on the same native slot.
+    // The native-facing function pointer is always the fixed trampoline below; only the field it
+    // reads is swapped.
     private static readonly object featureExtractorLock = new();
-    private static NativeFeatureExtractorCallback? nativeFeatureExtractorCallback;
+    private static FeatureExtractorCallback? currentFeatureExtractor;
 
     /// <summary>
     /// Sets a custom feature extractor. Corresponds to <c>cv::TrackerKCF::setFeatureExtractor</c>.
@@ -74,19 +77,11 @@ public class TrackerKCF : Tracker
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(extractor);
 
-        NativeFeatureExtractorCallback trampoline = (image, roi, features) =>
-        {
-            using var imageMat = new Mat(image, ownsHandle: false);
-            using var featuresMat = new Mat(features, ownsHandle: false);
-            var roiRect = Marshal.PtrToStructure<Rect>(roi);
-            extractor(imageMat, roiRect, featuresMat);
-        };
-
         lock (featureExtractorLock)
         {
-            nativeFeatureExtractorCallback = trampoline;
+            currentFeatureExtractor = extractor;
             NativeMethods.HandleException(
-                NativeMethods.tracking_TrackerKCF_setFeatureExtractor(RawPtr, nativeFeatureExtractorCallback, pcaFunc ? 1 : 0));
+                NativeMethods.tracking_TrackerKCF_setFeatureExtractor(RawPtr, GetFeatureExtractorTrampolinePointer(), pcaFunc ? 1 : 0));
         }
         GC.KeepAlive(this);
     }
@@ -99,17 +94,34 @@ public class TrackerKCF : Tracker
     /// <param name="features">The output feature matrix to fill in.</param>
     public delegate void FeatureExtractorCallback(Mat image, Rect roi, Mat features);
 
-    /// <summary>
-    /// Native-callable shape of <see cref="FeatureExtractorCallback"/>: pointers only (including for
-    /// <paramref name="roi"/>, read back with <see cref="Marshal.PtrToStructure{T}(IntPtr)"/>) rather
-    /// than <see cref="Mat"/> or a by-value <see cref="Rect"/> - passing a by-value struct through a
-    /// reverse P/Invoke thunk (native calling into a marshaled delegate) is best avoided, so every
-    /// argument here is pointer-sized, matching the pattern already used by
-    /// <see cref="OpenCvSharp.MouseCallback"/>. Public only because it must be at least as visible as
-    /// the P/Invoke entry point that takes it; not meant to be used directly.
-    /// </summary>
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void NativeFeatureExtractorCallback(IntPtr image, IntPtr roi, IntPtr features);
+    // Bridges cv::TrackerKCF's real by-value signature (const Mat, const Rect, Mat&) to an
+    // all-pointers one: a reverse P/Invoke thunk cannot replicate the MSVC by-value-object calling
+    // convention that cv::Mat's non-trivial copy constructor requires, and even a plain-POD
+    // by-value struct (interop::Rect) is risky to pass that way - so the native trampoline
+    // (tracking_TrackerKCF_featureExtractorTrampoline in tracking.h) hands us pointers only, with
+    // roi read back via Marshal.PtrToStructure.
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void FeatureExtractorTrampoline(IntPtr image, IntPtr roi, IntPtr features)
+    {
+        try
+        {
+            var extractor = currentFeatureExtractor;
+            if (extractor is null)
+                return;
+
+            using var imageMat = new Mat(image, ownsHandle: false);
+            using var featuresMat = new Mat(features, ownsHandle: false);
+            var roiRect = Marshal.PtrToStructure<Rect>(roi);
+            extractor(imageMat, roiRect, featuresMat);
+        }
+        catch
+        {
+            // Exceptions must never unwind into native code from an UnmanagedCallersOnly method.
+        }
+    }
+
+    private static unsafe IntPtr GetFeatureExtractorTrampolinePointer() =>
+        (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, void>)&FeatureExtractorTrampoline;
 
     #pragma warning disable CA1034
 #pragma warning disable CA1051

--- a/src/OpenCvSharp/Modules/videoio/StreamReaderBridge.cs
+++ b/src/OpenCvSharp/Modules/videoio/StreamReaderBridge.cs
@@ -1,46 +1,46 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace OpenCvSharp;
 
 /// <summary>
-/// Native callback invoked by cv::IStreamReader::read() through the <see cref="StreamReaderBridge"/>.
-/// </summary>
-[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate long StreamReaderReadCallback(IntPtr userData, IntPtr buffer, long size);
-
-/// <summary>
-/// Native callback invoked by cv::IStreamReader::seek() through the <see cref="StreamReaderBridge"/>.
-/// </summary>
-[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate long StreamReaderSeekCallback(IntPtr userData, long offset, int origin);
-
-/// <summary>
 /// Bridges a managed <see cref="IStreamReader"/> implementation to the native cv::IStreamReader callback ABI.
 /// </summary>
 /// <remarks>
-/// An instance must be kept alive (rooted) by the caller for as long as the associated native VideoCapture
-/// may still call back into it, since the delegates it exposes are passed to native code as raw function
-/// pointers and are not tracked by the GC.
+/// The native-facing function pointers (see <see cref="ReadCallbackPointer"/>/<see cref="SeekCallbackPointer"/>)
+/// are always the fixed, static <see cref="UnmanagedCallersOnlyAttribute"/> trampolines below; the real
+/// <see cref="IStreamReader"/> is boxed into a <see cref="GCHandle"/>-rooted context, whose <see cref="IntPtr"/>
+/// representation (<see cref="UserData"/>) is passed through as the native userData. An instance must be
+/// disposed once the associated native VideoCapture can no longer call back into it, both to free the
+/// GCHandle and because native never inspects userData beyond that call.
 /// </remarks>
-internal sealed class StreamReaderBridge
+internal sealed class StreamReaderBridge : IDisposable
 {
-    private readonly IStreamReader source;
+    private GCHandle handle;
 
-    public StreamReaderReadCallback ReadCallback { get; }
+    public IntPtr ReadCallbackPointer { get; } = GetReadTrampolinePointer();
 
-    public StreamReaderSeekCallback SeekCallback { get; }
+    public IntPtr SeekCallbackPointer { get; } = GetSeekTrampolinePointer();
+
+    public IntPtr UserData => GCHandle.ToIntPtr(handle);
 
     public StreamReaderBridge(IStreamReader source)
     {
-        this.source = source;
-        ReadCallback = Read;
-        SeekCallback = Seek;
+        handle = GCHandle.Alloc(source);
     }
 
-    private long Read(IntPtr userData, IntPtr buffer, long size)
+    public void Dispose()
+    {
+        if (handle.IsAllocated)
+            handle.Free();
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static long ReadTrampoline(IntPtr userData, IntPtr buffer, long size)
     {
         try
         {
+            var source = (IStreamReader)GCHandle.FromIntPtr(userData).Target!;
             unsafe
             {
                 var span = new Span<byte>((void*)buffer, checked((int)size));
@@ -54,14 +54,17 @@ internal sealed class StreamReaderBridge
         }
         catch
         {
+            // Exceptions must never unwind into native code from an UnmanagedCallersOnly method.
             return -1;
         }
     }
 
-    private long Seek(IntPtr userData, long offset, int origin)
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static long SeekTrampoline(IntPtr userData, long offset, int origin)
     {
         try
         {
+            var source = (IStreamReader)GCHandle.FromIntPtr(userData).Target!;
             var seekOrigin = origin switch
             {
                 0 => SeekOrigin.Begin,
@@ -73,7 +76,14 @@ internal sealed class StreamReaderBridge
         }
         catch
         {
+            // Exceptions must never unwind into native code from an UnmanagedCallersOnly method.
             return -1;
         }
     }
+
+    private static unsafe IntPtr GetReadTrampolinePointer() =>
+        (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, IntPtr, long, long>)&ReadTrampoline;
+
+    private static unsafe IntPtr GetSeekTrampolinePointer() =>
+        (IntPtr)(delegate* unmanaged[Cdecl]<IntPtr, long, int, long>)&SeekTrampoline;
 }

--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -121,11 +121,19 @@ public class VideoCapture : CvObject
         ArgumentNullException.ThrowIfNull(prms);
 
         var newBridge = new StreamReaderBridge(source);
-
-        NativeMethods.HandleException(
-            NativeMethods.videoio_VideoCapture_new6(
-                newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
-                (int)apiPreference, prms, prms.Length, out var p));
+        IntPtr p;
+        try
+        {
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_new6(
+                    newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
+                    (int)apiPreference, prms, prms.Length, out p));
+        }
+        catch
+        {
+            newBridge.Dispose();
+            throw;
+        }
 
         if (p == IntPtr.Zero)
         {
@@ -1258,11 +1266,19 @@ public class VideoCapture : CvObject
         ArgumentNullException.ThrowIfNull(prms);
 
         var newBridge = new StreamReaderBridge(source);
-
-        NativeMethods.HandleException(
-            NativeMethods.videoio_VideoCapture_open3(
-                Handle, newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
-                (int)apiPreference, prms, prms.Length, out var ret));
+        int ret;
+        try
+        {
+            NativeMethods.HandleException(
+                NativeMethods.videoio_VideoCapture_open3(
+                    Handle, newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
+                    (int)apiPreference, prms, prms.Length, out ret));
+        }
+        catch
+        {
+            newBridge.Dispose();
+            throw;
+        }
 
         streamReaderBridge?.Dispose();
         streamReaderBridge = newBridge;

--- a/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
+++ b/src/OpenCvSharp/Modules/videoio/VideoCapture.cs
@@ -120,16 +120,21 @@ public class VideoCapture : CvObject
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(prms);
 
-        streamReaderBridge = new StreamReaderBridge(source);
+        var newBridge = new StreamReaderBridge(source);
 
         NativeMethods.HandleException(
             NativeMethods.videoio_VideoCapture_new6(
-                streamReaderBridge.ReadCallback, streamReaderBridge.SeekCallback, IntPtr.Zero,
+                newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
                 (int)apiPreference, prms, prms.Length, out var p));
 
         if (p == IntPtr.Zero)
+        {
+            newBridge.Dispose();
             throw new OpenCvSharpException("Failed to create VideoCapture");
+        }
 
+        streamReaderBridge?.Dispose();
+        streamReaderBridge = newBridge;
         captureType = CaptureType.File;
         InitSafeHandle(p);
     }
@@ -307,6 +312,14 @@ public class VideoCapture : CvObject
     {
         SetSafeHandle(new OpenCvPtrSafeHandle(p, ownsHandle,
             static h => NativeMethods.HandleException(NativeMethods.videoio_VideoCapture_delete(h))));
+    }
+
+    /// <inheritdoc />
+    protected override void DisposeManaged()
+    {
+        streamReaderBridge?.Dispose();
+        streamReaderBridge = null;
+        base.DisposeManaged();
     }
 
     #endregion
@@ -1140,6 +1153,7 @@ public class VideoCapture : CvObject
             return false;
 
         captureType = CaptureType.File;
+        streamReaderBridge?.Dispose();
         streamReaderBridge = null;
         return true;
     }
@@ -1176,6 +1190,7 @@ public class VideoCapture : CvObject
             return false;
 
         captureType = CaptureType.File;
+        streamReaderBridge?.Dispose();
         streamReaderBridge = null;
         return true;
     }
@@ -1222,6 +1237,7 @@ public class VideoCapture : CvObject
             return false;
 
         captureType = CaptureType.Camera;
+        streamReaderBridge?.Dispose();
         streamReaderBridge = null;
         return true;
     }
@@ -1241,12 +1257,15 @@ public class VideoCapture : CvObject
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(prms);
 
-        streamReaderBridge = new StreamReaderBridge(source);
+        var newBridge = new StreamReaderBridge(source);
 
         NativeMethods.HandleException(
             NativeMethods.videoio_VideoCapture_open3(
-                Handle, streamReaderBridge.ReadCallback, streamReaderBridge.SeekCallback, IntPtr.Zero,
+                Handle, newBridge.ReadCallbackPointer, newBridge.SeekCallbackPointer, newBridge.UserData,
                 (int)apiPreference, prms, prms.Length, out var ret));
+
+        streamReaderBridge?.Dispose();
+        streamReaderBridge = newBridge;
 
         if (ret == 0)
             return false;

--- a/src/OpenCvSharpExtern/face_Facemark.h
+++ b/src/OpenCvSharpExtern/face_Facemark.h
@@ -52,11 +52,14 @@ struct FacemarkKazemiParamsData
     uint64_t num_test_splits;
 };
 
-typedef int (*FacemarkFaceDetectorCallback)(cv::Mat *image, interop::Rect *faces, int capacity);
+// userData is a GCHandle to the managed context rooting the real detector delegate (see
+// FacemarkFaceDetectorBridge), round-tripped opaquely - this native layer never dereferences it.
+typedef int (*FacemarkFaceDetectorCallback)(void *userData, cv::Mat *image, interop::Rect *faces, int capacity);
 
 struct FacemarkFaceDetectorCallbackData
 {
     FacemarkFaceDetectorCallback callback;
+    void *userData;
 };
 
 static bool face_Facemark_faceDetectorThunk(
@@ -66,7 +69,7 @@ static bool face_Facemark_faceDetectorThunk(
     if (data == nullptr || data->callback == nullptr)
         return false;
     auto imageMat = image.getMat();
-    const auto count = data->callback(&imageMat, nullptr, 0);
+    const auto count = data->callback(data->userData, &imageMat, nullptr, 0);
     if (count < 0)
         return false;
     if (count == 0)
@@ -75,7 +78,7 @@ static bool face_Facemark_faceDetectorThunk(
         return true;
     }
     std::vector<interop::Rect> interopFaces(count);
-    const auto written = data->callback(&imageMat, interopFaces.data(), count);
+    const auto written = data->callback(data->userData, &imageMat, interopFaces.data(), count);
     if (written != count)
         return false;
     std::vector<cv::Rect> nativeFaces(count);
@@ -231,11 +234,12 @@ CVAPI(ExceptionStatus) face_FacemarkTrain_getFaces(
 CVAPI(ExceptionStatus) face_FacemarkTrain_setFaceDetector(
     cv::face::FacemarkTrain *obj,
     const FacemarkFaceDetectorCallback callback,
+    void *userData,
     FacemarkFaceDetectorCallbackData **callbackData,
     int *returnValue)
 {
     return cvTry([&] {
-        const auto data = new FacemarkFaceDetectorCallbackData { callback };
+        const auto data = new FacemarkFaceDetectorCallbackData { callback, userData };
         if (!obj->setFaceDetector(face_Facemark_faceDetectorThunk, data))
         {
             delete data;
@@ -631,11 +635,12 @@ CVAPI(ExceptionStatus) face_FacemarkKazemi_getFaces(
 CVAPI(ExceptionStatus) face_FacemarkKazemi_setFaceDetector(
     cv::face::FacemarkKazemi *obj,
     const FacemarkFaceDetectorCallback callback,
+    void *userData,
     FacemarkFaceDetectorCallbackData **callbackData,
     int *returnValue)
 {
     return cvTry([&] {
-        const auto data = new FacemarkFaceDetectorCallbackData { callback };
+        const auto data = new FacemarkFaceDetectorCallbackData { callback, userData };
         if (!obj->setFaceDetector(face_Facemark_faceDetectorThunk, data))
         {
             delete data;

--- a/src/OpenCvSharpExtern/geometry.h
+++ b/src/OpenCvSharpExtern/geometry.h
@@ -1915,7 +1915,10 @@ CVAPI(ExceptionStatus) geometry_rotatedRectangleIntersection_vector(
 
 // SACSegmentation
 
-typedef int (*SacModelConstraintNativeCallback)(const double *coefficients, int length);
+// userData is a GCHandle to the managed context rooting the real constraint delegate (see
+// SACSegmentation.SetCustomModelConstraints), round-tripped opaquely - this native layer never
+// dereferences it.
+typedef int (*SacModelConstraintNativeCallback)(void *userData, const double *coefficients, int length);
 
 CVAPI(ExceptionStatus) geometry_createSACSegmentation(
     int sacModelType,
@@ -2084,7 +2087,8 @@ CVAPI(ExceptionStatus) geometry_SACSegmentation_getRandomGeneratorState(cv::SACS
 
 CVAPI(ExceptionStatus) geometry_SACSegmentation_setCustomModelConstraints(
     cv::SACSegmentation *obj,
-    SacModelConstraintNativeCallback callback)
+    SacModelConstraintNativeCallback callback,
+    void *userData)
 {
     return cvTry([&] {
         if (callback == nullptr)
@@ -2093,8 +2097,8 @@ CVAPI(ExceptionStatus) geometry_SACSegmentation_setCustomModelConstraints(
         }
         else
         {
-            obj->setCustomModelConstraints([callback](const std::vector<double> &coefficients) -> bool {
-                return callback(coefficients.data(), static_cast<int>(coefficients.size())) != 0;
+            obj->setCustomModelConstraints([callback, userData](const std::vector<double> &coefficients) -> bool {
+                return callback(userData, coefficients.data(), static_cast<int>(coefficients.size())) != 0;
             });
         }
     });


### PR DESCRIPTION
## Summary

Six entry points still took a delegate directly as a P/Invoke parameter, which `[LibraryImport]`'s source generator does not support, so they stayed on classic `[DllImport]`. Each is now routed through a static `[UnmanagedCallersOnly]` trampoline instead, following the pattern PR #2076 established for highgui's `setMouseCallback`/`createTrackbar`:

- `face_FacemarkTrain_setFaceDetector` / `face_FacemarkKazemi_setFaceDetector` and `geometry_SACSegmentation_setCustomModelConstraints` support multiple concurrent instances, each with its own callback, but neither native entry point threaded a `userData` pointer back to the raw callback - the previous per-delegate marshaled thunk was the only thing disambiguating instances. Native (`face_Facemark.h`/`geometry.h`) now carries a `void* userData` alongside the callback pointer through to the point of invocation, mirroring what videoio's `ManagedStreamReader` already did; the managed side boxes the real delegate into a `GCHandle`-rooted context and passes its `IntPtr` through as that `userData`.
- `videoio_VideoCapture_new6`/`open3`'s `ManagedStreamReader::ReadCallback`/`SeekCallback` already carried `userData` through to the point of invocation, so `StreamReaderBridge` just needed to become a `GCHandle`-based context holder instead of an instance whose delegates were marshaled directly.
- `tracking_TrackerKCF_setFeatureExtractor`'s `cv::TrackerKCF::FeatureExtractorCallbackFN` has no per-instance user-data slot at all (already documented as process-wide-singleton-only), so no `GCHandle` context is needed there - only the field the fixed trampoline reads is swapped.

Also deleted the dead, commented-out `//[DllImport(...)]` lines left over from the original Phase 2 bulk conversion to `LibraryImport`, scattered across `NativeMethods_highgui.cs`, `NativeMethods_videoio.cs`, and the core/imgproc `NativeMethods` files - they had no live counterpart to convert and were pure noise.

Native `face_Facemark.h`/`geometry.h` changed (new `userData` parameter), so this required a native rebuild; `core.h`/`highgui.h`/`videoio.h`/`tracking.h` were untouched (a function pointer's ABI is the same either way).

## Testing

- `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release`: 0 warnings, 0 errors.
- `cmake --build` (`OpenCvSharpExtern`, Release) for the `face_Facemark.h`/`geometry.h` changes.
- `dotnet test test/OpenCvSharp.Tests -f net10.0`: 1730 passed, 0 failed, 23 skipped (pre-existing, platform/model-file-gated skips) - including `FacemarkKazemiTest.CustomFaceDetectorIsInvoked`, `SACSegmentationTest.CustomModelConstraintsRejectingAllModelsYieldsZeroModels`, `TrackerKCFTest.SetFeatureExtractor`, and `VideoCaptureTest.OpenFromCustomStreamReader`, which exercise the new trampolines end-to-end.

Fixes #2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when using custom video streams, face detectors, segmentation constraints, and tracker feature extractors.
  * Improved callback handling, resource cleanup, and reopening behavior for video captures.
  * Reduced the risk of errors crossing between managed and native code.

* **Refactor**
  * Reworked internal callback plumbing to improve stability and lifetime management.
  * Added/updated support for creating `Mat` instances from existing matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->