### PR TITLE
Expose basic OpenCL runtime controls

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+#pragma warning disable CA1401 // P/Invokes should not be visible
+#pragma warning disable IDE1006 // Naming style
+
+namespace OpenCvSharp.Internal;
+
+static partial class NativeMethods
+{
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_finish();
+}

--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
@@ -10,5 +10,14 @@ namespace OpenCvSharp.Internal;
 static partial class NativeMethods
 {
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_haveOpenCL(out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_useOpenCL(out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_setUseOpenCL(int flag);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_ocl_finish();
 }

--- a/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
+++ b/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
@@ -1,0 +1,25 @@
+using OpenCvSharp.Internal;
+
+namespace OpenCvSharp;
+
+public static partial class Cv2
+{
+    /// <summary>
+    /// cv::ocl functions.
+    /// </summary>
+    public static partial class Ocl
+    {
+        /// <summary>
+        /// Waits for all queued OpenCL operations in the current default queue to complete.
+        /// </summary>
+        /// <remarks>
+        /// This method blocks the calling thread and is primarily useful at synchronization boundaries and when measuring OpenCL execution time.
+        /// Calling it after every operation can reduce performance by preventing asynchronous execution.
+        /// </remarks>
+        public static void Finish()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_finish());
+        }
+    }
+}

--- a/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
+++ b/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
@@ -10,6 +10,36 @@ public static partial class Cv2
     public static partial class Ocl
     {
         /// <summary>
+        /// Returns whether an OpenCL runtime with at least one platform is available.
+        /// </summary>
+        public static bool HaveOpenCL()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_haveOpenCL(out var returnValue));
+            return returnValue != 0;
+        }
+
+        /// <summary>
+        /// Returns whether OpenCL is currently enabled for the calling thread.
+        /// </summary>
+        public static bool UseOpenCL()
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_useOpenCL(out var returnValue));
+            return returnValue != 0;
+        }
+
+        /// <summary>
+        /// Enables or disables OpenCL use for the calling thread.
+        /// </summary>
+        /// <param name="flag">True to enable OpenCL when a suitable runtime and device are available; otherwise, false.</param>
+        public static void SetUseOpenCL(bool flag)
+        {
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_setUseOpenCL(flag ? 1 : 0));
+        }
+
+        /// <summary>
         /// Waits for all queued OpenCL operations in the current default queue to complete.
         /// </summary>
         /// <remarks>

--- a/src/OpenCvSharpExtern/core.cpp
+++ b/src/OpenCvSharpExtern/core.cpp
@@ -7,6 +7,7 @@
 #include "core_Mat.h"
 #include "core_UMat.h"
 #include "core_MatExpr.h"
+#include "core_ocl.h"
 #include "core_OutputArray.h"
 #include "core_PCA.h"
 #include "core_SparseMat.h"

--- a/src/OpenCvSharpExtern/core_ocl.h
+++ b/src/OpenCvSharpExtern/core_ocl.h
@@ -6,6 +6,27 @@
 // ReSharper disable CppInconsistentNaming
 // ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
 
+CVAPI(ExceptionStatus) core_ocl_haveOpenCL(int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::ocl::haveOpenCL() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_useOpenCL(int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = cv::ocl::useOpenCL() ? 1 : 0;
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_setUseOpenCL(int flag)
+{
+    return cvTry([&] {
+        cv::ocl::setUseOpenCL(flag != 0);
+    });
+}
+
 CVAPI(ExceptionStatus) core_ocl_finish()
 {
     return cvTry([] {

--- a/src/OpenCvSharpExtern/core_ocl.h
+++ b/src/OpenCvSharpExtern/core_ocl.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "include_opencv.h"
+#include <opencv2/core/ocl.hpp>
+
+// ReSharper disable CppInconsistentNaming
+// ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
+
+CVAPI(ExceptionStatus) core_ocl_finish()
+{
+    return cvTry([] {
+        cv::ocl::finish();
+    });
+}

--- a/test/OpenCvSharp.Tests/core/OclTest.cs
+++ b/test/OpenCvSharp.Tests/core/OclTest.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace OpenCvSharp.Tests.Core;
+
+public class OclTest : TestBase
+{
+    [Fact]
+    public void FinishAfterUMatOperation()
+    {
+        using var src = new UMat(32, 32, MatType.CV_8UC1, Scalar.All(1));
+        using var dst = new UMat();
+
+        Cv2.GaussianBlur(src, dst, new Size(5, 5), 0);
+        Cv2.Ocl.Finish();
+
+        using var result = dst.GetMat(AccessFlag.READ);
+        Assert.Equal(1, result.At<byte>(0, 0));
+    }
+}

--- a/test/OpenCvSharp.Tests/core/OclTest.cs
+++ b/test/OpenCvSharp.Tests/core/OclTest.cs
@@ -5,6 +5,25 @@ namespace OpenCvSharp.Tests.Core;
 public class OclTest : TestBase
 {
     [Fact]
+    public void RuntimeStatusCanBeQueriedAndRestored()
+    {
+        var initiallyEnabled = Cv2.Ocl.UseOpenCL();
+        Assert.False(initiallyEnabled && !Cv2.Ocl.HaveOpenCL());
+
+        try
+        {
+            Cv2.Ocl.SetUseOpenCL(false);
+            Assert.False(Cv2.Ocl.UseOpenCL());
+        }
+        finally
+        {
+            Cv2.Ocl.SetUseOpenCL(initiallyEnabled);
+        }
+
+        Assert.Equal(initiallyEnabled, Cv2.Ocl.UseOpenCL());
+    }
+
+    [Fact]
     public void FinishAfterUMatOperation()
     {
         using var src = new UMat(32, 32, MatType.CV_8UC1, Scalar.All(1));


### PR DESCRIPTION
## Summary

- expose `cv::ocl::haveOpenCL()`, `useOpenCL()`, and `setUseOpenCL()` as `Cv2.Ocl` runtime controls
- expose `cv::ocl::finish()` as `Cv2.Ocl.Finish()` for explicit default-queue synchronization
- document the thread-local control and synchronization behavior
- add tests for querying/restoring OpenCL state and synchronizing after a queued UMat operation

This allows applications to confirm whether OpenCL is available and active, temporarily enable or disable its use on the calling thread, and time queued workloads without forcing a `UMat` download through `GetMat()`. It does not change OpenCL kernel selection or optimize GPU operations.

Relates to #2110.

## Validation

- `dotnet build src\OpenCvSharp\OpenCvSharp.csproj -c Release --no-restore`
- `cmake --build src\build --config Release --target OpenCvSharpExtern`
- targeted `OclTest`: 2 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCL support for checking availability, viewing usage status, enabling or disabling acceleration, and completing queued operations.
  * Added OpenCL controls for processing workflows that use accelerated matrix operations.

* **Tests**
  * Added coverage for OpenCL runtime status and completing accelerated operations before retrieving results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->