### PR TITLE
Clarify Python API comparison terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 OpenCvSharp is a cross-platform .NET wrapper for OpenCV, providing a rich set of image processing and computer vision functionality. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API so that OpenCV concepts, documentation, and code can be transferred to .NET with minimal friction, while still using C# conventions such as typed enums, exceptions, and deterministic disposal.
 
-See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
+See [OpenCV C++, Python (cv2), and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
 
 ## 🚀 [Try the Live Demo](https://shimat.github.io/opencvsharp_blazor_sample/)
 

--- a/docs/docfx/articles/getting-started/opencv-api-comparison.md
+++ b/docs/docfx/articles/getting-started/opencv-api-comparison.md
@@ -1,4 +1,4 @@
-# OpenCV C++, OpenCV-Python, and OpenCvSharp
+# OpenCV C++, Python (cv2), and OpenCvSharp
 
 OpenCvSharp exposes OpenCV to .NET applications. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API so that OpenCV concepts, documentation, and code transfer naturally to .NET. Most computer vision concepts, algorithm behavior, and parameter constraints come directly from OpenCV, while the managed surface also follows C# conventions and cannot be translated mechanically from every C++ or Python example.
 
@@ -8,11 +8,11 @@ Use the official OpenCV documentation for algorithm theory and native parameter 
 
 OpenCV is implemented primarily in C++. Its C++ API is therefore the closest description of the native functions that OpenCvSharp eventually calls.
 
-OpenCV-Python is an official generated binding over the same native implementation. Images are normally presented as NumPy arrays, and the binding adapts many C++ output parameters into Python return values. Recent releases also provide `cv2.Mat`, a specialized `numpy.ndarray` subclass for preserving channel information, but it is not the usual image representation in Python code.
+OpenCV's Python bindings are generated from the same native API and are normally imported as `cv2`. Images are normally presented as NumPy arrays, and the binding adapts many C++ output parameters into Python return values. Recent releases also provide `cv2.Mat`, a specialized `numpy.ndarray` subclass for preserving channel information, but it is not the usual image representation in Python code.
 
 OpenCvSharp is a .NET wrapper with a managed API and a native bridge. It preserves many OpenCV names and concepts while representing them with .NET classes, enums, arrays, spans, exceptions, and `IDisposable`.
 
-| Concept | OpenCV C++ | OpenCV-Python | OpenCvSharp |
+| Concept | OpenCV C++ | Python (`cv2`) | OpenCvSharp |
 |---|---|---|---|
 | Free function | `cv::GaussianBlur` | `cv2.GaussianBlur` | `Cv2.GaussianBlur` |
 | Submodule function | `cv::dnn::readNetFromONNX` | `cv2.dnn.readNetFromONNX` | `Cv2.Dnn.ReadNetFromONNX` |
@@ -20,11 +20,13 @@ OpenCvSharp is a .NET wrapper with a managed API and a native bridge. It preserv
 | Image size | `cv::Size` | `(width, height)` tuple | `Size` |
 | Coordinate | `cv::Point` | `(x, y)` tuple | `Point` |
 | Color conversion enum and value | `cv::ColorConversionCodes` and `cv::COLOR_BGR2GRAY` | `cv2.COLOR_BGR2GRAY` | `ColorConversionCodes.BGR2GRAY` |
-| Output image | `OutputArray dst` argument | Usually a return value | Usually a caller-owned `Mat` argument |
+| Output image | Usually a caller-owned `cv::Mat` argument | Usually a return value | Usually a caller-owned `Mat` argument |
 | Native failure | `cv::Exception` | `cv2.error` | `OpenCVException` |
 | Lifetime | RAII and reference counting | Python and NumPy ownership | `IDisposable` and `using` |
 
 The correspondence is deliberately recognizable, but it is not a promise that every native overload has an identical managed overload.
+
+In both C++ and OpenCvSharp, many signatures declare the destination as `OutputArray`, but callers normally pass a `cv::Mat` or `Mat` directly.
 
 ## The same operation in three languages
 

--- a/docs/docfx/articles/index.md
+++ b/docs/docfx/articles/index.md
@@ -13,7 +13,7 @@ Start with these pages in order:
 5. Learn how to [manage native resources](guides/resource-management.md).
 6. Understand [array proxies and in-place processing](guides/input-output-arrays-and-in-place.md), then learn how to control [copies and native memory](guides/memory-copy-and-performance.md).
 
-Already familiar with OpenCV C++ or OpenCV-Python? Start with the [API comparison and translation guide](getting-started/opencv-api-comparison.md).
+Already familiar with OpenCV C++ or Python (`cv2`)? Start with the [API comparison and translation guide](getting-started/opencv-api-comparison.md).
 
 ## OpenCvSharp and .NET guides
 

--- a/packaging/nuget/README.managed.md
+++ b/packaging/nuget/README.managed.md
@@ -2,7 +2,7 @@
 
 A cross-platform .NET wrapper for [OpenCV](https://opencv.org/), providing image processing and computer vision functionality. Its API is intentionally designed to stay as close as practical to the native OpenCV C++ API while using C# conventions such as typed enums, exceptions, and deterministic disposal.
 
-See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
+See [OpenCV C++, Python (cv2), and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
 
 > This is the **OpenCvSharp5** family (OpenCV 5.x, .NET 8+). If you need .NET Framework, Unity, or another pre-.NET 8 runtime, use the **OpenCvSharp4** family (OpenCV 4.13.0) instead.
 

--- a/packaging/nuget/README.runtime.md
+++ b/packaging/nuget/README.runtime.md
@@ -2,7 +2,7 @@
 
 This is an **internal implementation package** for [OpenCvSharp](https://github.com/shimat/opencvsharp). It provides the native OpenCV shared library (`OpenCvSharpExtern`) for a specific platform.
 
-The managed OpenCvSharp API is intentionally designed to stay as close as practical to the native OpenCV C++ API. See [OpenCV C++, OpenCV-Python, and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
+The managed OpenCvSharp API is intentionally designed to stay as close as practical to the native OpenCV C++ API. See [OpenCV C++, Python (cv2), and OpenCvSharp](https://shimat.github.io/opencvsharp/articles/getting-started/opencv-api-comparison.html) for the main API and data-model differences.
 
 > In most cases you do not need to reference this package directly. Use one of the all-in-one packages instead:
 > - **Windows:** `OpenCvSharp5.Windows` or `OpenCvSharp5.Windows.Slim`


### PR DESCRIPTION
## Summary

- Present the Python API as Python (`cv2`) to distinguish the import namespace from the `opencv-python` package name.
- Replace the ambiguous claim that OpenCV-Python is an "official generated binding" with a concise description of how the bindings relate to the native API.
- Describe output images consistently from the caller's perspective: C++ and OpenCvSharp callers normally provide their own `Mat` objects.
- Clarify that both C++ and OpenCvSharp signatures commonly expose destination parameters as `OutputArray` even though callers pass `Mat` directly.

## Impact

The comparison page now distinguishes API terminology, package naming, signature abstractions, and normal call-site usage without adding package-history detail unrelated to OpenCvSharp.

## Validation

- `git diff --check`
- Reviewed all remaining `OpenCV-Python` occurrences; only official OpenCV reference titles remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API comparison references and headings to use “Python (`cv2`)” terminology.
  * Clarified Python image representations (typically NumPy arrays) and the availability of `cv2.Mat`.
  * Improved cross-API explanation of output image handling and typical parameter passing for C++, Python, and OpenCvSharp.
  * Refreshed getting-started wording and NuGet README guidance with links to the revised comparison article.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->