### PR TITLE
Audit manylinux FFmpeg feature selection

### DIFF
--- a/.github/actions/build-manylinux-variant/action.yml
+++ b/.github/actions/build-manylinux-variant/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Install system tools (${{ inputs.variant_label }})
       shell: bash
       run: |
-        pkgs="git zip unzip nasm yasm pkg-config ninja-build kernel-headers perl-IPC-Cmd perl-Time-Piece"
+        pkgs="git zip unzip pkg-config ninja-build kernel-headers perl-IPC-Cmd perl-Time-Piece"
         if [ "${{ inputs.install_gtk3_devel }}" = "true" ]; then
           pkgs="$pkgs gtk3-devel"
         fi
@@ -104,6 +104,17 @@ runs:
       if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
       shell: bash
       run: bash packaging/docker/manylinux/build_static_deps.sh
+
+    - name: Verify FFmpeg feature surface (${{ inputs.variant_label }})
+      shell: bash
+      run: bash packaging/docker/manylinux/verify_ffmpeg_features.sh
+
+    - name: Upload FFmpeg feature inventory
+      if: inputs.save_shared_caches == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: ffmpeg-feature-inventory
+        path: /opt/ffmpeg/share/opencvsharp/ffmpeg-feature-inventory.txt
 
     - name: Save FFmpeg cache (${{ inputs.variant_label }})
       if: steps.ffmpeg-cache.outputs.cache-hit != 'true' && inputs.save_shared_caches == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -223,8 +234,7 @@ runs:
         cmake --build ${{ inputs.extern_build_dir }} -j
         cp ${{ inputs.extern_build_dir }}/OpenCvSharpExtern/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/${{ inputs.output_so_name }}
 
-    - name: Verify no GTK3/X11/DRM dependency (${{ inputs.variant_label }})
-      if: inputs.verify_no_gui_deps == 'true'
+    - name: Verify ELF dependencies (${{ inputs.variant_label }})
       shell: bash
       run: |
         so_path=${GITHUB_WORKSPACE}/${{ inputs.output_so_name }}
@@ -240,7 +250,7 @@ runs:
           echo "ERROR: readelf found no NEEDED entries at all in ${{ inputs.variant_label }} .so - the check itself is broken, treat as inconclusive"
           exit 1
         fi
-        if echo "$needed" | grep -qi 'libgtk\|libx11\|libdrm'; then
+        if [ "${{ inputs.verify_no_gui_deps }}" = "true" ] && echo "$needed" | grep -qi 'libgtk\|libx11\|libdrm'; then
           echo "ERROR: ${{ inputs.variant_label }} .so unexpectedly depends on GTK3/X11/DRM:"
           echo "$needed"
           exit 1

--- a/packaging/docker/manylinux/README.md
+++ b/packaging/docker/manylinux/README.md
@@ -1,0 +1,11 @@
+# manylinux FFmpeg feature policy
+
+The full and headless `linux-x64` packages statically link the same FFmpeg build. The slim package does not include FFmpeg or OpenCV video I/O.
+
+The FFmpeg build provides OpenCV's required libraries (`avcodec`, `avformat`, `avutil`, and `swscale`), its built-in decoders, encoders, demuxers, and muxers, and non-secure local and network protocols. RTSP, TCP, UDP, HTTP, local files, and pipes are intended to work. CI exercises H.264-over-RTSP through OpenCV and checks a representative baseline of file formats and codecs in the generated feature inventory.
+
+External-library autodetection is disabled. FFmpeg must not silently acquire a dependency merely because the manylinux container adds a development package. The glibc-provided iconv implementation is explicitly enabled and introduces no additional ELF dependency. Hardware acceleration, `libdrm`, `avdevice`, `avfilter`, post-processing, and `swresample` are intentionally excluded because the packaged OpenCV backend does not require them. Assembly remains disabled pending a successful position-independent static link with the current toolchain and a representative H.264 file/RTSP decode benchmark.
+
+TLS is not currently included, so HTTPS and RTSPS are outside the supported feature surface. Adding a TLS backend requires an explicit decision covering license compatibility, CA certificate discovery, binary size, transitive dependencies, manylinux portability, and regression tests.
+
+`build_static_deps.sh` writes the exact configure flags and all enabled protocols, demuxers, muxers, decoders, and encoders to `/opt/ffmpeg/share/opencvsharp/ffmpeg-feature-inventory.txt`. CI uploads that file as the `ffmpeg-feature-inventory` artifact. `verify_ffmpeg_features.sh` reports section counts and fails if the expected baseline disappears, host autodetection is restored, or a TLS backend appears unexpectedly. The final full and headless shared libraries have their ELF `NEEDED` entries printed and validated with `readelf`.

--- a/packaging/docker/manylinux/build_static_deps.sh
+++ b/packaging/docker/manylinux/build_static_deps.sh
@@ -28,14 +28,11 @@ if [[ -f "${INSTALL_PREFIX}/lib/pkgconfig/libavcodec.pc" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# System build tools (nasm/yasm required by FFmpeg's assembly optimisations)
-# ---------------------------------------------------------------------------
-dnf install -y nasm yasm
-
-# ---------------------------------------------------------------------------
 # FFmpeg (LGPL v2.1+ — statically linked, no patented external codecs)
 # Internal decoders cover H.264, H.265, VP8, VP9, MPEG-4, MPEG-2, and many others.
 # Networking remains enabled so videoio can open RTSP and other network streams.
+# External-library autodetection is disabled so the feature set and final ELF
+# dependencies do not change when the manylinux image adds a development package.
 # Hwaccel autodetection (vaapi/vdpau/v4l2-m2m) is disabled explicitly: this build
 # never uses hardware acceleration, but if libva happens to be present in the
 # build container, FFmpeg's configure would auto-enable vaapi and silently add
@@ -51,28 +48,67 @@ curl -fL --retry 5 --retry-delay 2 \
     -o ffmpeg.tar.xz
 tar xf ffmpeg.tar.xz
 cd "ffmpeg-${FFMPEG_VERSION}"
-./configure \
-    --prefix="${INSTALL_PREFIX}" \
-    --enable-static \
-    --disable-shared \
-    --enable-pic \
-    --disable-asm \
-    --disable-doc \
-    --disable-programs \
-    --disable-debug \
-    --enable-network \
-    --disable-avdevice \
-    --disable-postproc \
-    --enable-avcodec \
-    --enable-avformat \
-    --enable-avutil \
-    --enable-swscale \
-    --enable-swresample \
-    --disable-vaapi \
-    --disable-vdpau \
-    --disable-v4l2-m2m \
+
+CONFIGURE_FLAGS=(
+    --prefix="${INSTALL_PREFIX}"
+    --enable-static
+    --disable-shared
+    --enable-pic
+    --disable-asm
+    --disable-autodetect
+    --disable-doc
+    --disable-programs
+    --disable-debug
+    --enable-network
+    --enable-iconv
+    --disable-avdevice
+    --disable-avfilter
+    --disable-postproc
+    --disable-swresample
+    --enable-avcodec
+    --enable-avformat
+    --enable-avutil
+    --enable-swscale
+    --disable-vaapi
+    --disable-vdpau
+    --disable-v4l2-m2m
     --disable-libdrm
+)
+
+./configure "${CONFIGURE_FLAGS[@]}"
 make -j"${NPROC}"
 make install
 
+INVENTORY_DIR="${INSTALL_PREFIX}/share/opencvsharp"
+INVENTORY_PATH="${INVENTORY_DIR}/ffmpeg-feature-inventory.txt"
+mkdir -p "${INVENTORY_DIR}"
+
+{
+    echo "FFmpeg ${FFMPEG_VERSION}"
+    echo
+    echo "[configure-flags]"
+    printf '%s\n' "${CONFIGURE_FLAGS[@]}"
+
+    for component in protocol demuxer muxer decoder encoder; do
+        echo
+        echo "[${component}s]"
+        awk -v suffix="_${component^^}" '
+            $1 == "#define" && $3 == "1" && index($2, "CONFIG_") == 1 &&
+                substr($2, length($2) - length(suffix) + 1) == suffix {
+                name = substr($2, length("CONFIG_") + 1)
+                name = substr(name, 1, length(name) - length(suffix))
+                print tolower(name)
+            }
+        ' config_components.h | sort
+    done
+
+    echo
+    echo "[tls-backends]"
+    for backend in gnutls libtls mbedtls openssl schannel securetransport; do
+        value=$(awk -v macro="CONFIG_${backend^^}" '$1 == "#define" && $2 == macro { print $3 }' config.h)
+        echo "${backend}=${value:-0}"
+    done
+} > "${INVENTORY_PATH}"
+
+echo "FFmpeg feature inventory written to ${INVENTORY_PATH}"
 echo "FFmpeg installed to ${INSTALL_PREFIX}"

--- a/packaging/docker/manylinux/verify_ffmpeg_features.sh
+++ b/packaging/docker/manylinux/verify_ffmpeg_features.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INVENTORY_PATH=${1:-/opt/ffmpeg/share/opencvsharp/ffmpeg-feature-inventory.txt}
+
+if [[ ! -f "${INVENTORY_PATH}" ]]; then
+    echo "ERROR: FFmpeg feature inventory not found: ${INVENTORY_PATH}"
+    exit 1
+fi
+
+feature_enabled()
+{
+    local section=$1
+    local feature=$2
+    awk -v section="[${section}]" -v feature="${feature}" '
+        $0 == section { in_section = 1; next }
+        /^\[/ { in_section = 0 }
+        in_section && $0 == feature { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "${INVENTORY_PATH}"
+}
+
+require_feature()
+{
+    local section=$1
+    local feature=$2
+    if feature_enabled "${section}" "${feature}"; then
+        echo "OK: ${section}/${feature}"
+    else
+        echo "ERROR: required FFmpeg feature is disabled: ${section}/${feature}"
+        return 1
+    fi
+}
+
+for protocol in file pipe tcp udp; do
+    require_feature protocols "${protocol}"
+done
+
+for demuxer in matroska mov rtsp; do
+    require_feature demuxers "${demuxer}"
+done
+
+for muxer in avi matroska mov; do
+    require_feature muxers "${muxer}"
+done
+
+for decoder in h264 hevc mjpeg mpeg4 vp8 vp9; do
+    require_feature decoders "${decoder}"
+done
+
+for encoder in ffv1 mjpeg mpeg4 rawvideo; do
+    require_feature encoders "${encoder}"
+done
+
+for protocol in https tls; do
+    if feature_enabled protocols "${protocol}"; then
+        echo "ERROR: secure protocol is enabled without an approved TLS dependency policy: ${protocol}"
+        exit 1
+    fi
+done
+
+if ! grep -qx -- '--disable-autodetect' "${INVENTORY_PATH}"; then
+    echo "ERROR: FFmpeg was built without --disable-autodetect"
+    exit 1
+fi
+
+if grep -Eq '^(gnutls|libtls|mbedtls|openssl|schannel|securetransport)=1$' "${INVENTORY_PATH}"; then
+    echo "ERROR: an unapproved TLS backend was enabled"
+    grep -E '^(gnutls|libtls|mbedtls|openssl|schannel|securetransport)=' "${INVENTORY_PATH}"
+    exit 1
+fi
+
+echo
+for section in protocols demuxers muxers decoders encoders; do
+    count=$(awk -v section="[${section}]" '
+        $0 == section { in_section = 1; next }
+        /^\[/ { in_section = 0 }
+        in_section && NF { count++ }
+        END { print count + 0 }
+    ' "${INVENTORY_PATH}")
+    echo "${section}: ${count} enabled"
+done
+echo "Full inventory: ${INVENTORY_PATH}"


### PR DESCRIPTION
Make the manylinux full/headless FFmpeg feature selection reproducible by disabling external-library autodetection and explicitly selecting the libraries OpenCV needs. Remove unused `avfilter`, `swresample`, `avdevice`, and asm-only build tools while keeping assembly disabled.

Generate and validate an inventory of enabled protocols, demuxers, muxers, decoders, and encoders, upload it from CI, and run the existing `readelf` dependency check for both full and headless builds. Document the intended package feature surface and the current lack of TLS support.

Assembly re-enablement and TLS backend selection remain follow-up work requiring the benchmarks and dependency/license evaluation described in #2085.

Refs #2085

## Test plan

- [x] Configure and compile FFmpeg 7.1.1 in the `manylinux_2_28_x86_64` container
- [x] Validate the generated feature inventory and required RTSP/H.264 baseline
- [x] Run Bash syntax checks and ShellCheck
- [x] Run actionlint
- [x] Run `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Packaging**
  * Standardized FFmpeg capabilities across manylinux builds for more predictable video and streaming support.
  * Added validation for required codecs, containers, protocols, and security-related features.
  * Published an FFmpeg feature inventory artifact to improve build transparency.
  * Added dependency checks to prevent unintended graphical libraries in headless outputs.

* **Documentation**
  * Documented FFmpeg support by package variant, including supported and excluded capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->