### PR TITLE
Fix more enums carrying stale native values from the OpenCV4->5 migration

### DIFF
--- a/src/OpenCvSharp/Modules/calib/Enum/FishEyeCalibrationFlags.cs
+++ b/src/OpenCvSharp/Modules/calib/Enum/FishEyeCalibrationFlags.cs
@@ -19,47 +19,47 @@ public enum FishEyeCalibrationFlags
     UseIntrinsicGuess = 1,
 
     /// <summary>
-    /// For fisheye model only. Recompute board position on each calibration iteration.
+    /// The principal point (cx, cy) stays the same as in the input camera matrix. Image center is used as principal point, if UseIntrinsicGuess is not set.
     /// </summary>
-    RecomputeExtrinsic = 1 << 1,
-
-    /// <summary>
-    /// For fisheye model only. Check SVD decomposition quality for each frame during extrinsics estimation.
-    /// </summary>
-    CheckCond = 1 << 2,
-
-    /// <summary>
-    /// For fisheye model only. Skew coefficient (alpha) is set to zero and stay zero.
-    /// </summary>
-    FixSkew = 1 << 3,
+    FixPrincipalPoint = 0x00004,
 
     /// <summary>
     /// The distortion coefficient k1 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
     /// </summary>
-    FixK1 = 1 << 4,
+    FixK1 = 0x00020,
 
     /// <summary>
     /// The distortion coefficient k2 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
     /// </summary>
-    FixK2 = 1 << 5,
+    FixK2 = 0x00040,
 
     /// <summary>
     /// The distortion coefficient k3 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
     /// </summary>
-    FixK3 = 1 << 6,
+    FixK3 = 0x00080,
 
     /// <summary>
     /// The distortion coefficient k4 is not changed during the optimization. 0 value is used, if UseIntrinsicGuess is not set.
     /// </summary>
-    FixK4 = 1 << 7,
+    FixK4 = 0x00800,
 
     /// <summary>
     /// For stereo and multi-camera calibration only. Do not optimize cameras intrinsics.
     /// </summary>
-    FixIntrinsic = 1 << 8,
+    FixIntrinsic = 0x00100,
 
     /// <summary>
-    /// The principal point (cx, cy) stays the same as in the input camera matrix. Image center is used as principal point, if UseIntrinsicGuess is not set.
+    /// For fisheye model only. Recompute board position on each calibration iteration.
     /// </summary>
-    FixPrincipalPoint = 1 << 9
+    RecomputeExtrinsic = 1 << 23,
+
+    /// <summary>
+    /// For fisheye model only. Check SVD decomposition quality for each frame during extrinsics estimation.
+    /// </summary>
+    CheckCond = 1 << 24,
+
+    /// <summary>
+    /// For fisheye model only. Skew coefficient (alpha) is set to zero and stay zero.
+    /// </summary>
+    FixSkew = 1 << 25
 }

--- a/src/OpenCvSharp/Modules/videoio/Enum/VideoCaptureAPIs.cs
+++ b/src/OpenCvSharp/Modules/videoio/Enum/VideoCaptureAPIs.cs
@@ -67,19 +67,9 @@ public enum VideoCaptureAPIs
     PVAPI = 800, 
 
     /// <summary>
-    /// OpenNI (for Kinect)
-    /// </summary>
-    OPENNI = 900, 
-
-    /// <summary>
-    /// OpenNI (for Asus Xtion)
-    /// </summary>
-    OPENNI_ASUS = 910, 
-
-    /// <summary>
     /// Android - not used
     /// </summary>
-    ANDROID = 1000, 
+    ANDROID = 1000,
 
     /// <summary>
     /// XIMEA Camera API
@@ -92,14 +82,9 @@ public enum VideoCaptureAPIs
     AVFOUNDATION = 1200, 
 
     /// <summary>
-    /// Smartek Giganetix GigEVisionSDK
-    /// </summary>
-    GIGANETIX = 1300, 
-
-    /// <summary>
     /// Microsoft Media Foundation (via videoInput)
     /// </summary>
-    MSMF = 1400, 
+    MSMF = 1400,
 
     /// <summary>
     /// Microsoft Windows Runtime using Media Foundation

--- a/src/OpenCvSharp/Modules/ximgproc/Enum/WMFWeightType.cs
+++ b/src/OpenCvSharp/Modules/ximgproc/Enum/WMFWeightType.cs
@@ -4,35 +4,36 @@ namespace OpenCvSharp.XImgProc;
 /// <summary>
 /// Specifies weight types of weighted median filter.
 /// </summary>
+[Flags]
 public enum WMFWeightType
 {
     /// <summary>
     /// \f$exp(-|I1-I2|^2/(2*sigma^2))\f$
     /// </summary>
-    EXP,
+    EXP = 1,
 
     /// <summary>
     /// \f$(|I1-I2|+sigma)^-1\f$
     /// </summary>
-    IV1,
+    IV1 = 1 << 1,
 
     /// <summary>
     /// \f$(|I1-I2|^2+sigma^2)^-1\f$
     /// </summary>
-    IV2,
+    IV2 = 1 << 2,
 
     /// <summary>
     ///  \f$dot(I1,I2)/(|I1|*|I2|)\f$
     /// </summary>
-    COS,
+    COS = 1 << 3,
 
     /// <summary>
     /// \f$(min(r1,r2)+min(g1,g2)+min(b1,b2))/(max(r1,r2)+max(g1,g2)+max(b1,b2))\f$
     /// </summary>
-    JAC,
+    JAC = 1 << 4,
 
     /// <summary>
     /// unweighted
     /// </summary>
-    OFF 
+    OFF = 1 << 5
 }

--- a/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
+++ b/test/OpenCvSharp.Tests/calib3d/Calib3dTest.cs
@@ -314,6 +314,35 @@ public class Calib3DTest(ITestOutputHelper output) : TestBase
         Assert.NotEmpty(translationVectors);
     }
 
+    // Regression test for issue #2080-adjacent enum drift: FishEyeCalibrationFlags used to carry
+    // stale OpenCV4 fisheye-only bit values instead of the OpenCV5 aliased CALIB_* values, so
+    // FixK1..FixK4 silently set the wrong native bits. If the flags don't reach native correctly,
+    // the corresponding distortion coefficients are optimized freely instead of being held at 0.
+    [Fact]
+    public void FishEyeCalibrateWithFixedDistortion()
+    {
+        var patternSize = new Size(10, 7);
+
+        using var image = LoadImage("calibration/00.jpg");
+        using var corners = new Mat<Point2f>();
+        Cv2.FindChessboardCorners(image, patternSize, corners);
+
+        var objectPointsArray = Create3DChessboardCorners(patternSize, 1.0f).ToArray();
+        var imagePointsArray = corners.ToArray();
+
+        using var objectPoints = Mat<Point3f>.FromArray(objectPointsArray);
+        using var imagePoints = Mat<Point2f>.FromArray(imagePointsArray);
+        using var cameraMatrix = Mat.EyeMat(3, 3, MatType.CV_64FC1);
+        using var distCoeffs = new Mat<double>();
+        Cv2.FishEye.Calibrate([objectPoints], [imagePoints], image.Size(), cameraMatrix,
+            distCoeffs, out _, out _,
+            FishEyeCalibrationFlags.FixK1 | FishEyeCalibrationFlags.FixK2 |
+            FishEyeCalibrationFlags.FixK3 | FishEyeCalibrationFlags.FixK4);
+
+        var distCoeffValues = distCoeffs.ToArray();
+        Assert.All(distCoeffValues, d => Assert.Equal(0.0, d, 10));
+    }
+
     [Fact]
     public void FishEyeCalibrateWithNonContinuousPoints()
     {


### PR DESCRIPTION
## Description

Following up on #2081 (SolvePnPMethod), I audited the rest of the managed enums for the same class of bug — numeric values that were left over from OpenCV4 while the corresponding native OpenCV5 enum got renumbered, added members, or dropped members. Two more live, high-impact cases turned up:

### `FishEyeCalibrationFlags`
In OpenCV4, `cv::fisheye` had its own small-valued flag enum. In OpenCV5 the `fisheye` namespace no longer defines its own flags — it just aliases the unified `cv::CALIB_*` flags via `using` declarations, and those live at completely different bit positions (e.g. `CALIB_RECOMPUTE_EXTRINSIC` is `1 << 23`, not `1 << 1`). The managed enum still had the old fisheye-only bit values, so every flag except `UseIntrinsicGuess`/`FixIntrinsic` (which happened to keep the same bit) silently set the wrong native bits, or collided with unrelated flags. Any fisheye calibration using more than the default flags was affected.

### `WMFWeightType`
Declared with no explicit values, so the compiler assigned a plain `0..5` sequence. The native `cv::ximgproc::WMFWeightType` is a bit-flag enum (`1, 2, 4, 8, 16, 32`). Every member except `EXP` (0, which happens to alias onto native's `default:` fallback) invoked the wrong weighting formula in `WeightedMedianFilter`.

### `VideoCaptureAPIs` cleanup
While cross-checking, also found `OPENNI`/`OPENNI_ASUS`/`GIGANETIX` reference native backend IDs (`CAP_OPENNI`/`CAP_OPENNI_ASUS`/`CAP_GIGANETIX`) that no longer exist in OpenCV5 at all — OpenNI was superseded by OpenNI2, and Giganetix support was dropped. Not a value-drift bug (nothing else shifted), but a dead/misleading member: `VideoCapture.Open()` with these silently fails to find a backend rather than throwing. Removed since OpenCvSharp5 doesn't guarantee source compatibility with the 4.x API.

## Changes

- Renumber `FishEyeCalibrationFlags` to match the native `CALIB_*` aliases.
- Add explicit bit-flag values to `WMFWeightType` matching native `WMF_*`.
- Remove the three dead `VideoCaptureAPIs` members.
- Add a regression test (`FishEyeCalibrateWithFixedDistortion`) that fixes k1-k4 during fisheye calibration and asserts the resulting distortion coefficients are exactly 0 — this fails against the old bit values and passes against the fix.

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test --filter "FullyQualifiedName~calib3d|FullyQualifiedName~ximgproc|FullyQualifiedName~videoio"` — 183 passed, 4 skipped (codec-dependent), 0 failed
- [x] Verified `FishEyeCalibrateWithFixedDistortion` actually fails against the pre-fix bit values (temporarily reverted locally) before confirming it passes against the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fisheye calibration flag values so fixed distortion and calibration constraints work as expected.
  * Updated weight-type flags to support proper combination of options.
  * Removed unsupported video capture backend options.

* **Tests**
  * Added coverage confirming fixed distortion coefficients remain unchanged during fisheye calibration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->