### PR TITLE
Split API members into separate pages

### DIFF
--- a/docs/docfx/docfx.json
+++ b/docs/docfx/docfx.json
@@ -8,6 +8,8 @@
         }
       ],
       "dest": "api",
+      "filter": "filterConfig.yml",
+      "memberLayout": "separatePages",
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
       "properties": {
@@ -21,6 +23,9 @@
         "files": [
           "api/**.yml",
           "api/index.md"
+        ],
+        "exclude": [
+          "api/OpenCvSharp.Internal*.yml"
         ]
       },
       {

--- a/docs/docfx/filterConfig.yml
+++ b/docs/docfx/filterConfig.yml
@@ -1,0 +1,3 @@
+apiRules:
+- exclude:
+    uidRegex: ^OpenCvSharp\.Internal(?:\.|$)


### PR DESCRIPTION
Split DocFX managed-reference members into dedicated pages so large types such as `Cv2` no longer render hundreds of method details in one document. Also filter `OpenCvSharp.Internal.*` from metadata and build input so `NativeMethods` and other implementation-only APIs do not inflate the site or search index, even when stale generated YAML is present locally.

The generated `Cv2` class page falls from 1,289,216 bytes to 265,793 bytes, a 79.4% reduction, and links to 611 dedicated member pages. The complete generated site is 84.1 MiB and contains no Internal API pages.

## Test plan

- [x] Generate API metadata and the complete site with DocFX 2.78.5
- [x] Build the final filtered site with 0 warnings and 0 errors
- [x] Verify representative class, member, guide, xref, and search-index outputs
- [x] Run `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated API documentation organization with separate pages for members.
  * Excluded internal APIs from published documentation.
  * Added filtering rules to keep internal implementation details out of the API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->