### PR TITLE
Migrate and expand OpenCvSharp usage guides

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -258,6 +258,8 @@ There is no custom native-library loader. Since `src/OpenCvSharp/` requires net8
 
 This repo has no `PULL_REQUEST_TEMPLATE.md`, so there's no fixed checklist to fill in — but that doesn't mean invent your own heading structure (`### Description`, `### Changes`, etc.). Look at a few recently merged PRs' bodies first and match their shape: a short plain-prose summary (no invented headings), optionally followed by a `## Test plan` checklist when the change needs one. Keep it terse — a large, sectioned write-up reads as noticeably more "AI-generated" than the plain style this repo's own history uses.
 
+When an agent creates a pull request or issue, it must inspect the repository's existing labels and apply at least one relevant label whenever a semantically appropriate label exists. If no existing label applies, explicitly report that instead of silently leaving the item unlabeled. Whenever an agent creates a pull request in this repository, it must also assign the pull request to `@shimat`. Verify both labels and assignees after creation before reporting the item as complete.
+
 ## Issue backlog
 
 `docs/issue-backlog.md` tracks actionable issues identified from closed/stale GitHub issues. Update the checkboxes as items are resolved.

--- a/docs/docfx/articles/guides/feature-detection-and-matching.md
+++ b/docs/docfx/articles/guides/feature-detection-and-matching.md
@@ -1,0 +1,112 @@
+# Feature Detection and Matching
+
+Local features describe visually distinctive points so that the same scene or object can be associated across images. A typical workflow detects keypoints, computes a descriptor for each point, matches descriptors, and rejects ambiguous matches.
+
+This guide replaces the old per-algorithm Wiki examples for BRISK, ORB, FREAK, MSER, SIFT, SURF, and StarDetector. Those short examples used obsolete APIs and did not explain how detector, descriptor, and matcher choices must agree.
+
+## Choose a feature algorithm
+
+| Algorithm | Descriptor | Matcher norm | Typical reason to choose it |
+|---|---|---|---|
+| ORB | Binary | `Hamming` | Fast general-purpose baseline with no extra model files |
+| BRISK | Binary | `Hamming` | Binary features with scale and rotation handling |
+| AKAZE | Usually binary | `Hamming` | Nonlinear scale-space features |
+| SIFT | Floating point | `L2` | More robust matching when computation cost is acceptable |
+
+Some algorithms only detect keypoints, and some only compute descriptors. For example, MSER detects regions and FREAK computes a descriptor for supplied keypoints. Combine such components only when their keypoint and descriptor requirements are compatible.
+
+Algorithms under `xfeatures2d`, including SURF and FREAK, require a runtime package that contains the corresponding OpenCV contrib module. Prefer a core algorithm such as ORB or SIFT unless a contrib algorithm is specifically required.
+
+## Match two images with ORB
+
+The following example uses two-nearest-neighbor matching and Lowe's ratio test to discard ambiguous matches:
+
+```csharp
+using OpenCvSharp;
+
+using var image1 = Cv2.ImRead("object.jpg", ImreadModes.Grayscale);
+using var image2 = Cv2.ImRead("scene.jpg", ImreadModes.Grayscale);
+if (image1.Empty() || image2.Empty())
+{
+    throw new FileNotFoundException("Could not decode one or both input images.");
+}
+
+using var orb = ORB.Create(nFeatures: 1_000);
+using var descriptors1 = new Mat();
+using var descriptors2 = new Mat();
+
+orb.DetectAndCompute(image1, default, out KeyPoint[] keypoints1, descriptors1);
+orb.DetectAndCompute(image2, default, out KeyPoint[] keypoints2, descriptors2);
+
+if (descriptors1.Empty() || descriptors2.Empty())
+{
+    throw new InvalidOperationException("No descriptors were found in one or both images.");
+}
+
+using var matcher = new BFMatcher(NormTypes.Hamming);
+DMatch[][] nearestNeighbors = matcher.KnnMatch(
+    descriptors1,
+    descriptors2,
+    k: 2);
+
+DMatch[] goodMatches = nearestNeighbors
+    .Where(matches => matches.Length == 2)
+    .Where(matches => matches[0].Distance < 0.75f * matches[1].Distance)
+    .Select(matches => matches[0])
+    .ToArray();
+
+using var visualization = new Mat();
+Cv2.DrawMatches(
+    image1,
+    keypoints1,
+    image2,
+    keypoints2,
+    goodMatches,
+    visualization,
+    flags: DrawMatchesFlags.NotDrawSinglePoints);
+
+Cv2.ImWrite("matches.jpg", visualization);
+```
+
+The ratio `0.75` is a starting point, not a universal threshold. A lower value keeps fewer, less ambiguous matches. Evaluate it against representative data.
+
+## Match the norm to the descriptor
+
+The matcher compares descriptor rows. Binary descriptors such as ORB and BRISK represent bit patterns and require Hamming distance. Floating-point descriptors such as SIFT require L2 distance.
+
+Using the wrong norm may produce poor results even though the code compiles:
+
+```csharp
+using var orbMatcher = new BFMatcher(NormTypes.Hamming);
+using var siftMatcher = new BFMatcher(NormTypes.L2);
+```
+
+ORB with `WTA_K` equal to 3 or 4 requires `NormTypes.Hamming2` instead of `Hamming`.
+
+## Matching is not geometric verification
+
+Descriptor similarity alone does not prove that all accepted pairs belong to one object or scene transformation. For planar objects, estimate a homography with RANSAC from the matched keypoint coordinates and keep only inliers. For 3D scenes or calibrated cameras, choose a geometric model appropriate to the application.
+
+Good production checks often include:
+
+- A minimum number of accepted matches.
+- A minimum number or ratio of geometric inliers.
+- Limits on the estimated scale, orientation, or projected shape.
+- Tests on images that contain no valid match.
+
+## Reuse algorithm objects
+
+Creating detectors and matchers for every frame adds unnecessary overhead. In a video or service pipeline, create them once, reuse them for sequential calls, and dispose them when the pipeline shuts down. Do not use one mutable native algorithm instance concurrently from multiple threads unless the underlying OpenCV API documents that use as safe.
+
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [Image Processing Pipeline](image-processing-pipeline.md)
+- [Resource Management](resource-management.md)
+
+## Related API
+
+- [ORB](xref:OpenCvSharp.ORB)
+- [SIFT](xref:OpenCvSharp.SIFT)
+- [BFMatcher](xref:OpenCvSharp.BFMatcher)
+- [Cv2.DrawMatches](xref:OpenCvSharp.Cv2.DrawMatches*)

--- a/docs/docfx/articles/guides/file-storage.md
+++ b/docs/docfx/articles/guides/file-storage.md
@@ -1,0 +1,77 @@
+# File Storage
+
+OpenCV `FileStorage` reads and writes matrices, scalars, sequences, and mappings in YAML, XML, or JSON. It is useful for calibration data and OpenCV-compatible model parameters. For ordinary application configuration, a .NET serializer may provide a more natural object model.
+
+## Write values and a matrix
+
+The file extension selects the format:
+
+```csharp
+using Mat transform = Mat.Eye(3, 3, MatType.CV_64FC1);
+
+using var storage = new FileStorage("settings.yml", FileStorage.Modes.Write);
+if (!storage.IsOpened())
+{
+    throw new InvalidOperationException("Could not open settings.yml for writing.");
+}
+
+storage.Write("threshold", 128);
+storage.Write("name", "example");
+storage.Write("transform", transform);
+```
+
+Use `.xml`, `.yml` or `.yaml`, and `.json` for the corresponding formats. Append `.gz` to write or read a compressed XML or YAML file.
+
+## Read values and a matrix
+
+`FileStorage` indexers return `FileNode` objects that own native resources. Dispose each node after reading it:
+
+```csharp
+using var storage = new FileStorage("settings.yml", FileStorage.Modes.Read);
+if (!storage.IsOpened())
+{
+    throw new InvalidOperationException("Could not open settings.yml.");
+}
+
+using var thresholdNode = storage["threshold"]
+    ?? throw new InvalidDataException("Missing threshold.");
+using var nameNode = storage["name"]
+    ?? throw new InvalidDataException("Missing name.");
+using var transformNode = storage["transform"]
+    ?? throw new InvalidDataException("Missing transform.");
+
+int threshold = thresholdNode.ReadInt();
+string name = nameNode.ReadString();
+using Mat transform = transformNode.ReadMat();
+```
+
+The returned `Mat` owns its native data and must also be disposed.
+
+## Work with an in-memory document
+
+Combine `Modes.Memory` with the write or read mode:
+
+```csharp
+string yaml;
+using (var writer = new FileStorage("yml", FileStorage.Modes.Write | FileStorage.Modes.Memory))
+{
+    writer.Write("answer", 42);
+    yaml = writer.ReleaseAndGetString();
+}
+
+using var reader = new FileStorage(yaml, FileStorage.Modes.Read | FileStorage.Modes.Memory);
+using var answerNode = reader["answer"]
+    ?? throw new InvalidDataException("Missing answer.");
+int answer = answerNode.ReadInt();
+```
+
+When writing in memory, the first constructor argument identifies the output format rather than a file path.
+
+## Nested data
+
+`FileStorage.Add` writes sequences and mappings using OpenCV's streaming syntax. `FileStorage.GetPath` reads a nested path while disposing intermediate `FileNode` instances. Prefer `GetPath` over a long indexer chain when reading nested data.
+
+## Related API
+
+- [FileStorage](xref:OpenCvSharp.FileStorage)
+- [FileNode](xref:OpenCvSharp.FileNode)

--- a/docs/docfx/articles/guides/histograms-and-contrast.md
+++ b/docs/docfx/articles/guides/histograms-and-contrast.md
@@ -1,0 +1,146 @@
+# Histograms and Contrast
+
+An image histogram counts how many pixels fall into each intensity range. Histograms are useful for diagnosing exposure, comparing image distributions, selecting thresholds, and improving contrast.
+
+## Calculate a grayscale histogram
+
+This example calculates 256 bins over the complete intensity range of an 8-bit grayscale image:
+
+```csharp
+using OpenCvSharp;
+
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Grayscale);
+if (source.Empty())
+{
+    throw new FileNotFoundException("Could not decode input.jpg.");
+}
+
+using var histogram = new Mat();
+Cv2.CalcHist(
+    images: [source],
+    channels: [0],
+    mask: default,
+    hist: histogram,
+    dims: 1,
+    histSize: [256],
+    ranges: [new Rangef(0, 256)]);
+
+float darkPixelCount = histogram.At<float>(32);
+Console.WriteLine($"Pixels with intensity 32: {darkPixelCount}");
+```
+
+The result is a `CV_32FC1` matrix with one row per bin. The range end is exclusive, so `[0, 256)` covers every possible value in an 8-bit image.
+
+## Plot the histogram
+
+Normalize the bin counts to the plot height before drawing them:
+
+```csharp
+const int plotWidth = 512;
+const int plotHeight = 300;
+
+using var normalized = new Mat();
+Cv2.Normalize(
+    histogram,
+    normalized,
+    alpha: 0,
+    beta: plotHeight - 1,
+    normType: NormTypes.MinMax);
+
+using var plot = new Mat(
+    rows: plotHeight,
+    cols: plotWidth,
+    type: MatType.CV_8UC3,
+    s: Scalar.White);
+
+int binWidth = plotWidth / 256;
+for (int bin = 1; bin < 256; bin++)
+{
+    int previousHeight = (int)Math.Round(normalized.At<float>(bin - 1));
+    int currentHeight = (int)Math.Round(normalized.At<float>(bin));
+
+    Cv2.Line(
+        plot,
+        new Point((bin - 1) * binWidth, plotHeight - 1 - previousHeight),
+        new Point(bin * binWidth, plotHeight - 1 - currentHeight),
+        Scalar.Black,
+        thickness: 2);
+}
+
+Cv2.ImWrite("histogram.png", plot);
+```
+
+Normalization here is only for display. Preserve the original histogram when its counts or proportions will be used in later calculations.
+
+## Limit calculation to a region
+
+`CalcHist` accepts an 8-bit single-channel mask. Nonzero mask pixels select the source pixels to include:
+
+```csharp
+using var mask = new Mat(source.Size(), MatType.CV_8UC1, Scalar.Black);
+Cv2.Rectangle(
+    mask,
+    new Rect(50, 40, 200, 150),
+    Scalar.White,
+    thickness: -1);
+
+using var regionHistogram = new Mat();
+Cv2.CalcHist(
+    images: [source],
+    channels: [0],
+    mask: mask,
+    hist: regionHistogram,
+    dims: 1,
+    histSize: [256],
+    ranges: [new Rangef(0, 256)]);
+```
+
+The mask must have the same width and height as the source image.
+
+## Improve grayscale contrast
+
+Global histogram equalization redistributes intensities across the complete image:
+
+```csharp
+using var equalized = new Mat();
+Cv2.EqualizeHist(source, equalized);
+```
+
+It works on an 8-bit single-channel source. It can over-amplify noise or produce unnatural results when illumination varies across the image.
+
+Contrast Limited Adaptive Histogram Equalization (CLAHE) processes local tiles and limits amplification:
+
+```csharp
+using var clahe = Cv2.CreateCLAHE(
+    clipLimit: 2.0,
+    tileGridSize: new Size(8, 8));
+using var improved = new Mat();
+
+clahe.Apply(source, improved);
+Cv2.ImWrite("improved.png", improved);
+```
+
+Treat `clipLimit` and `tileGridSize` as parameters to tune against representative images. Smaller tiles adapt to more local variation but can emphasize noise and tile boundaries.
+
+## Color histograms
+
+For a BGR image, channel index 0 is blue, 1 is green, and 2 is red. Separate BGR channel histograms describe the storage channels, but they are often poor measures of perceived color similarity. Convert to a color space such as HSV or Lab first when hue, saturation, or perceptual brightness is the quantity of interest.
+
+## Common mistakes
+
+- Match the histogram range to the source depth and the intended values; `[0, 256)` is specific to an 8-bit intensity channel.
+- Do not compare raw bin counts from images or masks containing different numbers of pixels. Normalize the histograms first.
+- Histogram similarity does not preserve spatial layout. Two visually different images can have the same histogram.
+- Use a mask for a region of interest when the surrounding background would dominate the distribution.
+
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [Image Processing Pipeline](image-processing-pipeline.md)
+- [Pixel Access](pixel-access.md)
+
+## Related API
+
+- [Cv2.CalcHist](xref:OpenCvSharp.Cv2.CalcHist*)
+- [Cv2.EqualizeHist](xref:OpenCvSharp.Cv2.EqualizeHist*)
+- [CLAHE](xref:OpenCvSharp.CLAHE)

--- a/docs/docfx/articles/guides/image-conversion.md
+++ b/docs/docfx/articles/guides/image-conversion.md
@@ -1,0 +1,82 @@
+# Image Encoding and Conversion
+
+An OpenCvSharp `Mat` stores decoded pixel data. A PNG or JPEG `byte[]` stores a compressed image file. UI frameworks such as GDI+ and WPF use their own decoded bitmap types. Choose the conversion that matches the representation needed by the application.
+
+## Encode a Mat to PNG or JPEG
+
+`Cv2.ImEncode` compresses a matrix into an image-file buffer. The extension selects the encoder:
+
+```csharp
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+
+if (!Cv2.ImEncode(".png", image, out byte[] pngBytes))
+{
+    throw new InvalidOperationException("PNG encoding failed.");
+}
+
+await File.WriteAllBytesAsync("copy.png", pngBytes);
+```
+
+`Mat.ToBytes` is a convenience wrapper around `Cv2.ImEncode`:
+
+```csharp
+byte[] jpegBytes = image.ToBytes(
+    ".jpg",
+    [new ImageEncodingParam(ImwriteFlags.JpegQuality, 90)]);
+```
+
+Encoding allocates a new managed byte array containing a complete compressed image file.
+
+## Decode an image buffer to a Mat
+
+Use `Cv2.ImDecode` when the application already has encoded image bytes:
+
+```csharp
+byte[] encoded = await File.ReadAllBytesAsync("input.png");
+using Mat image = Cv2.ImDecode(encoded, ImreadModes.Color);
+
+if (image.Empty())
+{
+    throw new InvalidOperationException("Image decoding failed.");
+}
+```
+
+`Mat.FromImageData` and `Mat.ImDecode` are convenience alternatives that call the same OpenCV decoder.
+
+Do not use `ImDecode` for a raw pixel buffer. Raw pixels require dimensions, channel layout, depth, and row stride; construct a `Mat` with the appropriate `FromPixelData` overload instead.
+
+## Convert between Mat and System.Drawing.Bitmap
+
+GDI+ conversion is Windows-only. Install `OpenCvSharp5.GdipExtensions`, or use the `OpenCvSharp5.Windows` convenience package, and import `OpenCvSharp.GdipExtensions`:
+
+```csharp
+using System.Drawing;
+using OpenCvSharp;
+using OpenCvSharp.GdipExtensions;
+
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+using Bitmap bitmap = image.ToBitmap();
+using Mat roundTrip = bitmap.ToMat();
+```
+
+Dispose both `Bitmap` and `Mat`. The converter supports common 1-, 3-, and 4-channel 8-bit formats. It does not make `System.Drawing.Common` cross-platform.
+
+## WPF
+
+Install `OpenCvSharp5.WpfExtensions` and use the converters in `OpenCvSharp.WpfExtensions`:
+
+- `BitmapSourceConverter.ToBitmapSource` converts a `Mat` to an immutable `BitmapSource`.
+- `WriteableBitmapConverter.ToWriteableBitmap` converts a `Mat` to a `WriteableBitmap`.
+- `WriteableBitmapConverter.ToMat` converts a `WriteableBitmap` to a `Mat`.
+
+Check pixel format and channel order when exchanging images with a UI framework. OpenCvSharp color matrices normally use BGR or BGRA order, while another API may describe the same bytes with a different format name or expect RGB/RGBA.
+
+## Avoid unnecessary round trips
+
+For file uploads, HTTP responses, and database blobs, encode directly with `Cv2.ImEncode` instead of converting through `Bitmap`. For image processing, keep data in `Mat` form and convert only at the UI boundary.
+
+## Related API
+
+- [Cv2.ImEncode](xref:OpenCvSharp.Cv2.ImEncode*)
+- [Cv2.ImDecode](xref:OpenCvSharp.Cv2.ImDecode*)
+- [Mat](xref:OpenCvSharp.Mat)

--- a/docs/docfx/articles/guides/image-processing-pipeline.md
+++ b/docs/docfx/articles/guides/image-processing-pipeline.md
@@ -1,0 +1,101 @@
+# Build an Image Processing Pipeline
+
+Most classical computer vision programs follow a pipeline: load an image, normalize it into the representation an algorithm expects, isolate interesting pixels, extract objects, and produce a result. This example detects sufficiently large bright regions and draws their contours.
+
+## Complete example
+
+```csharp
+using OpenCvSharp;
+
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new FileNotFoundException("Could not decode input.jpg.");
+}
+
+using var grayscale = new Mat();
+Cv2.CvtColor(source, grayscale, ColorConversionCodes.BGR2GRAY);
+
+using var blurred = new Mat();
+Cv2.GaussianBlur(grayscale, blurred, new Size(5, 5), sigmaX: 0);
+
+using var binary = new Mat();
+Cv2.Threshold(
+    blurred,
+    binary,
+    thresh: 0,
+    maxval: 255,
+    type: ThresholdTypes.Binary | ThresholdTypes.Otsu);
+
+using var kernel = Cv2.GetStructuringElement(MorphShapes.Rect, new Size(3, 3));
+using var cleaned = new Mat();
+Cv2.MorphologyEx(binary, cleaned, MorphTypes.Open, kernel);
+
+Cv2.FindContours(
+    cleaned,
+    out Point[][] contours,
+    out _,
+    RetrievalModes.External,
+    ContourApproximationModes.ApproxSimple);
+
+Point[][] significantContours = contours
+    .Where(contour => Cv2.ContourArea(contour) >= 100)
+    .ToArray();
+
+using var annotated = source.Clone();
+Cv2.DrawContours(
+    annotated,
+    significantContours,
+    contourIdx: -1,
+    color: Scalar.Red,
+    thickness: 2);
+
+Cv2.ImWrite("result.png", annotated);
+```
+
+## What each stage does
+
+### Normalize the input
+
+`CvtColor` produces a single-channel image because thresholding intensity is easier to reason about than thresholding three BGR channels independently. Choose the color conversion that matches the meaning of the input; `BGR2GRAY` is only one possibility.
+
+### Reduce noise
+
+`GaussianBlur` suppresses small intensity variations before thresholding. Kernel size and sigma affect how much detail is removed. Avoid copying a kernel size from an example without checking it against the size of objects in the real images.
+
+### Create a binary mask
+
+The combination of `Binary` and `Otsu` asks OpenCV to estimate one global threshold from the image histogram. It is a good baseline for images with two well-separated intensity groups. Uneven illumination may require `AdaptiveThreshold`, illumination correction, or a different segmentation method.
+
+### Clean the mask
+
+Morphological opening removes small foreground spots. Closing instead fills small holes and gaps. The structuring-element shape and size encode what counts as "small," so they should be treated as model parameters rather than universal constants.
+
+### Extract and filter objects
+
+`FindContours` returns arrays of points around connected shapes. `RetrievalModes.External` ignores nested contours, which is appropriate when only outer boundaries matter. Filter by area, geometry, or domain-specific measurements before drawing or analyzing the result.
+
+## Debug a pipeline stage by stage
+
+Save intermediate images while tuning a pipeline:
+
+```csharp
+Cv2.ImWrite("debug-01-grayscale.png", grayscale);
+Cv2.ImWrite("debug-02-binary.png", binary);
+Cv2.ImWrite("debug-03-cleaned.png", cleaned);
+```
+
+When a final result is wrong, intermediate images show which stage first lost the desired information. This is usually more useful than tuning several parameters at once.
+
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [Pixel Access](pixel-access.md)
+- [Resource Management](resource-management.md)
+
+## Related API
+
+- [Cv2.CvtColor](xref:OpenCvSharp.Cv2.CvtColor*)
+- [Cv2.Threshold](xref:OpenCvSharp.Cv2.Threshold*)
+- [Cv2.MorphologyEx](xref:OpenCvSharp.Cv2.MorphologyEx*)
+- [Cv2.FindContours](xref:OpenCvSharp.Cv2.FindContours*)

--- a/docs/docfx/articles/guides/mat-basics.md
+++ b/docs/docfx/articles/guides/mat-basics.md
@@ -1,0 +1,127 @@
+# Mat Basics
+
+`Mat` is the central data container in OpenCV. It can represent an image, a numeric matrix, or a multidimensional tensor. Understanding its type, ownership, and copy behavior prevents many subtle bugs.
+
+## Inspect a matrix
+
+Always check that file loading succeeded before processing an image:
+
+```csharp
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (image.Empty())
+{
+    throw new FileNotFoundException("Could not decode input.jpg.");
+}
+
+Console.WriteLine($"Size: {image.Width} x {image.Height}");
+Console.WriteLine($"Type: {image.Type()}");
+Console.WriteLine($"Depth: {image.Depth()}");
+Console.WriteLine($"Channels: {image.Channels()}");
+```
+
+`ImRead` does not throw merely because a file is missing or cannot be decoded. It returns an empty `Mat`.
+
+## Understand MatType
+
+A `MatType` combines element depth and channel count. For example, `CV_8UC3` means:
+
+- `8U`: each channel is an unsigned 8-bit integer.
+- `C3`: each element contains three channels.
+
+A normal color image loaded with `ImreadModes.Color` is usually `CV_8UC3`, with channels in BGR order. A grayscale image is usually `CV_8UC1`. Algorithms may require a specific depth or channel count, so inspect the input and perform an explicit conversion when necessary.
+
+## Create a matrix
+
+The following creates a 640 by 480 black BGR image and draws a filled blue rectangle:
+
+```csharp
+using var canvas = new Mat(
+    rows: 480,
+    cols: 640,
+    type: MatType.CV_8UC3,
+    s: Scalar.Black);
+
+Cv2.Rectangle(
+    canvas,
+    new Rect(40, 30, 200, 120),
+    Scalar.Blue,
+    thickness: -1);
+```
+
+The first dimension is rows (height) and the second is columns (width).
+
+## Regions of interest share data
+
+A region of interest is a lightweight view over the original matrix:
+
+```csharp
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+using var region = image.SubMat(new Rect(X: 20, Y: 30, Width: 100, Height: 80));
+
+region.SetTo(Scalar.Black);
+```
+
+Changing `region` also changes the corresponding pixels in `image`. Keep the parent matrix alive for at least as long as the region.
+
+Use `Clone` when an independent copy is required:
+
+```csharp
+using var copy = image.Clone(new Rect(X: 20, Y: 30, Width: 100, Height: 80));
+copy.SetTo(Scalar.Black);
+```
+
+Changing `copy` does not affect `image`.
+
+## Convert depth and color separately
+
+`ConvertTo` changes the element depth and optionally applies a scale and offset, but it does not perform color conversion:
+
+```csharp
+using var source8Bit = Cv2.ImRead("input.png", ImreadModes.Grayscale);
+using var normalized = new Mat();
+
+source8Bit.ConvertTo(normalized, MatType.CV_32FC1, alpha: 1.0 / 255.0);
+```
+
+Use `CvtColor` to change the color representation or channel count:
+
+```csharp
+using var color = Cv2.ImRead("input.jpg", ImreadModes.Color);
+using var grayscale = new Mat();
+
+Cv2.CvtColor(color, grayscale, ColorConversionCodes.BGR2GRAY);
+```
+
+## Wrap existing pixel data
+
+`Mat.FromPixelData` creates a matrix header over an existing managed array without copying it:
+
+```csharp
+byte[] pixels =
+[
+    0, 64,
+    128, 255,
+];
+
+using var image = Mat.FromPixelData(
+    rows: 2,
+    cols: 2,
+    type: MatType.CV_8UC1,
+    data: pixels);
+
+Cv2.BitwiseNot(image, image);
+```
+
+The array is pinned while the `Mat` is alive, and changes are shared in both directions. Call `Clone` if OpenCV needs to own an independent copy. When using the `IntPtr` overload, the caller is responsible for keeping the underlying unmanaged memory valid and eventually releasing it.
+
+## Related guides
+
+- [Pixel Access](pixel-access.md)
+- [Resource Management](resource-management.md)
+- [Image Encoding and Conversion](image-conversion.md)
+
+## Related API
+
+- [Mat](xref:OpenCvSharp.Mat)
+- [MatType](xref:OpenCvSharp.MatType)
+- [Cv2](xref:OpenCvSharp.Cv2)

--- a/docs/docfx/articles/guides/pixel-access.md
+++ b/docs/docfx/articles/guides/pixel-access.md
@@ -1,0 +1,89 @@
+# Pixel Access
+
+OpenCvSharp provides several ways to access matrix elements. Use `Mat.At<T>` for occasional access and `Mat.AsRows<T>` for loops that process many pixels. Prefer an OpenCV operation such as `Cv2.CvtColor`, `Cv2.LUT`, or `Cv2.Transform` when one already expresses the operation because native operations are usually faster than a managed pixel loop.
+
+## Match the element type
+
+The generic type must match the complete element type of the matrix, including its depth and channel count.
+
+| Mat type | C# element type |
+|---|---|
+| `CV_8UC1` | `byte` |
+| `CV_8UC3` | `Vec3b` |
+| `CV_8UC4` | `Vec4b` |
+| `CV_16SC1` | `short` |
+| `CV_32FC1` | `float` |
+| `CV_64FC1` | `double` |
+
+OpenCV stores color images in BGR order by default, so `Vec3b.Item0`, `Item1`, and `Item2` represent blue, green, and red respectively.
+
+## Access an occasional pixel
+
+`At<T>` returns a reference, so it can both read and update an element:
+
+```csharp
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (image.Type() != MatType.CV_8UC3)
+{
+    throw new InvalidOperationException($"Expected CV_8UC3, but received {image.Type()}.");
+}
+
+ref Vec3b pixel = ref image.At<Vec3b>(10, 20);
+byte blue = pixel.Item0;
+pixel.Item0 = pixel.Item2;
+pixel.Item2 = blue;
+```
+
+The first coordinate is the row (`y`) and the second coordinate is the column (`x`).
+
+## Process every pixel
+
+`AsRows<T>` captures the matrix data pointer and row stride once. It handles non-contiguous matrices and row padding, so it is suitable for both complete images and regions of interest:
+
+```csharp
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (image.Type() != MatType.CV_8UC3)
+{
+    throw new InvalidOperationException($"Expected CV_8UC3, but received {image.Type()}.");
+}
+
+var rows = image.AsRows<Vec3b>();
+for (int y = 0; y < rows.Count; y++)
+{
+    Span<Vec3b> row = rows[y];
+    for (int x = 0; x < row.Length; x++)
+    {
+        ref Vec3b pixel = ref row[x];
+        byte blue = pixel.Item0;
+        pixel.Item0 = pixel.Item2;
+        pixel.Item2 = blue;
+    }
+}
+```
+
+This example swaps the blue and red channels. For this particular operation, `Cv2.CvtColor(image, image, ColorConversionCodes.BGR2RGB)` is simpler and normally faster; the loop demonstrates access for operations that cannot be expressed by an existing OpenCV function.
+
+## Access a single row
+
+Use `RowSpan<T>` when only one row is needed:
+
+```csharp
+Span<byte> firstRow = grayscale.RowSpan<byte>(0);
+firstRow.Fill(0);
+```
+
+The span excludes any padding bytes between rows.
+
+## Continuous matrices
+
+`AsSpan<T>` returns a span over the entire matrix only when `Mat.IsContinuous()` is true. It returns an empty span for a non-contiguous matrix. Prefer `AsRows<T>` unless the algorithm specifically requires one flat continuous buffer.
+
+## Obsolete indexers
+
+`GetGenericIndexer<T>` and its indexer class use marshaling for each element and are obsolete. Existing code should move to `At<T>` or `AsRows<T>`. `Mat<T>.GetIndexer()` remains available, but `AsRows<T>` avoids creating a typed wrapper and makes row-stride handling explicit.
+
+## Related API
+
+- [Mat](xref:OpenCvSharp.Mat)
+- [MatRowAccessor&lt;T&gt;](xref:OpenCvSharp.MatRowAccessor`1)
+- [Vec3b](xref:OpenCvSharp.Vec3b)

--- a/docs/docfx/articles/guides/pixel-access.md
+++ b/docs/docfx/articles/guides/pixel-access.md
@@ -68,6 +68,7 @@ This example swaps the blue and red channels. For this particular operation, `Cv
 Use `RowSpan<T>` when only one row is needed:
 
 ```csharp
+using var grayscale = new Mat(480, 640, MatType.CV_8UC1);
 Span<byte> firstRow = grayscale.RowSpan<byte>(0);
 firstRow.Fill(0);
 ```

--- a/docs/docfx/articles/guides/video-io.md
+++ b/docs/docfx/articles/guides/video-io.md
@@ -1,0 +1,96 @@
+# Video I/O
+
+`VideoCapture` reads frames from video files, cameras, image sequences, and streams supported by the selected OpenCV backend. `VideoWriter` encodes a sequence of matrices into a video file.
+
+The full and headless Linux runtime packages include `videoio`. The slim runtime packages do not. Windows ARM64 runtime packages do not include FFmpeg-based video I/O.
+
+## Read a video file
+
+```csharp
+using var capture = new VideoCapture("input.mp4");
+if (!capture.IsOpened())
+{
+    throw new InvalidOperationException("Could not open input.mp4.");
+}
+
+using var frame = new Mat();
+while (capture.Read(frame))
+{
+    if (frame.Empty())
+    {
+        break;
+    }
+
+    Console.WriteLine($"Frame {capture.PosFrames}: {frame.Width} x {frame.Height}");
+    // Process frame here. Do not retain it after the next Read call unless you clone it.
+}
+```
+
+The same `Mat` is reused for every frame. Call `frame.Clone()` when a frame must outlive the next `Read`.
+
+Properties such as `Fps`, `FrameCount`, and `PosFrames` depend on the backend and input. A backend may report zero or an approximate value when the information is unavailable.
+
+## Open a camera
+
+```csharp
+using var capture = new VideoCapture(0);
+if (!capture.IsOpened())
+{
+    throw new InvalidOperationException("Could not open camera 0.");
+}
+
+capture.FrameWidth = 1280;
+capture.FrameHeight = 720;
+
+using var frame = new Mat();
+while (capture.Read(frame) && !frame.Empty())
+{
+    // Process or display the frame.
+}
+```
+
+Device index `0` selects the first camera. Camera properties are requests to the backend and device; read the property again when the exact negotiated value matters.
+
+An application can request a backend explicitly, for example `VideoCaptureAPIs.DSHOW` on Windows or `VideoCaptureAPIs.V4L2` on Linux, but the default automatic selection is more portable.
+
+## Write a video
+
+The following example copies frames to an MJPEG AVI file:
+
+```csharp
+using var capture = new VideoCapture("input.mp4");
+if (!capture.IsOpened())
+{
+    throw new InvalidOperationException("Could not open input.mp4.");
+}
+
+double fps = capture.Fps > 0 ? capture.Fps : 30;
+var frameSize = new Size((int)capture.FrameWidth, (int)capture.FrameHeight);
+int fourcc = VideoWriter.FourCC('M', 'J', 'P', 'G');
+
+using var writer = new VideoWriter("output.avi", fourcc, fps, frameSize);
+if (!writer.IsOpened())
+{
+    throw new InvalidOperationException("Could not open output.avi.");
+}
+
+using var frame = new Mat();
+while (capture.Read(frame) && !frame.Empty())
+{
+    writer.Write(frame);
+}
+```
+
+Every frame passed to a writer must have the configured size and a compatible channel layout. Resize or convert frames before calling `Write` when necessary. Set `isColor: false` in the `VideoWriter` constructor when writing single-channel frames.
+
+Codec availability depends on the operating system, OpenCV build, backend, and output container. `VideoWriter.FourCC` creates the four-character codec identifier, but it does not install an encoder.
+
+## Displaying frames
+
+`Cv2.ImShow` and `Cv2.WaitKey` require `highgui` and a graphical environment. They are unavailable in the Linux headless and slim runtime packages. Services should process, encode, or stream frames without creating native windows.
+
+## Related API
+
+- [VideoCapture](xref:OpenCvSharp.VideoCapture)
+- [VideoWriter](xref:OpenCvSharp.VideoWriter)
+- [VideoCaptureAPIs](xref:OpenCvSharp.VideoCaptureAPIs)

--- a/docs/docfx/articles/guides/video-io.md
+++ b/docs/docfx/articles/guides/video-io.md
@@ -64,8 +64,14 @@ if (!capture.IsOpened())
     throw new InvalidOperationException("Could not open input.mp4.");
 }
 
+using var frame = new Mat();
+if (!capture.Read(frame) || frame.Empty())
+{
+    throw new InvalidOperationException("Could not read the first frame.");
+}
+
 double fps = capture.Fps > 0 ? capture.Fps : 30;
-var frameSize = new Size((int)capture.FrameWidth, (int)capture.FrameHeight);
+var frameSize = new Size(frame.Width, frame.Height);
 int fourcc = VideoWriter.FourCC('M', 'J', 'P', 'G');
 
 using var writer = new VideoWriter("output.avi", fourcc, fps, frameSize);
@@ -74,7 +80,7 @@ if (!writer.IsOpened())
     throw new InvalidOperationException("Could not open output.avi.");
 }
 
-using var frame = new Mat();
+writer.Write(frame);
 while (capture.Read(frame) && !frame.Empty())
 {
     writer.Write(frame);

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -15,6 +15,7 @@ Start with these pages in order:
 ## Common tasks
 
 - [Build an image processing pipeline](guides/image-processing-pipeline.md)
+- [Analyze histograms and improve contrast](guides/histograms-and-contrast.md)
 - [Access and modify pixels](guides/pixel-access.md)
 - [Encode images and convert UI image types](guides/image-conversion.md)
 - [Read and write video](guides/video-io.md)

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -11,6 +11,13 @@ Start with these pages in order:
 3. [Build your first application](getting-started/first-application.md).
 4. Learn how to [manage native resources](guides/resource-management.md).
 
+## Common tasks
+
+- [Access and modify pixels](guides/pixel-access.md)
+- [Encode images and convert UI image types](guides/image-conversion.md)
+- [Read and write video](guides/video-io.md)
+- [Store matrices and parameters in YAML, XML, or JSON](guides/file-storage.md)
+
 ## Existing applications
 
 OpenCvSharp5 is recommended for new applications targeting .NET 8 or later. Applications that use OpenCvSharp4 can follow the [OpenCvSharp4 to OpenCvSharp5 migration guide](https://github.com/shimat/opencvsharp/blob/main/docs/migration-4-to-5.md).

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -9,13 +9,16 @@ Start with these pages in order:
 1. [Choose a version and package](getting-started/package-selection.md).
 2. [Install OpenCvSharp](getting-started/installation.md).
 3. [Build your first application](getting-started/first-application.md).
-4. Learn how to [manage native resources](guides/resource-management.md).
+4. Learn the [fundamentals of Mat](guides/mat-basics.md).
+5. Learn how to [manage native resources](guides/resource-management.md).
 
 ## Common tasks
 
+- [Build an image processing pipeline](guides/image-processing-pipeline.md)
 - [Access and modify pixels](guides/pixel-access.md)
 - [Encode images and convert UI image types](guides/image-conversion.md)
 - [Read and write video](guides/video-io.md)
+- [Detect and match local features](guides/feature-detection-and-matching.md)
 - [Store matrices and parameters in YAML, XML, or JSON](guides/file-storage.md)
 
 ## Existing applications

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -10,6 +10,14 @@
       href: getting-started/first-application.md
 - name: Guides
   items:
+    - name: Pixel Access
+      href: guides/pixel-access.md
+    - name: Image Encoding and Conversion
+      href: guides/image-conversion.md
+    - name: Video I/O
+      href: guides/video-io.md
+    - name: File Storage
+      href: guides/file-storage.md
     - name: Resource Management
       href: guides/resource-management.md
 - name: Troubleshooting

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -10,12 +10,18 @@
       href: getting-started/first-application.md
 - name: Guides
   items:
+    - name: Mat Basics
+      href: guides/mat-basics.md
     - name: Pixel Access
       href: guides/pixel-access.md
+    - name: Image Processing Pipeline
+      href: guides/image-processing-pipeline.md
     - name: Image Encoding and Conversion
       href: guides/image-conversion.md
     - name: Video I/O
       href: guides/video-io.md
+    - name: Feature Detection and Matching
+      href: guides/feature-detection-and-matching.md
     - name: File Storage
       href: guides/file-storage.md
     - name: Resource Management

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -16,6 +16,8 @@
       href: guides/pixel-access.md
     - name: Image Processing Pipeline
       href: guides/image-processing-pipeline.md
+    - name: Histograms and Contrast
+      href: guides/histograms-and-contrast.md
     - name: Image Encoding and Conversion
       href: guides/image-conversion.md
     - name: Video I/O

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -15,6 +15,13 @@ OpenCvSharp is a cross-platform .NET wrapper for OpenCV. This site contains the 
 - [Troubleshoot native library loading](articles/troubleshooting/native-library-loading.md)
 - [Migrate from OpenCvSharp4 to OpenCvSharp5](https://github.com/shimat/opencvsharp/blob/main/docs/migration-4-to-5.md)
 
+## Common tasks
+
+- [Access and modify pixels](articles/guides/pixel-access.md)
+- [Encode images and convert UI image types](articles/guides/image-conversion.md)
+- [Read and write video](articles/guides/video-io.md)
+- [Store matrices and parameters](articles/guides/file-storage.md)
+
 ## Supported platforms
 
 OpenCvSharp5 targets .NET 8 or later and provides runtime packages for Windows x64 and ARM64, Linux x64 and ARM64, macOS x64 and Apple Silicon, and WebAssembly. OpenCvSharp4 remains available for applications that require .NET Framework or .NET Standard.


### PR DESCRIPTION
Migrates the useful parts of the stale Wiki into maintained DocFX guides. Pixel access, image conversion, video I/O, file storage, and histograms are rewritten for OpenCvSharp5, while the old per-algorithm feature pages are consolidated into one feature detection and matching guide.

Adds new task-oriented guides for Mat fundamentals and a complete image-processing pipeline. Obsolete platform tutorials, the removed debugger visualizer, and small DFT, Subdiv2D, and equation snippets are intentionally not copied because they are outdated or provide little OpenCvSharp-specific guidance. The repository instructions now also record the Label and assignee convention for agent-created PRs and issues.

## Test plan

- [x] Compile all new guide examples against the current OpenCvSharp project with zero warnings and errors
- [x] Build the complete site with DocFX 2.78.5
- [x] Check generated HTML for broken local links
- [x] Run `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new beginner-friendly guides for **Mat Basics**, **Pixel Access**, **Image Processing Pipeline**, **Histograms and Contrast**, **Image Encoding and Conversion**, **Video I/O**, **Feature Detection and Matching**, and **File Storage**.
  * Expanded the docs index and table of contents with a **Common tasks** section linking to the new guides.
  * Included practical, example-driven tips on validation, resource management, performance considerations, and common pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->