### PR TITLE
Capture symbolized ARM64 crash diagnostics

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   OPENCV_VERSION: "5.0.0"
+  OPENCV_ARM64_CACHE_REVISION: "2"
   MEDIAMTX_VERSION: "1.19.3"
   MEDIAMTX_SHA256: "5d82148d1032a6a190d9909a2997d9989457aaadf49af87dd02cd4512d31bebe"
 
@@ -371,7 +372,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-z7
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-v${{ env.OPENCV_ARM64_CACHE_REVISION }}-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -449,7 +450,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-z7
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-v${{ env.OPENCV_ARM64_CACHE_REVISION }}-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
 
       - name: Build OpenCvSharpExtern (full)
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -371,7 +371,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-z7
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -410,6 +410,8 @@ jobs:
             -D OPENCV_EXTRA_MODULES_PATH="$env:GITHUB_WORKSPACE/opencv_contrib/modules" `
             -D CMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/opencv_artifacts" `
             -D WITH_FFMPEG=OFF `
+            -D CMAKE_C_FLAGS="/Z7" `
+            -D CMAKE_CXX_FLAGS="/Z7" `
             -D CMAKE_ASM_COMPILER="" `
             *>&1 | Tee-Object -FilePath "$env:TEMP\opencv-configure.log"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -438,7 +440,9 @@ jobs:
         shell: powershell
         run: |
           cmake --build opencv/build --config Release -j 4
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cmake --install opencv/build --config Release
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Save OpenCV cache
         if: steps.opencv-cache.outputs.cache-hit != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -460,8 +464,10 @@ jobs:
             -D VCPKG_TARGET_TRIPLET=arm64-windows-static `
             -D VCPKG_MANIFEST_INSTALL=OFF `
             -D "VCPKG_INSTALLED_DIR=$env:GITHUB_WORKSPACE/vcpkg_installed" `
-            -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets"
+            -D "VCPKG_OVERLAY_TRIPLETS=$env:GITHUB_WORKSPACE/cmake/triplets" `
+            -D OPENCVSHARP_BUILD_WITH_DEBUG_INFO=ON
           cmake --build src/build_arm64 --config Release -j 4
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build OpenCvSharpExtern (slim)
         shell: powershell
@@ -494,8 +500,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: windows-arm64-crash-dumps
-          path: test/OpenCvSharp.Tests/TestResults/
+          name: windows-arm64-crash-diagnostics
+          path: |
+            src/build_arm64/OpenCvSharpExtern/Release/OpenCvSharpExtern.dll
+            src/build_arm64/OpenCvSharpExtern/Release/OpenCvSharpExtern.pdb
+            test/OpenCvSharp.Tests/TestResults/
           if-no-files-found: ignore
 
       - name: Pack NuGet packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -449,7 +449,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-windows-arm64-${{ hashFiles('cmake/opencv_build_options.cmake') }}-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake') }}-z7
 
       - name: Build OpenCvSharpExtern (full)
         shell: powershell

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,12 +29,18 @@ option(NO_BARCODE "Disable barcode bindings" OFF)
 option(NO_HIGHGUI "Disable highgui bindings" OFF)
 option(NO_VIDEOIO "Disable videoio bindings" OFF)
 option(NO_INSTALL_TO_TEST "Skip copying built DLL to the test project directory (Windows only)" OFF)
+option(OPENCVSHARP_BUILD_WITH_DEBUG_INFO "Generate compiler and linker symbols for MSVC diagnostics" OFF)
 
 # Enable MSVC security hardening flags (issue #1841)
 if(MSVC)
   add_compile_options(/guard:cf /GS)
   # /HIGHENTROPYVA: enable high-entropy 64-bit ASLR
   add_link_options(/guard:cf /DYNAMICBASE /HIGHENTROPYVA)
+  if(OPENCVSHARP_BUILD_WITH_DEBUG_INFO)
+    # Embed debug information so cached static libraries remain self-contained.
+    add_compile_options(/Z7)
+    add_link_options(/DEBUG:FULL)
+  endif()
 endif()
 
 # Convert options to compile definitions so C++ preprocessor can see them

--- a/test/OpenCvSharp.Tests/optflow/Cv2OptFlowFactoriesTest.cs
+++ b/test/OpenCvSharp.Tests/optflow/Cv2OptFlowFactoriesTest.cs
@@ -67,8 +67,9 @@ public class Cv2OptFlowFactoriesTest : TestBase
     public void CreateOptFlow_SparseToDense_CalcSmoke()
     {
         using var src = LoadImage("lenna.png");
-        using var from = src[new Rect(0, 0, 64, 64)];
-        using var to = src[new Rect(2, 0, 64, 64)];
+        // SparseToDense uses K=128 by default, so provide enough grid points for interpolation.
+        using var from = src[new Rect(0, 0, 256, 256)];
+        using var to = src[new Rect(2, 0, 256, 256)];
         using var flow = Cv2.OptFlow.CreateOptFlow_SparseToDense();
         using var flowMat = new Mat();
 

--- a/test/OpenCvSharp.Tests/ximgproc/XimgProcTest.cs
+++ b/test/OpenCvSharp.Tests/ximgproc/XimgProcTest.cs
@@ -535,6 +535,8 @@ public class XImgProcTest : TestBase
         using var toPtsMat = Mat.FromArray(toPts);
         using var denseFlow = new Mat();
 
+        // OpenCV expects K not to exceed the number of available sparse matches.
+        interpolator.K = fromPts.Length;
         interpolator.Interpolate(fromImage, fromPtsMat, toImage, toPtsMat, denseFlow);
         Assert.False(denseFlow.Empty());
     }


### PR DESCRIPTION
## Summary

- embed debug information in the cached ARM64 OpenCV static libraries with `/Z7`
- generate a full `OpenCvSharpExtern.pdb` for the regular ARM64 Release build
- upload the symbol-matched native DLL and PDB together with crash dumps when the ARM64 test job fails
- fail immediately when the OpenCV build, install, or OpenCvSharpExtern build command fails
- ensure the EdgeAwareInterpolator and SparseToDense smoke tests provide enough matches for their configured neighbor counts

## Why

Issue #2096 is an intermittent native access violation inside OpenCV's parallel `dtFilter` implementation on Windows ARM64. The original dump did not contain enough matching native symbol information to identify the exact failing instruction, and focused stress runs did not reproduce it.

During the investigation, a separate ARM64 crash was reproduced in `EdgeAwareInterpolator`. That test supplied three sparse matches while leaving `K` at 64. OpenCV then consumed invalid neighbor labels in its RANSAC interpolation path. The test now sets `K` to the available match count before interpolation.

The first PR CI run then reproduced the same class of invalid-input crash through SparseToDense. Its 64x64 test image could generate at most 64 grid points while OpenCV uses `K=128` by default. The symbol-matched PDB resolved the null read to `sparse_match_interpolators.cpp:822`. The smoke test now uses a large enough image to supply the interpolator.

The regular ARM64 CI build retains sufficient symbol information so that a future recurrence of #2096 produces a dump, DLL, and PDB from the same build. The DTFilter-specific stress workflow and cross-run artifact reuse used during investigation are intentionally not included.

## Impact

Runtime optimization remains enabled because the build configuration is still Release. ARM64 OpenCV cache entries will be larger due to embedded debug information. The large PDB is uploaded only when the ARM64 job fails.

## Validation

- `dotnet build test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release -f net10.0 --no-restore`
- targeted EdgeAwareInterpolator test: 1 passed
- targeted SparseToDense test: 1 passed
- investigation build: ARM64 full suite completed successfully five consecutive times after the initial test correction
- PR CI failure path: matching DLL, PDB, sequence, and full dump were uploaded and used to resolve the SparseToDense crash to its exact OpenCV source line

Relates to #2096.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows ARM64 CI reliability with fail-fast checks after native OpenCV build/install steps.
  - Fixed an interpolation test to ensure `K` never exceeds the available sparse matches.
  - Updated an optical-flow test to use a larger input region for default interpolation requirements.

- **Diagnostics**
  - Enhanced ARM64 test-failure artifacts by publishing a diagnostics bundle (including the native DLL, symbol file, and test results).
  - Added an MSVC build option to embed debug symbols into cached static libraries for easier investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->