### PR TITLE
Expand OpenCvSharp usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 [![GitHub Actions Windows Status](https://github.com/shimat/opencvsharp/actions/workflows/windows.yml/badge.svg)](https://github.com/shimat/opencvsharp/actions/workflows/windows.yml)  [![GitHub Actions Docker Test Status](https://github.com/shimat/opencvsharp/actions/workflows/docker-test-ubuntu.yml/badge.svg)](https://github.com/shimat/opencvsharp/actions/workflows/docker-test-ubuntu.yml)  [![GitHub Actions manylinux Status](https://github.com/shimat/opencvsharp/actions/workflows/manylinux.yml/badge.svg)](https://github.com/shimat/opencvsharp/actions/workflows/manylinux.yml)  [![GitHub Actions Wasm Status](https://github.com/shimat/opencvsharp/actions/workflows/wasm.yml/badge.svg)](https://github.com/shimat/opencvsharp/actions/workflows/wasm.yml) [![GitHub Actions macOS Status](https://github.com/shimat/opencvsharp/actions/workflows/macos.yml/badge.svg)](https://github.com/shimat/opencvsharp/actions/workflows/macos.yml) [![GitHub license](https://img.shields.io/github/license/shimat/opencvsharp.svg)](https://github.com/shimat/opencvsharp/blob/master/LICENSE) 
 
-OpenCvSharp is a cross-platform .NET wrapper for OpenCV, providing a rich set of image processing and computer vision functionality.
+OpenCvSharp is a cross-platform .NET wrapper for OpenCV, providing a rich set of image processing and computer vision functionality. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API so that OpenCV concepts, documentation, and code can be transferred to .NET with minimal friction, while still using C# conventions such as typed enums, exceptions, and deterministic disposal.
+
+See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
 
 ## 🚀 [Try the Live Demo](https://shimat.github.io/opencvsharp_blazor_sample/)
 
@@ -58,7 +60,7 @@ dotnet add package OpenCvSharp5.runtime.osx.arm64
 For more installation options, see the [Installation](#installation) section below, or the full [NuGet package list](#nuget).
 
 ## Features
-* OpenCvSharp is modeled on the native OpenCV C/C++ API style as much as possible.
+* OpenCvSharp is modeled on the native OpenCV C++ API as closely as practical.
 * Many classes of OpenCvSharp implement IDisposable. Unsafe resources are managed automatically. 
 * OpenCvSharp does not force object-oriented programming style on you. You can also call native-style OpenCV functions.
 * OpenCvSharp provides functions for converting from `Mat` to `Bitmap` (GDI+) or `WriteableBitmap` (WPF).

--- a/docs/docfx/articles/getting-started/opencv-api-comparison.md
+++ b/docs/docfx/articles/getting-started/opencv-api-comparison.md
@@ -58,6 +58,8 @@ grayscale = cv.cvtColor(source, cv.COLOR_BGR2GRAY)
 ### OpenCvSharp
 
 ```csharp
+using OpenCvSharp;
+
 using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
 if (source.Empty())
 {

--- a/docs/docfx/articles/getting-started/opencv-api-comparison.md
+++ b/docs/docfx/articles/getting-started/opencv-api-comparison.md
@@ -1,0 +1,161 @@
+# OpenCV C++, OpenCV-Python, and OpenCvSharp
+
+OpenCvSharp exposes OpenCV to .NET applications. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API so that OpenCV concepts, documentation, and code transfer naturally to .NET. Most computer vision concepts, algorithm behavior, and parameter constraints come directly from OpenCV, while the managed surface also follows C# conventions and cannot be translated mechanically from every C++ or Python example.
+
+Use the official OpenCV documentation for algorithm theory and native parameter requirements. Use the OpenCvSharp guides and API reference for .NET package selection, managed types, overloads, resource ownership, and application integration.
+
+## How the three APIs relate
+
+OpenCV is implemented primarily in C++. Its C++ API is therefore the closest description of the native functions that OpenCvSharp eventually calls.
+
+OpenCV-Python is an official generated binding over the same native implementation. Images are normally presented as NumPy arrays, and the binding adapts many C++ output parameters into Python return values.
+
+OpenCvSharp is a .NET wrapper with a managed API and a native bridge. It preserves many OpenCV names and concepts while representing them with .NET classes, enums, arrays, spans, exceptions, and `IDisposable`.
+
+| Concept | OpenCV C++ | OpenCV-Python | OpenCvSharp |
+|---|---|---|---|
+| Free function | `cv::GaussianBlur` | `cv.GaussianBlur` | `Cv2.GaussianBlur` |
+| Submodule function | `cv::dnn::readNetFromONNX` | `cv.dnn.readNetFromONNX` | `Cv2.Dnn.ReadNetFromONNX` |
+| Image container | `cv::Mat` | `numpy.ndarray` or `cv.Mat` | `Mat` |
+| Image size | `cv::Size` | `(width, height)` tuple | `Size` |
+| Coordinate | `cv::Point` | `(x, y)` tuple | `Point` |
+| Color conversion enum and value | `cv::ColorConversionCodes` and `cv::COLOR_BGR2GRAY` | `cv.COLOR_BGR2GRAY` | `ColorConversionCodes.BGR2GRAY` |
+| Output image | `OutputArray dst` argument | Usually a return value | Usually a caller-owned `Mat` argument |
+| Native failure | `cv::Exception` | `cv2.error` | `OpenCVException` |
+| Lifetime | RAII and reference counting | Python and NumPy ownership | `IDisposable` and `using` |
+
+The correspondence is deliberately recognizable, but it is not a promise that every native overload has an identical managed overload.
+
+## The same operation in three languages
+
+The following examples all load a color image, validate it, and convert it to grayscale.
+
+### C++
+
+```cpp
+cv::Mat source = cv::imread("input.jpg", cv::IMREAD_COLOR);
+if (source.empty())
+{
+    throw std::runtime_error("Could not read input.jpg.");
+}
+
+cv::Mat grayscale;
+cv::cvtColor(source, grayscale, cv::COLOR_BGR2GRAY);
+```
+
+### Python
+
+```python
+import cv2 as cv
+
+source = cv.imread("input.jpg", cv.IMREAD_COLOR)
+if source is None:
+    raise RuntimeError("Could not read input.jpg.")
+
+grayscale = cv.cvtColor(source, cv.COLOR_BGR2GRAY)
+```
+
+### OpenCvSharp
+
+```csharp
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+using var grayscale = new Mat();
+Cv2.CvtColor(source, grayscale, ColorConversionCodes.BGR2GRAY);
+```
+
+The OpenCvSharp example resembles the C++ API because `grayscale` is an explicit destination. It also adds deterministic disposal because both managed objects own native resources.
+
+## Translating names from C++
+
+Most free functions in the `cv` namespace are static methods on `Cv2`, with .NET-style capitalization:
+
+| C++ | OpenCvSharp |
+|---|---|
+| `cv::imread` | `Cv2.ImRead` |
+| `cv::cvtColor` | `Cv2.CvtColor` |
+| `cv::findContours` | `Cv2.FindContours` |
+| `cv::warpPerspective` | `Cv2.WarpPerspective` |
+
+Functions in an OpenCV submodule normally use a nested `Cv2` class. For example, `cv::dnn` maps to `Cv2.Dnn`, while wrapper object types remain in namespaces such as `OpenCvSharp.Dnn`.
+
+OpenCvSharp enum types generally mirror named enums declared by the native C++ API. For example, OpenCV declares the unscoped enum `cv::ColorConversionCodes`; because its enumerators are injected into the enclosing `cv` namespace, C++ code normally writes `cv::COLOR_BGR2GRAY` without mentioning the enum type. OpenCvSharp exposes the same grouping through the scoped C# expression `ColorConversionCodes.BGR2GRAY`.
+
+Apply the same rule when translating names such as `cv::INTER_AREA` or `cv::THRESH_OTSU`: identify the native enum declaration or inspect the parameter type, then use the corresponding OpenCvSharp enum member.
+
+## Translating Python examples
+
+Python tutorials are valuable explanations of OpenCV algorithms, but NumPy operations need special attention.
+
+### NumPy arrays are not OpenCvSharp Mat objects
+
+A Python image commonly exposes shape, data type, channels, slicing, broadcasting, and arithmetic through NumPy. OpenCvSharp keeps the native `cv::Mat` model instead:
+
+| Python and NumPy | OpenCvSharp |
+|---|---|
+| `image.shape` | `image.Rows`, `image.Cols`, and `image.Channels()` |
+| `image.dtype` | `image.Depth()` or `image.Type()` |
+| `image[y, x]` | `image.At<T>(y, x)` or span-based access |
+| `image[y1:y2, x1:x2]` | A `Mat` region of interest |
+| NumPy vectorized expression | A corresponding `Cv2` operation, matrix expression, or span loop |
+
+Do not translate a NumPy loop or slice one token at a time. First identify whether the operation is a native OpenCV function. Native operations usually express intent more clearly and avoid repeated managed-to-native calls.
+
+See [Mat Basics](../guides/mat-basics.md) and [Pixel Access](../guides/pixel-access.md) for the OpenCvSharp data model.
+
+### Python often returns C++ output arguments
+
+The generated Python binding turns many C++ `OutputArray` arguments into return values. For example, Python thresholding returns both the selected threshold and the output image:
+
+```python
+selected_threshold, binary = cv.threshold(
+    grayscale, 0, 255, cv.THRESH_BINARY | cv.THRESH_OTSU)
+```
+
+OpenCvSharp keeps the destination as an argument and returns the scalar result:
+
+```csharp
+using var binary = new Mat();
+double selectedThreshold = Cv2.Threshold(
+    grayscale, binary, 0, 255, ThresholdTypes.Binary | ThresholdTypes.Otsu);
+```
+
+Functions with several Python return values may instead use `out` parameters, arrays, tuples, or result objects in OpenCvSharp. Check the managed signature rather than assuming the Python return shape.
+
+## Resource ownership is a .NET concern
+
+OpenCvSharp objects that own native resources must be disposed. This includes `Mat`, `VideoCapture`, `VideoWriter`, `Net`, feature detectors, and many other wrappers.
+
+Use `using` declarations for local ownership and document ownership when returning an OpenCvSharp object from a method. Garbage collection does not provide timely accounting for native image buffers.
+
+Read [Resource Management](../guides/resource-management.md) before translating a long-running Python application or a C++ pipeline that relies on scope-based RAII.
+
+## Find the corresponding OpenCvSharp API
+
+When starting from an OpenCV C++ or Python page:
+
+1. Identify the C++ function and its module in the official OpenCV reference.
+2. Map `cv::functionName` to `Cv2.FunctionName`, or `cv::module::functionName` to `Cv2.Module.FunctionName`.
+3. Replace global constants with the enum type accepted by the OpenCvSharp parameter.
+4. Search the [OpenCvSharp API reference](../../api/index.md) for the managed overload.
+5. Check whether returned images or algorithm objects need disposal.
+6. Confirm that the OpenCvSharp and OpenCV versions provide the same module and behavior.
+
+If a direct mapping is missing, search the [issue tracker](https://github.com/shimat/opencvsharp/issues) before assuming that the native feature is unavailable.
+
+## Version and package differences
+
+This documentation describes OpenCvSharp5 and OpenCV 5.x. OpenCvSharp4 wraps the OpenCV 4.x line and targets older .NET applications. Some module names, APIs, data types, and package requirements differ between the two major versions.
+
+See [Choose a Version and Package](package-selection.md) before combining code or documentation from different OpenCV generations.
+
+## Official OpenCV references
+
+- [OpenCV 5 documentation](https://docs.opencv.org/5.0/index.html)
+- [OpenCV 5 tutorials](https://docs.opencv.org/5.0/tutorials/tutorials.html)
+- [OpenCV-Python tutorials](https://docs.opencv.org/5.0/py_tutorials/py_tutorials.html)
+- [How OpenCV-Python bindings work](https://docs.opencv.org/5.0/py_tutorials/py_bindings/py_bindings_basics/py_bindings_basics.html)

--- a/docs/docfx/articles/guides/contours-shape-analysis.md
+++ b/docs/docfx/articles/guides/contours-shape-analysis.md
@@ -1,0 +1,140 @@
+# Contours and Shape Analysis
+
+Contours describe object boundaries in a binary image. They are useful for measuring area, locating bounding boxes, approximating shapes, and drawing annotations.
+
+## Prepare a binary input
+
+`Cv2.FindContours` expects an 8-bit single-channel image where zero is background and non-zero pixels are foreground:
+
+```csharp
+using var source = Cv2.ImRead("objects.png", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new InvalidOperationException("Could not read objects.png.");
+}
+
+using var grayscale = new Mat();
+using var binary = new Mat();
+
+Cv2.CvtColor(source, grayscale, ColorConversionCodes.BGR2GRAY);
+Cv2.Threshold(
+    grayscale,
+    binary,
+    0,
+    255,
+    ThresholdTypes.Binary | ThresholdTypes.Otsu);
+```
+
+If the objects are darker than the background, use `ThresholdTypes.BinaryInv | ThresholdTypes.Otsu`.
+
+## Find external contours
+
+Use `RetrievalModes.External` when only the outer boundary of each foreground object matters:
+
+```csharp
+using Mat contourInput = binary.Clone();
+Cv2.FindContours(
+    contourInput,
+    out Point[][] contours,
+    out HierarchyIndex[] hierarchy,
+    RetrievalModes.External,
+    ContourApproximationModes.ApproxSimple);
+```
+
+Each element in `contours` is a managed array of image coordinates. `ApproxSimple` compresses straight segments to their endpoints and is appropriate for most measurement and drawing tasks.
+
+The cloned input makes the ownership and reuse of `binary` unambiguous across OpenCV versions and overloads.
+
+## Filter and draw contours
+
+Measure contour area before drawing or performing more expensive analysis:
+
+```csharp
+Point[][] significantContours = contours
+    .Where(contour => Cv2.ContourArea(contour) >= 500)
+    .ToArray();
+
+using Mat annotated = source.Clone();
+Cv2.DrawContours(
+    annotated,
+    significantContours,
+    contourIdx: -1,
+    color: new Scalar(0, 255, 0),
+    thickness: 2);
+
+foreach (Point[] contour in significantContours)
+{
+    Rect bounds = Cv2.BoundingRect(contour);
+    Cv2.Rectangle(
+        annotated,
+        bounds,
+        new Scalar(0, 0, 255),
+        thickness: 2);
+}
+```
+
+`contourIdx: -1` draws every contour in the supplied collection. OpenCV colors are BGR by default, so `(0, 255, 0)` is green and `(0, 0, 255)` is red.
+
+## Understand contour hierarchy
+
+`HierarchyIndex` records four indices for each contour:
+
+- The next contour at the same level.
+- The previous contour at the same level.
+- The first child contour.
+- The parent contour.
+
+Missing relationships use `-1`. `RetrievalModes.External` produces no nested children. Use `RetrievalModes.CComp` for two-level component boundaries or `RetrievalModes.Tree` for the full nesting structure.
+
+## Use connected components for filled regions
+
+Connected-component labeling is often simpler when the goal is to enumerate filled blobs rather than analyze their boundaries:
+
+```csharp
+ConnectedComponents components = Cv2.ConnectedComponentsEx(binary);
+using Mat annotated = source.Clone();
+
+foreach (ConnectedComponents.Blob blob in components.Blobs.Skip(1))
+{
+    if (blob.Area < 500)
+    {
+        continue;
+    }
+
+    Cv2.Rectangle(
+        annotated,
+        blob.Rect,
+        new Scalar(255, 0, 0),
+        thickness: 2);
+}
+```
+
+Label zero is the background, so typical applications skip the first blob. Each remaining blob includes its area, centroid, and bounding rectangle.
+
+Choose contours when perimeter geometry and nested boundaries matter. Choose connected components when labels, areas, centroids, and axis-aligned bounds are sufficient.
+
+## Common mistakes
+
+- Passing a three-channel color image to `FindContours`.
+- Treating grayscale intensity as a mask without thresholding it first.
+- Forgetting that `Point.X` is the column and `Point.Y` is the row.
+- Using `RetrievalModes.External` when holes or nested objects are significant.
+- Comparing contour area with bounding-box area as if they were equivalent.
+- Keeping every noise contour instead of filtering by scale or applying morphology first.
+
+## From C++ or Python
+
+The native `std::vector<std::vector<cv::Point>>` and the Python contour sequence map naturally to `Point[][]` in the common OpenCvSharp overload. Python returns contours and hierarchy together, while OpenCvSharp uses `out` parameters.
+
+## Official OpenCV references
+
+- [Structural analysis and shape descriptors](https://docs.opencv.org/5.0/main_modules/imgproc_shape.html)
+- [OpenCV image processing tutorials](https://docs.opencv.org/5.0/tutorials/imgproc/imgproc.html)
+
+## Related OpenCvSharp API
+
+- [Cv2](xref:OpenCvSharp.Cv2)
+- [HierarchyIndex](xref:OpenCvSharp.HierarchyIndex)
+- [RetrievalModes](xref:OpenCvSharp.RetrievalModes)
+- [ContourApproximationModes](xref:OpenCvSharp.ContourApproximationModes)
+- [ConnectedComponents](xref:OpenCvSharp.ConnectedComponents)

--- a/docs/docfx/articles/guides/displaying-images-dotnet.md
+++ b/docs/docfx/articles/guides/displaying-images-dotnet.md
@@ -1,0 +1,149 @@
+# Display Images in .NET Applications
+
+OpenCV's HighGUI windows are useful for experiments, but production .NET applications normally display images through their UI framework. OpenCvSharp provides separate extension packages that convert `Mat` objects to framework-native bitmap types.
+
+## Choose the integration package
+
+Install the package that matches the application:
+
+| UI technology | Package | Primary bitmap type |
+|---|---|---|
+| WPF | `OpenCvSharp5.WpfExtensions` | `BitmapSource` or `WriteableBitmap` |
+| Windows Forms or GDI+ | `OpenCvSharp5.GdipExtensions` | `System.Drawing.Bitmap` |
+| Avalonia | `OpenCvSharp5.AvaloniaExtensions` | `Avalonia.Media.Imaging.WriteableBitmap` |
+
+These packages supplement the core `OpenCvSharp5` package and a matching native runtime package. See [Installation](../getting-started/installation.md) for the complete package combination.
+
+## Display a Mat in WPF
+
+Add the WPF extension package:
+
+```bash
+dotnet add package OpenCvSharp5.WpfExtensions
+```
+
+Convert a `Mat` to a `BitmapSource` and assign it to an `Image` control:
+
+```csharp
+using OpenCvSharp;
+using OpenCvSharp.WpfExtensions;
+using System.Windows.Media.Imaging;
+
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (image.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+BitmapSource imageSource = image.ToBitmapSource();
+PreviewImage.Source = imageSource;
+```
+
+`ToBitmapSource` handles the channel order expected by WPF. If a bitmap is created on a worker thread and then passed to the UI thread, freeze it before publishing it:
+
+```csharp
+BitmapSource imageSource = image.ToBitmapSource();
+imageSource.Freeze();
+```
+
+For a stream of identically sized frames, reuse a `WriteableBitmap` instead of allocating a new bitmap for every frame:
+
+```csharp
+WriteableBitmap displayBitmap = firstFrame.ToWriteableBitmap();
+PreviewImage.Source = displayBitmap;
+
+// Run on the UI thread when updating the bound bitmap.
+WriteableBitmapConverter.ToWriteableBitmap(nextFrame, displayBitmap);
+```
+
+The source `Mat` and destination bitmap must keep compatible dimensions and pixel formats.
+
+## Display a Mat in Avalonia
+
+Add the Avalonia extension package:
+
+```bash
+dotnet add package OpenCvSharp5.AvaloniaExtensions
+```
+
+Convert a frame and assign it to an Avalonia `Image` control:
+
+```csharp
+using Avalonia.Media.Imaging;
+using OpenCvSharp;
+using OpenCvSharp.AvaloniaExtensions;
+
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (image.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+WriteableBitmap bitmap = image.ToWriteableBitmap();
+PreviewImage.Source = bitmap;
+```
+
+The Avalonia converter accepts one-, three-, and four-channel `Mat` objects and creates a BGRA bitmap. Reuse an existing bitmap for repeated frames of the same size:
+
+```csharp
+WriteableBitmapConverter.ToWriteableBitmap(nextFrame, bitmap);
+```
+
+Update UI-owned bitmap objects through Avalonia's UI thread or dispatcher.
+
+## Convert between Mat and System.Drawing.Bitmap
+
+Add the GDI+ extension package:
+
+```bash
+dotnet add package OpenCvSharp5.GdipExtensions
+```
+
+Use the conversion extension methods:
+
+```csharp
+using OpenCvSharp;
+using OpenCvSharp.GdipExtensions;
+using System.Drawing;
+
+using var image = Cv2.ImRead("input.jpg", ImreadModes.Color);
+using Bitmap bitmap = image.ToBitmap();
+using Mat roundTrip = bitmap.ToMat();
+```
+
+`System.Drawing.Common` is supported for Windows desktop use. Prefer WPF or Avalonia-native bitmap types in those frameworks rather than converting through `System.Drawing.Bitmap`.
+
+## Keep processing away from the UI thread
+
+A responsive camera or video application normally separates work into stages:
+
+1. Read and process a frame on a worker task.
+2. Produce an owned final `Mat` or encoded image buffer.
+3. Dispatch only the display update to the UI thread.
+4. Dispose replaced frames and stop the worker when the view closes.
+
+Do not mutate the same `Mat` concurrently from capture, processing, and rendering code. Either transfer ownership of each frame or synchronize access. A `Mat` region of interest also shares storage with its parent and is not an independent frame.
+
+For long-running streams, reuse destination `Mat` and bitmap objects when dimensions remain stable. Avoid creating an unbounded queue of frames when rendering is slower than capture; keep only the newest frame or use a bounded channel.
+
+## HighGUI is different
+
+`Cv2.ImShow` and `Cv2.WaitKey` use OpenCV's HighGUI backend. They are convenient for samples and debugging, but they do not integrate with WPF, Windows Forms, or Avalonia layout and event systems. Headless runtime packages disable HighGUI entirely.
+
+Use a framework extension package for application UI, and use [Image Encoding and Conversion](image-conversion.md) when the destination is a file, HTTP response, or in-memory byte buffer rather than a control.
+
+## From C++ or Python
+
+C++ and Python tutorials frequently call `cv::imshow` or `cv.imshow`. In a .NET desktop application, translate the image-processing portion but replace HighGUI display calls with the framework conversion described above. The `Mat` remains BGR or BGRA unless a converter or explicit `Cv2.CvtColor` operation changes it.
+
+## Official OpenCV references
+
+- [OpenCV application utilities](https://docs.opencv.org/5.0/tutorials/application_utils/application_utils.html)
+- [OpenCV configuration options for GUI backends](https://docs.opencv.org/5.0/tutorials/introduction/config_reference/config_reference.html)
+
+## Related OpenCvSharp API
+
+- [OpenCvSharp5.WpfExtensions package](https://www.nuget.org/packages/OpenCvSharp5.WpfExtensions)
+- [OpenCvSharp5.GdipExtensions package](https://www.nuget.org/packages/OpenCvSharp5.GdipExtensions)
+- [OpenCvSharp5.AvaloniaExtensions package](https://www.nuget.org/packages/OpenCvSharp5.AvaloniaExtensions)
+- [Mat](xref:OpenCvSharp.Mat)

--- a/docs/docfx/articles/guides/feature-detection-and-matching.md
+++ b/docs/docfx/articles/guides/feature-detection-and-matching.md
@@ -104,6 +104,11 @@ Creating detectors and matchers for every frame adds unnecessary overhead. In a 
 - [Image Processing Pipeline](image-processing-pipeline.md)
 - [Resource Management](resource-management.md)
 
+## Official OpenCV references
+
+- [OpenCV features framework](https://docs.opencv.org/5.0/main_modules/features.html)
+- [OpenCV feature tutorials](https://docs.opencv.org/5.0/tutorials/features/features.html)
+
 ## Related API
 
 - [ORB](xref:OpenCvSharp.ORB)

--- a/docs/docfx/articles/guides/file-storage.md
+++ b/docs/docfx/articles/guides/file-storage.md
@@ -71,6 +71,10 @@ When writing in memory, the first constructor argument identifies the output for
 
 `FileStorage.Add` writes sequences and mappings using OpenCV's streaming syntax. `FileStorage.GetPath` reads a nested path while disposing intermediate `FileNode` instances. Prefer `GetPath` over a long indexer chain when reading nested data.
 
+## Official OpenCV references
+
+- [File input and output using XML, YAML, and JSON](https://docs.opencv.org/5.0/tutorials/core/file_input_output_with_xml_yml/file_input_output_with_xml_yml.html)
+
 ## Related API
 
 - [FileStorage](xref:OpenCvSharp.FileStorage)

--- a/docs/docfx/articles/guides/geometric-transformations.md
+++ b/docs/docfx/articles/guides/geometric-transformations.md
@@ -1,0 +1,152 @@
+# Geometric Transformations
+
+Geometric transformations change an image's size, orientation, or coordinate system. OpenCvSharp follows the native OpenCV model: a source `Mat`, a destination `Mat`, a transformation definition, and an interpolation or border policy.
+
+## Resize an image
+
+Specify the final dimensions when the output size is known:
+
+```csharp
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+using var resized = new Mat();
+Cv2.Resize(
+    source,
+    resized,
+    new Size(640, 480),
+    interpolation: InterpolationFlags.Area);
+```
+
+`InterpolationFlags.Area` is normally a good choice when reducing an image. `InterpolationFlags.Linear` is a common default for enlargement, while `InterpolationFlags.Nearest` preserves exact class values in label images and masks.
+
+To preserve the aspect ratio, calculate one dimension:
+
+```csharp
+const int targetWidth = 800;
+double scale = (double)targetWidth / source.Width;
+int targetHeight = (int)Math.Round(source.Height * scale);
+
+using var resized = new Mat();
+Cv2.Resize(
+    source,
+    resized,
+    new Size(targetWidth, targetHeight),
+    interpolation: InterpolationFlags.Area);
+```
+
+## Crop with a region of interest
+
+A region of interest is a lightweight `Mat` header that views the source image data:
+
+```csharp
+var roi = new Rect(x: 100, y: 80, width: 320, height: 240);
+using Mat view = source.SubMat(roi);
+```
+
+The rectangle must remain inside the source image. The view and source share pixel storage, so modifications through `view` affect `source`, and `source` must remain alive while the view is used.
+
+Clone the view when the cropped image must own independent storage or outlive the source:
+
+```csharp
+using Mat cropped = view.Clone();
+```
+
+## Rotate by a right angle
+
+Use `Cv2.Rotate` for exact 90-degree operations:
+
+```csharp
+using var rotated = new Mat();
+Cv2.Rotate(source, rotated, RotateFlags.Rotate90Clockwise);
+```
+
+This is simpler than constructing an affine matrix and does not interpolate pixels.
+
+## Rotate by an arbitrary angle
+
+Create a 2-by-3 affine transformation matrix and pass it to `Cv2.WarpAffine`:
+
+```csharp
+var center = new Point2f(source.Width / 2f, source.Height / 2f);
+using Mat rotation = Cv2.GetRotationMatrix2D(center, angle: 15, scale: 1);
+using var rotated = new Mat();
+
+Cv2.WarpAffine(
+    source,
+    rotated,
+    rotation,
+    source.Size(),
+    InterpolationFlags.Linear,
+    BorderTypes.Constant,
+    new Scalar(0, 0, 0));
+```
+
+The destination size is independent of the transformation. Keeping `source.Size()` can clip corners after rotation. Calculate a larger destination and adjust the translation terms in the matrix when the entire rotated image must remain visible.
+
+## Rectify a quadrilateral
+
+A perspective transformation maps four source points to four destination points. The point order must correspond between the two arrays:
+
+```csharp
+Point2f[] sourceCorners =
+[
+    new(120, 80),
+    new(920, 110),
+    new(880, 680),
+    new(150, 650),
+];
+
+Point2f[] destinationCorners =
+[
+    new(0, 0),
+    new(799, 0),
+    new(799, 599),
+    new(0, 599),
+];
+
+using Mat transform = Cv2.GetPerspectiveTransform(
+    sourceCorners,
+    destinationCorners);
+using var rectified = new Mat();
+
+Cv2.WarpPerspective(
+    source,
+    rectified,
+    transform,
+    new Size(800, 600));
+```
+
+Use a consistent order such as top-left, top-right, bottom-right, bottom-left. A crossed or inconsistent order produces a folded or mirrored result.
+
+## Interpolation and border choices
+
+The official OpenCV reference defines the exact interpolation formulas and supported flags. In typical OpenCvSharp applications:
+
+- Use `Area` when shrinking photographs.
+- Use `Linear` for general-purpose resizing and warping.
+- Use `Cubic` or `Lanczos4` when enlargement quality matters more than speed.
+- Use `Nearest` for masks, labels, and other discrete values.
+- Use `BorderTypes.Constant` when pixels outside the image should have a known value.
+- Use `BorderTypes.Replicate` or `Reflect101` when filters or transforms should extend edge content.
+
+Always pass destination dimensions as `(width, height)` through `Size`. Image indexing and `Mat` construction otherwise commonly use `(rows, columns)`, which correspond to `(height, width)`.
+
+## From C++ or Python
+
+The native functions `cv::resize`, `cv::warpAffine`, and `cv::warpPerspective` map to `Cv2.Resize`, `Cv2.WarpAffine`, and `Cv2.WarpPerspective`. Python commonly returns a new NumPy array, while OpenCvSharp normally receives a destination `Mat` that the caller owns and disposes.
+
+## Official OpenCV references
+
+- [Geometric image transformations](https://docs.opencv.org/5.0/main_modules/imgproc_transform.html)
+- [Image processing tutorials](https://docs.opencv.org/5.0/tutorials/imgproc/imgproc.html)
+
+## Related OpenCvSharp API
+
+- [Cv2](xref:OpenCvSharp.Cv2)
+- [Mat](xref:OpenCvSharp.Mat)
+- [InterpolationFlags](xref:OpenCvSharp.InterpolationFlags)
+- [BorderTypes](xref:OpenCvSharp.BorderTypes)

--- a/docs/docfx/articles/guides/geometric-transformations.md
+++ b/docs/docfx/articles/guides/geometric-transformations.md
@@ -131,7 +131,8 @@ The official OpenCV reference defines the exact interpolation formulas and suppo
 - Use `Cubic` or `Lanczos4` when enlargement quality matters more than speed.
 - Use `Nearest` for masks, labels, and other discrete values.
 - Use `BorderTypes.Constant` when pixels outside the image should have a known value.
-- Use `BorderTypes.Replicate` or `Reflect101` when filters or transforms should extend edge content.
+- Use `BorderTypes.Replicate` when a warp should extend the nearest edge pixels.
+- Use reflection modes such as `BorderTypes.Reflect101` only with APIs whose OpenCV reference explicitly supports them, commonly filter operations.
 
 Always pass destination dimensions as `(width, height)` through `Size`. Image indexing and `Mat` construction otherwise commonly use `(rows, columns)`, which correspond to `(height, width)`.
 

--- a/docs/docfx/articles/guides/histograms-and-contrast.md
+++ b/docs/docfx/articles/guides/histograms-and-contrast.md
@@ -139,6 +139,12 @@ For a BGR image, channel index 0 is blue, 1 is green, and 2 is red. Separate BGR
 - [Image Processing Pipeline](image-processing-pipeline.md)
 - [Pixel Access](pixel-access.md)
 
+## Official OpenCV references
+
+- [OpenCV histogram API](https://docs.opencv.org/5.0/main_modules/imgproc_hist.html)
+- [Histogram calculation tutorial](https://docs.opencv.org/5.0/tutorials/imgproc/histograms/histogram_calculation/histogram_calculation.html)
+- [Histogram equalization tutorial](https://docs.opencv.org/5.0/tutorials/imgproc/histograms/histogram_equalization/histogram_equalization.html)
+
 ## Related API
 
 - [Cv2.CalcHist](xref:OpenCvSharp.Cv2.CalcHist*)

--- a/docs/docfx/articles/guides/image-conversion.md
+++ b/docs/docfx/articles/guides/image-conversion.md
@@ -75,6 +75,13 @@ Check pixel format and channel order when exchanging images with a UI framework.
 
 For file uploads, HTTP responses, and database blobs, encode directly with `Cv2.ImEncode` instead of converting through `Bitmap`. For image processing, keep data in `Mat` form and convert only at the UI boundary.
 
+See [Display Images in .NET Applications](displaying-images-dotnet.md) for WPF, Avalonia, GDI+, UI-thread, and live-frame guidance.
+
+## Official OpenCV references
+
+- [OpenCV image file reading and writing](https://docs.opencv.org/5.0/main_modules/imgcodecs.html)
+- [OpenCV color space conversions](https://docs.opencv.org/5.0/main_modules/imgproc_color_conversions.html)
+
 ## Related API
 
 - [Cv2.ImEncode](xref:OpenCvSharp.Cv2.ImEncode*)

--- a/docs/docfx/articles/guides/image-processing-pipeline.md
+++ b/docs/docfx/articles/guides/image-processing-pipeline.md
@@ -91,7 +91,14 @@ When a final result is wrong, intermediate images show which stage first lost th
 
 - [Mat Basics](mat-basics.md)
 - [Pixel Access](pixel-access.md)
+- [Thresholding, Masks, and Morphology](thresholding-masks-morphology.md)
+- [Contours and Shape Analysis](contours-shape-analysis.md)
 - [Resource Management](resource-management.md)
+
+## Official OpenCV references
+
+- [OpenCV image processing tutorials](https://docs.opencv.org/5.0/tutorials/imgproc/imgproc.html)
+- [OpenCV image processing API](https://docs.opencv.org/5.0/main_modules/imgproc.html)
 
 ## Related API
 

--- a/docs/docfx/articles/guides/mat-basics.md
+++ b/docs/docfx/articles/guides/mat-basics.md
@@ -120,6 +120,11 @@ The array is pinned while the `Mat` is alive, and changes are shared in both dir
 - [Resource Management](resource-management.md)
 - [Image Encoding and Conversion](image-conversion.md)
 
+## Official OpenCV references
+
+- [Mat: the basic image container](https://docs.opencv.org/5.0/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.html)
+- [OpenCV core functionality](https://docs.opencv.org/5.0/main_modules/core.html)
+
 ## Related API
 
 - [Mat](xref:OpenCvSharp.Mat)

--- a/docs/docfx/articles/guides/pixel-access.md
+++ b/docs/docfx/articles/guides/pixel-access.md
@@ -83,6 +83,11 @@ The span excludes any padding bytes between rows.
 
 `GetGenericIndexer<T>` and its indexer class use marshaling for each element and are obsolete. Existing code should move to `At<T>` or `AsRows<T>`. `Mat<T>.GetIndexer()` remains available, but `AsRows<T>` avoids creating a typed wrapper and makes row-stride handling explicit.
 
+## Official OpenCV references
+
+- [Basic operations on images in OpenCV-Python](https://docs.opencv.org/5.0/py_tutorials/py_core/py_basic_ops/py_basic_ops.html)
+- [Mat: the basic image container](https://docs.opencv.org/5.0/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.html)
+
 ## Related API
 
 - [Mat](xref:OpenCvSharp.Mat)

--- a/docs/docfx/articles/guides/resource-management.md
+++ b/docs/docfx/articles/guides/resource-management.md
@@ -76,6 +76,12 @@ The caller owns and disposes the returned `Mat`. The method disposes the result 
 
 `Window` and other OpenCvSharp wrappers that implement `IDisposable` follow the same rule. Scope them with `using` rather than relying on finalization.
 
+## Official OpenCV references
+
+- [Mat: the basic image container](https://docs.opencv.org/5.0/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.html)
+
+The OpenCV reference explains native `cv::Mat` header and buffer ownership. OpenCvSharp adds managed `IDisposable` wrappers, so follow the .NET ownership rules in this guide even when translating a C++ example.
+
 ## Related API
 
 - [Mat](xref:OpenCvSharp.Mat)

--- a/docs/docfx/articles/guides/thresholding-masks-morphology.md
+++ b/docs/docfx/articles/guides/thresholding-masks-morphology.md
@@ -1,0 +1,144 @@
+# Thresholding, Masks, and Morphology
+
+Binary masks select pixels for later processing. In OpenCvSharp, a conventional mask is a single-channel `CV_8UC1` `Mat`: zero excludes a pixel and any non-zero value includes it.
+
+## Create a binary image with a fixed threshold
+
+Convert color input to grayscale before applying a simple threshold:
+
+```csharp
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+using var grayscale = new Mat();
+using var binary = new Mat();
+
+Cv2.CvtColor(source, grayscale, ColorConversionCodes.BGR2GRAY);
+Cv2.Threshold(
+    grayscale,
+    binary,
+    thresh: 128,
+    maxval: 255,
+    ThresholdTypes.Binary);
+```
+
+Pixels greater than the threshold become 255 and the remaining pixels become zero. Use `ThresholdTypes.BinaryInv` when dark objects should become foreground.
+
+## Select the threshold automatically
+
+Otsu thresholding calculates a global threshold from the input histogram:
+
+```csharp
+using var binary = new Mat();
+double selectedThreshold = Cv2.Threshold(
+    grayscale,
+    binary,
+    thresh: 0,
+    maxval: 255,
+    ThresholdTypes.Binary | ThresholdTypes.Otsu);
+
+Console.WriteLine($"Selected threshold: {selectedThreshold}");
+```
+
+`Cv2.Threshold` returns the selected scalar threshold and writes the binary image to the destination `Mat`. This differs from Python, where both values are normally returned as a tuple.
+
+## Handle uneven lighting
+
+Adaptive thresholding calculates a local value for each neighborhood:
+
+```csharp
+using var adaptive = new Mat();
+Cv2.AdaptiveThreshold(
+    grayscale,
+    adaptive,
+    maxValue: 255,
+    AdaptiveThresholdTypes.GaussianC,
+    ThresholdTypes.Binary,
+    blockSize: 21,
+    c: 5);
+```
+
+`blockSize` must be an odd value greater than one. Larger neighborhoods follow slower illumination changes; `c` shifts the local threshold.
+
+## Select a color range
+
+Convert BGR input to a color space suited to the selection, then use `Cv2.InRange`. This example creates a mask for a green hue range:
+
+```csharp
+using var hsv = new Mat();
+using var greenMask = new Mat();
+
+Cv2.CvtColor(source, hsv, ColorConversionCodes.BGR2HSV);
+Cv2.InRange(
+    hsv,
+    new Scalar(35, 50, 50),
+    new Scalar(85, 255, 255),
+    greenMask);
+```
+
+For 8-bit HSV images, OpenCV represents hue in the range 0 through 179. Hue ranges that cross red's wraparound point require two `InRange` calls followed by `Cv2.BitwiseOr`.
+
+## Remove small mask defects
+
+Morphological opening removes small foreground regions. Closing fills small holes and gaps:
+
+```csharp
+using Mat kernel = Cv2.GetStructuringElement(
+    MorphShapes.Ellipse,
+    new Size(5, 5));
+using var opened = new Mat();
+using var cleaned = new Mat();
+
+Cv2.MorphologyEx(
+    greenMask,
+    opened,
+    MorphTypes.Open,
+    kernel);
+Cv2.MorphologyEx(
+    opened,
+    cleaned,
+    MorphTypes.Close,
+    kernel);
+```
+
+Kernel shape and size should reflect the image scale. A large kernel can erase narrow objects or merge nearby regions.
+
+## Apply a mask
+
+Pass the mask to `Mat.CopyTo` to copy only selected pixels:
+
+```csharp
+using var selected = new Mat();
+source.CopyTo(selected, cleaned);
+```
+
+The source and mask must have the same width and height. The mask remains single-channel even when the source has three or four channels.
+
+## Choose the right operation
+
+- Use a fixed threshold when lighting and foreground intensity are controlled.
+- Use Otsu or Triangle thresholding when a global histogram separates foreground and background.
+- Use adaptive thresholding when illumination varies across the image.
+- Use `InRange` when selection depends on an interval or color range.
+- Use morphology to refine a mask after thresholding, not as a substitute for a meaningful segmentation rule.
+
+## From C++ or Python
+
+`cv::threshold`, `cv::adaptiveThreshold`, `cv::inRange`, and `cv::morphologyEx` map to the corresponding PascalCase methods on `Cv2`. Python examples often combine masks through NumPy operators; use `Cv2.BitwiseAnd`, `Cv2.BitwiseOr`, and `Cv2.BitwiseNot` when the operands are OpenCvSharp `Mat` objects.
+
+## Official OpenCV references
+
+- [Miscellaneous image transformations](https://docs.opencv.org/5.0/main_modules/imgproc_misc.html)
+- [Image filtering and morphology](https://docs.opencv.org/5.0/main_modules/imgproc_filter.html)
+- [OpenCV image processing tutorials](https://docs.opencv.org/5.0/tutorials/imgproc/imgproc.html)
+
+## Related OpenCvSharp API
+
+- [Cv2](xref:OpenCvSharp.Cv2)
+- [ThresholdTypes](xref:OpenCvSharp.ThresholdTypes)
+- [AdaptiveThresholdTypes](xref:OpenCvSharp.AdaptiveThresholdTypes)
+- [MorphTypes](xref:OpenCvSharp.MorphTypes)
+- [MorphShapes](xref:OpenCvSharp.MorphShapes)

--- a/docs/docfx/articles/guides/video-io.md
+++ b/docs/docfx/articles/guides/video-io.md
@@ -95,6 +95,11 @@ Codec availability depends on the operating system, OpenCV build, backend, and o
 
 `Cv2.ImShow` and `Cv2.WaitKey` require `highgui` and a graphical environment. They are unavailable in the Linux headless and slim runtime packages. Services should process, encode, or stream frames without creating native windows.
 
+## Official OpenCV references
+
+- [OpenCV Video I/O](https://docs.opencv.org/5.0/main_modules/videoio.html)
+- [OpenCV application utilities](https://docs.opencv.org/5.0/tutorials/application_utils/application_utils.html)
+
 ## Related API
 
 - [VideoCapture](xref:OpenCvSharp.VideoCapture)

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -12,12 +12,18 @@ Start with these pages in order:
 4. Learn the [fundamentals of Mat](guides/mat-basics.md).
 5. Learn how to [manage native resources](guides/resource-management.md).
 
+Already familiar with OpenCV C++ or OpenCV-Python? Start with the [API comparison and translation guide](getting-started/opencv-api-comparison.md).
+
 ## Common tasks
 
 - [Build an image processing pipeline](guides/image-processing-pipeline.md)
 - [Analyze histograms and improve contrast](guides/histograms-and-contrast.md)
+- [Resize, crop, rotate, and rectify images](guides/geometric-transformations.md)
+- [Create and refine masks](guides/thresholding-masks-morphology.md)
+- [Measure contours and connected components](guides/contours-shape-analysis.md)
 - [Access and modify pixels](guides/pixel-access.md)
 - [Encode images and convert UI image types](guides/image-conversion.md)
+- [Display images in .NET UI frameworks](guides/displaying-images-dotnet.md)
 - [Read and write video](guides/video-io.md)
 - [Detect and match local features](guides/feature-detection-and-matching.md)
 - [Store matrices and parameters in YAML, XML, or JSON](guides/file-storage.md)
@@ -28,4 +34,4 @@ OpenCvSharp5 is recommended for new applications targeting .NET 8 or later. Appl
 
 ## Get help
 
-Check [native library loading](troubleshooting/native-library-loading.md) when an application builds successfully but cannot load `OpenCvSharpExtern` at run time. For problems not covered here, search or open an issue in the [OpenCvSharp issue tracker](https://github.com/shimat/opencvsharp/issues).
+Start with [Common Errors and Diagnostics](troubleshooting/common-errors.md) when an operation fails or produces unexpected output. Check [Native Library Loading](troubleshooting/native-library-loading.md) when an application builds successfully but cannot load `OpenCvSharpExtern` at run time. For problems not covered here, search or open an issue in the [OpenCvSharp issue tracker](https://github.com/shimat/opencvsharp/issues).

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -8,6 +8,8 @@
       href: getting-started/installation.md
     - name: First Application
       href: getting-started/first-application.md
+    - name: From OpenCV C++ or Python
+      href: getting-started/opencv-api-comparison.md
 - name: Guides
   items:
     - name: Mat Basics
@@ -18,8 +20,16 @@
       href: guides/image-processing-pipeline.md
     - name: Histograms and Contrast
       href: guides/histograms-and-contrast.md
+    - name: Geometric Transformations
+      href: guides/geometric-transformations.md
+    - name: Thresholding, Masks, and Morphology
+      href: guides/thresholding-masks-morphology.md
+    - name: Contours and Shape Analysis
+      href: guides/contours-shape-analysis.md
     - name: Image Encoding and Conversion
       href: guides/image-conversion.md
+    - name: Display Images in .NET Applications
+      href: guides/displaying-images-dotnet.md
     - name: Video I/O
       href: guides/video-io.md
     - name: Feature Detection and Matching
@@ -30,5 +40,7 @@
       href: guides/resource-management.md
 - name: Troubleshooting
   items:
+    - name: Common Errors and Diagnostics
+      href: troubleshooting/common-errors.md
     - name: Native Library Loading
       href: troubleshooting/native-library-loading.md

--- a/docs/docfx/articles/troubleshooting/common-errors.md
+++ b/docs/docfx/articles/troubleshooting/common-errors.md
@@ -1,0 +1,190 @@
+# Common Errors and Diagnostics
+
+Most OpenCvSharp failures fall into one of four groups: an input image is empty, a `Mat` has the wrong size or type, a native component is unavailable, or an object was used with the wrong ownership or lifetime.
+
+## Start with the complete exception
+
+An `OpenCVException` contains the native status, function name, message, source file, and source line:
+
+```csharp
+static void RunWithOpenCvDiagnostics(Action operation)
+{
+    try
+    {
+        operation();
+    }
+    catch (OpenCVException ex)
+    {
+        Console.Error.WriteLine(
+            $"{ex.Status} in {ex.FuncName}: {ex.ErrMsg} " +
+            $"({ex.FileName}:{ex.Line})");
+        throw;
+    }
+}
+```
+
+An OpenCV assertion such as `(-215:Assertion failed)` normally means that a documented precondition was violated. Read the named native function's official OpenCV reference and compare its accepted depth, channels, dimensions, and empty-input behavior with the actual `Mat`.
+
+## Check every decoded or captured image
+
+Image decoding can return an empty `Mat` without throwing:
+
+```csharp
+using var image = Cv2.ImRead(fileName, ImreadModes.Color);
+if (image.Empty())
+{
+    throw new InvalidOperationException(
+        $"Could not decode image: {fileName}");
+}
+```
+
+For video, check both the Boolean return value and the frame:
+
+```csharp
+using var frame = new Mat();
+if (!capture.Read(frame) || frame.Empty())
+{
+    throw new InvalidOperationException("Could not read a frame.");
+}
+```
+
+Common causes include an incorrect working directory, a missing file, unsupported encoded data, the end of a stream, or an unavailable backend.
+
+## Print the Mat contract
+
+Before the failing call, record the properties that OpenCV uses for validation:
+
+```csharp
+static void PrintMat(string name, Mat mat)
+{
+    Console.WriteLine(
+        $"{name}: {mat.Width}x{mat.Height}, " +
+        $"type={mat.Type()}, depth={mat.Depth()}, " +
+        $"channels={mat.Channels()}, empty={mat.Empty()}, " +
+        $"continuous={mat.IsContinuous()}");
+}
+```
+
+Typical mismatches include:
+
+- Passing BGR input to an operation that requires grayscale.
+- Passing floating-point input where only 8-bit input is supported.
+- Combining images with different sizes or types.
+- Passing a three-channel image where a single-channel mask is required.
+- Using the source size where a destination or kernel size is expected.
+
+Convert explicitly with `Cv2.CvtColor` or `Mat.ConvertTo` rather than changing metadata or assuming an implicit conversion.
+
+## Treat masks as single-channel selectors
+
+A conventional mask has the same width and height as the source and type `CV_8UC1`. Its non-zero pixels select source pixels.
+
+If an operation reports a mask assertion, print both contracts:
+
+```csharp
+PrintMat("source", source);
+PrintMat("mask", mask);
+```
+
+Do not pass a BGR visualization of a mask back into an operation that expects the original single-channel mask.
+
+## Distinguish native loading failures
+
+`DllNotFoundException` means the .NET runtime could not locate `OpenCvSharpExtern` or one of its native dependencies. `BadImageFormatException` commonly indicates an architecture mismatch, such as loading an x64 native library from an ARM64 process.
+
+Check:
+
+1. The managed and runtime packages belong to the same OpenCvSharp major version.
+2. The runtime identifier matches the process architecture and operating system.
+3. The native package is present in the application's `runtimes/{rid}/native/` output.
+4. Required system libraries are installed.
+5. A single-file, container, or plugin deployment did not remove or relocate native assets.
+
+Continue with [Native Library Loading](native-library-loading.md) for platform-specific diagnosis.
+
+## Inspect the native OpenCV build
+
+Print the OpenCV version and build configuration when a codec, GUI, or optional module behaves differently across machines:
+
+```csharp
+Console.WriteLine(Cv2.GetVersionString());
+Console.WriteLine(Cv2.GetBuildInformation());
+```
+
+The build information reports enabled modules and dependencies such as image codecs, video backends, GUI support, and parallel runtimes.
+
+For an opened video source or writer, record its selected backend:
+
+```csharp
+Console.WriteLine($"Capture backend: {capture.GetBackendName()}");
+Console.WriteLine($"Writer backend: {writer.GetBackendName()}");
+```
+
+Codec and camera behavior can vary by backend even when the same managed code is used.
+
+## Diagnose color problems
+
+OpenCV image decoding normally produces BGR channel order. Many UI, web, and plotting systems expect RGB or BGRA.
+
+Symptoms include:
+
+- Red and blue appear swapped.
+- An image is transparent or has an unexpected alpha channel.
+- A grayscale image is treated as color.
+
+Use an explicit conversion at the integration boundary:
+
+```csharp
+using var rgb = new Mat();
+Cv2.CvtColor(bgr, rgb, ColorConversionCodes.BGR2RGB);
+```
+
+OpenCvSharp UI extension converters handle their documented framework formats. Do not apply an extra red-blue swap unless the destination actually expects it.
+
+## Diagnose memory growth
+
+OpenCvSharp objects can own native memory that the .NET garbage collector does not measure accurately.
+
+Check for:
+
+- A new `Mat` created on every loop iteration without `using` or `Dispose`.
+- Captured frames stored in an unbounded collection.
+- A region of interest keeping a large parent buffer alive.
+- Replaced `VideoCapture`, `VideoWriter`, `Net`, or algorithm objects that were never disposed.
+- A method returning a `Mat` without a clear ownership contract.
+
+Reuse destinations inside stable loops and follow [Resource Management](../guides/resource-management.md).
+
+## Diagnose display failures
+
+`Cv2.ImShow` requires a HighGUI backend and a graphical environment. It does not work with a headless runtime package and may fail in a container, service, SSH session, or CI runner without a display server.
+
+For desktop applications, convert the `Mat` to a framework-native bitmap as described in [Display Images in .NET Applications](../guides/displaying-images-dotnet.md). For services and tests, encode or save the result instead of opening a window.
+
+## Minimal reproduction checklist
+
+When asking for help, reduce the failure to:
+
+- The smallest input that still fails.
+- A complete runnable C# example.
+- OpenCvSharp package names and versions.
+- Operating system and process architecture.
+- The full exception, including inner exceptions.
+- `Cv2.GetVersionString()` and the relevant portion of `Cv2.GetBuildInformation()`.
+- The printed size, type, depth, and channel count of every input `Mat`.
+
+Avoid posting only the final assertion line; the function name and input contracts usually contain the actual explanation.
+
+## Official OpenCV references
+
+- [OpenCV configuration options](https://docs.opencv.org/5.0/tutorials/introduction/config_reference/config_reference.html)
+- [OpenCV environment variables](https://docs.opencv.org/5.0/tutorials/introduction/env_reference/env_reference.html)
+- [OpenCV 5 documentation](https://docs.opencv.org/5.0/index.html)
+
+## Related OpenCvSharp API
+
+- [OpenCVException](xref:OpenCvSharp.OpenCVException)
+- [Mat](xref:OpenCvSharp.Mat)
+- [Cv2](xref:OpenCvSharp.Cv2)
+- [VideoCapture](xref:OpenCvSharp.VideoCapture)
+- [VideoWriter](xref:OpenCvSharp.VideoWriter)

--- a/docs/docfx/articles/troubleshooting/native-library-loading.md
+++ b/docs/docfx/articles/troubleshooting/native-library-loading.md
@@ -109,6 +109,11 @@ Calling `NativeLibrary.Load` by itself only returns a native handle; returning t
 
 Most applications should use an official runtime package instead of a custom resolver.
 
+## Official OpenCV references
+
+- [OpenCV configuration options](https://docs.opencv.org/5.0/tutorials/introduction/config_reference/config_reference.html)
+- [OpenCV environment variables](https://docs.opencv.org/5.0/tutorials/introduction/env_reference/env_reference.html)
+
 ## Still failing
 
 When opening an [issue](https://github.com/shimat/opencvsharp/issues), include:

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -7,18 +7,24 @@ OpenCvSharp is a cross-platform .NET wrapper for OpenCV. This site contains the 
 - [Choose an OpenCvSharp version and package](articles/getting-started/package-selection.md)
 - [Install OpenCvSharp](articles/getting-started/installation.md)
 - [Build your first application](articles/getting-started/first-application.md)
+- [Translate OpenCV C++ or Python code](articles/getting-started/opencv-api-comparison.md)
 - [Browse the API reference](api/index.md)
 
 ## Essential guides
 
 - [Manage native resources](articles/guides/resource-management.md)
+- [Diagnose common errors](articles/troubleshooting/common-errors.md)
 - [Troubleshoot native library loading](articles/troubleshooting/native-library-loading.md)
 - [Migrate from OpenCvSharp4 to OpenCvSharp5](https://github.com/shimat/opencvsharp/blob/main/docs/migration-4-to-5.md)
 
 ## Common tasks
 
 - [Access and modify pixels](articles/guides/pixel-access.md)
+- [Resize, crop, rotate, and rectify images](articles/guides/geometric-transformations.md)
+- [Create masks and analyze shapes](articles/guides/thresholding-masks-morphology.md)
+- [Measure contours and connected components](articles/guides/contours-shape-analysis.md)
 - [Encode images and convert UI image types](articles/guides/image-conversion.md)
+- [Display images in .NET UI frameworks](articles/guides/displaying-images-dotnet.md)
 - [Read and write video](articles/guides/video-io.md)
 - [Store matrices and parameters](articles/guides/file-storage.md)
 

--- a/packaging/nuget/README.managed.md
+++ b/packaging/nuget/README.managed.md
@@ -1,6 +1,8 @@
 # OpenCvSharp
 
-A cross-platform .NET wrapper for [OpenCV](https://opencv.org/), providing image processing and computer vision functionality.
+A cross-platform .NET wrapper for [OpenCV](https://opencv.org/), providing image processing and computer vision functionality. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API while using C# conventions such as typed enums, exceptions, and deterministic disposal.
+
+See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
 
 > This is the **OpenCvSharp5** family (OpenCV 5.x, .NET 8+). If you need .NET Framework, Unity, or another pre-.NET 8 runtime, use the **OpenCvSharp4** family (OpenCV 4.13.0) instead.
 

--- a/packaging/nuget/README.runtime.md
+++ b/packaging/nuget/README.runtime.md
@@ -2,6 +2,8 @@
 
 This is an **internal implementation package** for [OpenCvSharp](https://github.com/shimat/opencvsharp). It provides the native OpenCV shared library (`OpenCvSharpExtern`) for a specific platform.
 
+The managed OpenCvSharp API is intentionally designed to stay as close as practical to the native OpenCV C++ API. See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
+
 > In most cases you do not need to reference this package directly. Use one of the all-in-one packages instead:
 > - **Windows:** `OpenCvSharp5.Windows` or `OpenCvSharp5.Windows.Slim`
 > - **Linux:** `OpenCvSharp5` + `OpenCvSharp5.official.runtime.linux-x64`


### PR DESCRIPTION
Add a C++/Python-to-OpenCvSharp API comparison and expand the task-oriented documentation with guides for geometric transforms, masks and morphology, contour analysis, .NET UI display, and common diagnostics.

The guides keep OpenCvSharp-specific C# usage and ownership guidance local while linking algorithm theory and native constraints to the official OpenCV 5 documentation. The README and NuGet READMEs now also state that OpenCvSharp intentionally follows the native C++ API as closely as practical.

## Test plan

- [x] Compile the main C# examples with `dotnet build OpenCvSharp.Tests.csproj --no-restore`
- [x] Check local Markdown and TOC links
- [x] Check Markdown code fences, UTF-8 encoding, and `git diff --check`

A full DocFX build was not run because DocFX is not installed in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new DocFX guides for translating OpenCV C++/Python to OpenCvSharp, including an OpenCV API correspondence article.
  * Introduced/expanded practical guides for contours & shape analysis, thresholding/masks/morphology, geometric transformations, video I/O, and image display in .NET UI frameworks.
  * Enhanced multiple guides and the troubleshooting section with “Official OpenCV references”, improved navigation, and clearer guidance for diagnostics (including native library loading and display/headless scenarios).
  * Updated READMEs and package documentation to reflect the intended API design approach and link to the API comparison material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->