### PR TITLE
Add .NET-specific OpenCvSharp guides

### DIFF
--- a/docs/docfx/articles/guides/aspnet-image-processing.md
+++ b/docs/docfx/articles/guides/aspnet-image-processing.md
@@ -45,14 +45,22 @@ public sealed class ImagesController : ControllerBase
         await file.CopyToAsync(encoded, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
 
+        Mat source;
         try
         {
-            using var source = Cv2.ImDecode(
+            source = Cv2.ImDecode(
                 encoded.GetBuffer().AsSpan(
                     start: 0,
                     length: checked((int)encoded.Length)),
                 ImreadModes.Color);
+        }
+        catch (OpenCVException)
+        {
+            return BadRequest("The upload could not be decoded.");
+        }
 
+        using (source)
+        {
             if (source.Empty())
             {
                 return BadRequest("The upload is not a supported image.");
@@ -79,10 +87,6 @@ public sealed class ImagesController : ControllerBase
             }
 
             return File(png, "image/png");
-        }
-        catch (OpenCVException)
-        {
-            return BadRequest("The upload could not be decoded.");
         }
     }
 }

--- a/docs/docfx/articles/guides/aspnet-image-processing.md
+++ b/docs/docfx/articles/guides/aspnet-image-processing.md
@@ -1,0 +1,247 @@
+# ASP.NET Core Image Uploads and Streams
+
+An uploaded PNG or JPEG is compressed file data, while an OpenCvSharp `Mat` contains decoded pixels. A typical ASP.NET Core request therefore crosses two explicit conversion boundaries:
+
+1. Read and limit the uploaded bytes.
+2. Decode the bytes with `Cv2.ImDecode`.
+3. Process caller-owned `Mat` objects.
+4. Encode the result with `Cv2.ImEncode`.
+5. Return the encoded managed byte array.
+
+OpenCV does not decode an arbitrary .NET `Stream` incrementally. Even when ASP.NET Core receives the request as a stream, the encoded image must be collected into a contiguous buffer before calling `ImDecode`.
+
+## Process an IFormFile in a controller
+
+The following controller accepts one buffered multipart upload, converts it to grayscale, and returns a PNG:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OpenCvSharp;
+
+namespace ImageApi.Controllers;
+
+[ApiController]
+[Route("images")]
+public sealed class ImagesController : ControllerBase
+{
+    private const long MaxFileBytes = 10 * 1024 * 1024;
+    private const long MaxRequestBytes = 11 * 1024 * 1024;
+    private const long MaxDecodedPixels = 40_000_000;
+
+    [HttpPost("grayscale")]
+    [RequestSizeLimit(MaxRequestBytes)]
+    public async Task<IActionResult> Grayscale(
+        IFormFile file,
+        CancellationToken cancellationToken)
+    {
+        if (file.Length is <= 0 or > MaxFileBytes)
+        {
+            return BadRequest("Upload one non-empty image up to 10 MiB.");
+        }
+
+        using var encoded = new MemoryStream(
+            capacity: checked((int)file.Length));
+        await file.CopyToAsync(encoded, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            using var source = Cv2.ImDecode(
+                encoded.GetBuffer().AsSpan(
+                    start: 0,
+                    length: checked((int)encoded.Length)),
+                ImreadModes.Color);
+
+            if (source.Empty())
+            {
+                return BadRequest("The upload is not a supported image.");
+            }
+
+            if (source.Total() > MaxDecodedPixels)
+            {
+                return BadRequest("The decoded image is too large.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var grayscale = new Mat();
+            Cv2.CvtColor(
+                source,
+                grayscale,
+                ColorConversionCodes.BGR2GRAY);
+
+            if (!Cv2.ImEncode(".png", grayscale, out byte[] png))
+            {
+                return StatusCode(
+                    StatusCodes.Status500InternalServerError,
+                    "Could not encode the result.");
+            }
+
+            return File(png, "image/png");
+        }
+        catch (OpenCVException)
+        {
+            return BadRequest("The upload could not be decoded.");
+        }
+    }
+}
+```
+
+`IFormFile` is already buffered by ASP.NET Core, potentially in memory or a temporary file. Copying it into a `MemoryStream` creates a contiguous buffer for `ImDecode`. `GetBuffer()` avoids the additional array copy that `ToArray()` would make.
+
+The request limit is slightly larger than the file limit because a multipart request also contains boundaries and headers. Hosting layers such as IIS or a reverse proxy may impose their own limits.
+
+Do not trust `IFormFile.FileName` or `ContentType` to select a decoder or response type. Decode the content, choose the output format on the server, and return the media type that matches that encoder.
+
+## Decode an arbitrary Stream with a byte limit
+
+For `HttpRequest.Body`, blob storage, or another stream source, enforce a byte limit while buffering. This helper returns a caller-owned `Mat`:
+
+```csharp
+using OpenCvSharp;
+
+static async Task<Mat> DecodeImageAsync(
+    Stream source,
+    int maxEncodedBytes,
+    ImreadModes mode,
+    CancellationToken cancellationToken)
+{
+    ArgumentNullException.ThrowIfNull(source);
+    ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxEncodedBytes);
+
+    using var encoded = new MemoryStream(
+        capacity: Math.Min(maxEncodedBytes, 64 * 1024));
+    byte[] chunk = new byte[64 * 1024];
+
+    while (true)
+    {
+        int remaining = maxEncodedBytes - checked((int)encoded.Length);
+        int readSize = remaining >= chunk.Length
+            ? chunk.Length
+            : remaining + 1;
+        int read = await source.ReadAsync(
+            chunk.AsMemory(0, readSize),
+            cancellationToken);
+
+        if (read == 0)
+        {
+            break;
+        }
+
+        if (read > remaining)
+        {
+            throw new InvalidDataException(
+                "The encoded image exceeds the configured limit.");
+        }
+
+        await encoded.WriteAsync(
+            chunk.AsMemory(0, read),
+            cancellationToken);
+    }
+
+    if (encoded.Length == 0)
+    {
+        throw new InvalidDataException("The encoded image is empty.");
+    }
+
+    cancellationToken.ThrowIfCancellationRequested();
+
+    Mat image = Cv2.ImDecode(
+        encoded.GetBuffer().AsSpan(
+            start: 0,
+            length: checked((int)encoded.Length)),
+        mode);
+
+    if (!image.Empty())
+    {
+        return image;
+    }
+
+    image.Dispose();
+    throw new InvalidDataException(
+        "The stream does not contain a supported image.");
+}
+```
+
+The caller owns the returned matrix:
+
+```csharp
+using Mat image = await DecodeImageAsync(
+    Request.Body,
+    maxEncodedBytes: 10 * 1024 * 1024,
+    ImreadModes.Color,
+    HttpContext.RequestAborted);
+```
+
+This helper applies an application limit even when the stream does not report a length. Configure the server or endpoint request-body limit as the first line of defense so the application does not need to receive an oversized body before rejecting it.
+
+For very frequent requests, an `ArrayPool<byte>` or a recyclable stream can reduce managed buffer allocation. Return pooled storage only after `ImDecode` completes because the decoder reads the buffer synchronously during the call.
+
+## Validate encoded and decoded sizes
+
+An encoded file can expand to a much larger pixel buffer. Validate at multiple layers:
+
+- Request-body size at Kestrel, IIS, or the reverse proxy.
+- Multipart and per-file size before copying an `IFormFile`.
+- A byte limit while reading an arbitrary stream.
+- `Empty()`, dimensions, channel count, and decoded pixel count after `ImDecode`.
+- Application-specific limits before expensive processing or encoding.
+
+Checking decoded dimensions happens after the decoder has allocated the image. If hostile image formats or decompression bombs are in scope, use an image-header parser with strict dimension limits, isolate decoding in a constrained worker, or apply operating-system memory limits. A post-decode check alone cannot prevent the decoder's initial allocation.
+
+## Manage cancellation and CPU work
+
+`CopyToAsync` and `ReadAsync` observe a `CancellationToken`. Most `Cv2` calls are synchronous native operations and cannot be interrupted by an ASP.NET Core cancellation token after they start.
+
+Check cancellation before expensive stages and avoid starting new work after `HttpContext.RequestAborted` is signaled. For long-running or untrusted workloads, move processing to a bounded queue or worker process that has an explicit timeout and resource limits.
+
+Wrapping every `Cv2` call in `Task.Run` does not reduce its CPU or memory cost. Under load it can add ThreadPool contention. Use bounded concurrency, and benchmark it together with OpenCV's own native thread usage. `Cv2.SetNumThreads` changes process-wide OpenCV behavior, so configure it once only when measurements justify doing so.
+
+Each request should own its mutable matrices. Do not share a writable `Mat` between concurrent requests without external synchronization and a clear ownership model.
+
+## Return encoded data, not a Mat
+
+`Mat` is a native resource and is not an HTTP response representation. Encode it before leaving the request scope:
+
+```csharp
+if (!Cv2.ImEncode(".jpg", result, out byte[] jpeg, [
+    new ImageEncodingParam(
+        ImwriteFlags.JpegQuality,
+        90),
+]))
+{
+    throw new InvalidOperationException(
+        "Could not encode the JPEG response.");
+}
+
+return Results.File(jpeg, "image/jpeg");
+```
+
+The returned `byte[]` is managed and remains valid after the source and result matrices are disposed. Encoding necessarily creates a compressed output buffer; it is not a zero-copy view of the `Mat`.
+
+## Deploy without a desktop GUI
+
+ASP.NET Core services normally do not use `Cv2.ImShow`, WPF, or another desktop UI. Choose the headless runtime package when the service needs the full non-GUI OpenCV module set, or the slim package only when its reduced modules are sufficient.
+
+Native runtime assets must match the deployment runtime identifier and architecture. Containers may also require native dependencies for the selected image codecs. Log `Cv2.GetVersionString()` and `Cv2.GetBuildInformation()` when production codec behavior differs from development.
+
+## Related guides
+
+- [Image Encoding and Conversion](image-conversion.md)
+- [Copies, Native Memory, and Performance](memory-copy-and-performance.md)
+- [Common Errors and Diagnostics](../troubleshooting/common-errors.md)
+- [Native Library Loading](../troubleshooting/native-library-loading.md)
+
+## Official references
+
+- [OpenCV image file reading and writing](https://docs.opencv.org/5.0/main_modules/imgcodecs.html)
+- [Upload files in ASP.NET Core](https://learn.microsoft.com/aspnet/core/mvc/models/file-uploads)
+- [Configure Kestrel server limits](https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/options)
+
+## Related OpenCvSharp API
+
+- [Cv2](xref:OpenCvSharp.Cv2)
+- [Mat](xref:OpenCvSharp.Mat)
+- [ImreadModes](xref:OpenCvSharp.ImreadModes)
+- [ImageEncodingParam](xref:OpenCvSharp.ImageEncodingParam)

--- a/docs/docfx/articles/guides/image-conversion.md
+++ b/docs/docfx/articles/guides/image-conversion.md
@@ -77,6 +77,8 @@ For file uploads, HTTP responses, and database blobs, encode directly with `Cv2.
 
 See [Display Images in .NET Applications](displaying-images-dotnet.md) for WPF, Avalonia, GDI+, UI-thread, and live-frame guidance.
 
+See [ASP.NET Core Image Uploads and Streams](aspnet-image-processing.md) for bounded upload buffering, `IFormFile`, request cancellation, and HTTP responses.
+
 ## Official OpenCV references
 
 - [OpenCV image file reading and writing](https://docs.opencv.org/5.0/main_modules/imgcodecs.html)

--- a/docs/docfx/articles/guides/input-output-arrays-and-in-place.md
+++ b/docs/docfx/articles/guides/input-output-arrays-and-in-place.md
@@ -54,7 +54,28 @@ static void Blur(InputArray source, OutputArray destination)
 
 An optional `InputArray` whose value is `default` represents OpenCV's `noArray()`. Callers normally omit optional masks rather than constructing this value explicitly.
 
-`InputArray.Create<T>` overloads can adapt managed arrays or sequences by materializing a temporary matrix representation. This is not the same allocation-free path as passing an existing `Mat`. Prefer a dedicated `ReadOnlySpan<T>`, array, or collection overload when the OpenCvSharp method provides one. In a repeated call where only an `InputArray` overload exists, create and dispose the hosting `Mat` explicitly so its storage and lifetime are visible.
+`InputArray.Create<T>` is not the same allocation-free path as passing an existing `Mat`. For an array, it creates a native `Mat` header over the managed storage without copying the elements and pins the array. For an `IEnumerable<T>`, it first materializes a new array and then creates the pinned matrix header.
+
+The returned `InputArray` is a non-disposable `ref struct`. It keeps the temporary `Mat` reachable through the native call, but the caller cannot deterministically dispose that hidden matrix afterward, so its native header and array pin may remain until finalization. Prefer a dedicated `ReadOnlySpan<T>`, array, or collection overload when the OpenCvSharp method provides one, and avoid `InputArray.Create<T>` in a hot loop.
+
+When repeated calls require an `InputArray`, own and reuse the hosting `Mat` explicitly:
+
+```csharp
+double[] values = [1.0, 2.0, 3.0, 4.0];
+using var valuesMat = Mat.FromPixelData(
+    rows: values.Length,
+    cols: 1,
+    type: MatType.CV_64FC1,
+    data: values);
+
+for (var iteration = 0; iteration < 100; iteration++)
+{
+    Scalar mean = Cv2.Mean(valuesMat);
+    Console.WriteLine(mean.Val0);
+}
+```
+
+`valuesMat` keeps `values` pinned until the matrix is disposed, and edits to either view are visible through the other.
 
 ## Understand output allocation
 

--- a/docs/docfx/articles/guides/input-output-arrays-and-in-place.md
+++ b/docs/docfx/articles/guides/input-output-arrays-and-in-place.md
@@ -1,0 +1,199 @@
+# InputArray, OutputArray, and In-place Processing
+
+OpenCV uses `InputArray`, `OutputArray`, and `InputOutputArray` to accept several matrix-like types through one C++ signature. OpenCvSharp mirrors those roles, but normal application code should usually pass a `Mat` directly and let the implicit conversion create the required proxy.
+
+## Read the parameter roles
+
+The wrapper type describes how the native function uses the argument:
+
+| OpenCvSharp parameter | Meaning | Common arguments |
+|---|---|---|
+| `InputArray` | Read-only input | `Mat`, `UMat`, `MatExpr`, `Scalar`, `double`, or a supported `Vec` |
+| `OutputArray` | Output that OpenCV may allocate or reallocate | `Mat` or `UMat` |
+| `InputOutputArray` | Existing content may be read and then modified | `Mat` or `UMat` |
+
+These are API roles, not alternative image containers. The pixels still belong to the `Mat` or `UMat` passed by the caller.
+
+## Pass Mat directly
+
+Although the signature of `Cv2.GaussianBlur` accepts `InputArray` and `OutputArray`, no explicit wrapper is needed:
+
+```csharp
+using OpenCvSharp;
+
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+if (source.Empty())
+{
+    throw new InvalidOperationException("Could not read input.jpg.");
+}
+
+using var blurred = new Mat();
+Cv2.GaussianBlur(
+    source,
+    blurred,
+    new Size(5, 5),
+    sigmaX: 1.2);
+```
+
+The current OpenCvSharp5 implementation converts `Mat` and `UMat` to stack-only proxy values without allocating a managed or native wrapper object. The proxy keeps the source object reachable for the duration of the native call. It does not own or dispose the source.
+
+Explicit creation is mainly useful when writing a helper whose own signature preserves the OpenCV parameter roles:
+
+```csharp
+static void Blur(InputArray source, OutputArray destination)
+{
+    Cv2.GaussianBlur(
+        source,
+        destination,
+        new Size(5, 5),
+        sigmaX: 1.2);
+}
+```
+
+`InputArray`, `OutputArray`, and `InputOutputArray` are `ref struct` types in OpenCvSharp5. They cannot be boxed, stored in ordinary class fields, captured by lambdas, or kept across an `await` or `yield` boundary. Pass them through short synchronous call chains instead of treating them as long-lived objects.
+
+An optional `InputArray` whose value is `default` represents OpenCV's `noArray()`. Callers normally omit optional masks rather than constructing this value explicitly.
+
+`InputArray.Create<T>` overloads can adapt managed arrays or sequences by materializing a temporary matrix representation. This is not the same allocation-free path as passing an existing `Mat`. Prefer a dedicated `ReadOnlySpan<T>`, array, or collection overload when the OpenCvSharp method provides one. In a repeated call where only an `InputArray` overload exists, create and dispose the hosting `Mat` explicitly so its storage and lifetime are visible.
+
+## Understand output allocation
+
+An empty destination `Mat` is idiomatic:
+
+```csharp
+using var grayscale = new Mat();
+Cv2.CvtColor(
+    source,
+    grayscale,
+    ColorConversionCodes.BGR2GRAY);
+```
+
+The native function creates the destination storage with the required size and type. If a destination already has compatible storage, many OpenCV functions reuse it; otherwise they reallocate it. The exact output contract belongs to the native function and is documented in the official OpenCV reference.
+
+Reusing a destination is useful in a loop:
+
+```csharp
+using var capture = new VideoCapture("input.mp4");
+using var frame = new Mat();
+using var grayscale = new Mat();
+
+while (capture.Read(frame))
+{
+    if (frame.Empty())
+    {
+        break;
+    }
+
+    Cv2.CvtColor(
+        frame,
+        grayscale,
+        ColorConversionCodes.BGR2GRAY);
+
+    // Consume grayscale before the next iteration.
+}
+```
+
+Do not keep a `Span<T>`, data pointer, or assumption about the destination buffer across a call that may reallocate that `Mat`.
+
+## InputOutputArray is one read/write argument
+
+`InputOutputArray` means that one argument carries data into the function and may be changed by it. Drawing functions are a simple example:
+
+```csharp
+using var canvas = new Mat(
+    rows: 480,
+    cols: 640,
+    type: MatType.CV_8UC3,
+    s: Scalar.Black);
+
+Cv2.Line(
+    canvas,
+    new Point(20, 20),
+    new Point(620, 460),
+    Scalar.LimeGreen,
+    thickness: 3);
+```
+
+Other examples include calibration parameters initialized with a prior estimate, masks updated by segmentation functions, and matrices filled with random values. Read the individual method documentation to determine whether the incoming contents are required or only the existing allocation is reused.
+
+`InputOutputArray` is different from passing the same `Mat` as separate `src` and `dst` arguments. The former is part of the function signature. The latter creates aliasing between two parameters and is valid only when the native operation explicitly supports in-place execution.
+
+## Use in-place processing only when documented
+
+OpenCvSharp passes the same native `cv::Mat` when the same managed `Mat` is supplied as both input and output. OpenCvSharp does not add a temporary buffer to make unsupported aliasing safe.
+
+OpenCV documents Gaussian filtering as supporting in-place operation:
+
+```csharp
+Cv2.GaussianBlur(
+    source,
+    source,
+    new Size(5, 5),
+    sigmaX: 1.2);
+```
+
+By contrast, geometric warp functions document that they cannot operate in-place. Use a separate destination:
+
+```csharp
+using var transform = Cv2.GetRotationMatrix2D(
+    new Point2f(source.Width / 2f, source.Height / 2f),
+    angle: 10,
+    scale: 1);
+
+using var rotated = new Mat();
+Cv2.WarpAffine(
+    source,
+    rotated,
+    transform,
+    source.Size());
+```
+
+Use the following rule:
+
+1. Check the native OpenCV reference for the exact function.
+2. Use the same `Mat` only when the documentation explicitly permits in-place operation or defines the argument as input/output.
+3. Prefer a separate destination when the output size, depth, or channel count changes.
+4. Avoid partially overlapping source and destination regions unless the function explicitly supports that layout.
+
+In-place processing can reduce one destination allocation, but it can also destroy data needed by later stages and make ownership harder to understand. Measure before using it as a general optimization.
+
+## MatExpr inputs are different
+
+Passing a `Mat` or `UMat` through an input proxy is allocation-free. Passing a `MatExpr` requires materializing the deferred expression before the native call:
+
+```csharp
+MatExpr expression = source * 0.5 + Scalar.All(20);
+
+using var result = new Mat();
+Cv2.Max(expression, 0, result);
+```
+
+Materialize an expression once with `ToMat()` when several later operations need the same result. Reusing the expression itself may evaluate it again.
+
+## Common mistakes
+
+- Do not call `Dispose` on a source `Mat` while a native operation is using it.
+- Do not store an array proxy for later work; store the owning `Mat` instead.
+- Do not assume that every function with separate input and output parameters supports the same object for both.
+- Do not retain spans or pointers when the associated `Mat` may be disposed or reallocated.
+- Do not assume a preallocated output forces OpenCV to keep its current size or type.
+
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [Copies, Native Memory, and Performance](memory-copy-and-performance.md)
+- [Resource Management](resource-management.md)
+
+## Official OpenCV references
+
+- [Operations on arrays](https://docs.opencv.org/5.0/main_modules/core_array.html)
+- [Image filtering](https://docs.opencv.org/5.0/main_modules/imgproc_filter.html)
+- [Geometric image transformations](https://docs.opencv.org/5.0/main_modules/imgproc_transform.html)
+
+## Related OpenCvSharp API
+
+- [InputArray](xref:OpenCvSharp.InputArray)
+- [OutputArray](xref:OpenCvSharp.OutputArray)
+- [InputOutputArray](xref:OpenCvSharp.InputOutputArray)
+- [Mat](xref:OpenCvSharp.Mat)
+- [MatExpr](xref:OpenCvSharp.MatExpr)

--- a/docs/docfx/articles/guides/mat-basics.md
+++ b/docs/docfx/articles/guides/mat-basics.md
@@ -117,6 +117,8 @@ The array is pinned while the `Mat` is alive, and changes are shared in both dir
 ## Related guides
 
 - [Pixel Access](pixel-access.md)
+- [InputArray, OutputArray, and In-place Processing](input-output-arrays-and-in-place.md)
+- [Copies, Native Memory, and Performance](memory-copy-and-performance.md)
 - [Resource Management](resource-management.md)
 - [Image Encoding and Conversion](image-conversion.md)
 

--- a/docs/docfx/articles/guides/memory-copy-and-performance.md
+++ b/docs/docfx/articles/guides/memory-copy-and-performance.md
@@ -1,0 +1,247 @@
+# Copies, Native Memory, and Performance
+
+OpenCvSharp combines C# object references with OpenCV's reference-counted native matrices. Understanding which operation aliases an object, shares pixel storage, or performs a deep copy is more important than applying isolated micro-optimizations.
+
+## Distinguish assignment, views, and copies
+
+These operations have different ownership:
+
+| C# operation | Managed object | Pixel storage |
+|---|---|---|
+| `Mat alias = source;` | Same `Mat` object | Same storage |
+| `new Mat(source, roi)` | New `Mat` header | Shared storage |
+| `source.Clone()` | New `Mat` | Independent copied storage |
+| `source.CopyTo(destination)` | Existing destination object | Independent storage, reused when compatible |
+
+A C# assignment does not copy a native `cv::Mat` header:
+
+```csharp
+Mat alias = source;
+```
+
+`alias` and `source` are two managed references to the same disposable object. Disposing either reference disposes that object, so do not use assignment to express independent ownership.
+
+## Regions of interest share pixels
+
+A region of interest creates a separate native matrix header that views the source storage:
+
+```csharp
+using var region = new Mat(
+    source,
+    new Rect(X: 20, Y: 30, Width: 200, Height: 120));
+
+region.SetTo(Scalar.Black);
+```
+
+The change is visible in `source`. The region keeps the underlying reference-counted OpenCV allocation alive, but both managed headers must still be disposed.
+
+Create an independent result when the pixels must outlive or diverge from the source:
+
+```csharp
+using var copy = region.Clone();
+```
+
+`Clone()` always performs a deep copy. `Clone(roi)` is a convenient way to create an independent crop.
+
+## Use CopyTo when the destination should be reused
+
+`CopyTo` performs a deep copy but writes through an existing destination object:
+
+```csharp
+using var destination = new Mat();
+
+source.CopyTo(destination);
+```
+
+If `destination` already has the required size and type, OpenCV can reuse its allocation. If not, OpenCV reallocates it. This makes `CopyTo` appropriate when a long-lived component owns the destination:
+
+```csharp
+static void CopyFrames(
+    IEnumerable<Mat> frames,
+    Action<Mat> consume)
+{
+    using var snapshot = new Mat();
+
+    foreach (Mat frame in frames)
+    {
+        frame.CopyTo(snapshot);
+        consume(snapshot);
+    }
+}
+```
+
+Do not retain `snapshot` outside the loop unless the consumer finishes before the next copy. Use `Clone()` when each iteration needs an independently owned image.
+
+## Dispose native owners deterministically
+
+The pixel buffer of a normal `Mat` is native memory. The .NET garbage collector tracks the small managed wrapper but does not accurately account for the native allocation behind it.
+
+Prefer lexical ownership:
+
+```csharp
+using var source = Cv2.ImRead("input.jpg", ImreadModes.Color);
+using var grayscale = new Mat();
+using var edges = new Mat();
+
+Cv2.CvtColor(
+    source,
+    grayscale,
+    ColorConversionCodes.BGR2GRAY);
+Cv2.Canny(grayscale, edges, 80, 160);
+```
+
+Dispose temporary matrices inside long-running loops rather than waiting for finalization. Do not call `GC.Collect()` as a resource-management strategy.
+
+Returning a `Mat` transfers disposal responsibility to the caller:
+
+```csharp
+static Mat CreateThumbnail(Mat source)
+{
+    var thumbnail = new Mat();
+    Cv2.Resize(
+        source,
+        thumbnail,
+        new Size(320, 180),
+        interpolation: InterpolationFlags.Area);
+    return thumbnail;
+}
+
+using var thumbnail = CreateThumbnail(source);
+```
+
+## Reuse outputs in hot loops
+
+Most OpenCV functions create or resize an `OutputArray` as needed. Keep destination `Mat` objects outside a loop when the output contract is stable:
+
+```csharp
+using var capture = new VideoCapture("input.mp4");
+using var frame = new Mat();
+using var grayscale = new Mat();
+using var edges = new Mat();
+
+while (capture.Read(frame))
+{
+    if (frame.Empty())
+    {
+        break;
+    }
+
+    Cv2.CvtColor(
+        frame,
+        grayscale,
+        ColorConversionCodes.BGR2GRAY);
+    Cv2.Canny(grayscale, edges, 80, 160);
+
+    Process(edges);
+}
+```
+
+This reuses managed wrappers and normally reuses native buffers while the dimensions and types remain unchanged. It is still correct when a new frame size forces reallocation.
+
+Reuse is not equivalent to retaining every frame. Clone only frames that must remain stable after the next iteration.
+
+## Wrap managed pixel memory carefully
+
+`Mat.FromPixelData` can create a matrix header without copying an existing managed array:
+
+```csharp
+const int width = 640;
+const int height = 480;
+
+byte[] pixels = new byte[width * height * 3];
+
+using var image = Mat.FromPixelData(
+    rows: height,
+    cols: width,
+    type: MatType.CV_8UC3,
+    data: pixels);
+```
+
+The array overload pins the managed array while the `Mat` is alive. Changes are shared in both directions. Dispose the `Mat` promptly so the array is unpinned; long-lived pinned arrays make the managed heap harder to compact.
+
+The `IntPtr` overload does not own the pointed-to allocation. The caller must keep the memory valid for every native access and release it separately.
+
+Treat a zero-copy matrix as a view over external storage. If it is passed as an output to a function that changes the size or type, OpenCV may replace its backing allocation, after which it no longer represents the original array or pointer. Use `Clone()` when OpenCV should own independent storage.
+
+## Respect stride and continuity
+
+Rows may contain padding, and a region of interest is not necessarily continuous. Do not calculate every row as `DataPointer + row * width * elementSize` unless continuity is guaranteed.
+
+Use `AsRows<T>()` for fast row-by-row access:
+
+```csharp
+if (image.Type() != MatType.CV_8UC3)
+{
+    throw new ArgumentException("Expected CV_8UC3.", nameof(image));
+}
+
+var rows = image.AsRows<Vec3b>();
+for (var y = 0; y < rows.Count; y++)
+{
+    Span<Vec3b> row = rows[y];
+    for (var x = 0; x < row.Length; x++)
+    {
+        Vec3b pixel = row[x];
+        row[x] = new Vec3b(pixel.Item2, pixel.Item1, pixel.Item0);
+    }
+}
+```
+
+`AsRows<T>()` captures the data pointer, stride, and dimensions. Do not dispose or reallocate the `Mat` while the accessor or one of its spans is in use. `AsSpan<T>()` returns an empty span for a non-continuous matrix.
+
+Prefer an existing `Cv2` operation over a managed pixel loop when OpenCV already provides the transformation. The native implementation can use vectorization, parallelism, and optimized libraries that a per-pixel P/Invoke or general managed loop cannot match.
+
+## Account for hidden copies
+
+Common copy boundaries include:
+
+- `Clone()` and `CopyTo`.
+- Encoding a `Mat` to PNG or JPEG.
+- Decoding PNG or JPEG bytes to a `Mat`.
+- Converting to UI-framework bitmap types.
+- Materializing a `MatExpr`.
+- Calling `ToArray()` or similar APIs that return managed data.
+
+Removing one copy is useful only if it is meaningful relative to decoding, inference, filtering, encoding, network I/O, and UI presentation. Measure the complete pipeline with representative image sizes.
+
+## Benchmark native work correctly
+
+When using BenchmarkDotNet or another harness:
+
+1. Load or generate source images outside the measured operation.
+2. Reuse destinations in one benchmark and allocate them in a separate benchmark.
+3. Dispose every native object created by an iteration.
+4. Consume or validate output so the benchmark represents real work.
+5. Test the same size, type, channels, backend, and thread configuration used in production.
+6. Report throughput and peak working set as well as managed allocations.
+
+Managed allocation counters do not include most `Mat` pixel storage. Use process memory, native profilers, or a controlled working-set test when native memory is the concern.
+
+## Choose an ownership operation
+
+| Requirement | Preferred operation |
+|---|---|
+| Another name for the same managed object | C# assignment |
+| Temporary rectangular view | ROI constructor |
+| Independent image owned by the caller | `Clone()` |
+| Copy into a component-owned reusable buffer | `CopyTo()` |
+| View a managed array without copying | `Mat.FromPixelData(Array)` with a short `using` scope |
+| Process many same-shaped frames | Reuse destination `Mat` objects |
+
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [Pixel Access](pixel-access.md)
+- [InputArray, OutputArray, and In-place Processing](input-output-arrays-and-in-place.md)
+- [Resource Management](resource-management.md)
+
+## Official OpenCV references
+
+- [Mat: the basic image container](https://docs.opencv.org/5.0/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.html)
+- [OpenCV core functionality](https://docs.opencv.org/5.0/main_modules/core.html)
+
+## Related OpenCvSharp API
+
+- [Mat](xref:OpenCvSharp.Mat)
+- [MatExpr](xref:OpenCvSharp.MatExpr)
+- [Cv2](xref:OpenCvSharp.Cv2)

--- a/docs/docfx/articles/guides/resource-management.md
+++ b/docs/docfx/articles/guides/resource-management.md
@@ -76,6 +76,12 @@ The caller owns and disposes the returned `Mat`. The method disposes the result 
 
 `Window` and other OpenCvSharp wrappers that implement `IDisposable` follow the same rule. Scope them with `using` rather than relying on finalization.
 
+## Related guides
+
+- [Mat Basics](mat-basics.md)
+- [InputArray, OutputArray, and In-place Processing](input-output-arrays-and-in-place.md)
+- [Copies, Native Memory, and Performance](memory-copy-and-performance.md)
+
 ## Official OpenCV references
 
 - [Mat: the basic image container](https://docs.opencv.org/5.0/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.html)

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -11,6 +11,7 @@ Start with these pages in order:
 3. [Build your first application](getting-started/first-application.md).
 4. Learn the [fundamentals of Mat](guides/mat-basics.md).
 5. Learn how to [manage native resources](guides/resource-management.md).
+6. Understand [array proxies and in-place processing](guides/input-output-arrays-and-in-place.md), then learn how to control [copies and native memory](guides/memory-copy-and-performance.md).
 
 Already familiar with OpenCV C++ or OpenCV-Python? Start with the [API comparison and translation guide](getting-started/opencv-api-comparison.md).
 
@@ -22,7 +23,10 @@ Already familiar with OpenCV C++ or OpenCV-Python? Start with the [API compariso
 - [Create and refine masks](guides/thresholding-masks-morphology.md)
 - [Measure contours and connected components](guides/contours-shape-analysis.md)
 - [Access and modify pixels](guides/pixel-access.md)
+- [Use InputArray, OutputArray, and in-place processing safely](guides/input-output-arrays-and-in-place.md)
+- [Control copies, native memory, and hot-loop allocations](guides/memory-copy-and-performance.md)
 - [Encode images and convert UI image types](guides/image-conversion.md)
+- [Process uploaded images and streams in ASP.NET Core](guides/aspnet-image-processing.md)
 - [Display images in .NET UI frameworks](guides/displaying-images-dotnet.md)
 - [Read and write video](guides/video-io.md)
 - [Detect and match local features](guides/feature-detection-and-matching.md)

--- a/docs/docfx/articles/toc.yml
+++ b/docs/docfx/articles/toc.yml
@@ -14,6 +14,10 @@
   items:
     - name: Mat Basics
       href: guides/mat-basics.md
+    - name: InputArray, OutputArray, and In-place Processing
+      href: guides/input-output-arrays-and-in-place.md
+    - name: Copies, Native Memory, and Performance
+      href: guides/memory-copy-and-performance.md
     - name: Pixel Access
       href: guides/pixel-access.md
     - name: Image Processing Pipeline
@@ -28,6 +32,8 @@
       href: guides/contours-shape-analysis.md
     - name: Image Encoding and Conversion
       href: guides/image-conversion.md
+    - name: ASP.NET Core Image Uploads and Streams
+      href: guides/aspnet-image-processing.md
     - name: Display Images in .NET Applications
       href: guides/displaying-images-dotnet.md
     - name: Video I/O

--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -13,6 +13,8 @@ OpenCvSharp is a cross-platform .NET wrapper for OpenCV. This site contains the 
 ## Essential guides
 
 - [Manage native resources](articles/guides/resource-management.md)
+- [Understand InputArray, OutputArray, and in-place processing](articles/guides/input-output-arrays-and-in-place.md)
+- [Control copies, native memory, and performance](articles/guides/memory-copy-and-performance.md)
 - [Diagnose common errors](articles/troubleshooting/common-errors.md)
 - [Troubleshoot native library loading](articles/troubleshooting/native-library-loading.md)
 - [Migrate from OpenCvSharp4 to OpenCvSharp5](https://github.com/shimat/opencvsharp/blob/main/docs/migration-4-to-5.md)
@@ -24,6 +26,7 @@ OpenCvSharp is a cross-platform .NET wrapper for OpenCV. This site contains the 
 - [Create masks and analyze shapes](articles/guides/thresholding-masks-morphology.md)
 - [Measure contours and connected components](articles/guides/contours-shape-analysis.md)
 - [Encode images and convert UI image types](articles/guides/image-conversion.md)
+- [Process uploaded images and streams in ASP.NET Core](articles/guides/aspnet-image-processing.md)
 - [Display images in .NET UI frameworks](articles/guides/displaying-images-dotnet.md)
 - [Read and write video](articles/guides/video-io.md)
 - [Store matrices and parameters](articles/guides/file-storage.md)


### PR DESCRIPTION
Add three guides focused on behavior that is specific to OpenCvSharp and .NET: InputArray/OutputArray proxies and in-place processing, copy and native-memory ownership, and ASP.NET Core upload and stream integration.

The guides explain the current OpenCvSharp5 ref-struct proxy design, distinguish C# aliases from shared ROI views and deep copies, and provide bounded IFormFile/Stream examples with decoding, encoding, cancellation, concurrency, and headless deployment guidance. Navigation and related-guide links now expose the new material from the documentation landing pages.

## Test plan

- [x] Compile representative OpenCvSharp and ASP.NET Core examples with 0 warnings and 0 errors
- [x] Check Markdown and TOC local links
- [x] Check code fences, UTF-8 encoding, and `git diff --check`

A full DocFX build was not run because DocFX is not installed in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new guides covering safe ASP.NET Core image handling for uploads/streams, including size validation, decoding/encoding error handling, cancellation, and guidance to return encoded data.
  - Added a guide explaining `InputArray`, `OutputArray`, and in-place processing, with lifetime and common pitfalls.
  - Added a performance/ownership guide for native memory, copies, and correct benchmarking practices.
  - Updated and expanded guide navigation and related links to make the new material easier to find.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->