### PR TITLE
Fix SolvePnPMethod enum values to match native OpenCV5 numbering

### DIFF
--- a/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
+++ b/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
@@ -28,31 +28,18 @@ public enum SolvePnPMethod
     P3P = 2,
 
     /// <summary>
-    /// **Broken implementation. Using this flag will fallback to EPnP**.
-    /// Joel A. Hesch and Stergios I. Roumeliotis. "A Direct Least-Squares (DLS) Method for PnP"
-    /// </summary>
-    DLS = 3,
-
-    /// <summary>
-    /// **Broken implementation. Using this flag will fallback to EPnP.**
-    /// Method is based on the paper of A.Penate-Sanchez, J.Andrade-Cetto, F.Moreno-Noguer.
-    /// "Exhaustive Linearization for Robust Camera Pose and Focal Length Estimation"
-    /// </summary>
-    UPNP = 4,
-
-    /// <summary>
     /// Method is based on the paper of T. Ke, S. Roumeliotis
     /// "An Efficient Algebraic Solution to the Perspective-Three-Point Problem"
     /// In this case the function requires exactly four object and image points.
     /// </summary>
-    AP3P = 5,
+    AP3P = 3,
 
     /// <summary>
     /// Method is based on the paper of T. Collins and A. Bartoli.
     /// "Infinitesimal Plane-Based Pose Estimation".
     /// This method requires coplanar object points.
     /// </summary>
-    IPPE = 6,
+    IPPE = 4,
 
     /// <summary>
     /// Method is based on the paper of Toby Collins and Adrien Bartoli.
@@ -63,46 +50,11 @@ public enum SolvePnPMethod
     ///   - point 2: [squareLength / 2, -squareLength / 2, 0]
     ///   - point 3: [-squareLength / 2, -squareLength / 2, 0]
     /// </summary>
-    IPPE_SQUARE = 7,
+    IPPE_SQUARE = 5,
 
     /// <summary>
     /// Method is based on the paper "A Consistently Fast and Globally Optimal Solution to the
     /// Perspective-n-Point Problem" by G. Terzakis and M. Lourakis. It requires 3 or more points.
     /// </summary>
-    SQPNP = 8,
-}
-
-/// <summary>
-/// Obsolete: Use SolvePnPMethod instead. This enum is kept for backward compatibility.
-/// </summary>
-[Obsolete("Use SolvePnPMethod instead", true)]
-public enum SolvePnPFlags
-{
-    /// <summary>
-    /// Iterative method is based on Levenberg-Marquardt optimization. 
-    /// In this case the function finds such a pose that minimizes reprojection error, 
-    /// that is the sum of squared distances between the observed projections imagePoints and the projected (using projectPoints() ) objectPoints .
-    /// </summary>
-    Iterative = 0,
-
-    /// <summary>
-    /// Method has been introduced by F.Moreno-Noguer, V.Lepetit and P.Fua in the paper “EPnP: Efficient Perspective-n-Point Camera Pose Estimation”.
-    /// </summary>
-    EPNP = 1,
-
-    /// <summary>
-    /// Method is based on the paper of X.S. Gao, X.-R. Hou, J. Tang, H.-F. Chang“Complete Solution Classification for 
-    /// the Perspective-Three-Point Problem”. In this case the function requires exactly four object and image points.
-    /// </summary>
-    P3P = 2,
-
-    /// <summary>
-    /// Joel A. Hesch and Stergios I. Roumeliotis. "A Direct Least-Squares (DLS) Method for PnP"
-    /// </summary>
-    DLS = 3,
-
-    /// <summary>
-    /// A.Penate-Sanchez, J.Andrade-Cetto, F.Moreno-Noguer. "Exhaustive Linearization for Robust Camera Pose and Focal Length Estimation"
-    /// </summary>
-    UPNP = 4,
+    SQPNP = 6,
 }

--- a/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
+++ b/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
@@ -50,7 +50,7 @@ public enum SolvePnPMethod
     ///   - point 2: [squareLength / 2, -squareLength / 2, 0]
     ///   - point 3: [-squareLength / 2, -squareLength / 2, 0]
     /// </summary>
-    IPPE_SQUARE = 5,
+    IppeSquare = 5,
 
     /// <summary>
     /// Method is based on the paper "A Consistently Fast and Globally Optimal Solution to the

--- a/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
+++ b/src/OpenCvSharp/Modules/geometry/Enum/SolvePnPMethod.cs
@@ -50,7 +50,7 @@ public enum SolvePnPMethod
     ///   - point 2: [squareLength / 2, -squareLength / 2, 0]
     ///   - point 3: [-squareLength / 2, -squareLength / 2, 0]
     /// </summary>
-    IppeSquare = 5,
+    IPPESquare = 5,
 
     /// <summary>
     /// Method is based on the paper "A Consistently Fast and Globally Optimal Solution to the

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -522,7 +522,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
     }
 
     [Fact]
-    public void SolvePnPTestByArrayIppeSquare()
+    public void SolvePnPTestByArrayIPPESquare()
     {
         var rvec = new double[] { 3, 0, 0 };
         var tvec = new double[] { 0, 0, 10 };
@@ -544,7 +544,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out _);
 
-        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: SolvePnPMethod.IppeSquare);
+        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: SolvePnPMethod.IPPESquare);
 
         Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var reprojected, out _);
         for (var i = 0; i < imgPts.Length; i++)

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -489,7 +489,7 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
     public void SolvePnPTestByArrayMethods(SolvePnPMethod method)
     {
         var rvec = new double[] { 3, 0, 0 };
-        var tvec = new double[] { 0, 0, -10 };
+        var tvec = new double[] { 0, 0, 10 };
         var cameraMatrix = new double[,]
         {
             { 1, 0, 0 },
@@ -509,13 +509,23 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out _);
 
         Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: method);
+
+        // Verify the recovered pose actually reprojects onto imgPts (rather than just "didn't throw"):
+        // a stale/misdirected enum value can silently dispatch to a different native solver that
+        // still runs to completion without throwing, but produces a wrong pose.
+        Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var reprojected, out _);
+        for (var i = 0; i < imgPts.Length; i++)
+        {
+            Assert.Equal(imgPts[i].X, reprojected[i].X, 3);
+            Assert.Equal(imgPts[i].Y, reprojected[i].Y, 3);
+        }
     }
 
     [Fact]
     public void SolvePnPTestByArrayIppeSquare()
     {
         var rvec = new double[] { 3, 0, 0 };
-        var tvec = new double[] { 0, 0, -10 };
+        var tvec = new double[] { 0, 0, 10 };
         var cameraMatrix = new double[,]
         {
             { 1, 0, 0 },
@@ -534,7 +544,14 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
 
         Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out _);
 
-        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: SolvePnPMethod.IPPE_SQUARE);
+        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: SolvePnPMethod.IppeSquare);
+
+        Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var reprojected, out _);
+        for (var i = 0; i < imgPts.Length; i++)
+        {
+            Assert.Equal(imgPts[i].X, reprojected[i].X, 3);
+            Assert.Equal(imgPts[i].Y, reprojected[i].Y, 3);
+        }
     }
 
     [Fact]

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -481,6 +481,62 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, useExtrinsicGuess: useExtrinsicGuess);
     }
 
+    [Theory]
+    [InlineData(SolvePnPMethod.P3P)]
+    [InlineData(SolvePnPMethod.AP3P)]
+    [InlineData(SolvePnPMethod.IPPE)]
+    [InlineData(SolvePnPMethod.SQPNP)]
+    public void SolvePnPTestByArrayMethods(SolvePnPMethod method)
+    {
+        var rvec = new double[] { 3, 0, 0 };
+        var tvec = new double[] { 0, 0, -10 };
+        var cameraMatrix = new double[,]
+        {
+            { 1, 0, 0 },
+            { 0, 1, 0 },
+            { 0, 0, 1 }
+        };
+        var dist = new double[] { 0, 0, 0, 0, 0 };
+
+        var objPts = new[]
+        {
+            new Point3f(0,0,1),
+            new Point3f(1,0,1),
+            new Point3f(0,1,1),
+            new Point3f(1,1,1)
+        };
+
+        Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out _);
+
+        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: method);
+    }
+
+    [Fact]
+    public void SolvePnPTestByArrayIppeSquare()
+    {
+        var rvec = new double[] { 3, 0, 0 };
+        var tvec = new double[] { 0, 0, -10 };
+        var cameraMatrix = new double[,]
+        {
+            { 1, 0, 0 },
+            { 0, 1, 0 },
+            { 0, 0, 1 }
+        };
+        var dist = new double[] { 0, 0, 0, 0, 0 };
+
+        var objPts = new[]
+        {
+            new Point3f(-0.5f, 0.5f, 0),
+            new Point3f(0.5f, 0.5f, 0),
+            new Point3f(0.5f, -0.5f, 0),
+            new Point3f(-0.5f, -0.5f, 0)
+        };
+
+        Cv2.ProjectPoints(objPts, rvec, tvec, cameraMatrix, dist, out var imgPts, out _);
+
+        Cv2.SolvePnP(objPts, imgPts, cameraMatrix, dist, ref rvec, ref tvec, flags: SolvePnPMethod.IPPE_SQUARE);
+    }
+
     [Fact]
     public void SolvePnPTestByMat()
     {


### PR DESCRIPTION
## Description

`Cv2.SolvePnP` / `Cv2.SolvePnPRansac` pass `SolvePnPMethod` straight through as a native `int flags` value, but the enum's numeric values were never updated when the `geometry` module dropped `SOLVEPNP_DLS` and `SOLVEPNP_UPNP` (both were broken implementations that only fell back to EPnP) and renumbered the remaining `SOLVEPNP_*` constants:

| | Iterative | EPNP | P3P | AP3P | IPPE | IPPE_SQUARE | SQPNP |
|---|---|---|---|---|---|---|---|
| native (current) | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
| managed (before) | 0 | 1 | 2 | 5 | 6 | 7 | 8 |

This meant `AP3P`/`IPPE` silently invoked the wrong native algorithm, and `IPPE_SQUARE`/`SQPNP` fell outside the native flag range and threw `StsBadArg`.

## Changes

- Renumber `SolvePnPMethod` (`AP3P=3, IPPE=4, IPPE_SQUARE=5, SQPNP=6`) to match the native enum, and drop the now-nonexistent `DLS`/`UPNP` members.
- Remove the obsolete `SolvePnPFlags` alias enum (kept around from the OpenCvSharp4 days) since OpenCvSharp5 doesn't guarantee source compatibility with the old API. Renamed the containing file to `SolvePnPMethod.cs` to match its sole remaining type.
- Add regression tests in `Calib3dTest` covering `P3P`/`AP3P`/`IPPE`/`SQPNP`/`IPPE_SQUARE`.

Fixes #2080

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test --filter FullyQualifiedName~calib3d` — 90 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed unsupported `SolvePnPMethod` options `DLS` and `UPNP`.
  * Updated numeric values for the remaining `SolvePnPMethod` members.
  * Renamed `IPPE_SQUARE` to `IPPESquare`.

* **Tests**
  * Added additional `SolvePnP` test cases that validate accuracy across multiple `SolvePnPMethod` values.
  * Added a dedicated test covering `SolvePnPMethod.IPPESquare`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->