### PR TITLE
Fix double InputArray multi-channel semantics

### DIFF
--- a/src/OpenCvSharp/Modules/core/InputArray.cs
+++ b/src/OpenCvSharp/Modules/core/InputArray.cs
@@ -27,7 +27,7 @@ public enum ArrayProxyKind
     MatExpr = 3,
     /// <summary>A <see cref="Scalar"/> value (inline).</summary>
     Scalar = 4,
-    /// <summary>A scalar <see cref="double"/> value (inline, as Scalar(d,0,0,0)).</summary>
+    /// <summary>A scalar <see cref="double"/> value (inline, as a 1x1 CV_64F input).</summary>
     Double = 5,
     /// <summary>A small fixed-length vector value (inline).</summary>
     Vec = 6,
@@ -137,7 +137,7 @@ public readonly ref struct InputArray
     public static implicit operator InputArray(Scalar s) =>
         new(null, InputArrayProxy.FromScalar(s));
 
-    /// <summary>Wraps a <see cref="double"/> value (no allocation; travels inline as Scalar(d,0,0,0)).</summary>
+    /// <summary>Wraps a <see cref="double"/> value (no allocation; travels inline as a 1x1 CV_64F input).</summary>
     public static implicit operator InputArray(double d) =>
         new(null, new InputArrayProxy { Kind = (int)ArrayProxyKind.Double, Payload0 = d });
 

--- a/src/OpenCvSharpExtern/my_types.h
+++ b/src/OpenCvSharpExtern/my_types.h
@@ -423,11 +423,10 @@ static cv::Moments cpp(const interop::Moments &m)
 // no heap cv::_InputArray is allocated per call. Use the InProxy/OutProxy/IoProxy
 // views below at the head of a CVAPI body.
 //
-// Scalar/Double inputs: cv::_InputArray references a cv::Scalar, so the caller must
-// keep `scalarScratch` alive for the whole OpenCV call (one scratch per input that
-// may be a scalar).
-// Vec inputs: cv::_InputArray references proxy.payload; the by-value parameter copy
-// stays valid for the call.
+// Scalar inputs: cv::_InputArray references a cv::Scalar, so the caller must keep
+// `scalarScratch` alive for the whole OpenCV call (one scratch per scalar input).
+// Double/Vec inputs: cv::_InputArray references proxy.payload; the proxy stays valid
+// for the call.
 // -------------------------------------------------------------------------
 static cv::_InputArray fromInputProxy(const interop::InputArrayProxy &p, cv::Scalar &scalarScratch)
 {
@@ -437,9 +436,9 @@ static cv::_InputArray fromInputProxy(const interop::InputArrayProxy &p, cv::Sca
     case 2: return cv::_InputArray(*static_cast<cv::UMat *>(p.handle));
     case 3: return cv::_InputArray(*static_cast<cv::MatExpr *>(p.handle));
     case 4:
-    case 5:
         scalarScratch = cv::Scalar(p.payload[0], p.payload[1], p.payload[2], p.payload[3]);
         return cv::_InputArray(scalarScratch);
+    case 5: return cv::_InputArray(p.payload[0]);
     case 6:
         switch (p.vecDepth)
         {
@@ -493,10 +492,10 @@ static cv::_InputOutputArray fromInputOutputProxy(const interop::InputOutputArra
 class InProxy
 {
     // Stable storage for a scalar operand. A cv::_InputArray built from a cv::Scalar keeps a POINTER
-    // to that Scalar (it does not copy it), so the Scalar must outlive the _InputArray's use. For
-    // Scalar/Double kinds fromInputProxy() writes scratch_ and returns a cv::_InputArray referencing
+    // to that Scalar (it does not copy it), so the Scalar must outlive the _InputArray's use.
+    // For the Scalar kind, fromInputProxy() writes scratch_ and returns a cv::_InputArray referencing
     // it; holding scratch_ as a member keeps it alive for the whole OpenCV call (the InProxy lives to
-    // the end of the call expression). Unused for Mat/UMat/MatExpr/Vec/Raw kinds.
+    // the end of the call expression). Unused for Mat/UMat/MatExpr/Double/Vec/Raw kinds.
     cv::Scalar scratch_;
     cv::_InputArray ia_;
 public:

--- a/test/OpenCvSharp.Tests/core/InputArrayTest.cs
+++ b/test/OpenCvSharp.Tests/core/InputArrayTest.cs
@@ -53,6 +53,30 @@ public class InputArrayTest : TestBase
     }
 
     [Fact]
+    public void DoubleAndScalar_PreserveDistinctMultiChannelSemantics()
+    {
+        using var src = new Mat(1, 1, MatType.CV_64FC4, Scalar.All(10));
+
+        using var fromDouble = new Mat();
+        Cv2.Add(src, 5.0, fromDouble);
+        Assert.Equal(new Vec4d(15, 15, 15, 15), fromDouble.At<Vec4d>(0, 0));
+
+        using var fromScalar = new Mat();
+        Cv2.Add(src, new Scalar(5), fromScalar);
+        Assert.Equal(new Vec4d(15, 10, 10, 10), fromScalar.At<Vec4d>(0, 0));
+    }
+
+    [Fact]
+    public void Randu_DoubleBoundsBroadcastAcrossChannels()
+    {
+        using var mat = new Mat(1, 1, MatType.CV_8UC4);
+
+        Cv2.Randu(mat, 100, 101);
+
+        Assert.Equal(new Vec4b(100, 100, 100, 100), mat.At<Vec4b>(0, 0));
+    }
+
+    [Fact]
     public void Transpose_Vec_IsAllocationFree()
     {
         var v = new Vec3d(1, 2, 3);


### PR DESCRIPTION
Preserve native OpenCV `double`-to-`InputArray` semantics by reconstructing a 1x1 `CV_64F` input instead of `Scalar(d, 0, 0, 0)`. This restores OpenCvSharp4 behavior for multi-channel scalar-aware operations while leaving explicit `Scalar` values channel-specific.

Add multi-channel `Add` and `Randu` regression coverage.

Fixes #2124

## Test plan

- [x] Build `OpenCvSharpExtern` in Release mode on Windows x64
- [x] Run all `OpenCvSharp.Tests.Core` tests (452 passed, 1 skipped)