### PR TITLE
Enable RTSP capture in Linux runtime and add CI coverage

### DIFF
--- a/.github/actions/test-rtsp-macos/action.yml
+++ b/.github/actions/test-rtsp-macos/action.yml
@@ -1,0 +1,14 @@
+name: Test RTSP capture on macOS
+description: Run the OpenCvSharp RTSP integration test against a temporary MediaMTX server
+
+inputs:
+  mediamtx-version:
+    description: MediaMTX release version
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run RTSP integration test
+      shell: bash
+      run: bash "${{ github.action_path }}/test-rtsp.sh" "${{ inputs.mediamtx-version }}"

--- a/.github/actions/test-rtsp-macos/action.yml
+++ b/.github/actions/test-rtsp-macos/action.yml
@@ -5,10 +5,16 @@ inputs:
   mediamtx-version:
     description: MediaMTX release version
     required: true
+  mediamtx-sha256:
+    description: SHA-256 of the MediaMTX macOS arm64 archive
+    default: b57e9e2f2fe418b37048ab613ae05fb744ac260dbc3f2ba63a64f9f6cf00156e
 
 runs:
   using: composite
   steps:
     - name: Run RTSP integration test
       shell: bash
-      run: bash "${{ github.action_path }}/test-rtsp.sh" "${{ inputs.mediamtx-version }}"
+      run: >-
+        bash "${{ github.action_path }}/test-rtsp.sh"
+        "${{ inputs.mediamtx-version }}"
+        "${{ inputs.mediamtx-sha256 }}"

--- a/.github/actions/test-rtsp-macos/test-rtsp.sh
+++ b/.github/actions/test-rtsp-macos/test-rtsp.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 readonly mediamtx_version="$1"
+readonly expected_checksum="$2"
 readonly archive_name="mediamtx_v${mediamtx_version}_darwin_arm64.tar.gz"
 readonly download_base="https://github.com/bluenviron/mediamtx/releases/download/v${mediamtx_version}"
 readonly server_dir="${RUNNER_TEMP}/mediamtx"
 readonly archive_path="${RUNNER_TEMP}/${archive_name}"
-readonly checksums_path="${RUNNER_TEMP}/mediamtx-checksums.sha256"
 readonly log_path="${RUNNER_TEMP}/mediamtx.log"
 server_pid=""
 
@@ -27,13 +27,6 @@ cleanup() {
 trap cleanup EXIT
 
 curl -fL --retry 5 "${download_base}/${archive_name}" -o "${archive_path}"
-curl -fL --retry 5 "${download_base}/checksums.sha256" -o "${checksums_path}"
-
-expected_checksum="$(grep -E "[ *]${archive_name}$" "${checksums_path}" | awk '{print $1}')"
-if [[ -z "${expected_checksum}" ]]; then
-  echo "Checksum not found for ${archive_name}"
-  exit 1
-fi
 
 actual_checksum="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
 if [[ "${actual_checksum}" != "${expected_checksum}" ]]; then

--- a/.github/actions/test-rtsp-macos/test-rtsp.sh
+++ b/.github/actions/test-rtsp-macos/test-rtsp.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly mediamtx_version="$1"
+readonly archive_name="mediamtx_v${mediamtx_version}_darwin_arm64.tar.gz"
+readonly download_base="https://github.com/bluenviron/mediamtx/releases/download/v${mediamtx_version}"
+readonly server_dir="${RUNNER_TEMP}/mediamtx"
+readonly archive_path="${RUNNER_TEMP}/${archive_name}"
+readonly checksums_path="${RUNNER_TEMP}/mediamtx-checksums.sha256"
+readonly log_path="${RUNNER_TEMP}/mediamtx.log"
+server_pid=""
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+
+  if [[ "${status}" -ne 0 && -f "${log_path}" ]]; then
+    cat "${log_path}"
+  fi
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+
+  exit "${status}"
+}
+trap cleanup EXIT
+
+curl -fL --retry 5 "${download_base}/${archive_name}" -o "${archive_path}"
+curl -fL --retry 5 "${download_base}/checksums.sha256" -o "${checksums_path}"
+
+expected_checksum="$(grep -E "[ *]${archive_name}$" "${checksums_path}" | awk '{print $1}')"
+if [[ -z "${expected_checksum}" ]]; then
+  echo "Checksum not found for ${archive_name}"
+  exit 1
+fi
+
+actual_checksum="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
+if [[ "${actual_checksum}" != "${expected_checksum}" ]]; then
+  echo "Checksum mismatch for ${archive_name}: expected ${expected_checksum}, got ${actual_checksum}"
+  exit 1
+fi
+
+mkdir -p "${server_dir}"
+tar -xzf "${archive_path}" -C "${server_dir}"
+"${server_dir}/mediamtx" "${GITHUB_WORKSPACE}/test/rtsp/mediamtx.yml" >"${log_path}" 2>&1 &
+server_pid=$!
+
+ready=false
+for attempt in $(seq 1 30); do
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    echo "MediaMTX exited before the stream became available"
+    exit 1
+  fi
+  if grep -q "stream is available" "${log_path}"; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${ready}" != true ]]; then
+  echo "Timed out waiting for MediaMTX"
+  exit 1
+fi
+
+export OPENCVSHARP_TEST_RTSP_URL="rtsp://127.0.0.1:8554/test"
+export DYLD_LIBRARY_PATH="/usr/local/lib:${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
+dotnet test "${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj" \
+  -c Release \
+  -f net10.0 \
+  --runtime osx-arm64 \
+  --no-build \
+  --no-restore \
+  --filter "FullyQualifiedName=OpenCvSharp.Tests.VideoIO.VideoCaptureTest.ReadRtspStreamWithFFmpeg" \
+  < /dev/null

--- a/.github/actions/test-rtsp-windows/action.yml
+++ b/.github/actions/test-rtsp-windows/action.yml
@@ -1,0 +1,16 @@
+name: Test RTSP capture on Windows
+description: Run the OpenCvSharp RTSP integration test against a temporary MediaMTX server
+
+inputs:
+  mediamtx-version:
+    description: MediaMTX release version
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run RTSP integration test
+      shell: pwsh
+      run: >-
+        & "${{ github.action_path }}/test-rtsp.ps1"
+        -MediaMtxVersion "${{ inputs.mediamtx-version }}"

--- a/.github/actions/test-rtsp-windows/action.yml
+++ b/.github/actions/test-rtsp-windows/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   mediamtx-sha256:
     description: SHA-256 of the MediaMTX Windows amd64 archive
-    default: 5d82148d1032a6a190d9909a2997d9989457aaadf49af87dd02cd4512d31bebe
+    required: true
 
 runs:
   using: composite

--- a/.github/actions/test-rtsp-windows/action.yml
+++ b/.github/actions/test-rtsp-windows/action.yml
@@ -5,6 +5,9 @@ inputs:
   mediamtx-version:
     description: MediaMTX release version
     required: true
+  mediamtx-sha256:
+    description: SHA-256 of the MediaMTX Windows amd64 archive
+    default: 5d82148d1032a6a190d9909a2997d9989457aaadf49af87dd02cd4512d31bebe
 
 runs:
   using: composite
@@ -14,3 +17,4 @@ runs:
       run: >-
         & "${{ github.action_path }}/test-rtsp.ps1"
         -MediaMtxVersion "${{ inputs.mediamtx-version }}"
+        -MediaMtxSha256 "${{ inputs.mediamtx-sha256 }}"

--- a/.github/actions/test-rtsp-windows/test-rtsp.ps1
+++ b/.github/actions/test-rtsp-windows/test-rtsp.ps1
@@ -1,7 +1,10 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string] $MediaMtxVersion
+    [string] $MediaMtxVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string] $MediaMtxSha256
 )
 
 $ErrorActionPreference = "Stop"
@@ -10,22 +13,14 @@ $archiveName = "mediamtx_v${MediaMtxVersion}_windows_amd64.zip"
 $downloadBase = "https://github.com/bluenviron/mediamtx/releases/download/v${MediaMtxVersion}"
 $serverDir = Join-Path $env:RUNNER_TEMP "mediamtx"
 $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
-$checksumsPath = Join-Path $env:RUNNER_TEMP "mediamtx-checksums.sha256"
 $stdoutPath = Join-Path $env:RUNNER_TEMP "mediamtx.stdout.log"
 $stderrPath = Join-Path $env:RUNNER_TEMP "mediamtx.stderr.log"
 $server = $null
 
 try {
     Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
-    Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
 
-    $checksumLine = Get-Content $checksumsPath |
-        Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
-    if (-not $checksumLine) {
-        throw "Checksum not found for $archiveName"
-    }
-
-    $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+    $expectedChecksum = $MediaMtxSha256.ToLowerInvariant()
     $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($actualChecksum -ne $expectedChecksum) {
         throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"

--- a/.github/actions/test-rtsp-windows/test-rtsp.ps1
+++ b/.github/actions/test-rtsp-windows/test-rtsp.ps1
@@ -4,6 +4,7 @@ param(
     [string] $MediaMtxVersion,
 
     [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-fA-F]{64}$")]
     [string] $MediaMtxSha256
 )
 

--- a/.github/actions/test-rtsp-windows/test-rtsp.ps1
+++ b/.github/actions/test-rtsp-windows/test-rtsp.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $MediaMtxVersion
+)
+
+$ErrorActionPreference = "Stop"
+
+$archiveName = "mediamtx_v${MediaMtxVersion}_windows_amd64.zip"
+$downloadBase = "https://github.com/bluenviron/mediamtx/releases/download/v${MediaMtxVersion}"
+$serverDir = Join-Path $env:RUNNER_TEMP "mediamtx"
+$archivePath = Join-Path $env:RUNNER_TEMP $archiveName
+$checksumsPath = Join-Path $env:RUNNER_TEMP "mediamtx-checksums.sha256"
+$stdoutPath = Join-Path $env:RUNNER_TEMP "mediamtx.stdout.log"
+$stderrPath = Join-Path $env:RUNNER_TEMP "mediamtx.stderr.log"
+$server = $null
+
+try {
+    Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
+    Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
+
+    $checksumLine = Get-Content $checksumsPath |
+        Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
+    if (-not $checksumLine) {
+        throw "Checksum not found for $archiveName"
+    }
+
+    $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+    $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualChecksum -ne $expectedChecksum) {
+        throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"
+    }
+
+    Expand-Archive $archivePath -DestinationPath $serverDir
+    $server = Start-Process `
+        (Join-Path $serverDir "mediamtx.exe") `
+        -ArgumentList "${env:GITHUB_WORKSPACE}\test\rtsp\mediamtx.yml" `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -WindowStyle Hidden `
+        -PassThru
+
+    $ready = $false
+    for ($attempt = 1; $attempt -le 30; $attempt++) {
+        if ($server.HasExited) {
+            Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+            throw "MediaMTX exited with code $($server.ExitCode)"
+        }
+        if ((Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) -match "stream is available") {
+            $ready = $true
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    if (-not $ready) {
+        Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+        throw "Timed out waiting for MediaMTX"
+    }
+
+    $env:OPENCVSHARP_TEST_RTSP_URL = "rtsp://127.0.0.1:8554/test"
+    dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 `
+        --no-build --no-restore `
+        --filter "FullyQualifiedName=OpenCvSharp.Tests.VideoIO.VideoCaptureTest.ReadRtspStreamWithFFmpeg"
+    if ($LASTEXITCODE -ne 0) {
+        Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+        throw "RTSP integration test failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    if ($server -and -not $server.HasExited) {
+        Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -335,51 +335,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Start local RTSP test server
-        run: |
-          version="${MEDIAMTX_VERSION}"
-          archive_name="mediamtx_v${version}_darwin_arm64.tar.gz"
-          download_base="https://github.com/bluenviron/mediamtx/releases/download/v${version}"
-          server_dir="${RUNNER_TEMP}/mediamtx"
-          archive_path="${RUNNER_TEMP}/${archive_name}"
-          checksums_path="${RUNNER_TEMP}/mediamtx-checksums.sha256"
-
-          curl -fL --retry 5 "${download_base}/${archive_name}" -o "${archive_path}"
-          curl -fL --retry 5 "${download_base}/checksums.sha256" -o "${checksums_path}"
-
-          expected_checksum=$(grep -E "[ *]${archive_name}$" "${checksums_path}" | awk '{print $1}')
-          if [ -z "${expected_checksum}" ]; then
-            echo "Checksum not found for ${archive_name}"
-            exit 1
-          fi
-          actual_checksum=$(shasum -a 256 "${archive_path}" | awk '{print $1}')
-          if [ "${actual_checksum}" != "${expected_checksum}" ]; then
-            echo "Checksum mismatch for ${archive_name}: expected ${expected_checksum}, got ${actual_checksum}"
-            exit 1
-          fi
-
-          mkdir -p "${server_dir}"
-          tar -xzf "${archive_path}" -C "${server_dir}"
-          "${server_dir}/mediamtx" "${GITHUB_WORKSPACE}/test/rtsp/mediamtx.yml" \
-            >"${RUNNER_TEMP}/mediamtx.log" 2>&1 &
-          server_pid=$!
-
-          for attempt in $(seq 1 30); do
-            if ! kill -0 "${server_pid}" 2>/dev/null; then
-              cat "${RUNNER_TEMP}/mediamtx.log"
-              exit 1
-            fi
-            if grep -q "stream is available" "${RUNNER_TEMP}/mediamtx.log"; then
-              echo "OPENCVSHARP_TEST_RTSP_URL=rtsp://127.0.0.1:8554/test" >> "${GITHUB_ENV}"
-              echo "OPENCVSHARP_RTSP_SERVER_PID=${server_pid}" >> "${GITHUB_ENV}"
-              exit 0
-            fi
-            sleep 1
-          done
-
-          cat "${RUNNER_TEMP}/mediamtx.log"
-          exit 1
-
       - name: Test
         run: |
           cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
@@ -396,12 +351,10 @@ jobs:
             --logger "trx;LogFileName=test-results.trx" \
             --blame-crash --blame-crash-dump-type full < /dev/null
 
-      - name: Stop local RTSP test server
-        if: always()
-        run: |
-          if [ -n "${OPENCVSHARP_RTSP_SERVER_PID:-}" ]; then
-            kill "${OPENCVSHARP_RTSP_SERVER_PID}" 2>/dev/null || true
-          fi
+      - name: Test RTSP capture
+        uses: ./.github/actions/test-rtsp-macos
+        with:
+          mediamtx-version: ${{ env.MEDIAMTX_VERSION }}
 
       - name: Test Avalonia extensions
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,7 @@ on:
 env:
   OPENCV_VERSION: 5.0.0
   CACHE_VERSION: "1"
+  MEDIAMTX_VERSION: 1.19.3
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -334,6 +335,51 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Start local RTSP test server
+        run: |
+          version="${MEDIAMTX_VERSION}"
+          archive_name="mediamtx_v${version}_darwin_arm64.tar.gz"
+          download_base="https://github.com/bluenviron/mediamtx/releases/download/v${version}"
+          server_dir="${RUNNER_TEMP}/mediamtx"
+          archive_path="${RUNNER_TEMP}/${archive_name}"
+          checksums_path="${RUNNER_TEMP}/mediamtx-checksums.sha256"
+
+          curl -fL --retry 5 "${download_base}/${archive_name}" -o "${archive_path}"
+          curl -fL --retry 5 "${download_base}/checksums.sha256" -o "${checksums_path}"
+
+          expected_checksum=$(grep -E "[ *]${archive_name}$" "${checksums_path}" | awk '{print $1}')
+          if [ -z "${expected_checksum}" ]; then
+            echo "Checksum not found for ${archive_name}"
+            exit 1
+          fi
+          actual_checksum=$(shasum -a 256 "${archive_path}" | awk '{print $1}')
+          if [ "${actual_checksum}" != "${expected_checksum}" ]; then
+            echo "Checksum mismatch for ${archive_name}: expected ${expected_checksum}, got ${actual_checksum}"
+            exit 1
+          fi
+
+          mkdir -p "${server_dir}"
+          tar -xzf "${archive_path}" -C "${server_dir}"
+          "${server_dir}/mediamtx" "${GITHUB_WORKSPACE}/test/rtsp/mediamtx.yml" \
+            >"${RUNNER_TEMP}/mediamtx.log" 2>&1 &
+          server_pid=$!
+
+          for attempt in $(seq 1 30); do
+            if ! kill -0 "${server_pid}" 2>/dev/null; then
+              cat "${RUNNER_TEMP}/mediamtx.log"
+              exit 1
+            fi
+            if grep -q "stream is available" "${RUNNER_TEMP}/mediamtx.log"; then
+              echo "OPENCVSHARP_TEST_RTSP_URL=rtsp://127.0.0.1:8554/test" >> "${GITHUB_ENV}"
+              echo "OPENCVSHARP_RTSP_SERVER_PID=${server_pid}" >> "${GITHUB_ENV}"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat "${RUNNER_TEMP}/mediamtx.log"
+          exit 1
+
       - name: Test
         run: |
           cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
@@ -349,6 +395,13 @@ jobs:
           DYLD_LIBRARY_PATH=/usr/local/lib:${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime osx-arm64 \
             --logger "trx;LogFileName=test-results.trx" \
             --blame-crash --blame-crash-dump-type full < /dev/null
+
+      - name: Stop local RTSP test server
+        if: always()
+        run: |
+          if [ -n "${OPENCVSHARP_RTSP_SERVER_PID:-}" ]; then
+            kill "${OPENCVSHARP_RTSP_SERVER_PID}" 2>/dev/null || true
+          fi
 
       - name: Test Avalonia extensions
         run: |

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,6 +10,7 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   OPENCV_VERSION: 5.0.0
+  MEDIAMTX_VERSION: 1.19.3
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -204,7 +205,27 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Start local RTSP test server
+        run: |
+          docker run --detach --rm \
+            --name opencvsharp-rtsp \
+            --publish 8554:8554 \
+            --volume "${GITHUB_WORKSPACE}/test/rtsp/mediamtx.yml:/mediamtx.yml:ro" \
+            bluenviron/mediamtx:${MEDIAMTX_VERSION}
+
+          for attempt in $(seq 1 30); do
+            if docker logs opencvsharp-rtsp 2>&1 | grep -q "stream is available"; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs opencvsharp-rtsp
+          exit 1
+
       - name: Test (full)
+        env:
+          OPENCVSHARP_TEST_RTSP_URL: rtsp://127.0.0.1:8554/test
         run: |
           cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
           dotnet build -c Release -f net10.0
@@ -224,6 +245,8 @@ jobs:
       # Headless has the same module set as full except highgui, so it runs the same xunit
       # suite minus the one test class that calls into highgui (WaitKey/PollKey/...).
       - name: Test (headless)
+        env:
+          OPENCVSHARP_TEST_RTSP_URL: rtsp://127.0.0.1:8554/test
         run: |
           cd ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests
           cp ${GITHUB_WORKSPACE}/nuget-headless/libOpenCvSharpExtern-headless.so bin/Release/net10.0/libOpenCvSharpExtern.so
@@ -232,6 +255,10 @@ jobs:
           LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-x64 --no-build \
             --filter "FullyQualifiedName!~OpenCvSharp.Tests.HighGui.HighGuiTest" \
             --logger "trx;LogFileName=test-results-headless.trx" < /dev/null
+
+      - name: Stop local RTSP test server
+        if: always()
+        run: docker stop opencvsharp-rtsp >/dev/null 2>&1 || true
 
       - name: Smoke test (slim)
         run: |

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -211,7 +211,7 @@ jobs:
             --name opencvsharp-rtsp \
             --publish 8554:8554 \
             --volume "${GITHUB_WORKSPACE}/test/rtsp/mediamtx.yml:/mediamtx.yml:ro" \
-            bluenviron/mediamtx:${MEDIAMTX_VERSION}
+            bluenviron/mediamtx:${MEDIAMTX_VERSION}@sha256:7797ed3df88df21e8c04ecd0aff08ce49a5232d1db453e51f5480ef36bc80865
 
           for attempt in $(seq 1 30); do
             if docker logs opencvsharp-rtsp 2>&1 | grep -q "stream is available"; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,7 @@ on:
 env:
   OPENCV_VERSION: "5.0.0"
   MEDIAMTX_VERSION: "1.19.3"
+  MEDIAMTX_SHA256: "5d82148d1032a6a190d9909a2997d9989457aaadf49af87dd02cd4512d31bebe"
 
 jobs:
   build:
@@ -195,6 +196,7 @@ jobs:
         uses: ./.github/actions/test-rtsp-windows
         with:
           mediamtx-version: ${{ env.MEDIAMTX_VERSION }}
+          mediamtx-sha256: ${{ env.MEDIAMTX_SHA256 }}
 
       - name: Upload crash dumps on failure
         if: failure()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   OPENCV_VERSION: "5.0.0"
+  MEDIAMTX_VERSION: "1.19.3"
 
 jobs:
   build:
@@ -174,6 +175,55 @@ jobs:
             -D NO_INSTALL_TO_TEST=ON
           cmake --build src/build_slim --config Release -j 4
 
+      - name: Start local RTSP test server
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = $env:MEDIAMTX_VERSION
+          $archiveName = "mediamtx_v${version}_windows_amd64.zip"
+          $downloadBase = "https://github.com/bluenviron/mediamtx/releases/download/v${version}"
+          $serverDir = Join-Path $env:RUNNER_TEMP "mediamtx"
+          $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
+          $checksumsPath = Join-Path $env:RUNNER_TEMP "mediamtx-checksums.sha256"
+
+          Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
+          Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
+
+          $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
+          if (-not $checksumLine) { throw "Checksum not found for $archiveName" }
+          $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+          $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualChecksum -ne $expectedChecksum) {
+            throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"
+          }
+
+          Expand-Archive $archivePath -DestinationPath $serverDir
+          $stdoutPath = Join-Path $env:RUNNER_TEMP "mediamtx.stdout.log"
+          $stderrPath = Join-Path $env:RUNNER_TEMP "mediamtx.stderr.log"
+          $server = Start-Process `
+            (Join-Path $serverDir "mediamtx.exe") `
+            -ArgumentList "${env:GITHUB_WORKSPACE}\test\rtsp\mediamtx.yml" `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath `
+            -WindowStyle Hidden `
+            -PassThru
+
+          for ($attempt = 1; $attempt -le 30; $attempt++) {
+            if ($server.HasExited) {
+              Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+              throw "MediaMTX exited with code $($server.ExitCode)"
+            }
+            if ((Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) -match "stream is available") {
+              "OPENCVSHARP_TEST_RTSP_URL=rtsp://127.0.0.1:8554/test" | Out-File $env:GITHUB_ENV -Append
+              "OPENCVSHARP_RTSP_SERVER_PID=$($server.Id)" | Out-File $env:GITHUB_ENV -Append
+              exit 0
+            }
+            Start-Sleep -Seconds 1
+          }
+
+          Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+          throw "Timed out waiting for MediaMTX"
+
       - name: Test
         shell: cmd
         # --blame-crash* collects a full memory dump and a Sequence_*.xml (listing tests executed,
@@ -181,6 +231,14 @@ jobs:
         # intermittent native access violation can be attributed to a specific test without a
         # re-run. See "Upload crash dumps on failure" below.
         run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full
+
+      - name: Stop local RTSP test server
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:OPENCVSHARP_RTSP_SERVER_PID) {
+            Stop-Process -Id $env:OPENCVSHARP_RTSP_SERVER_PID -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Upload crash dumps on failure
         if: failure()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,6 +153,14 @@ jobs:
             -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets"
           cmake --build src/build --config Release -j 4
 
+      - name: Verify FFmpeg plugin deployment
+        shell: pwsh
+        run: |
+          $ffmpegPlugin = "test\OpenCvSharp.Tests\opencv_videoio_ffmpeg500_64.dll"
+          if (-not (Test-Path $ffmpegPlugin)) {
+            throw "OpenCV FFmpeg plugin was not deployed to the test project: $ffmpegPlugin"
+          }
+
       - name: Build OpenCvSharpExtern (slim)
         shell: powershell
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -192,71 +192,9 @@ jobs:
         run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full
 
       - name: Test RTSP capture
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $version = $env:MEDIAMTX_VERSION
-          $archiveName = "mediamtx_v${version}_windows_amd64.zip"
-          $downloadBase = "https://github.com/bluenviron/mediamtx/releases/download/v${version}"
-          $serverDir = Join-Path $env:RUNNER_TEMP "mediamtx"
-          $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
-          $checksumsPath = Join-Path $env:RUNNER_TEMP "mediamtx-checksums.sha256"
-          $stdoutPath = Join-Path $env:RUNNER_TEMP "mediamtx.stdout.log"
-          $stderrPath = Join-Path $env:RUNNER_TEMP "mediamtx.stderr.log"
-          $server = $null
-
-          try {
-            Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
-            Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
-
-            $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
-            if (-not $checksumLine) { throw "Checksum not found for $archiveName" }
-            $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
-            $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
-            if ($actualChecksum -ne $expectedChecksum) {
-              throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"
-            }
-
-            Expand-Archive $archivePath -DestinationPath $serverDir
-            $server = Start-Process `
-              (Join-Path $serverDir "mediamtx.exe") `
-              -ArgumentList "${env:GITHUB_WORKSPACE}\test\rtsp\mediamtx.yml" `
-              -RedirectStandardOutput $stdoutPath `
-              -RedirectStandardError $stderrPath `
-              -WindowStyle Hidden `
-              -PassThru
-
-            $ready = $false
-            for ($attempt = 1; $attempt -le 30; $attempt++) {
-              if ($server.HasExited) {
-                Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
-                throw "MediaMTX exited with code $($server.ExitCode)"
-              }
-              if ((Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) -match "stream is available") {
-                $ready = $true
-                break
-              }
-              Start-Sleep -Seconds 1
-            }
-            if (-not $ready) {
-              Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
-              throw "Timed out waiting for MediaMTX"
-            }
-
-            $env:OPENCVSHARP_TEST_RTSP_URL = "rtsp://127.0.0.1:8554/test"
-            dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 `
-              --no-build --no-restore `
-              --filter "FullyQualifiedName=OpenCvSharp.Tests.VideoIO.VideoCaptureTest.ReadRtspStreamWithFFmpeg"
-            if ($LASTEXITCODE -ne 0) {
-              Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
-              throw "RTSP integration test failed with exit code $LASTEXITCODE"
-            }
-          }
-          finally {
-            if ($server -and -not $server.HasExited) {
-              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
-            }
-          }
+        uses: ./.github/actions/test-rtsp-windows
+        with:
+          mediamtx-version: ${{ env.MEDIAMTX_VERSION }}
 
       - name: Upload crash dumps on failure
         if: failure()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -183,7 +183,15 @@ jobs:
             -D NO_INSTALL_TO_TEST=ON
           cmake --build src/build_slim --config Release -j 4
 
-      - name: Start local RTSP test server
+      - name: Test
+        shell: cmd
+        # --blame-crash* collects a full memory dump and a Sequence_*.xml (listing tests executed,
+        # in order) into test\OpenCvSharp.Tests\TestResults\ if the test host crashes, so an
+        # intermittent native access violation can be attributed to a specific test without a
+        # re-run. See "Upload crash dumps on failure" below.
+        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full
+
+      - name: Test RTSP capture
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -193,59 +201,61 @@ jobs:
           $serverDir = Join-Path $env:RUNNER_TEMP "mediamtx"
           $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
           $checksumsPath = Join-Path $env:RUNNER_TEMP "mediamtx-checksums.sha256"
-
-          Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
-          Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
-
-          $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
-          if (-not $checksumLine) { throw "Checksum not found for $archiveName" }
-          $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
-          $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actualChecksum -ne $expectedChecksum) {
-            throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"
-          }
-
-          Expand-Archive $archivePath -DestinationPath $serverDir
           $stdoutPath = Join-Path $env:RUNNER_TEMP "mediamtx.stdout.log"
           $stderrPath = Join-Path $env:RUNNER_TEMP "mediamtx.stderr.log"
-          $server = Start-Process `
-            (Join-Path $serverDir "mediamtx.exe") `
-            -ArgumentList "${env:GITHUB_WORKSPACE}\test\rtsp\mediamtx.yml" `
-            -RedirectStandardOutput $stdoutPath `
-            -RedirectStandardError $stderrPath `
-            -WindowStyle Hidden `
-            -PassThru
+          $server = $null
 
-          for ($attempt = 1; $attempt -le 30; $attempt++) {
-            if ($server.HasExited) {
+          try {
+            Invoke-WebRequest "$downloadBase/$archiveName" -OutFile $archivePath
+            Invoke-WebRequest "$downloadBase/checksums.sha256" -OutFile $checksumsPath
+
+            $checksumLine = Get-Content $checksumsPath | Where-Object { $_ -match "[ *]$([regex]::Escape($archiveName))$" }
+            if (-not $checksumLine) { throw "Checksum not found for $archiveName" }
+            $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+            $actualChecksum = (Get-FileHash $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($actualChecksum -ne $expectedChecksum) {
+              throw "Checksum mismatch for ${archiveName}: expected $expectedChecksum, got $actualChecksum"
+            }
+
+            Expand-Archive $archivePath -DestinationPath $serverDir
+            $server = Start-Process `
+              (Join-Path $serverDir "mediamtx.exe") `
+              -ArgumentList "${env:GITHUB_WORKSPACE}\test\rtsp\mediamtx.yml" `
+              -RedirectStandardOutput $stdoutPath `
+              -RedirectStandardError $stderrPath `
+              -WindowStyle Hidden `
+              -PassThru
+
+            $ready = $false
+            for ($attempt = 1; $attempt -le 30; $attempt++) {
+              if ($server.HasExited) {
+                Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+                throw "MediaMTX exited with code $($server.ExitCode)"
+              }
+              if ((Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) -match "stream is available") {
+                $ready = $true
+                break
+              }
+              Start-Sleep -Seconds 1
+            }
+            if (-not $ready) {
               Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
-              throw "MediaMTX exited with code $($server.ExitCode)"
+              throw "Timed out waiting for MediaMTX"
             }
-            if ((Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) -match "stream is available") {
-              "OPENCVSHARP_TEST_RTSP_URL=rtsp://127.0.0.1:8554/test" | Out-File $env:GITHUB_ENV -Append
-              "OPENCVSHARP_RTSP_SERVER_PID=$($server.Id)" | Out-File $env:GITHUB_ENV -Append
-              exit 0
+
+            $env:OPENCVSHARP_TEST_RTSP_URL = "rtsp://127.0.0.1:8554/test"
+            dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 `
+              --no-build --no-restore `
+              --filter "FullyQualifiedName=OpenCvSharp.Tests.VideoIO.VideoCaptureTest.ReadRtspStreamWithFFmpeg"
+            if ($LASTEXITCODE -ne 0) {
+              Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+              throw "RTSP integration test failed with exit code $LASTEXITCODE"
             }
-            Start-Sleep -Seconds 1
           }
-
-          Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
-          throw "Timed out waiting for MediaMTX"
-
-      - name: Test
-        shell: cmd
-        # --blame-crash* collects a full memory dump and a Sequence_*.xml (listing tests executed,
-        # in order) into test\OpenCvSharp.Tests\TestResults\ if the test host crashes, so an
-        # intermittent native access violation can be attributed to a specific test without a
-        # re-run. See "Upload crash dumps on failure" below.
-        run: dotnet test test\OpenCvSharp.Tests -c Release -f net10.0 --runtime win-x64 --blame-crash --blame-crash-dump-type full
-
-      - name: Stop local RTSP test server
-        if: always()
-        shell: pwsh
-        run: |
-          if ($env:OPENCVSHARP_RTSP_SERVER_PID) {
-            Stop-Process -Id $env:OPENCVSHARP_RTSP_SERVER_PID -Force -ErrorAction SilentlyContinue
+          finally {
+            if ($server -and -not $server.HasExited) {
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+            }
           }
 
       - name: Upload crash dumps on failure

--- a/packaging/docker/manylinux/build_static_deps.sh
+++ b/packaging/docker/manylinux/build_static_deps.sh
@@ -35,6 +35,7 @@ dnf install -y nasm yasm
 # ---------------------------------------------------------------------------
 # FFmpeg (LGPL v2.1+ — statically linked, no patented external codecs)
 # Internal decoders cover H.264, H.265, VP8, VP9, MPEG-4, MPEG-2, and many others.
+# Networking remains enabled so videoio can open RTSP and other network streams.
 # Hwaccel autodetection (vaapi/vdpau/v4l2-m2m) is disabled explicitly: this build
 # never uses hardware acceleration, but if libva happens to be present in the
 # build container, FFmpeg's configure would auto-enable vaapi and silently add
@@ -59,7 +60,7 @@ cd "ffmpeg-${FFMPEG_VERSION}"
     --disable-doc \
     --disable-programs \
     --disable-debug \
-    --disable-network \
+    --enable-network \
     --disable-avdevice \
     --disable-postproc \
     --enable-avcodec \

--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -107,10 +107,9 @@ if(OpenCV_FOUND)
 			COMMENT "Copying OpenCvSharpExtern.dll to test project"
 		)
 
-		# Derive the OpenCV install root from the cmake config path (lib/cmake/opencv4 → root)
-		get_filename_component(OPENCV_INSTALL_PREFIX "${OpenCV_DIR}/../../.." ABSOLUTE)
 		set(OPENCV_VER_STR "${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH}")
-		set(OPENCV_FFMPEG_DLL "${OPENCV_INSTALL_PREFIX}/bin/opencv_videoio_ffmpeg${OPENCV_VER_STR}_64.dll")
+		set(OPENCV_FFMPEG_DLL
+			"${OpenCV_INSTALL_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/bin/opencv_videoio_ffmpeg${OPENCV_VER_STR}_64.dll")
 
 		if(EXISTS "${OPENCV_FFMPEG_DLL}")
 			add_custom_command(TARGET OpenCvSharpExtern POST_BUILD

--- a/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
+++ b/test/OpenCvSharp.Tests/videoio/VideoCaptureTest.cs
@@ -12,6 +12,12 @@ namespace OpenCvSharp.Tests.VideoIO;
         // True only when a real V4L2 device is present (e.g. /dev/video0)
         public static bool HasV4L2Device => IsLinux && Directory.EnumerateFiles("/dev", "video*").Any();
 
+        private const string RtspUrlEnvironmentVariable = "OPENCVSHARP_TEST_RTSP_URL";
+
+        // The CI workflows start a local MediaMTX instance and set this URL.
+        public static bool HasRtspTestUrl =>
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(RtspUrlEnvironmentVariable));
+
         // Backend used for the custom-stream (IStreamReader/Stream) VideoCapture tests below.
         // FFMPEG's custom-stream support (VideoCapture(Ptr<IStreamReader>, ...)) is flaky on the
         // Windows CI runners' prebuilt FFmpeg plugin DLL (createCapture(stream, ...) reports not
@@ -98,6 +104,30 @@ namespace OpenCvSharp.Tests.VideoIO;
             {
                 Window.ShowImages(frame1, frame2, frame3, frame4);
             }
+        }
+
+        [Fact(
+            Skip = $"Set {RtspUrlEnvironmentVariable} to run the RTSP integration test",
+            SkipUnless = nameof(HasRtspTestUrl))]
+        public void ReadRtspStreamWithFFmpeg()
+        {
+            var url = Environment.GetEnvironmentVariable(RtspUrlEnvironmentVariable)!;
+            using var capture = new VideoCapture(
+                url,
+                VideoCaptureAPIs.FFMPEG,
+                [
+                    (int)VideoCaptureProperties.OpenTimeoutMsec, 10_000,
+                    (int)VideoCaptureProperties.ReadTimeoutMsec, 10_000,
+                ]);
+
+            Assert.True(capture.IsOpened());
+            Assert.Equal("FFMPEG", capture.GetBackendName());
+
+            using var frame = new Mat();
+            Assert.True(capture.Read(frame));
+            Assert.False(frame.Empty());
+            Assert.True(frame.Width > 0);
+            Assert.True(frame.Height > 0);
         }
 
         [Fact]

--- a/test/rtsp/mediamtx.yml
+++ b/test/rtsp/mediamtx.yml
@@ -1,0 +1,13 @@
+logLevel: info
+rtspTransports: [tcp]
+rtmp: false
+hls: false
+webrtc: false
+srt: false
+moq: false
+
+paths:
+  test:
+    alwaysAvailable: true
+    alwaysAvailableTracks:
+      - codec: H264


### PR DESCRIPTION
## Summary

- add an environment-gated `VideoCapture` RTSP integration test using the FFmpeg backend
- run a local MediaMTX H.264 stream in the manylinux full and headless test jobs
- run the same test with pinned, checksum-verified MediaMTX binaries on Windows x64 and macOS arm64
- enable FFmpeg networking in the manylinux static dependency build

## Root cause

The FFmpeg libraries statically linked into `OpenCvSharp5.official.runtime.linux-x64` were configured with `--disable-network`. As a result, the FFmpeg videoio backend was present but could not open RTSP URLs. GStreamer is intentionally disabled in the full build, so there was no alternative network videoio backend.

The build now explicitly uses `--enable-network`. Since `build_static_deps.sh` participates in the FFmpeg and OpenCV cache keys, CI will rebuild FFmpeg, OpenCV, and `libOpenCvSharpExtern.so` with networking enabled.

## Test setup

MediaMTX 1.19.3 provides an always-available built-in H.264 segment, so the tests do not depend on a public RTSP endpoint, camera, or separate FFmpeg publisher. The shared configuration exposes only RTSP over TCP.

- manylinux: pinned MediaMTX Docker image
- Windows x64: pinned official Windows binary with SHA-256 verification
- macOS arm64: pinned official Darwin binary with SHA-256 verification
- other local runs: the test is skipped unless `OPENCVSHARP_TEST_RTSP_URL` is set

Windows ARM64 remains excluded because that build currently disables FFmpeg. The macOS x64 job currently builds artifacts without running the test suite, so macOS coverage is provided by the native arm64 runner.

## Validation

- `dotnet build test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release -f net10.0 --no-restore`
- RTSP test against MediaMTX Docker on Windows
- RTSP test against the official native Windows MediaMTX binary
- VideoCapture test suite with the RTSP test skipped when no URL is configured
- MediaMTX Windows and macOS release checksum verification
- `actionlint` for the changed manylinux, Windows, and macOS workflows
- `git diff --check`

Fixes #2083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated RTSP streaming integration tests for macOS, Windows, and Linux using a local Mediamtx RTSP server.
  * Added an environment-variable switch (`OPENCVSHARP_TEST_RTSP_URL`) to enable the RTSP VideoCapture test only in CI.
* **Bug Fixes**
  * Improved Windows FFmpeg plugin handling with an early check that fails the job if the required DLL isn’t found.
* **Chores**
  * Hardened CI RTSP server startup/health checks with readiness polling and improved failure log capture; added best-effort cleanup for the Linux container.
* **Refactor**
  * Adjusted the Windows FFmpeg plugin DLL lookup used during test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->