### PR TITLE
Indent cvTry lambda bodies consistently

### DIFF
--- a/src/OpenCvSharpExtern/aruco.h
+++ b/src/OpenCvSharpExtern/aruco.h
@@ -159,23 +159,23 @@ CVAPI(ExceptionStatus) aruco_drawDetectedMarkers(
 	interop::Scalar borderColor)
 {
 	return cvTry([&] {
-	std::vector< std::vector<cv::Point2f> > cornerVec(cornerSize1);
-	std::vector<int> idxVec;
+		std::vector< std::vector<cv::Point2f> > cornerVec(cornerSize1);
+		std::vector<int> idxVec;
 
-	for (int i = 0; i < cornerSize1; i++)
-		cornerVec[i] = std::vector<cv::Point2f>(corners[i], corners[i] + cornerSize2[i]);
-	if (idx != nullptr)
-		idxVec = std::vector<int>(idx, idx + idxCount);
+		for (int i = 0; i < cornerSize1; i++)
+			cornerVec[i] = std::vector<cv::Point2f>(corners[i], corners[i] + cornerSize2[i]);
+		if (idx != nullptr)
+			idxVec = std::vector<int>(idx, idx + idxCount);
 
-	cv::aruco::drawDetectedMarkers(IoProxy(*image), cornerVec, idxVec, cpp(borderColor));
+		cv::aruco::drawDetectedMarkers(IoProxy(*image), cornerVec, idxVec, cpp(borderColor));
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_getPredefinedDictionary(int name, cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	const auto dictionary = cv::aruco::getPredefinedDictionary(name);
-	*returnValue = new cv::aruco::Dictionary(dictionary);
+		const auto dictionary = cv::aruco::getPredefinedDictionary(name);
+		*returnValue = new cv::aruco::Dictionary(dictionary);
 	});
 }
 
@@ -183,16 +183,16 @@ CVAPI(ExceptionStatus) aruco_readDictionary(const char* dictionaryFile, cv::aruc
 {
 	return cvTry([&] {
 
-	auto readMode = cv::FileStorage::READ | cv::FileStorage::FORMAT_YAML;
-	cv::FileStorage storeage(dictionaryFile, readMode);
-	cv::FileNode rootNode = storeage.root();
+		auto readMode = cv::FileStorage::READ | cv::FileStorage::FORMAT_YAML;
+		cv::FileStorage storeage(dictionaryFile, readMode);
+		cv::FileNode rootNode = storeage.root();
 
-	cv::aruco::Dictionary dictionary;
-	auto result = dictionary.readDictionary(rootNode);
+		cv::aruco::Dictionary dictionary;
+		auto result = dictionary.readDictionary(rootNode);
 
-	storeage.release();
+		storeage.release();
 
-	*returnValue = new cv::aruco::Dictionary(dictionary);
+		*returnValue = new cv::aruco::Dictionary(dictionary);
 
 	});
 }
@@ -200,7 +200,7 @@ CVAPI(ExceptionStatus) aruco_readDictionary(const char* dictionaryFile, cv::aruc
 CVAPI(ExceptionStatus) aruco_Dictionary_new_default(cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::Dictionary();
+		*returnValue = new cv::aruco::Dictionary();
 	});
 }
 
@@ -208,59 +208,59 @@ CVAPI(ExceptionStatus) aruco_Dictionary_new(
 	cv::Mat* bytesList, int markerSize, int maxCorrectionBits, cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::Dictionary(*bytesList, markerSize, maxCorrectionBits);
+		*returnValue = new cv::aruco::Dictionary(*bytesList, markerSize, maxCorrectionBits);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_delete(cv::aruco::Dictionary* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_readDictionary(cv::aruco::Dictionary* obj, cv::FileNode* fn, int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->readDictionary(*fn) ? 1 : 0;
+		*returnValue = obj->readDictionary(*fn) ? 1 : 0;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_writeDictionary(cv::aruco::Dictionary* obj, cv::FileStorage* fs, const char* name)
 {
 	return cvTry([&] {
-	obj->writeDictionary(*fs, cv::String(name));
+		obj->writeDictionary(*fs, cv::String(name));
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Dictionary_setMarkerSize(cv::aruco::Dictionary* obj, int value)
 {
 	return cvTry([&] {
-	obj->markerSize = value;
+		obj->markerSize = value;
 	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_setMaxCorrectionBits(cv::aruco::Dictionary* obj, int value)
 {
 	return cvTry([&] {
-	obj->maxCorrectionBits = value;
+		obj->maxCorrectionBits = value;
 	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getBytesList(cv::aruco::Dictionary* obj, cv::Mat** returnValue)
 {
 	return cvTry([&] {
-	* returnValue = new cv::Mat(obj->bytesList);
+		* returnValue = new cv::Mat(obj->bytesList);
 	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getMarkerSize(cv::aruco::Dictionary* obj, int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->markerSize;
+		*returnValue = obj->markerSize;
 	});
 }
 CVAPI(ExceptionStatus) aruco_Dictionary_getMaxCorrectionBits(cv::aruco::Dictionary* obj, int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->maxCorrectionBits;
+		*returnValue = obj->maxCorrectionBits;
 	});
 }
 
@@ -273,7 +273,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_identify(
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->identify(*onlyBits, *idx, *rotation, maxCorrectionRate) != 0;
+		*returnValue = obj->identify(*onlyBits, *idx, *rotation, maxCorrectionRate) != 0;
 	});
 }
 
@@ -287,7 +287,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_identify_withThreshold(
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->identify(*onlyCellPixelRatio, *idx, *rotation, maxCorrectionRate, validBitIdThreshold) ? 1 : 0;
+		*returnValue = obj->identify(*onlyCellPixelRatio, *idx, *rotation, maxCorrectionRate, validBitIdThreshold) ? 1 : 0;
 	});
 }
 
@@ -299,7 +299,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getDistanceToId(
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = obj->getDistanceToId(InProxy(*bits), id, allRotations != 0);
+		*returnValue = obj->getDistanceToId(InProxy(*bits), id, allRotations != 0);
 	});
 }
 
@@ -311,7 +311,7 @@ CVAPI(ExceptionStatus) aruco_Dictionary_generateImageMarker(
 	int borderBits)
 {
 	return cvTry([&] {
-	obj->generateImageMarker(id, sidePixels, OutProxy(*img), borderBits);
+		obj->generateImageMarker(id, sidePixels, OutProxy(*img), borderBits);
 	});
 }
 
@@ -320,8 +320,8 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getByteListFromBits(
 	cv::Mat* returnValue)
 {
 	return cvTry([&] {
-	const auto result = cv::aruco::Dictionary::getByteListFromBits(*bits);
-	result.copyTo(*returnValue);
+		const auto result = cv::aruco::Dictionary::getByteListFromBits(*bits);
+		result.copyTo(*returnValue);
 	});
 }
 
@@ -332,8 +332,8 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getBitsFromByteList(
 	cv::Mat* returnValue)
 {
 	return cvTry([&] {
-	const auto result = cv::aruco::Dictionary::getBitsFromByteList(*byteList, markerSize, rotationId);
-	result.copyTo(*returnValue);
+		const auto result = cv::aruco::Dictionary::getBitsFromByteList(*byteList, markerSize, rotationId);
+		result.copyTo(*returnValue);
 	});
 }
 
@@ -344,8 +344,8 @@ CVAPI(ExceptionStatus) aruco_Dictionary_getMarkerBits(
 	cv::Mat* returnValue)
 {
 	return cvTry([&] {
-	const auto result = obj->getMarkerBits(markerId, rotationId);
-	result.copyTo(*returnValue);
+		const auto result = obj->getMarkerBits(markerId, rotationId);
+		result.copyTo(*returnValue);
 	});
 }
 
@@ -354,10 +354,10 @@ CVAPI(ExceptionStatus) aruco_extendDictionary(
 	cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	const auto result = (baseDictionary == nullptr)
-		? cv::aruco::extendDictionary(nMarkers, markerSize, cv::aruco::Dictionary(), randomSeed)
-		: cv::aruco::extendDictionary(nMarkers, markerSize, *baseDictionary, randomSeed);
-	*returnValue = new cv::aruco::Dictionary(result);
+		const auto result = (baseDictionary == nullptr)
+			? cv::aruco::extendDictionary(nMarkers, markerSize, cv::aruco::Dictionary(), randomSeed)
+			: cv::aruco::extendDictionary(nMarkers, markerSize, *baseDictionary, randomSeed);
+		*returnValue = new cv::aruco::Dictionary(result);
 	});
 }
 
@@ -372,12 +372,12 @@ CVAPI(ExceptionStatus) aruco_drawDetectedDiamonds(
 	return cvTry([&] {
 		std::vector< std::vector<cv::Point2f> > cornerVec(cornerSize1);
 
-	for (int i = 0; i < cornerSize1; i++)
-		cornerVec[i] = std::vector<cv::Point2f>(corners[i], corners[i] + cornerSize2[i]);
+		for (int i = 0; i < cornerSize1; i++)
+			cornerVec[i] = std::vector<cv::Point2f>(corners[i], corners[i] + cornerSize2[i]);
 
-	const cv::_InputArray idArray = (ids != nullptr) ? *ids : static_cast<cv::_InputArray>(cv::noArray());
+		const cv::_InputArray idArray = (ids != nullptr) ? *ids : static_cast<cv::_InputArray>(cv::noArray());
 
-	cv::aruco::drawDetectedDiamonds(IoProxy(*image), cornerVec, idArray, cpp(borderColor));
+		cv::aruco::drawDetectedDiamonds(IoProxy(*image), cornerVec, idArray, cpp(borderColor));
 	});
 }
 
@@ -388,9 +388,9 @@ CVAPI(ExceptionStatus) aruco_drawDetectedCornersCharuco(
 	interop::Scalar cornerColor)
 {
 	return cvTry([&] {
-	cv::_InputArray idArray = cv::noArray();
-	if (ids != nullptr) idArray = *ids;
-	cv::aruco::drawDetectedCornersCharuco(IoProxy(*image), *corners, idArray, cpp(cornerColor));
+		cv::_InputArray idArray = cv::noArray();
+		if (ids != nullptr) idArray = *ids;
+		cv::aruco::drawDetectedCornersCharuco(IoProxy(*image), *corners, idArray, cpp(cornerColor));
 	});
 }
 
@@ -403,16 +403,16 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_create(
 	cv::aruco::ArucoDetector** returnValue)
 {
 	return cvTry([&] {
-	const auto dp = cpp(*detectorParams);
-	const auto rp = cpp(*refineParams);
-	*returnValue = new cv::aruco::ArucoDetector(*dictionary, dp, rp);
+		const auto dp = cpp(*detectorParams);
+		const auto rp = cpp(*refineParams);
+		*returnValue = new cv::aruco::ArucoDetector(*dictionary, dp, rp);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_delete(cv::aruco::ArucoDetector* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
@@ -424,7 +424,7 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkers(
 	std::vector<std::vector<cv::Point2f>>* rejectedImgPoints)
 {
 	return cvTry([&] {
-	detector->detectMarkers(InProxy(*image), *corners, *ids, *rejectedImgPoints);
+		detector->detectMarkers(InProxy(*image), *corners, *ids, *rejectedImgPoints);
 	});
 }
 
@@ -443,23 +443,23 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_refineDetectedMarkers(
 	std::vector<int>* recoveredIdxs)
 {
 	return cvTry([&] {
-	std::vector<std::vector<cv::Point2f>> detectedCornersVec(detectedCornersSize1);
-	for (int i = 0; i < detectedCornersSize1; i++)
-		detectedCornersVec[i] = std::vector<cv::Point2f>(detectedCorners[i], detectedCorners[i] + detectedCornersSize2[i]);
-	std::vector<int> detectedIdsVec(detectedIds, detectedIds + detectedIdsSize);
-	std::vector<std::vector<cv::Point2f>> rejectedCornersVec(rejectedCornersSize1);
-	for (int i = 0; i < rejectedCornersSize1; i++)
-		rejectedCornersVec[i] = std::vector<cv::Point2f>(rejectedCorners[i], rejectedCorners[i] + rejectedCornersSize2[i]);
+		std::vector<std::vector<cv::Point2f>> detectedCornersVec(detectedCornersSize1);
+		for (int i = 0; i < detectedCornersSize1; i++)
+			detectedCornersVec[i] = std::vector<cv::Point2f>(detectedCorners[i], detectedCorners[i] + detectedCornersSize2[i]);
+		std::vector<int> detectedIdsVec(detectedIds, detectedIds + detectedIdsSize);
+		std::vector<std::vector<cv::Point2f>> rejectedCornersVec(rejectedCornersSize1);
+		for (int i = 0; i < rejectedCornersSize1; i++)
+			rejectedCornersVec[i] = std::vector<cv::Point2f>(rejectedCorners[i], rejectedCorners[i] + rejectedCornersSize2[i]);
 
-	cv::_OutputArray recoveredIdxsArr = cv::noArray();
-	if (recoveredIdxs != nullptr) recoveredIdxsArr = *recoveredIdxs;
+		cv::_OutputArray recoveredIdxsArr = cv::noArray();
+		if (recoveredIdxs != nullptr) recoveredIdxsArr = *recoveredIdxs;
 
-	detector->refineDetectedMarkers(InProxy(*image), *board, detectedCornersVec, detectedIdsVec, rejectedCornersVec,
-		InProxy(*cameraMatrix), InProxy(*distCoeffs), recoveredIdxsArr);
+		detector->refineDetectedMarkers(InProxy(*image), *board, detectedCornersVec, detectedIdsVec, rejectedCornersVec,
+			InProxy(*cameraMatrix), InProxy(*distCoeffs), recoveredIdxsArr);
 
-	*outDetectedCorners = detectedCornersVec;
-	*outDetectedIds = detectedIdsVec;
-	*outRejectedCorners = rejectedCornersVec;
+		*outDetectedCorners = detectedCornersVec;
+		*outDetectedIds = detectedIdsVec;
+		*outRejectedCorners = rejectedCornersVec;
 	});
 }
 
@@ -470,13 +470,13 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_create_MultiDict(
 	cv::aruco::ArucoDetector** returnValue)
 {
 	return cvTry([&] {
-	std::vector<cv::aruco::Dictionary> dictVec;
-	dictVec.reserve(dictionariesSize);
-	for (int i = 0; i < dictionariesSize; i++)
-		dictVec.push_back(*dictionaries[i]);
-	const auto dp = cpp(*detectorParams);
-	const auto rp = cpp(*refineParams);
-	*returnValue = new cv::aruco::ArucoDetector(dictVec, dp, rp);
+		std::vector<cv::aruco::Dictionary> dictVec;
+		dictVec.reserve(dictionariesSize);
+		for (int i = 0; i < dictionariesSize; i++)
+			dictVec.push_back(*dictionaries[i]);
+		const auto dp = cpp(*detectorParams);
+		const auto rp = cpp(*refineParams);
+		*returnValue = new cv::aruco::ArucoDetector(dictVec, dp, rp);
 	});
 }
 
@@ -489,7 +489,7 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkersWithConfidence(
 	std::vector<std::vector<cv::Point2f>>* rejectedImgPoints)
 {
 	return cvTry([&] {
-	detector->detectMarkersWithConfidence(InProxy(*image), *corners, *ids, *markersConfidence, *rejectedImgPoints);
+		detector->detectMarkersWithConfidence(InProxy(*image), *corners, *ids, *markersConfidence, *rejectedImgPoints);
 	});
 }
 
@@ -502,28 +502,28 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_detectMarkersMultiDict(
 	std::vector<int>* dictIndices)
 {
 	return cvTry([&] {
-	detector->detectMarkersMultiDict(InProxy(*image), *corners, *ids, *rejectedImgPoints, *dictIndices);
+		detector->detectMarkersMultiDict(InProxy(*image), *corners, *ids, *rejectedImgPoints, *dictIndices);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_getDictionary(const cv::aruco::ArucoDetector* detector, cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::Dictionary(detector->getDictionary());
+		*returnValue = new cv::aruco::Dictionary(detector->getDictionary());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_setDictionary(cv::aruco::ArucoDetector* detector, cv::aruco::Dictionary* dictionary)
 {
 	return cvTry([&] {
-	detector->setDictionary(*dictionary);
+		detector->setDictionary(*dictionary);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_getDictionariesSize(const cv::aruco::ArucoDetector* detector, int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = static_cast<int>(detector->getDictionaries().size());
+		*returnValue = static_cast<int>(detector->getDictionaries().size());
 	});
 }
 
@@ -534,10 +534,10 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_getDictionaries(
 	const cv::aruco::ArucoDetector* detector, cv::aruco::Dictionary** outArray, int arraySize)
 {
 	return cvTry([&] {
-	const auto dicts = detector->getDictionaries();
-	const size_t n = std::min(dicts.size(), static_cast<size_t>(arraySize));
-	for (size_t i = 0; i < n; i++)
-		outArray[i] = new cv::aruco::Dictionary(dicts[i]);
+		const auto dicts = detector->getDictionaries();
+		const size_t n = std::min(dicts.size(), static_cast<size_t>(arraySize));
+		for (size_t i = 0; i < n; i++)
+			outArray[i] = new cv::aruco::Dictionary(dicts[i]);
 	});
 }
 
@@ -546,40 +546,40 @@ CVAPI(ExceptionStatus) aruco_ArucoDetector_setDictionaries(
 	cv::aruco::Dictionary** dictionaries, int dictionariesSize)
 {
 	return cvTry([&] {
-	std::vector<cv::aruco::Dictionary> dictVec;
-	dictVec.reserve(dictionariesSize);
-	for (int i = 0; i < dictionariesSize; i++)
-		dictVec.push_back(*dictionaries[i]);
-	detector->setDictionaries(dictVec);
+		std::vector<cv::aruco::Dictionary> dictVec;
+		dictVec.reserve(dictionariesSize);
+		for (int i = 0; i < dictionariesSize; i++)
+			dictVec.push_back(*dictionaries[i]);
+		detector->setDictionaries(dictVec);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_getDetectorParameters(const cv::aruco::ArucoDetector* detector, aruco_DetectorParameters* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(detector->getDetectorParameters());
+		*returnValue = c(detector->getDetectorParameters());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_setDetectorParameters(cv::aruco::ArucoDetector* detector, aruco_DetectorParameters* detectorParameters)
 {
 	return cvTry([&] {
-	detector->setDetectorParameters(cpp(*detectorParameters));
+		detector->setDetectorParameters(cpp(*detectorParameters));
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_getRefineParameters(const cv::aruco::ArucoDetector* detector, aruco_RefineParameters* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(detector->getRefineParameters());
+		*returnValue = c(detector->getRefineParameters());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_ArucoDetector_setRefineParameters(cv::aruco::ArucoDetector* detector, aruco_RefineParameters* refineParameters)
 {
 	return cvTry([&] {
-	const auto rp = cpp(*refineParameters);
-	detector->setRefineParameters(rp);
+		const auto rp = cpp(*refineParameters);
+		detector->setRefineParameters(rp);
 	});
 }
 
@@ -593,51 +593,51 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_create(
 	cv::aruco::CharucoBoard** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::CharucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, *dictionary, *ids);
+		*returnValue = new cv::aruco::CharucoBoard(cv::Size(squaresX, squaresY), squareLength, markerLength, *dictionary, *ids);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_delete(cv::aruco::CharucoBoard* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getChessboardSize(cv::aruco::CharucoBoard* ptr, interop::Size* returnValue)
 {
 	return cvTry([&] {
-	const auto s = ptr->getChessboardSize();
-	returnValue->width = s.width;
-	returnValue->height = s.height;
+		const auto s = ptr->getChessboardSize();
+		returnValue->width = s.width;
+		returnValue->height = s.height;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getSquareLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getSquareLength();
+		*returnValue = ptr->getSquareLength();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getMarkerLength(cv::aruco::CharucoBoard* ptr, float* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getMarkerLength();
+		*returnValue = ptr->getMarkerLength();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_setLegacyPattern(cv::aruco::CharucoBoard* ptr, int value)
 {
 	return cvTry([&] {
-	ptr->setLegacyPattern(value != 0);
+		ptr->setLegacyPattern(value != 0);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getLegacyPattern(cv::aruco::CharucoBoard* ptr, int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getLegacyPattern() ? 1 : 0;
+		*returnValue = ptr->getLegacyPattern() ? 1 : 0;
 	});
 }
 
@@ -649,7 +649,7 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_generateImage(
 	int borderBits)
 {
 	return cvTry([&] {
-	ptr->generateImage(cpp(outSize), OutProxy(*img), marginSize, borderBits);
+		ptr->generateImage(cpp(outSize), OutProxy(*img), marginSize, borderBits);
 	});
 }
 
@@ -659,28 +659,28 @@ CVAPI(ExceptionStatus) aruco_CharucoBoard_checkCharucoCornersCollinear(
 	int* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->checkCharucoCornersCollinear(InProxy(*charucoIds)) ? 1 : 0;
+		*returnValue = ptr->checkCharucoCornersCollinear(InProxy(*charucoIds)) ? 1 : 0;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getChessboardCorners(const cv::aruco::CharucoBoard* ptr, std::vector<cv::Point3f>* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getChessboardCorners();
+		*returnValue = ptr->getChessboardCorners();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getNearestMarkerIdx(const cv::aruco::CharucoBoard* ptr, std::vector<std::vector<int>>* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getNearestMarkerIdx();
+		*returnValue = ptr->getNearestMarkerIdx();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoBoard_getNearestMarkerCorners(const cv::aruco::CharucoBoard* ptr, std::vector<std::vector<int>>* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getNearestMarkerCorners();
+		*returnValue = ptr->getNearestMarkerCorners();
 	});
 }
 
@@ -698,27 +698,27 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_create(
 	cv::aruco::CharucoDetector** returnValue)
 {
 	return cvTry([&] {
-	cv::aruco::CharucoParameters cp;
-	cv::Scalar cameraMatrixScratch, distCoeffsScratch;
-	const cv::_InputArray cameraMatrixArr = fromInputProxy(*cameraMatrix, cameraMatrixScratch);
-	const cv::_InputArray distCoeffsArr = fromInputProxy(*distCoeffs, distCoeffsScratch);
-	if (!cameraMatrixArr.empty())
-		cp.cameraMatrix = cameraMatrixArr.getMat();
-	if (!distCoeffsArr.empty())
-		cp.distCoeffs = distCoeffsArr.getMat();
-	cp.minMarkers = minMarkers;
-	cp.tryRefineMarkers = tryRefineMarkers;
-	cp.checkMarkers = checkMarkers;
-	const auto dp = cpp(*detectorParams);
-	const auto rp = cpp(*refineParams);
-	*returnValue = new cv::aruco::CharucoDetector(*board, cp, dp, rp);
+		cv::aruco::CharucoParameters cp;
+		cv::Scalar cameraMatrixScratch, distCoeffsScratch;
+		const cv::_InputArray cameraMatrixArr = fromInputProxy(*cameraMatrix, cameraMatrixScratch);
+		const cv::_InputArray distCoeffsArr = fromInputProxy(*distCoeffs, distCoeffsScratch);
+		if (!cameraMatrixArr.empty())
+			cp.cameraMatrix = cameraMatrixArr.getMat();
+		if (!distCoeffsArr.empty())
+			cp.distCoeffs = distCoeffsArr.getMat();
+		cp.minMarkers = minMarkers;
+		cp.tryRefineMarkers = tryRefineMarkers;
+		cp.checkMarkers = checkMarkers;
+		const auto dp = cpp(*detectorParams);
+		const auto rp = cpp(*refineParams);
+		*returnValue = new cv::aruco::CharucoDetector(*board, cp, dp, rp);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_delete(cv::aruco::CharucoDetector* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
@@ -750,21 +750,21 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_detectDiamonds(
 	std::vector<int>* markerIds)
 {
 	return cvTry([&] {
-	detector->detectDiamonds(InProxy(*image), *diamondCorners, *diamondIds, *markerCorners, *markerIds);
+		detector->detectDiamonds(InProxy(*image), *diamondCorners, *diamondIds, *markerCorners, *markerIds);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_getBoard(const cv::aruco::CharucoDetector* detector, cv::aruco::CharucoBoard** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::CharucoBoard(detector->getBoard());
+		*returnValue = new cv::aruco::CharucoBoard(detector->getBoard());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_setBoard(cv::aruco::CharucoDetector* detector, cv::aruco::CharucoBoard* board)
 {
 	return cvTry([&] {
-	detector->setBoard(*board);
+		detector->setBoard(*board);
 	});
 }
 
@@ -773,12 +773,12 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_getCharucoParameters(
 	cv::Mat** cameraMatrix, cv::Mat** distCoeffs, int* minMarkers, int* tryRefineMarkers, int* checkMarkers)
 {
 	return cvTry([&] {
-	const auto& cp = detector->getCharucoParameters();
-	*cameraMatrix = new cv::Mat(cp.cameraMatrix);
-	*distCoeffs = new cv::Mat(cp.distCoeffs);
-	*minMarkers = cp.minMarkers;
-	*tryRefineMarkers = cp.tryRefineMarkers ? 1 : 0;
-	*checkMarkers = cp.checkMarkers ? 1 : 0;
+		const auto& cp = detector->getCharucoParameters();
+		*cameraMatrix = new cv::Mat(cp.cameraMatrix);
+		*distCoeffs = new cv::Mat(cp.distCoeffs);
+		*minMarkers = cp.minMarkers;
+		*tryRefineMarkers = cp.tryRefineMarkers ? 1 : 0;
+		*checkMarkers = cp.checkMarkers ? 1 : 0;
 	});
 }
 
@@ -788,47 +788,47 @@ CVAPI(ExceptionStatus) aruco_CharucoDetector_setCharucoParameters(
 	int minMarkers, int tryRefineMarkers, int checkMarkers)
 {
 	return cvTry([&] {
-	cv::aruco::CharucoParameters cp;
-	cv::Scalar cameraMatrixScratch, distCoeffsScratch;
-	const cv::_InputArray cameraMatrixArr = fromInputProxy(*cameraMatrix, cameraMatrixScratch);
-	const cv::_InputArray distCoeffsArr = fromInputProxy(*distCoeffs, distCoeffsScratch);
-	if (!cameraMatrixArr.empty())
-		cp.cameraMatrix = cameraMatrixArr.getMat();
-	if (!distCoeffsArr.empty())
-		cp.distCoeffs = distCoeffsArr.getMat();
-	cp.minMarkers = minMarkers;
-	cp.tryRefineMarkers = tryRefineMarkers != 0;
-	cp.checkMarkers = checkMarkers != 0;
-	detector->setCharucoParameters(cp);
+		cv::aruco::CharucoParameters cp;
+		cv::Scalar cameraMatrixScratch, distCoeffsScratch;
+		const cv::_InputArray cameraMatrixArr = fromInputProxy(*cameraMatrix, cameraMatrixScratch);
+		const cv::_InputArray distCoeffsArr = fromInputProxy(*distCoeffs, distCoeffsScratch);
+		if (!cameraMatrixArr.empty())
+			cp.cameraMatrix = cameraMatrixArr.getMat();
+		if (!distCoeffsArr.empty())
+			cp.distCoeffs = distCoeffsArr.getMat();
+		cp.minMarkers = minMarkers;
+		cp.tryRefineMarkers = tryRefineMarkers != 0;
+		cp.checkMarkers = checkMarkers != 0;
+		detector->setCharucoParameters(cp);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_getDetectorParameters(const cv::aruco::CharucoDetector* detector, aruco_DetectorParameters* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(detector->getDetectorParameters());
+		*returnValue = c(detector->getDetectorParameters());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_setDetectorParameters(cv::aruco::CharucoDetector* detector, aruco_DetectorParameters* detectorParameters)
 {
 	return cvTry([&] {
-	detector->setDetectorParameters(cpp(*detectorParameters));
+		detector->setDetectorParameters(cpp(*detectorParameters));
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_getRefineParameters(const cv::aruco::CharucoDetector* detector, aruco_RefineParameters* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(detector->getRefineParameters());
+		*returnValue = c(detector->getRefineParameters());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_CharucoDetector_setRefineParameters(cv::aruco::CharucoDetector* detector, aruco_RefineParameters* refineParameters)
 {
 	return cvTry([&] {
-	const auto rp = cpp(*refineParameters);
-	detector->setRefineParameters(rp);
+		const auto rp = cpp(*refineParameters);
+		detector->setRefineParameters(rp);
 	});
 }
 
@@ -841,52 +841,52 @@ CVAPI(ExceptionStatus) aruco_Board_create(
 	cv::aruco::Board** returnValue)
 {
 	return cvTry([&] {
-	std::vector<std::vector<cv::Point3f>> objPointsVec(objPointsSize1);
-	for (int i = 0; i < objPointsSize1; i++)
-	{
-		if (objPointsSize2[i] != 4)
-			CV_Error(cv::Error::StsBadArg, "Each marker must have exactly 4 corners");
-		objPointsVec[i] = std::vector<cv::Point3f>(objPoints[i], objPoints[i] + objPointsSize2[i]);
-	}
-	*returnValue = new cv::aruco::Board(objPointsVec, *dictionary, *ids);
+		std::vector<std::vector<cv::Point3f>> objPointsVec(objPointsSize1);
+		for (int i = 0; i < objPointsSize1; i++)
+		{
+			if (objPointsSize2[i] != 4)
+				CV_Error(cv::Error::StsBadArg, "Each marker must have exactly 4 corners");
+			objPointsVec[i] = std::vector<cv::Point3f>(objPoints[i], objPoints[i] + objPointsSize2[i]);
+		}
+		*returnValue = new cv::aruco::Board(objPointsVec, *dictionary, *ids);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Board_delete(cv::aruco::Board* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Board_getDictionary(const cv::aruco::Board* ptr, cv::aruco::Dictionary** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::Dictionary(ptr->getDictionary());
+		*returnValue = new cv::aruco::Dictionary(ptr->getDictionary());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Board_getObjPoints(const cv::aruco::Board* ptr, std::vector<cv::Point3f>* returnValue)
 {
 	return cvTry([&] {
-	returnValue->clear();
-	for (const auto& marker : ptr->getObjPoints())
-		for (const auto& p : marker)
-			returnValue->push_back(p);
+		returnValue->clear();
+		for (const auto& marker : ptr->getObjPoints())
+			for (const auto& p : marker)
+				returnValue->push_back(p);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Board_getIds(const cv::aruco::Board* ptr, std::vector<int>* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getIds();
+		*returnValue = ptr->getIds();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_Board_getRightBottomCorner(const cv::aruco::Board* ptr, interop::Point3f* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(ptr->getRightBottomCorner());
+		*returnValue = c(ptr->getRightBottomCorner());
 	});
 }
 
@@ -898,10 +898,10 @@ CVAPI(ExceptionStatus) aruco_Board_matchImagePoints(
 	const interop::OutputArrayProxy* imgPoints)
 {
 	return cvTry([&] {
-	std::vector<std::vector<cv::Point2f>> cornersVec(detectedCornersSize1);
-	for (int i = 0; i < detectedCornersSize1; i++)
-		cornersVec[i] = std::vector<cv::Point2f>(detectedCorners[i], detectedCorners[i] + detectedCornersSize2[i]);
-	ptr->matchImagePoints(cornersVec, InProxy(*detectedIds), OutProxy(*objPoints), OutProxy(*imgPoints));
+		std::vector<std::vector<cv::Point2f>> cornersVec(detectedCornersSize1);
+		for (int i = 0; i < detectedCornersSize1; i++)
+			cornersVec[i] = std::vector<cv::Point2f>(detectedCorners[i], detectedCorners[i] + detectedCornersSize2[i]);
+		ptr->matchImagePoints(cornersVec, InProxy(*detectedIds), OutProxy(*objPoints), OutProxy(*imgPoints));
 	});
 }
 
@@ -915,7 +915,7 @@ CVAPI(ExceptionStatus) aruco_Board_matchImagePoints_flat(
 	const interop::OutputArrayProxy* imgPoints)
 {
 	return cvTry([&] {
-	ptr->matchImagePoints(*detectedCorners, InProxy(*detectedIds), OutProxy(*objPoints), OutProxy(*imgPoints));
+		ptr->matchImagePoints(*detectedCorners, InProxy(*detectedIds), OutProxy(*objPoints), OutProxy(*imgPoints));
 	});
 }
 
@@ -927,7 +927,7 @@ CVAPI(ExceptionStatus) aruco_Board_generateImage(
 	int borderBits)
 {
 	return cvTry([&] {
-	ptr->generateImage(cpp(outSize), OutProxy(*img), marginSize, borderBits);
+		ptr->generateImage(cpp(outSize), OutProxy(*img), marginSize, borderBits);
 	});
 }
 
@@ -942,35 +942,35 @@ CVAPI(ExceptionStatus) aruco_GridBoard_create(
 	cv::aruco::GridBoard** returnValue)
 {
 	return cvTry([&] {
-	*returnValue = new cv::aruco::GridBoard(cpp(size), markerLength, markerSeparation, *dictionary, *ids);
+		*returnValue = new cv::aruco::GridBoard(cpp(size), markerLength, markerSeparation, *dictionary, *ids);
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_GridBoard_delete(cv::aruco::GridBoard* ptr)
 {
 	return cvTry([&] {
-	delete ptr;
+		delete ptr;
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_GridBoard_getGridSize(const cv::aruco::GridBoard* ptr, interop::Size* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = c(ptr->getGridSize());
+		*returnValue = c(ptr->getGridSize());
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_GridBoard_getMarkerLength(const cv::aruco::GridBoard* ptr, float* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getMarkerLength();
+		*returnValue = ptr->getMarkerLength();
 	});
 }
 
 CVAPI(ExceptionStatus) aruco_GridBoard_getMarkerSeparation(const cv::aruco::GridBoard* ptr, float* returnValue)
 {
 	return cvTry([&] {
-	*returnValue = ptr->getMarkerSeparation();
+		*returnValue = ptr->getMarkerSeparation();
 	});
 }
 

--- a/src/OpenCvSharpExtern/core_OutputArray.h
+++ b/src/OpenCvSharpExtern/core_OutputArray.h
@@ -24,7 +24,7 @@ CVAPI(ExceptionStatus) core_OutputArray_new_byUMat(cv::UMat* mat, cv::_OutputArr
 {
     return cvTry([&] {
         const cv::_OutputArray ia(*mat);
-    *returnValue = new cv::_OutputArray(ia);
+        *returnValue = new cv::_OutputArray(ia);
     });
 }
 

--- a/src/OpenCvSharpExtern/core_UMat.h
+++ b/src/OpenCvSharpExtern/core_UMat.h
@@ -199,7 +199,7 @@ CVAPI(ExceptionStatus) core_UMat_diag(
 {
     return cvTry([&] {
         const auto ret = self->diag(d);
-    *returnValue = new cv::UMat(ret);
+        *returnValue = new cv::UMat(ret);
     });
 }
 CVAPI(ExceptionStatus) core_UMat_diag_static(cv::UMat* self, cv::UMat** returnValue)


### PR DESCRIPTION
## Summary

- indent 76 multiline `cvTry` lambda bodies in `aruco.h` to reflect their actual scope
- fix two isolated indentation slips in `core_OutputArray.h` and `core_UMat.h`
- leave `aruco_CharucoDetector_detectBoard` to #2105 so the two PRs do not modify the same lines

## Why

Most native wrappers already indent the body passed to `cvTry`, but several blocks retained the old macro-era indentation. The inconsistent examples make lambda scope harder to read and easy to copy into new code.

This is a whitespace-only change. Together with #2105, every multiline `cvTry` body under `OpenCvSharpExtern` is consistently indented.

## Validation

- inspected all 3,673 multiline `cvTry` blocks; the only intentionally excluded block is corrected by #2105
- `git diff -w --exit-code` confirms there are no non-whitespace changes
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected detector cleanup to properly release ArUco detector resources.

* **Refactor**
  * Reformatted internal computer vision wrappers without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->