### PR TITLE
Bootstrap vcpkg after baseline checkout

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,7 @@ jobs:
           $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
           git -C $env:VCPKG_INSTALLATION_ROOT fetch --depth=1 origin $baseline
           git -C $env:VCPKG_INSTALLATION_ROOT checkout $baseline
+          & "$env:VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Install vcpkg dependencies
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -355,6 +356,7 @@ jobs:
           $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
           git -C $env:VCPKG_INSTALLATION_ROOT fetch --depth=1 origin $baseline
           git -C $env:VCPKG_INSTALLATION_ROOT checkout $baseline
+          & "$env:VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Install vcpkg dependencies
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Run `bootstrap-vcpkg.bat` after the Windows jobs check out the manifest's pinned vcpkg baseline. This keeps the vcpkg executable compatible with the checked-out scripts and fixes the `vcpkg-tools.json` schema mismatch on both x64 and arm64 runners.

## Test plan

- [ ] Windows (x64) workflow completes successfully
- [ ] Windows (arm64) workflow completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Windows builds now bootstrap vcpkg with metrics collection disabled, improving build privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->