### PR TITLE
Expose OpenCL platform and device information

### DIFF
--- a/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
+++ b/src/OpenCvSharp/Internal/PInvoke/NativeMethods/core/NativeMethods_core_Ocl.cs
@@ -20,4 +20,49 @@ static partial class NativeMethods
 
     [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial ExceptionStatus core_ocl_finish();
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_getPlatformsInfo(out IntPtr returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_PlatformInfoVector_delete(IntPtr obj);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_PlatformInfoVector_size(
+        OpenCvSafeHandle obj,
+        out int returnValue);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_PlatformInfoVector_getPlatform(
+        OpenCvSafeHandle obj,
+        int platformIndex,
+        IntPtr name,
+        IntPtr vendor,
+        IntPtr version,
+        out int versionMajor,
+        out int versionMinor,
+        out int deviceCount);
+
+    [LibraryImport(DllExtern), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial ExceptionStatus core_ocl_PlatformInfoVector_getDevice(
+        OpenCvSafeHandle obj,
+        int platformIndex,
+        int deviceIndex,
+        IntPtr name,
+        IntPtr vendorName,
+        IntPtr version,
+        IntPtr openCLVersion,
+        IntPtr openCLCVersion,
+        IntPtr driverVersion,
+        out int type,
+        out int addressBits,
+        out int available,
+        out int compilerAvailable,
+        out int linkerAvailable,
+        out int maxClockFrequency,
+        out int maxComputeUnits,
+        out ulong globalMemorySize,
+        out ulong localMemorySize,
+        out int hostUnifiedMemory,
+        out int imageSupport);
 }

--- a/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
+++ b/src/OpenCvSharp/Modules/core/Cv2.Ocl.cs
@@ -51,5 +51,130 @@ public static partial class Cv2
             NativeMethods.HandleException(
                 NativeMethods.core_ocl_finish());
         }
+
+        /// <summary>
+        /// Returns snapshots of the available OpenCL platforms and their devices.
+        /// </summary>
+        /// <remarks>
+        /// Returns an empty list when no OpenCL runtime is available. The returned objects do not own native OpenCL handles.
+        /// </remarks>
+        public static IReadOnlyList<OclPlatformInfo> GetPlatformsInfo()
+        {
+            if (!HaveOpenCL())
+                return Array.Empty<OclPlatformInfo>();
+
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_getPlatformsInfo(out var nativePointer));
+            using var nativePlatforms = new OclPlatformInfoVector(nativePointer);
+
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_PlatformInfoVector_size(
+                    nativePlatforms.Handle,
+                    out var platformCount));
+
+            var platforms = new OclPlatformInfo[platformCount];
+            for (var platformIndex = 0; platformIndex < platformCount; platformIndex++)
+            {
+                platforms[platformIndex] = ReadPlatform(nativePlatforms, platformIndex);
+            }
+            return Array.AsReadOnly(platforms);
+        }
+
+        private static OclPlatformInfo ReadPlatform(OclPlatformInfoVector nativePlatforms, int platformIndex)
+        {
+            using var name = new StdString();
+            using var vendor = new StdString();
+            using var version = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_PlatformInfoVector_getPlatform(
+                    nativePlatforms.Handle,
+                    platformIndex,
+                    name.CvPtr,
+                    vendor.CvPtr,
+                    version.CvPtr,
+                    out var versionMajor,
+                    out var versionMinor,
+                    out var deviceCount));
+
+            var devices = new OclDeviceInfo[deviceCount];
+            for (var deviceIndex = 0; deviceIndex < deviceCount; deviceIndex++)
+            {
+                devices[deviceIndex] = ReadDevice(nativePlatforms, platformIndex, deviceIndex);
+            }
+
+            return new OclPlatformInfo(
+                name.ToString(),
+                vendor.ToString(),
+                version.ToString(),
+                versionMajor,
+                versionMinor,
+                Array.AsReadOnly(devices));
+        }
+
+        private static OclDeviceInfo ReadDevice(
+            OclPlatformInfoVector nativePlatforms,
+            int platformIndex,
+            int deviceIndex)
+        {
+            using var name = new StdString();
+            using var vendorName = new StdString();
+            using var version = new StdString();
+            using var openCLVersion = new StdString();
+            using var openCLCVersion = new StdString();
+            using var driverVersion = new StdString();
+            NativeMethods.HandleException(
+                NativeMethods.core_ocl_PlatformInfoVector_getDevice(
+                    nativePlatforms.Handle,
+                    platformIndex,
+                    deviceIndex,
+                    name.CvPtr,
+                    vendorName.CvPtr,
+                    version.CvPtr,
+                    openCLVersion.CvPtr,
+                    openCLCVersion.CvPtr,
+                    driverVersion.CvPtr,
+                    out var type,
+                    out var addressBits,
+                    out var available,
+                    out var compilerAvailable,
+                    out var linkerAvailable,
+                    out var maxClockFrequency,
+                    out var maxComputeUnits,
+                    out var globalMemorySize,
+                    out var localMemorySize,
+                    out var hostUnifiedMemory,
+                    out var imageSupport));
+
+            return new OclDeviceInfo(
+                name.ToString(),
+                vendorName.ToString(),
+                version.ToString(),
+                openCLVersion.ToString(),
+                openCLCVersion.ToString(),
+                driverVersion.ToString(),
+                (OclDeviceTypes) type,
+                addressBits,
+                available != 0,
+                compilerAvailable != 0,
+                linkerAvailable != 0,
+                maxClockFrequency,
+                maxComputeUnits,
+                globalMemorySize,
+                localMemorySize,
+                hostUnifiedMemory != 0,
+                imageSupport != 0);
+        }
+
+        private sealed class OclPlatformInfoVector : CvObject
+        {
+            public OclPlatformInfoVector(IntPtr ptr)
+            {
+                SetSafeHandle(new OpenCvPtrSafeHandle(
+                    ptr,
+                    ownsHandle: true,
+                    releaseAction: static p => NativeMethods.HandleException(
+                        NativeMethods.core_ocl_PlatformInfoVector_delete(p))));
+            }
+        }
     }
 }

--- a/src/OpenCvSharp/Modules/core/Enum/OclDeviceTypes.cs
+++ b/src/OpenCvSharp/Modules/core/Enum/OclDeviceTypes.cs
@@ -1,0 +1,43 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// OpenCL device types reported by cv::ocl::Device.
+/// </summary>
+[Flags]
+public enum OclDeviceTypes : uint
+{
+    /// <summary>
+    /// The default OpenCL device type.
+    /// </summary>
+    Default = 1U << 0,
+
+    /// <summary>
+    /// A CPU OpenCL device.
+    /// </summary>
+    Cpu = 1U << 1,
+
+    /// <summary>
+    /// A GPU OpenCL device.
+    /// </summary>
+    Gpu = 1U << 2,
+
+    /// <summary>
+    /// A dedicated accelerator OpenCL device.
+    /// </summary>
+    Accelerator = 1U << 3,
+
+    /// <summary>
+    /// A discrete GPU selector used by OpenCV device configuration.
+    /// </summary>
+    DiscreteGpu = Gpu | (1U << 16),
+
+    /// <summary>
+    /// An integrated GPU selector used by OpenCV device configuration.
+    /// </summary>
+    IntegratedGpu = Gpu | (1U << 17),
+
+    /// <summary>
+    /// All OpenCL device types.
+    /// </summary>
+    All = uint.MaxValue,
+}

--- a/src/OpenCvSharp/Modules/core/OclPlatformInfo.cs
+++ b/src/OpenCvSharp/Modules/core/OclPlatformInfo.cs
@@ -1,0 +1,57 @@
+namespace OpenCvSharp;
+
+/// <summary>
+/// A read-only snapshot of an OpenCL platform.
+/// </summary>
+/// <param name="Name">Platform name.</param>
+/// <param name="Vendor">Platform vendor.</param>
+/// <param name="Version">Platform version string.</param>
+/// <param name="VersionMajor">Parsed platform major version.</param>
+/// <param name="VersionMinor">Parsed platform minor version.</param>
+/// <param name="Devices">Devices exposed by the platform.</param>
+public sealed record OclPlatformInfo(
+    string Name,
+    string Vendor,
+    string Version,
+    int VersionMajor,
+    int VersionMinor,
+    IReadOnlyList<OclDeviceInfo> Devices);
+
+/// <summary>
+/// A read-only snapshot of an OpenCL device.
+/// </summary>
+/// <param name="Name">Device name.</param>
+/// <param name="VendorName">Device vendor name.</param>
+/// <param name="Version">OpenCV's device version string.</param>
+/// <param name="OpenCLVersion">OpenCL device version string.</param>
+/// <param name="OpenCLCVersion">OpenCL C version string.</param>
+/// <param name="DriverVersion">OpenCL driver version.</param>
+/// <param name="Type">Device type.</param>
+/// <param name="AddressBits">Device address width in bits.</param>
+/// <param name="Available">Whether the device is available.</param>
+/// <param name="CompilerAvailable">Whether the OpenCL compiler is available.</param>
+/// <param name="LinkerAvailable">Whether the OpenCL linker is available.</param>
+/// <param name="MaxClockFrequency">Maximum clock frequency in MHz.</param>
+/// <param name="MaxComputeUnits">Maximum number of parallel compute units.</param>
+/// <param name="GlobalMemorySize">Global memory size in bytes.</param>
+/// <param name="LocalMemorySize">Local memory size in bytes.</param>
+/// <param name="HostUnifiedMemory">Whether the device and host share unified memory.</param>
+/// <param name="ImageSupport">Whether OpenCL image objects are supported.</param>
+public sealed record OclDeviceInfo(
+    string Name,
+    string VendorName,
+    string Version,
+    string OpenCLVersion,
+    string OpenCLCVersion,
+    string DriverVersion,
+    OclDeviceTypes Type,
+    int AddressBits,
+    bool Available,
+    bool CompilerAvailable,
+    bool LinkerAvailable,
+    int MaxClockFrequency,
+    int MaxComputeUnits,
+    ulong GlobalMemorySize,
+    ulong LocalMemorySize,
+    bool HostUnifiedMemory,
+    bool ImageSupport);

--- a/src/OpenCvSharpExtern/core_ocl.h
+++ b/src/OpenCvSharpExtern/core_ocl.h
@@ -6,6 +6,8 @@
 // ReSharper disable CppInconsistentNaming
 // ReSharper disable CppNonInlineFunctionDefinitionInHeaderFile
 
+using OclPlatformInfoVector = std::vector<cv::ocl::PlatformInfo>;
+
 CVAPI(ExceptionStatus) core_ocl_haveOpenCL(int* returnValue)
 {
     return cvTry([&] {
@@ -31,5 +33,96 @@ CVAPI(ExceptionStatus) core_ocl_finish()
 {
     return cvTry([] {
         cv::ocl::finish();
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_getPlatformsInfo(OclPlatformInfoVector** returnValue)
+{
+    return cvTry([&] {
+        auto platformInfo = std::make_unique<OclPlatformInfoVector>();
+        cv::ocl::getPlatfomsInfo(*platformInfo);
+        *returnValue = platformInfo.release();
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_PlatformInfoVector_delete(OclPlatformInfoVector* obj)
+{
+    return cvTry([&] {
+        delete obj;
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_PlatformInfoVector_size(OclPlatformInfoVector* obj, int* returnValue)
+{
+    return cvTry([&] {
+        *returnValue = static_cast<int>(obj->size());
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_PlatformInfoVector_getPlatform(
+    OclPlatformInfoVector* obj,
+    int platformIndex,
+    std::string* name,
+    std::string* vendor,
+    std::string* version,
+    int* versionMajor,
+    int* versionMinor,
+    int* deviceCount)
+{
+    return cvTry([&] {
+        const auto& platform = obj->at(static_cast<size_t>(platformIndex));
+        name->assign(platform.name());
+        vendor->assign(platform.vendor());
+        version->assign(platform.version());
+        *versionMajor = platform.versionMajor();
+        *versionMinor = platform.versionMinor();
+        *deviceCount = platform.deviceNumber();
+    });
+}
+
+CVAPI(ExceptionStatus) core_ocl_PlatformInfoVector_getDevice(
+    OclPlatformInfoVector* obj,
+    int platformIndex,
+    int deviceIndex,
+    std::string* name,
+    std::string* vendorName,
+    std::string* version,
+    std::string* openCLVersion,
+    std::string* openCLCVersion,
+    std::string* driverVersion,
+    int* type,
+    int* addressBits,
+    int* available,
+    int* compilerAvailable,
+    int* linkerAvailable,
+    int* maxClockFrequency,
+    int* maxComputeUnits,
+    uint64_t* globalMemorySize,
+    uint64_t* localMemorySize,
+    int* hostUnifiedMemory,
+    int* imageSupport)
+{
+    return cvTry([&] {
+        const auto& platform = obj->at(static_cast<size_t>(platformIndex));
+        cv::ocl::Device device;
+        platform.getDevice(device, deviceIndex);
+
+        name->assign(device.name());
+        vendorName->assign(device.vendorName());
+        version->assign(device.version());
+        openCLVersion->assign(device.OpenCLVersion());
+        openCLCVersion->assign(device.OpenCL_C_Version());
+        driverVersion->assign(device.driverVersion());
+        *type = device.type();
+        *addressBits = device.addressBits();
+        *available = device.available() ? 1 : 0;
+        *compilerAvailable = device.compilerAvailable() ? 1 : 0;
+        *linkerAvailable = device.linkerAvailable() ? 1 : 0;
+        *maxClockFrequency = device.maxClockFrequency();
+        *maxComputeUnits = device.maxComputeUnits();
+        *globalMemorySize = static_cast<uint64_t>(device.globalMemSize());
+        *localMemorySize = static_cast<uint64_t>(device.localMemSize());
+        *hostUnifiedMemory = device.hostUnifiedMemory() ? 1 : 0;
+        *imageSupport = device.imageSupport() ? 1 : 0;
     });
 }

--- a/test/OpenCvSharp.Tests/core/OclTest.cs
+++ b/test/OpenCvSharp.Tests/core/OclTest.cs
@@ -35,4 +35,37 @@ public class OclTest : TestBase
         using var result = dst.GetMat(AccessFlag.READ);
         Assert.Equal(1, result.At<byte>(0, 0));
     }
+
+    [Fact]
+    public void GetPlatformsInfoReturnsSnapshots()
+    {
+        var platforms = Cv2.Ocl.GetPlatformsInfo();
+
+        if (!Cv2.Ocl.HaveOpenCL())
+        {
+            Assert.Empty(platforms);
+            return;
+        }
+
+        Assert.NotEmpty(platforms);
+        Assert.All(platforms, platform =>
+        {
+            Assert.NotNull(platform.Name);
+            Assert.NotNull(platform.Vendor);
+            Assert.NotNull(platform.Version);
+            Assert.True(platform.VersionMajor >= 0);
+            Assert.True(platform.VersionMinor >= 0);
+            Assert.All(platform.Devices, device =>
+            {
+                Assert.NotNull(device.Name);
+                Assert.NotNull(device.VendorName);
+                Assert.NotNull(device.OpenCLVersion);
+                Assert.NotNull(device.OpenCLCVersion);
+                Assert.NotNull(device.DriverVersion);
+                Assert.True(device.AddressBits >= 0);
+                Assert.True(device.MaxClockFrequency >= 0);
+                Assert.True(device.MaxComputeUnits >= 0);
+            });
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- expose `Cv2.Ocl.GetPlatformsInfo()` as read-only platform and device snapshots
- add `OclPlatformInfo`, `OclDeviceInfo`, and `OclDeviceTypes`
- keep native OpenCL handles internal and return an empty list when OpenCL is unavailable
- add coverage for platform and device snapshot retrieval

Follow-up to #2111.

## Validation
- `cmake --build src\build --config Release --target OpenCvSharpExtern`
- `dotnet build src\OpenCvSharp\OpenCvSharp.csproj -c Release --no-restore`
- `dotnet test test\OpenCvSharp.Tests\OpenCvSharp.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~OpenCvSharp.Tests.Core.OclTest"` (3 passed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCL platform discovery with read-only platform and device information.
  * Exposes platform metadata, device types, versions, availability, compute capabilities, and memory details.
  * Added device type classifications, including CPU, GPU, accelerator, and integrated or discrete GPU.
  * Gracefully returns an empty result when OpenCL is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->