### PR TITLE
Fix CharucoDetector returning only the first corner

### DIFF
--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -733,10 +733,17 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 	return cvTry([&] {
 	cv::Mat charucoCorners_mat, charucoIds_mat;
 	detector->detectBoard(InProxy(*image), charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
-	for (int i = 0; i < charucoCorners_mat.rows; ++i)
+	CV_Assert(charucoCorners_mat.total() == charucoIds_mat.total());
+	if (!charucoCorners_mat.empty())
 	{
-		charucoCorners->push_back(charucoCorners_mat.at<cv::Point2f>(i, 0));
-		charucoIds->push_back(charucoIds_mat.at<int>(i, 0));
+		charucoCorners->insert(
+			charucoCorners->end(),
+			charucoCorners_mat.begin<cv::Point2f>(),
+			charucoCorners_mat.end<cv::Point2f>());
+		charucoIds->insert(
+			charucoIds->end(),
+			charucoIds_mat.begin<int>(),
+			charucoIds_mat.end<int>());
 	}
 	});
 }

--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -731,20 +731,20 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectBoard(
 	std::vector<int>* markerIds)
 {
 	return cvTry([&] {
-	cv::Mat charucoCorners_mat, charucoIds_mat;
-	detector->detectBoard(InProxy(*image), charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
-	CV_Assert(charucoCorners_mat.total() == charucoIds_mat.total());
-	if (!charucoCorners_mat.empty())
-	{
-		charucoCorners->insert(
-			charucoCorners->end(),
-			charucoCorners_mat.begin<cv::Point2f>(),
-			charucoCorners_mat.end<cv::Point2f>());
-		charucoIds->insert(
-			charucoIds->end(),
-			charucoIds_mat.begin<int>(),
-			charucoIds_mat.end<int>());
-	}
+		cv::Mat charucoCorners_mat, charucoIds_mat;
+		detector->detectBoard(InProxy(*image), charucoCorners_mat, charucoIds_mat, *markerCorners, *markerIds);
+		CV_Assert(charucoCorners_mat.total() == charucoIds_mat.total());
+		if (!charucoCorners_mat.empty())
+		{
+			charucoCorners->insert(
+				charucoCorners->end(),
+				charucoCorners_mat.begin<cv::Point2f>(),
+				charucoCorners_mat.end<cv::Point2f>());
+			charucoIds->insert(
+				charucoIds->end(),
+				charucoIds_mat.begin<int>(),
+				charucoIds_mat.end<int>());
+		}
 	});
 }
 

--- a/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
+++ b/test/OpenCvSharp.Tests/aruco/ArucoTest.cs
@@ -736,7 +736,9 @@ public class ArucoTest : TestBase
         Assert.NotNull(charucoIds);
         Assert.NotNull(markerCorners);
         Assert.NotNull(markerIds);
-        Assert.True(charucoIds.Length > 0, "Expected at least one charuco corner detected");
+        var expectedCornerCount = (board.ChessboardSize.Width - 1) * (board.ChessboardSize.Height - 1);
+        Assert.Equal(expectedCornerCount, charucoCorners.Length);
+        Assert.Equal(expectedCornerCount, charucoIds.Length);
         Assert.Equal(charucoCorners.Length, charucoIds.Length);
         Assert.Equal(markerCorners.Length, markerIds.Length);
     }


### PR DESCRIPTION
## Summary

- copy all detected ChArUco corners and IDs from OpenCV's matrix outputs instead of only iterating their rows
- preserve empty detection results while supporting both row- and column-vector matrix layouts
- strengthen the regression test to require every synthetic board corner

## Root cause and impact

OpenCV 5 returns the detected ChArUco corners and IDs as `1 x N` matrices. The native bridge iterated `Mat::rows` and accessed `(i, 0)`, so it copied only the first element. As a result, `CharucoDetector.DetectBoard` returned one checkerboard corner even when OpenCV detected the full board.

The bridge now copies the complete matrix ranges through OpenCV iterators and verifies that the corner and ID counts match. Empty outputs are handled without constructing an invalid iterator range.

## Validation

- `OpenCvSharpExtern` Release build
- targeted `CharucoDetector_DetectBoard` tests: 2 passed
- `ArucoTest`: 65 passed
- `git diff --check`

Closes #2104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Charuco board detection reliability by validating that detected corners and IDs are consistent in count.
  * Ensured corner and ID outputs are populated together for accurate, complete results.

* **Tests**
  * Strengthened Charuco detection assertions by verifying both detected corners and IDs match the expected number of entries derived from the board configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->