### PR TITLE
Fix FeaturesMatcher collection overload dropping keypoints

### DIFF
--- a/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
+++ b/src/OpenCvSharp/Modules/stitching/FeaturesMatcher.cs
@@ -102,7 +102,7 @@ public abstract class FeaturesMatcher : CvObject
                     throw new ArgumentException("features contain null descriptor mat", nameof(features));
                 featuresArray[i].Descriptors.ThrowIfDisposed();
 
-                keypointVecs[i] = new StdVector<KeyPoint>();
+                keypointVecs[i] = new StdVector<KeyPoint>(featuresArray[i].Keypoints);
                 wImageFeatures[i] = new WImageFeatures
                 {
                     ImgIdx = featuresArray[i].ImgIdx,

--- a/test/OpenCvSharp.Tests/stitching/FeaturesMatcherTest.cs
+++ b/test/OpenCvSharp.Tests/stitching/FeaturesMatcherTest.cs
@@ -46,9 +46,8 @@ public class FeaturesMatcherTest : TestBase
         using var source = LoadImage("lenna.png", ImreadModes.Grayscale);
         var images = new[]
         {
-            source[new Rect(0, 0, 200, 200)].Clone(),
-            source[new Rect(100, 100, 200, 200)].Clone(),
-            source[new Rect(200, 0, 200, 200)].Clone(),
+            source.Clone(),
+            source.Clone(),
         };
         try
         {
@@ -70,6 +69,12 @@ public class FeaturesMatcherTest : TestBase
                     Assert.InRange(m.SrcImgIdx, -1, images.Length - 1);
                     Assert.InRange(m.DstImgIdx, -1, images.Length - 1);
                 }
+
+                var forwardMatch = Assert.Single(
+                    matches, m => m.SrcImgIdx == 0 && m.DstImgIdx == 1);
+                Assert.NotEmpty(forwardMatch.Matches);
+                Assert.True(forwardMatch.NumInliers > 0);
+                Assert.False(forwardMatch.H.Empty());
 
                 foreach (var m in matches)
                     m.Dispose();


### PR DESCRIPTION
## Summary

- populate each native keypoint vector from the corresponding `ImageFeatures.Keypoints`
- add regression coverage that verifies pairwise matches, inliers, and the homography produced by the collection overload

## Background

Sorry for only bringing this older report back up now. While revisiting #1676, we found that the collection overload of `FeaturesMatcher.Apply` was still discarding the managed keypoints; the concrete bug is tracked in #2100.

## Root cause and impact

The overload created an empty `StdVector<KeyPoint>` for every input feature set and passed those empty vectors to native code. Descriptors were preserved, but the missing keypoints left the resulting `MatchesInfo` incomplete or unusable. This change constructs each native vector from the matching managed keypoint collection.

## Validation

- `FeaturesMatcherTest`: 2 passed
- stitching test suite (`OpenCvSharp.Tests.Stitching`): 64 passed
- `git diff --check`

Closes #2100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-image feature matching by correctly preserving keypoint data for each image.
  * Matching results now provide more reliable pairwise matches and homography information.

* **Tests**
  * Expanded coverage for multi-image matching, including validation of matches, homographies, and inlier counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->