### PR TITLE
Remove obsolete native preflight helpers

### DIFF
--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -167,7 +167,19 @@ jobs:
           cp ${GITHUB_WORKSPACE}/packaging/nuget/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/bin/Release/net10.0/
           cp ${GITHUB_WORKSPACE}/packaging/nuget/libOpenCvSharpExtern.so ${GITHUB_WORKSPACE}/test/OpenCvSharp.Tests/
           sudo cp ${GITHUB_WORKSPACE}/packaging/nuget/libOpenCvSharpExtern.so /usr/lib/
-          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-arm64 --logger "trx;LogFileName=test-results.trx" < /dev/null
+          # Preserve the executed-test sequence and a native dump when the test host crashes,
+          # including failures that happen during process teardown after all tests complete.
+          LD_LIBRARY_PATH=. dotnet test OpenCvSharp.Tests.csproj -c Release -f net10.0 --runtime linux-arm64 \
+            --logger "trx;LogFileName=test-results.trx" \
+            --blame-crash --blame-crash-dump-type full < /dev/null
+
+      - name: Upload crash dumps on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-arm64-crash-dumps
+          path: test/OpenCvSharp.Tests/TestResults/
+          if-no-files-found: ignore
 
       - name: Test Avalonia extensions
         run: |

--- a/docs/docfx/articles/troubleshooting/native-library-loading.md
+++ b/docs/docfx/articles/troubleshooting/native-library-loading.md
@@ -67,6 +67,7 @@ OpenCvSharp uses the .NET runtime's native library resolution. A host that does 
 ```csharp
 using System.Reflection;
 using System.Runtime.InteropServices;
+using OpenCvSharp;
 using OpenCvSharp.Internal;
 
 Assembly openCvSharpAssembly = typeof(NativeMethods).Assembly;
@@ -98,14 +99,15 @@ NativeLibrary.SetDllImportResolver(
         return NativeLibrary.Load(nativeLibraryPath);
     });
 
-NativeMethods.TryPInvoke();
+// Optional eager validation after registering the resolver.
+Console.WriteLine(Cv2.GetVersionString());
 ```
 
 This example expects the custom native library in a `native` directory beside `OpenCvSharp.dll`. Alternatively, obtain a fully qualified native-library path from the host's configuration. Do not derive it from the process current directory because a host can change that directory.
 
 Register the resolver before the first call to any OpenCvSharp API. The resolver must target `typeof(NativeMethods).Assembly`, not the host or plugin assembly, because native resolution is scoped to the assembly containing the P/Invoke declaration.
 
-Calling `NativeLibrary.Load` by itself only returns a native handle; returning that handle from the resolver connects it reliably to OpenCvSharp's `OpenCvSharpExtern` imports. `NativeMethods.TryPInvoke()` is an optional explicit pre-flight check after resolver registration and is not required for normal API calls.
+Calling `NativeLibrary.Load` by itself only returns a native handle; returning that handle from the resolver connects it reliably to OpenCvSharp's `OpenCvSharpExtern` imports. The first ordinary OpenCvSharp API call loads the native library through the registered resolver. OpenCvSharp5 has no separate library-loading or P/Invoke pre-flight helper; use a lightweight public API such as `Cv2.GetVersionString()` when eager validation is useful.
 
 Most applications should use an official runtime package instead of a custom resolver.
 

--- a/docs/issue-backlog.md
+++ b/docs/issue-backlog.md
@@ -46,8 +46,8 @@ Check off items as they are resolved.
 
 - **State**: closed (stale)
 - **URL**: https://github.com/shimat/opencvsharp/issues/1753
-- **Root cause**: `NativeMethods` calls `TryPInvoke` in its static constructor, which runs before user code has a chance to register a custom `NativeLibrary.SetDllImportResolver`. Custom native loaders therefore cannot intercept the first P/Invoke.
-- **Fix**: Removed the automatic `TryPInvoke()` call from `NativeMethods`' static constructor. `TryPInvoke()` remains public for explicit opt-in validation but is no longer called automatically. Users can now register `NativeLibrary.SetDllImportResolver` (via `typeof(NativeMethods).Assembly`) before any OpenCvSharp API call, then optionally call `NativeMethods.TryPInvoke()` for pre-flight validation.
+- **Root cause**: `NativeMethods` performed an automatic pre-flight P/Invoke in its static constructor, before applications could reliably configure custom native library resolution.
+- **Fix**: Removed the static constructor and the obsolete `TryPInvoke()` and `LoadLibraries()` helpers from OpenCvSharp5. Native libraries are now resolved by the .NET runtime on the first ordinary OpenCvSharp API call, so applications can register `NativeLibrary.SetDllImportResolver` via `typeof(NativeMethods).Assembly` beforehand.
 - **Effort**: Medium
 
 ---

--- a/docs/migration-4-to-5.md
+++ b/docs/migration-4-to-5.md
@@ -186,6 +186,7 @@ These wrap OpenCV functions that were removed in OpenCV 5 (no replacement), so t
 | `TrackerGOTURN` | Removed from OpenCV 5 |
 | The entire `OpenCvSharp.Cuda` namespace (`GpuMat`, `Stream`, `DeviceInfo`, …) | Was already non-functional dead code in OpenCvSharp4 (guarded by a build symbol that was never actually defined) and has now been deleted outright. OpenCvSharp has never supported CUDA — see the main README. |
 | `OutputArray.Create(List<T>)` | See §2 — use a `Mat` output and `Mat.GetArray<T>(out T[])` instead |
+| `OpenCvSharp.Internal.NativeMethods.LoadLibraries`, `TryPInvoke` | No replacement is normally needed: OpenCvSharp5 relies on the .NET runtime to resolve the native library on the first API call. For a nonstandard native library location, register `NativeLibrary.SetDllImportResolver` before that call; use a lightweight public API such as `Cv2.GetVersionString()` if eager validation is required. |
 
 > **Caffe/Darknet has no runtime fallback, not just a removed convenience method.** The generic dispatcher `Cv2.Dnn.ReadNet(model, config)` still *detects* `.caffemodel`/`.prototxt`/`.weights`/`.cfg` extensions, but on a match it unconditionally throws `cv::Exception: Caffe importer has been removed. Please use ONNX-converted models or use an older OpenCV version.` (same for Darknet). Converting the model to ONNX is mandatory, not just recommended, for any code that used to load `.caffemodel`/Darknet models.
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/NativeMethods.cs
@@ -1,49 +1,23 @@
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 
 // ReSharper disable InconsistentNaming
 #pragma warning disable 1591
-#pragma warning disable CA1805 // Do not initialize unnecessarily.
 
 namespace OpenCvSharp.Internal;
 
 /// <summary>
-/// P/Invoke methods of OpenCV 2.x C++ interface
+/// P/Invoke methods for the OpenCV C++ interface.
 /// </summary>
 public static partial class NativeMethods
 {
     public const string DllExtern = "OpenCvSharpExtern";
 
-    //private const UnmanagedType StringUnmanagedType = UnmanagedType.LPStr;
-
     private const UnmanagedType StringUnmanagedTypeWindows = UnmanagedType.LPStr;
 
     private const UnmanagedType StringUnmanagedTypeNotWindows =
         UnmanagedType.LPUTF8Str;
-
-    /// <summary>
-    /// Is tried P/Invoke once
-    /// </summary>
-    private static int tried;
-
-    /// <summary>
-    /// Static constructor
-    /// </summary>
-    static NativeMethods()
-    {
-        try
-        {
-            LoadLibraries();
-        }
-        catch (Exception ex) when (ex is DllNotFoundException or BadImageFormatException or EntryPointNotFoundException)
-        {
-            // Keep type initialization usable so TryPInvoke can retry after the application
-            // configures native resolution and report the loader failure without wrapping it
-            // in TypeInitializationException.
-        }
-    }
 
     public static void HandleException(ExceptionStatus status)
     {
@@ -53,87 +27,6 @@ public static partial class NativeMethods
         {
             ExceptionHandler.ThrowPossibleException();
         }
-    }
-
-    /// <summary>
-    /// Triggers native library resolution and installs the default error handler.
-    /// </summary>
-    public static void LoadLibraries()
-    {
-        if (IsWasm())
-        {
-            return;
-        }
-
-        // On both Windows and *nix, the native library is resolved by the .NET runtime's
-        // default probing (the runtimes/{rid}/native/ layout produced by the
-        // OpenCvSharp5.runtime.* packages). The P/Invoke below triggers the load and installs
-        // the default error handler.
-        InstallDefaultErrorHandler();
-    }
-
-    /// <summary>
-    /// Installs the default native (managed-free) OpenCV error handler. It only mutes
-    /// OpenCV's stderr dump; error details are captured natively and surfaced as a managed
-    /// exception via <see cref="HandleException"/> on each call's returned status.
-    /// </summary>
-    private static void InstallDefaultErrorHandler()
-    {
-        HandleException(core_setSilentErrorHandler());
-    }
-
-    /// <summary>
-    /// Checks whether PInvoke functions can be called and throws a descriptive exception if not.
-    /// This method is not called automatically. Call it explicitly for pre-flight validation
-    /// after setting up any custom native library loading (e.g. NativeLibrary.SetDllImportResolver).
-    /// </summary>
-    public static void TryPInvoke()
-    {
-#pragma warning disable CA1031
-        if (Volatile.Read(ref tried) != 0)
-            return;
-
-        try
-        {
-            LoadLibraries();
-            var ret = core_Mat_sizeof();
-            GC.KeepAlive(ret);
-            Volatile.Write(ref tried, 1);
-        }
-        catch (DllNotFoundException e)
-        {
-            var exception = new OpenCvSharpException(e.Message, e);
-            try{Console.WriteLine(exception.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            try{Debug.WriteLine(exception.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            throw exception;
-        }
-        catch (BadImageFormatException e)
-        {
-            var exception = new OpenCvSharpException(e.Message, e);
-            try { Console.WriteLine(exception.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            try { Debug.WriteLine(exception.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            throw exception;
-        }
-        catch (Exception e)
-        {
-            var ex = e.InnerException ?? e;
-            try{ Console.WriteLine(ex.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            try { Debug.WriteLine(ex.Message); }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch { }
-            throw;
-        }
-#pragma warning restore CA1031
     }
 
     /// <summary>

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core.cs
@@ -19,9 +19,6 @@ static partial class NativeMethods
     public static partial int core_setBreakOnError(int flag);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial ExceptionStatus core_setSilentErrorHandler();
-
-    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_getLastException(out int code, out int line, IntPtr func, IntPtr file, IntPtr message);
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/OpenCvSharpExtern/core.h
+++ b/src/OpenCvSharpExtern/core.h
@@ -1223,24 +1223,6 @@ CVAPI(int) core_setBreakOnError(int flag)
     return cv::setBreakOnError(flag != 0) ? 1 : 0;
 }
 
-// Native, managed-free OpenCV error handler installed by default. It exists only to
-// suppress OpenCV's stderr dump (OpenCV prints to stderr only when no handler is set).
-// Error details are captured by cvTry from the thrown exception, not here.
-static int opencvsharp_silentErrorHandler(int /*status*/, const char* /*funcName*/,
-    const char* /*errMsg*/, const char* /*fileName*/, int /*line*/, void* /*userdata*/)
-{
-    return 0;
-}
-
-// Installs the default native silent error handler. Idempotent. Called once at managed
-// startup (see NativeMethods.InstallDefaultErrorHandler).
-CVAPI(ExceptionStatus) core_setSilentErrorHandler()
-{
-    return cvTry([&] {
-        cv::redirectError(opencvsharp_silentErrorHandler);
-    });
-}
-
 // Reads the per-thread record of the last exception caught at the export boundary
 // (see cvTry / LastNativeException). The managed side calls this after an export
 // returns ExceptionStatus::Occurred.

--- a/test/OpenCvSharp.Tests/system/ExceptionTest.cs
+++ b/test/OpenCvSharp.Tests/system/ExceptionTest.cs
@@ -3,7 +3,7 @@ using Xunit;
 namespace OpenCvSharp.Tests;
 
 /// <summary>
-/// RedirectError tests
+/// Native exception propagation tests.
 /// </summary>
 public class ExceptionTest : TestBase
 {


### PR DESCRIPTION
## Summary

- remove `NativeMethods.LoadLibraries()` and `NativeMethods.TryPInvoke()` from OpenCvSharp5
- remove the silent native error-handler export that existed only for `LoadLibraries()`
- document that normal calls use .NET native-library resolution and recommend `Cv2.GetVersionString()` only when eager validation is useful
- record the breaking API removal in the OpenCvSharp4-to-5 migration guide and update the related backlog entry
- preserve Linux ARM64 crash sequences, full native dumps, and TRX output as failure artifacts so intermittent testhost crashes can be diagnosed without reproducing them

This PR now targets `main` after its original parent, #2094, was merged.

## Why

OpenCvSharp5 runtime packages already use the standard `runtimes/{rid}/native` layout, so the .NET runtime resolves `OpenCvSharpExtern` on the first ordinary API call. The helpers duplicated that behavior, exposed an internal pre-flight API without adding loader guarantees, and installed an error callback whose only effect was suppressing OpenCV's stderr diagnostics. Native exceptions continue to propagate through the existing `cvTry` / `core_getLastException` path.

The first Linux ARM64 CI run after rebasing crashed with exit code 139 during testhost teardown after all 698 tests had completed (679 passed and 19 skipped). The same code had passed in the preceding run, the parent PR's ARM64 job passed, every other platform passed, and rerunning the failed job also passed. No implementation change was indicated, but the workflow previously discarded its TRX and did not enable crash blame or upload a dump. The added diagnostics ensure the next intermittent crash leaves an executed-test sequence and native dump.

## Impact

Most applications require no replacement. Hosts that keep the native library in a nonstandard location should register `NativeLibrary.SetDllImportResolver` for `typeof(NativeMethods).Assembly` before the first OpenCvSharp API call. Applications that want eager validation can call `Cv2.GetVersionString()`.

OpenCvSharp4 is unchanged.

## Validation

- `cmake --build src/build --config Release --target OpenCvSharpExtern`
- `dotnet build src/OpenCvSharp/OpenCvSharp.csproj -c Release --no-restore`
- `dotnet test test/OpenCvSharp.Tests/OpenCvSharp.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~OpenCvSharp.Tests.ExceptionTest"` (5 passed)
- `docfx docs/docfx/docfx.json` (0 errors; 2 pre-existing duplicate-source warnings)
- reran failed Linux ARM64 job successfully: https://github.com/shimat/opencvsharp/actions/runs/30198307527
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified native library loading and configuration guidance for nonstandard locations.
  - Updated migration documentation to explain removed library-loading helpers and recommended runtime resolver configuration.
  - Revised troubleshooting examples to show eager validation through a standard OpenCvSharp API.

- **Bug Fixes**
  - Improved native library resolution by relying on runtime loading during the first OpenCvSharp API call.
  - Removed obsolete silent native error-handler behavior, supporting clearer exception propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->