### PR TITLE
Add ICP and Gray-code structured light bindings

### DIFF
--- a/cmake/opencv_build_options.cmake
+++ b/cmake/opencv_build_options.cmake
@@ -38,8 +38,8 @@ set(BUILD_opencv_reg                       OFF CACHE BOOL "" FORCE)
 # OpenCV 5: calib3d was split and StereoMatcher/StereoBM/StereoSGBM now live in
 # the main "stereo" module, so it must be built (ximgproc/disparity_filter needs it).
 set(BUILD_opencv_stereo                    ON  CACHE BOOL "" FORCE)
-set(BUILD_opencv_structured_light          OFF CACHE BOOL "" FORCE)
-set(BUILD_opencv_surface_matching          OFF CACHE BOOL "" FORCE)
+set(BUILD_opencv_structured_light          ON  CACHE BOOL "" FORCE)
+set(BUILD_opencv_surface_matching          ON  CACHE BOOL "" FORCE)
 set(BUILD_opencv_videostab                 OFF CACHE BOOL "" FORCE)
 set(BUILD_opencv_wechat_qrcode             ON  CACHE BOOL "" FORCE)
 

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/structured_light/NativeMethods_structured_light.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/structured_light/NativeMethods_structured_light.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401
+#pragma warning disable IDE1006
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_Ptr_GrayCodePattern_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_Ptr_GrayCodePattern_get(
+        IntPtr obj,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_create(
+        int width,
+        int height,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_StructuredLightPattern_generate(
+        OpenCvSafeHandle obj,
+        IntPtr patternImages,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_StructuredLightPattern_decode(
+        OpenCvSafeHandle obj,
+        [In] IntPtr[] patternImages,
+        [In] int[] patternImageCounts,
+        int cameraCount,
+        IntPtr blackImages,
+        IntPtr whiteImages,
+        in OutputArrayProxy disparityMap,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_getNumberOfPatternImages(
+        OpenCvSafeHandle obj,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_setWhiteThreshold(
+        OpenCvSafeHandle obj,
+        int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_setBlackThreshold(
+        OpenCvSafeHandle obj,
+        int value);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_getImagesForShadowMasks(
+        OpenCvSafeHandle obj,
+        in OutputArrayProxy blackImage,
+        in OutputArrayProxy whiteImage);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus structured_light_GrayCodePattern_getProjectorPixel(
+        OpenCvSafeHandle obj,
+        IntPtr patternImages,
+        int x,
+        int y,
+        out Point projectorPixel,
+        out int returnValue);
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/surface_matching/NativeMethods_surface_matching.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/surface_matching/NativeMethods_surface_matching.cs
@@ -1,0 +1,43 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401
+#pragma warning disable IDE1006
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus surface_matching_ICP_new1(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus surface_matching_ICP_new2(
+        int iterations,
+        float tolerance,
+        float rejectionScale,
+        int numberOfLevels,
+        out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus surface_matching_ICP_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus surface_matching_ICP_registerModelToScene(
+        OpenCvSafeHandle obj,
+        in InputArrayProxy sourcePointCloud,
+        in InputArrayProxy destinationPointCloud,
+        out double residual,
+        out IntPtr pose,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial ExceptionStatus surface_matching_computeNormalsPC3d(
+        in InputArrayProxy pointCloud,
+        in OutputArrayProxy pointCloudWithNormals,
+        int numberOfNeighbors,
+        int flipViewpoint,
+        Vec3f viewpoint,
+        out int returnValue);
+}

--- a/src/OpenCvSharp/Modules/structured_light/GrayCodePattern.cs
+++ b/src/OpenCvSharp/Modules/structured_light/GrayCodePattern.cs
@@ -1,0 +1,153 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.StructuredLight;
+
+/// <summary>
+/// Gray-code structured-light pattern generator and decoder.
+/// </summary>
+public sealed class GrayCodePattern : StructuredLightPattern
+{
+    private GrayCodePattern(IntPtr smartPtr, IntPtr rawPtr)
+        : base(
+            smartPtr,
+            rawPtr,
+            static p => NativeMethods.HandleException(
+                NativeMethods.structured_light_Ptr_GrayCodePattern_delete(p)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a Gray-code pattern for a projector resolution.
+    /// </summary>
+    /// <param name="width">Projector width.</param>
+    /// <param name="height">Projector height.</param>
+    public static GrayCodePattern Create(int width = 1024, int height = 768)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_create(
+                width,
+                height,
+                out var smartPtr));
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_Ptr_GrayCodePattern_get(
+                smartPtr,
+                out var rawPtr));
+        return new GrayCodePattern(smartPtr, rawPtr);
+    }
+
+    /// <summary>
+    /// Gets the number of Gray-code images required for projection and decoding.
+    /// </summary>
+    public int GetNumberOfPatternImages()
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_getNumberOfPatternImages(
+                Handle,
+                out var returnValue));
+        GC.KeepAlive(this);
+        return returnValue;
+    }
+
+    /// <summary>
+    /// Sets the minimum brightness difference between a pattern and its inverse.
+    /// </summary>
+    public void SetWhiteThreshold(int value)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 255);
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_setWhiteThreshold(
+                Handle,
+                value));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Sets the minimum brightness difference between white and black reference images.
+    /// </summary>
+    public void SetBlackThreshold(int value)
+    {
+        ThrowIfDisposed();
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 255);
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_setBlackThreshold(
+                Handle,
+                value));
+        GC.KeepAlive(this);
+    }
+
+    /// <summary>
+    /// Generates black and white images used to compute shadow masks.
+    /// </summary>
+    public void GetImagesForShadowMasks(
+        OutputArray blackImage,
+        OutputArray whiteImage)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_getImagesForShadowMasks(
+                Handle,
+                blackImage.Proxy,
+                whiteImage.Proxy));
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(blackImage.Source);
+        GC.KeepAlive(whiteImage.Source);
+    }
+
+    /// <summary>
+    /// Decodes the projector coordinate corresponding to a camera pixel.
+    /// </summary>
+    /// <param name="patternImages">Captured Gray-code pattern sequence.</param>
+    /// <param name="x">Camera pixel x coordinate.</param>
+    /// <param name="y">Camera pixel y coordinate.</param>
+    /// <param name="projectorPixel">Decoded projector coordinate.</param>
+    /// <returns>True when the coordinate is decoded successfully.</returns>
+    public bool TryGetProjectorPixel(
+        IEnumerable<Mat> patternImages,
+        int x,
+        int y,
+        out Point projectorPixel)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(patternImages);
+        ArgumentOutOfRangeException.ThrowIfNegative(x);
+        ArgumentOutOfRangeException.ThrowIfNegative(y);
+
+        var patternImageArray = patternImages.ToArray();
+        if (patternImageArray.Length != GetNumberOfPatternImages())
+            throw new ArgumentException(
+                "The image sequence length does not match the Gray-code pattern.",
+                nameof(patternImages));
+        foreach (var image in patternImageArray)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+            image.ThrowIfDisposed();
+        }
+
+        using var patternImageVector = new VectorOfMat(patternImageArray);
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_GrayCodePattern_getProjectorPixel(
+                Handle,
+                patternImageVector.CvPtr,
+                x,
+                y,
+                out projectorPixel,
+                out var returnValue));
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(patternImageArray);
+        return returnValue != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/structured_light/GrayCodePattern.cs
+++ b/src/OpenCvSharp/Modules/structured_light/GrayCodePattern.cs
@@ -24,8 +24,8 @@ public sealed class GrayCodePattern : StructuredLightPattern
     /// <param name="height">Projector height.</param>
     public static GrayCodePattern Create(int width = 1024, int height = 768)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentOutOfRangeException.ThrowIfLessThan(width, 2);
+        ArgumentOutOfRangeException.ThrowIfLessThan(height, 2);
 
         NativeMethods.HandleException(
             NativeMethods.structured_light_GrayCodePattern_create(
@@ -38,6 +38,9 @@ public sealed class GrayCodePattern : StructuredLightPattern
                 out var rawPtr));
         return new GrayCodePattern(smartPtr, rawPtr);
     }
+
+    /// <inheritdoc />
+    protected override int? GetRequiredPatternImageCount() => GetNumberOfPatternImages();
 
     /// <summary>
     /// Gets the number of Gray-code images required for projection and decoding.
@@ -135,6 +138,11 @@ public sealed class GrayCodePattern : StructuredLightPattern
             ArgumentNullException.ThrowIfNull(image);
             image.ThrowIfDisposed();
         }
+
+        var imageSize = patternImageArray[0].Size();
+        ValidateImages(patternImageArray, imageSize, nameof(patternImages));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(x, imageSize.Width);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(y, imageSize.Height);
 
         using var patternImageVector = new VectorOfMat(patternImageArray);
         NativeMethods.HandleException(

--- a/src/OpenCvSharp/Modules/structured_light/StructuredLightPattern.cs
+++ b/src/OpenCvSharp/Modules/structured_light/StructuredLightPattern.cs
@@ -18,6 +18,11 @@ public abstract class StructuredLightPattern : Algorithm
     }
 
     /// <summary>
+    /// Gets the required number of captured pattern images, when the implementation has a fixed sequence length.
+    /// </summary>
+    protected virtual int? GetRequiredPatternImageCount() => null;
+
+    /// <summary>
     /// Generates the pattern images to project.
     /// </summary>
     /// <returns>CV_8U images at projector resolution.</returns>
@@ -67,6 +72,13 @@ public abstract class StructuredLightPattern : Algorithm
             throw new ArgumentException("Camera image sequences must not be empty.", nameof(patternImages));
         if (patterns[0].Length != patterns[1].Length)
             throw new ArgumentException("Camera image sequences must have the same length.", nameof(patternImages));
+        if (GetRequiredPatternImageCount() is { } requiredPatternImageCount &&
+            patterns[0].Length != requiredPatternImageCount)
+        {
+            throw new ArgumentException(
+                "The image sequence length does not match the structured-light pattern.",
+                nameof(patternImages));
+        }
 
         var blackImageArray = blackImages.ToArray();
         var whiteImageArray = whiteImages.ToArray();
@@ -82,6 +94,14 @@ public abstract class StructuredLightPattern : Algorithm
             ArgumentNullException.ThrowIfNull(image);
             image.ThrowIfDisposed();
         }
+
+        var expectedImageSize = patterns[0][0].Size();
+        ValidateImages(
+            patterns.SelectMany(static images => images),
+            expectedImageSize,
+            nameof(patternImages));
+        ValidateImages(blackImageArray, expectedImageSize, nameof(blackImages));
+        ValidateImages(whiteImageArray, expectedImageSize, nameof(whiteImages));
 
         var patternPointers = patterns
             .Select(cameraImages => cameraImages.Select(static image => image.CvPtr).ToArray())
@@ -107,5 +127,27 @@ public abstract class StructuredLightPattern : Algorithm
         GC.KeepAlive(whiteImageArray);
         GC.KeepAlive(disparityMap.Source);
         return returnValue != 0;
+    }
+
+    /// <summary>
+    /// Validates captured structured-light images before passing them to native code.
+    /// </summary>
+    /// <param name="images">Images to validate.</param>
+    /// <param name="expectedSize">Required image dimensions.</param>
+    /// <param name="parameterName">Public API parameter represented by the images.</param>
+    protected static void ValidateImages(
+        IEnumerable<Mat> images,
+        Size expectedSize,
+        string parameterName)
+    {
+        foreach (var image in images)
+        {
+            if (image.Empty())
+                throw new ArgumentException("Images must not be empty.", parameterName);
+            if (image.Type() != MatType.CV_8UC1)
+                throw new ArgumentException("Images must have type CV_8UC1.", parameterName);
+            if (image.Size() != expectedSize)
+                throw new ArgumentException("Images must have uniform dimensions.", parameterName);
+        }
     }
 }

--- a/src/OpenCvSharp/Modules/structured_light/StructuredLightPattern.cs
+++ b/src/OpenCvSharp/Modules/structured_light/StructuredLightPattern.cs
@@ -1,0 +1,111 @@
+using OpenCvSharp.Internal;
+using OpenCvSharp.Internal.Util;
+using OpenCvSharp.Internal.Vectors;
+
+namespace OpenCvSharp.StructuredLight;
+
+/// <summary>
+/// Abstract base class for generating and decoding structured-light patterns.
+/// </summary>
+public abstract class StructuredLightPattern : Algorithm
+{
+    /// <summary>
+    /// Initializes a structured-light pattern wrapper.
+    /// </summary>
+    protected StructuredLightPattern(IntPtr smartPtr, IntPtr rawPtr, Action<IntPtr> release)
+        : base(smartPtr, rawPtr, release)
+    {
+    }
+
+    /// <summary>
+    /// Generates the pattern images to project.
+    /// </summary>
+    /// <returns>CV_8U images at projector resolution.</returns>
+    public virtual Mat[] Generate()
+    {
+        ThrowIfDisposed();
+
+        using var patternImages = new VectorOfMat();
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_StructuredLightPattern_generate(
+                Handle,
+                patternImages.CvPtr,
+                out var returnValue));
+
+        GC.KeepAlive(this);
+        if (returnValue == 0)
+            throw new OpenCvSharpException("Structured-light pattern generation failed.");
+        return patternImages.ToArray();
+    }
+
+    /// <summary>
+    /// Decodes structured-light images captured by a stereo camera pair.
+    /// </summary>
+    /// <param name="patternImages">Two sets of captured pattern images, one set for each camera.</param>
+    /// <param name="disparityMap">Output CV_64F disparity map.</param>
+    /// <param name="blackImages">Black reference image for each camera.</param>
+    /// <param name="whiteImages">White reference image for each camera.</param>
+    /// <returns>True when decoding succeeds.</returns>
+    public virtual bool Decode(
+        IEnumerable<IEnumerable<Mat>> patternImages,
+        OutputArray disparityMap,
+        IEnumerable<Mat> blackImages,
+        IEnumerable<Mat> whiteImages)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(patternImages);
+        ArgumentNullException.ThrowIfNull(blackImages);
+        ArgumentNullException.ThrowIfNull(whiteImages);
+
+        var patterns = patternImages
+            .Select(cameraImages => cameraImages?.ToArray() ??
+                throw new ArgumentException("A camera image sequence is null.", nameof(patternImages)))
+            .ToArray();
+        if (patterns.Length != 2)
+            throw new ArgumentException("Exactly two camera image sequences are required.", nameof(patternImages));
+        if (patterns.Any(cameraImages => cameraImages.Length == 0))
+            throw new ArgumentException("Camera image sequences must not be empty.", nameof(patternImages));
+        if (patterns[0].Length != patterns[1].Length)
+            throw new ArgumentException("Camera image sequences must have the same length.", nameof(patternImages));
+
+        var blackImageArray = blackImages.ToArray();
+        var whiteImageArray = whiteImages.ToArray();
+        if (blackImageArray.Length != patterns.Length)
+            throw new ArgumentException("One black reference image is required for each camera.", nameof(blackImages));
+        if (whiteImageArray.Length != patterns.Length)
+            throw new ArgumentException("One white reference image is required for each camera.", nameof(whiteImages));
+
+        foreach (var image in patterns.SelectMany(static images => images)
+                     .Concat(blackImageArray)
+                     .Concat(whiteImageArray))
+        {
+            ArgumentNullException.ThrowIfNull(image);
+            image.ThrowIfDisposed();
+        }
+
+        var patternPointers = patterns
+            .Select(cameraImages => cameraImages.Select(static image => image.CvPtr).ToArray())
+            .ToArray();
+        using var patternAddresses = new ArrayAddress2<IntPtr>(patternPointers);
+        using var blackImageVector = new VectorOfMat(blackImageArray);
+        using var whiteImageVector = new VectorOfMat(whiteImageArray);
+
+        NativeMethods.HandleException(
+            NativeMethods.structured_light_StructuredLightPattern_decode(
+                Handle,
+                patternAddresses.GetPointer(),
+                patternAddresses.GetDim2Lengths(),
+                patternAddresses.GetDim1Length(),
+                blackImageVector.CvPtr,
+                whiteImageVector.CvPtr,
+                disparityMap.Proxy,
+                out var returnValue));
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(patterns);
+        GC.KeepAlive(blackImageArray);
+        GC.KeepAlive(whiteImageArray);
+        GC.KeepAlive(disparityMap.Source);
+        return returnValue != 0;
+    }
+}

--- a/src/OpenCvSharp/Modules/surface_matching/Cv2.PpfMatch3D.cs
+++ b/src/OpenCvSharp/Modules/surface_matching/Cv2.PpfMatch3D.cs
@@ -1,0 +1,44 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+public static partial class Cv2
+{
+    /// <summary>
+    /// Surface-matching helpers in the native cv::ppf_match_3d namespace.
+    /// </summary>
+    public static class PpfMatch3D
+    {
+        /// <summary>
+        /// Computes surface normals for a point cloud using local plane fitting.
+        /// </summary>
+        /// <param name="pointCloud">Input point cloud as an N-by-3 CV_32F matrix.</param>
+        /// <param name="pointCloudWithNormals">Output N-by-6 CV_32F matrix containing XYZ coordinates and normals.</param>
+        /// <param name="numberOfNeighbors">Number of neighboring points used for each local plane fit.</param>
+        /// <param name="flipViewpoint">Whether normals should be oriented toward <paramref name="viewpoint"/>.</param>
+        /// <param name="viewpoint">Viewpoint used when <paramref name="flipViewpoint"/> is true.</param>
+        /// <returns>One on success, matching the OpenCV implementation.</returns>
+        public static int ComputeNormalsPC3d(
+            InputArray pointCloud,
+            OutputArray pointCloudWithNormals,
+            int numberOfNeighbors = 6,
+            bool flipViewpoint = false,
+            Vec3f viewpoint = default)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfNeighbors);
+
+            NativeMethods.HandleException(
+                NativeMethods.surface_matching_computeNormalsPC3d(
+                    pointCloud.Proxy,
+                    pointCloudWithNormals.Proxy,
+                    numberOfNeighbors,
+                    flipViewpoint ? 1 : 0,
+                    viewpoint,
+                    out var returnValue));
+
+            GC.KeepAlive(pointCloud.Source);
+            GC.KeepAlive(pointCloudWithNormals.Source);
+            return returnValue;
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/surface_matching/ICP.cs
+++ b/src/OpenCvSharp/Modules/surface_matching/ICP.cs
@@ -1,0 +1,87 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp.PpfMatch3D;
+
+/// <summary>
+/// Iterative Closest Point registration for 3D point clouds.
+/// </summary>
+public sealed class ICP : CvObject
+{
+    /// <summary>
+    /// Creates an ICP instance with the OpenCV defaults.
+    /// </summary>
+    public ICP()
+    {
+        NativeMethods.HandleException(
+            NativeMethods.surface_matching_ICP_new1(out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(
+            ptr,
+            ownsHandle: true,
+            releaseAction: static p => NativeMethods.HandleException(
+                NativeMethods.surface_matching_ICP_delete(p))));
+    }
+
+    /// <summary>
+    /// Creates an ICP instance.
+    /// </summary>
+    /// <param name="iterations">Maximum number of ICP iterations.</param>
+    /// <param name="tolerance">Registration accuracy at each pyramid level.</param>
+    /// <param name="rejectionScale">Standard-deviation coefficient used for robust outlier rejection.</param>
+    /// <param name="numberOfLevels">Number of point-cloud pyramid levels.</param>
+    public ICP(
+        int iterations,
+        float tolerance = 0.05f,
+        float rejectionScale = 2.5f,
+        int numberOfLevels = 6)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(iterations);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(tolerance);
+        ArgumentOutOfRangeException.ThrowIfNegative(rejectionScale);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(numberOfLevels);
+
+        NativeMethods.HandleException(
+            NativeMethods.surface_matching_ICP_new2(
+                iterations,
+                tolerance,
+                rejectionScale,
+                numberOfLevels,
+                out var ptr));
+        SetSafeHandle(new OpenCvPtrSafeHandle(
+            ptr,
+            ownsHandle: true,
+            releaseAction: static p => NativeMethods.HandleException(
+                NativeMethods.surface_matching_ICP_delete(p))));
+    }
+
+    /// <summary>
+    /// Registers a source point cloud to a destination point cloud.
+    /// </summary>
+    /// <param name="sourcePointCloud">Source point cloud as an N-by-6 CV_32F matrix containing XYZ coordinates and normals.</param>
+    /// <param name="destinationPointCloud">Destination point cloud as an N-by-6 CV_32F matrix containing XYZ coordinates and normals.</param>
+    /// <param name="residual">Output registration error.</param>
+    /// <param name="pose">Output 4-by-4 CV_64F transformation from the source point cloud to the destination point cloud.</param>
+    /// <returns>Zero on success.</returns>
+    public int RegisterModelToScene(
+        InputArray sourcePointCloud,
+        InputArray destinationPointCloud,
+        out double residual,
+        out Mat pose)
+    {
+        ThrowIfDisposed();
+
+        NativeMethods.HandleException(
+            NativeMethods.surface_matching_ICP_registerModelToScene(
+                Handle,
+                sourcePointCloud.Proxy,
+                destinationPointCloud.Proxy,
+                out residual,
+                out var posePtr,
+                out var returnValue));
+        pose = new Mat(posePtr);
+
+        GC.KeepAlive(this);
+        GC.KeepAlive(sourcePointCloud.Source);
+        GC.KeepAlive(destinationPointCloud.Source);
+        return returnValue;
+    }
+}

--- a/src/OpenCvSharpExtern/CMakeLists.txt
+++ b/src/OpenCvSharpExtern/CMakeLists.txt
@@ -38,6 +38,17 @@ endif()
 
 find_package(OpenCV REQUIRED)
 
+# OpenCV's installed package exposes built modules as imported targets, but it
+# does not propagate the HAVE_OPENCV_* macros used by OpenCV's own build. Mirror
+# those two module-presence macros so the bindings stay disabled in slim/WASM
+# profiles where the corresponding targets are absent.
+if(TARGET opencv_structured_light)
+	add_compile_definitions(HAVE_OPENCV_STRUCTURED_LIGHT)
+endif()
+if(TARGET opencv_surface_matching)
+	add_compile_definitions(HAVE_OPENCV_SURFACE_MATCHING)
+endif()
+
 # iconv support isn't automatic on some systems
 find_package(Iconv QUIET)
 if(NOT Iconv_FOUND)

--- a/src/OpenCvSharpExtern/structured_light.cpp
+++ b/src/OpenCvSharpExtern/structured_light.cpp
@@ -1,0 +1,1 @@
+#include "structured_light.h"

--- a/src/OpenCvSharpExtern/structured_light.h
+++ b/src/OpenCvSharpExtern/structured_light.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#if !defined(NO_CONTRIB) && defined(HAVE_OPENCV_STRUCTURED_LIGHT)
+
+#include "include_opencv.h"
+#include <opencv2/structured_light.hpp>
+
+CVAPI(ExceptionStatus) structured_light_Ptr_GrayCodePattern_delete(
+    cv::Ptr<cv::structured_light::GrayCodePattern>* obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_Ptr_GrayCodePattern_get(
+    cv::Ptr<cv::structured_light::GrayCodePattern>* ptr,
+    cv::structured_light::GrayCodePattern** returnValue)
+{
+    return cvTry([&] {
+        *returnValue = ptr->get();
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_create(
+    int width,
+    int height,
+    cv::Ptr<cv::structured_light::GrayCodePattern>** returnValue)
+{
+    return cvTry([&] {
+        const auto ptr = cv::structured_light::GrayCodePattern::create(width, height);
+        *returnValue = new cv::Ptr<cv::structured_light::GrayCodePattern>(ptr);
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_StructuredLightPattern_generate(
+    cv::structured_light::StructuredLightPattern* obj,
+    std::vector<cv::Mat>* patternImages,
+    int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = obj->generate(*patternImages) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_StructuredLightPattern_decode(
+    cv::structured_light::StructuredLightPattern* obj,
+    cv::Mat*** patternImages,
+    const int* patternImageCounts,
+    int cameraCount,
+    std::vector<cv::Mat>* blackImages,
+    std::vector<cv::Mat>* whiteImages,
+    const interop::OutputArrayProxy* disparityMap,
+    int* returnValue)
+{
+    return cvTry([&] {
+        std::vector<std::vector<cv::Mat>> patternImageVector(cameraCount);
+        for (int cameraIndex = 0; cameraIndex < cameraCount; cameraIndex++)
+        {
+            auto& cameraImages = patternImageVector[cameraIndex];
+            cameraImages.reserve(patternImageCounts[cameraIndex]);
+            for (int imageIndex = 0; imageIndex < patternImageCounts[cameraIndex]; imageIndex++)
+            {
+                cameraImages.emplace_back(*patternImages[cameraIndex][imageIndex]);
+            }
+        }
+
+        *returnValue = obj->decode(
+            patternImageVector,
+            OutProxy(*disparityMap),
+            *blackImages,
+            *whiteImages,
+            cv::structured_light::DECODE_3D_UNDERWORLD) ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_getNumberOfPatternImages(
+    cv::structured_light::GrayCodePattern* obj,
+    int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = static_cast<int>(obj->getNumberOfPatternImages());
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_setWhiteThreshold(
+    cv::structured_light::GrayCodePattern* obj,
+    int value)
+{
+    return cvTry([&] {
+        obj->setWhiteThreshold(static_cast<size_t>(value));
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_setBlackThreshold(
+    cv::structured_light::GrayCodePattern* obj,
+    int value)
+{
+    return cvTry([&] {
+        obj->setBlackThreshold(static_cast<size_t>(value));
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_getImagesForShadowMasks(
+    cv::structured_light::GrayCodePattern* obj,
+    const interop::OutputArrayProxy* blackImage,
+    const interop::OutputArrayProxy* whiteImage)
+{
+    return cvTry([&] {
+        cv::Mat blackImageValue;
+        cv::Mat whiteImageValue;
+        obj->getImagesForShadowMasks(blackImageValue, whiteImageValue);
+        blackImageValue.copyTo(OutProxy(*blackImage));
+        whiteImageValue.copyTo(OutProxy(*whiteImage));
+    });
+}
+
+CVAPI(ExceptionStatus) structured_light_GrayCodePattern_getProjectorPixel(
+    cv::structured_light::GrayCodePattern* obj,
+    std::vector<cv::Mat>* patternImages,
+    int x,
+    int y,
+    interop::Point* projectorPixel,
+    int* returnValue)
+{
+    return cvTry([&] {
+        cv::Point projectorPixelValue;
+        const bool hasError = obj->getProjPixel(
+            *patternImages,
+            x,
+            y,
+            projectorPixelValue);
+        *projectorPixel = c(projectorPixelValue);
+        *returnValue = hasError ? 0 : 1;
+    });
+}
+
+#endif

--- a/src/OpenCvSharpExtern/surface_matching.cpp
+++ b/src/OpenCvSharpExtern/surface_matching.cpp
@@ -1,0 +1,1 @@
+#include "surface_matching.h"

--- a/src/OpenCvSharpExtern/surface_matching.h
+++ b/src/OpenCvSharpExtern/surface_matching.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#if !defined(NO_CONTRIB) && defined(HAVE_OPENCV_SURFACE_MATCHING)
+
+#include "include_opencv.h"
+#include <opencv2/surface_matching.hpp>
+#include <opencv2/surface_matching/ppf_helpers.hpp>
+
+CVAPI(ExceptionStatus) surface_matching_ICP_new1(cv::ppf_match_3d::ICP** returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::ppf_match_3d::ICP();
+    });
+}
+
+CVAPI(ExceptionStatus) surface_matching_ICP_new2(
+    int iterations,
+    float tolerance,
+    float rejectionScale,
+    int numLevels,
+    cv::ppf_match_3d::ICP** returnValue)
+{
+    return cvTry([&] {
+        *returnValue = new cv::ppf_match_3d::ICP(
+            iterations,
+            tolerance,
+            rejectionScale,
+            numLevels);
+    });
+}
+
+CVAPI(ExceptionStatus) surface_matching_ICP_delete(cv::ppf_match_3d::ICP* obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) surface_matching_ICP_registerModelToScene(
+    cv::ppf_match_3d::ICP* obj,
+    const interop::InputArrayProxy* sourcePointCloud,
+    const interop::InputArrayProxy* destinationPointCloud,
+    double* residual,
+    cv::Mat** pose,
+    int* returnValue)
+{
+    return cvTry([&] {
+        cv::Matx44d poseValue;
+        *returnValue = obj->registerModelToScene(
+            static_cast<const cv::_InputArray&>(InProxy(*sourcePointCloud)).getMat(),
+            static_cast<const cv::_InputArray&>(InProxy(*destinationPointCloud)).getMat(),
+            *residual,
+            poseValue);
+        *pose = new cv::Mat(poseValue);
+    });
+}
+
+CVAPI(ExceptionStatus) surface_matching_computeNormalsPC3d(
+    const interop::InputArrayProxy* pointCloud,
+    const interop::OutputArrayProxy* pointCloudWithNormals,
+    int numberOfNeighbors,
+    int flipViewpoint,
+    interop::Vec3f viewpoint,
+    int* returnValue)
+{
+    return cvTry([&] {
+        cv::Mat result;
+        const cv::Vec3f viewpointValue(viewpoint.val);
+        *returnValue = cv::ppf_match_3d::computeNormalsPC3d(
+            static_cast<const cv::_InputArray&>(InProxy(*pointCloud)).getMat(),
+            result,
+            numberOfNeighbors,
+            flipViewpoint != 0,
+            viewpointValue);
+        result.copyTo(OutProxy(*pointCloudWithNormals));
+    });
+}
+
+#endif

--- a/test/OpenCvSharp.Tests/structured_light/GrayCodePatternTest.cs
+++ b/test/OpenCvSharp.Tests/structured_light/GrayCodePatternTest.cs
@@ -1,0 +1,102 @@
+using OpenCvSharp.StructuredLight;
+using Xunit;
+
+namespace OpenCvSharp.Tests.StructuredLight;
+
+public class GrayCodePatternTest : TestBase
+{
+    [Fact]
+    public void GenerateAndDecodeProjectorPixel()
+    {
+        const int width = 16;
+        const int height = 8;
+        using var grayCode = GrayCodePattern.Create(width, height);
+
+        var patternImages = grayCode.Generate();
+        try
+        {
+            Assert.Equal(14, grayCode.GetNumberOfPatternImages());
+            Assert.Equal(grayCode.GetNumberOfPatternImages(), patternImages.Length);
+            Assert.All(patternImages, image =>
+            {
+                Assert.Equal(width, image.Cols);
+                Assert.Equal(height, image.Rows);
+                Assert.Equal(MatType.CV_8UC1, image.Type());
+            });
+
+            Assert.True(grayCode.TryGetProjectorPixel(
+                patternImages,
+                x: 11,
+                y: 5,
+                out var projectorPixel));
+            Assert.Equal(new Point(11, 5), projectorPixel);
+        }
+        finally
+        {
+            DisposeAll(patternImages);
+        }
+    }
+
+    [Fact]
+    public void DecodeProducesDisparityMap()
+    {
+        const int width = 16;
+        const int height = 8;
+        using var grayCode = GrayCodePattern.Create(width, height);
+        grayCode.SetWhiteThreshold(1);
+        grayCode.SetBlackThreshold(1);
+
+        var firstCameraPatterns = grayCode.Generate();
+        var secondCameraPatterns = firstCameraPatterns.Select(ShiftLeft).ToArray();
+        try
+        {
+            using var black = new Mat();
+            using var white = new Mat();
+            grayCode.GetImagesForShadowMasks(black, white);
+            using var blackSecondCamera = black.Clone();
+            using var whiteSecondCamera = white.Clone();
+            using var disparity = new Mat();
+
+            var decoded = grayCode.Decode(
+                [firstCameraPatterns, secondCameraPatterns],
+                disparity,
+                [black, blackSecondCamera],
+                [white, whiteSecondCamera]);
+
+            Assert.True(decoded);
+            Assert.Equal(height, disparity.Rows);
+            Assert.Equal(width, disparity.Cols);
+            Assert.Equal(MatType.CV_64FC1, disparity.Type());
+            Assert.Equal(-1.0, disparity.Get<double>(height / 2, width / 2), 6);
+        }
+        finally
+        {
+            DisposeAll(firstCameraPatterns);
+            DisposeAll(secondCameraPatterns);
+        }
+    }
+
+    private static Mat ShiftLeft(Mat source)
+    {
+        using var transformation = Mat.FromArray(new double[,]
+        {
+            { 1, 0, -1 },
+            { 0, 1, 0 },
+        });
+        var destination = new Mat();
+        Cv2.WarpAffine(
+            source,
+            destination,
+            transformation,
+            source.Size(),
+            InterpolationFlags.Nearest,
+            BorderTypes.Replicate);
+        return destination;
+    }
+
+    private static void DisposeAll(IEnumerable<Mat> images)
+    {
+        foreach (var image in images)
+            image.Dispose();
+    }
+}

--- a/test/OpenCvSharp.Tests/structured_light/GrayCodePatternTest.cs
+++ b/test/OpenCvSharp.Tests/structured_light/GrayCodePatternTest.cs
@@ -5,6 +5,14 @@ namespace OpenCvSharp.Tests.StructuredLight;
 
 public class GrayCodePatternTest : TestBase
 {
+    [Theory]
+    [InlineData(1, 8)]
+    [InlineData(16, 1)]
+    public void CreateRejectsSinglePixelProjectorAxis(int width, int height)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => GrayCodePattern.Create(width, height));
+    }
+
     [Fact]
     public void GenerateAndDecodeProjectorPixel()
     {
@@ -73,6 +81,87 @@ public class GrayCodePatternTest : TestBase
         {
             DisposeAll(firstCameraPatterns);
             DisposeAll(secondCameraPatterns);
+        }
+    }
+
+    [Fact]
+    public void DecodeValidatesPatternCountAndImageProperties()
+    {
+        const int width = 16;
+        const int height = 8;
+        using var grayCode = GrayCodePattern.Create(width, height);
+        var patternImages = grayCode.Generate();
+        try
+        {
+            using var black = new Mat();
+            using var white = new Mat();
+            grayCode.GetImagesForShadowMasks(black, white);
+            using var disparity = new Mat();
+
+            Assert.Throws<ArgumentException>(() => grayCode.Decode(
+                [patternImages[..^1], patternImages[..^1]],
+                disparity,
+                [black, black],
+                [white, white]));
+
+            using var wrongTypePattern = new Mat(height, width, MatType.CV_8UC3);
+            var patternsWithWrongType = patternImages.ToArray();
+            patternsWithWrongType[0] = wrongTypePattern;
+            Assert.Throws<ArgumentException>(() => grayCode.Decode(
+                [patternsWithWrongType, patternImages],
+                disparity,
+                [black, black],
+                [white, white]));
+
+            using var wrongSizeBlack = new Mat(height - 1, width, MatType.CV_8UC1);
+            Assert.Throws<ArgumentException>(() => grayCode.Decode(
+                [patternImages, patternImages],
+                disparity,
+                [wrongSizeBlack, black],
+                [white, white]));
+
+            using var wrongTypeWhite = new Mat(height, width, MatType.CV_32FC1);
+            Assert.Throws<ArgumentException>(() => grayCode.Decode(
+                [patternImages, patternImages],
+                disparity,
+                [black, black],
+                [wrongTypeWhite, white]));
+        }
+        finally
+        {
+            DisposeAll(patternImages);
+        }
+    }
+
+    [Fact]
+    public void TryGetProjectorPixelValidatesImagesAndCoordinates()
+    {
+        const int width = 16;
+        const int height = 8;
+        using var grayCode = GrayCodePattern.Create(width, height);
+        var patternImages = grayCode.Generate();
+        try
+        {
+            using var wrongTypePattern = new Mat(height, width, MatType.CV_8UC3);
+            var patternsWithWrongType = patternImages.ToArray();
+            patternsWithWrongType[0] = wrongTypePattern;
+            Assert.Throws<ArgumentException>(() =>
+                grayCode.TryGetProjectorPixel(patternsWithWrongType, 0, 0, out _));
+
+            using var wrongSizePattern = new Mat(height - 1, width, MatType.CV_8UC1);
+            var patternsWithWrongSize = patternImages.ToArray();
+            patternsWithWrongSize[0] = wrongSizePattern;
+            Assert.Throws<ArgumentException>(() =>
+                grayCode.TryGetProjectorPixel(patternsWithWrongSize, 0, 0, out _));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                grayCode.TryGetProjectorPixel(patternImages, width, 0, out _));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                grayCode.TryGetProjectorPixel(patternImages, 0, height, out _));
+        }
+        finally
+        {
+            DisposeAll(patternImages);
         }
     }
 

--- a/test/OpenCvSharp.Tests/surface_matching/ICPTest.cs
+++ b/test/OpenCvSharp.Tests/surface_matching/ICPTest.cs
@@ -1,0 +1,100 @@
+using OpenCvSharp.PpfMatch3D;
+using Xunit;
+
+namespace OpenCvSharp.Tests.SurfaceMatching;
+
+public class ICPTest : TestBase
+{
+    [Fact]
+    public void CreateAndDispose()
+    {
+        using var icp = new ICP();
+    }
+
+    [Fact]
+    public void ComputeNormalsPC3dProducesPointCloudWithNormals()
+    {
+        using var pointCloud = CreateCurvedPointCloud();
+        using var pointCloudWithNormals = new Mat();
+
+        var result = Cv2.PpfMatch3D.ComputeNormalsPC3d(
+            pointCloud,
+            pointCloudWithNormals,
+            numberOfNeighbors: 12);
+
+        Assert.Equal(1, result);
+        Assert.Equal(pointCloud.Rows, pointCloudWithNormals.Rows);
+        Assert.Equal(6, pointCloudWithNormals.Cols);
+        Assert.Equal(MatType.CV_32FC1, pointCloudWithNormals.Type());
+
+        var normalLength = Math.Sqrt(
+            Math.Pow(pointCloudWithNormals.Get<float>(pointCloudWithNormals.Rows / 2, 3), 2) +
+            Math.Pow(pointCloudWithNormals.Get<float>(pointCloudWithNormals.Rows / 2, 4), 2) +
+            Math.Pow(pointCloudWithNormals.Get<float>(pointCloudWithNormals.Rows / 2, 5), 2));
+        Assert.InRange(normalLength, 0.9, 1.1);
+    }
+
+    [Fact]
+    public void RegisterModelToSceneReturnsPose()
+    {
+        using var destinationPoints = CreateCurvedPointCloud();
+        using var destination = new Mat();
+        Assert.Equal(1, Cv2.PpfMatch3D.ComputeNormalsPC3d(
+            destinationPoints,
+            destination,
+            numberOfNeighbors: 12));
+
+        using var source = destination.Clone();
+        using var icp = new ICP(
+            iterations: 100,
+            tolerance: 0.005f,
+            rejectionScale: 2.5f,
+            numberOfLevels: 6);
+
+        var result = icp.RegisterModelToScene(
+            source,
+            destination,
+            out var residual,
+            out var pose);
+        using (pose)
+        {
+            Assert.Equal(0, result);
+            Assert.True(double.IsFinite(residual));
+            Assert.Equal(4, pose.Rows);
+            Assert.Equal(4, pose.Cols);
+            Assert.Equal(MatType.CV_64FC1, pose.Type());
+
+            for (var row = 0; row < 4; row++)
+            {
+                for (var column = 0; column < 4; column++)
+                {
+                    var expected = row == column ? 1.0 : 0.0;
+                    Assert.Equal(expected, pose.Get<double>(row, column), 5);
+                }
+            }
+        }
+    }
+
+    private static Mat<float> CreateCurvedPointCloud()
+    {
+        const int width = 20;
+        const int height = 15;
+        var points = new float[width * height, 3];
+        var index = 0;
+
+        for (var y = 0; y < height; y++)
+        {
+            var yf = (y - (height - 1) / 2f) / 5f;
+            for (var x = 0; x < width; x++)
+            {
+                var xf = (x - (width - 1) / 2f) / 5f;
+                points[index, 0] = xf;
+                points[index, 1] = yf;
+                points[index, 2] = 0.15f * xf * xf + 0.08f * yf * yf + 0.03f * xf * yf;
+                index++;
+            }
+        }
+
+        return Mat.FromArray(points);
+    }
+}


### PR DESCRIPTION
## Summary

- enable OpenCV's `surface_matching` and `structured_light` modules in the full build profile
- add managed/native bindings for ICP registration and point-cloud normal estimation
- add managed/native bindings for Gray-code generation, decoding, shadow-mask images, thresholds, and projector-pixel lookup
- keep the bindings disabled automatically when the corresponding OpenCV target is absent, preserving the slim and WASM profiles

The exposed surface is intentionally narrow: this does not expose `PPF3DDetector` or `SinusoidalPattern`. That avoids publishing the patent-sensitive PPF API and keeps the structured-light scope focused on the dependency-free Gray-code path.

## Impact

- no changes to the vcpkg manifest and no new external dependencies
- the existing OpenSSL dependency is unchanged
- local Windows x64 full-build measurement: `OpenCvSharpExtern.dll` increased by 52,736 bytes (about 51.5 KiB, 0.0646%)

## Validation

- full OpenCV 5 build with both modules enabled: passed
- `OpenCvSharpExtern` native compile and static link: passed
- targeted ICP / Gray-code tests: 5 passed
- full managed test run: 1,736 passed, 24 skipped, 11 failed because the sandbox blocked existing tests from downloading model files from `github.com`; all 11 failures occurred in `FileDownloader` before reaching the native API
- `git diff --check`: passed

Closes #252
Closes #1308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured-light support via `GrayCodePattern` for generating/decoding Gray-code patterns, setting black/white thresholds, producing shadow-mask reference images, and mapping camera pixels to projector pixels.
  * Added 3D surface-matching tools, including normal computation (`PpfMatch3D.ComputeNormalsPC3d`) and ICP registration (`PpfMatch3D.ICP.RegisterModelToScene`), including pose output.
* **Tests**
  * Added unit tests covering Gray-code generation/decoding and validation, point-cloud normal computation, and ICP registration pose/residual behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->