### PR TITLE
Reduce pull request cache churn

### DIFF
--- a/.github/workflows/docker-test-ubuntu.yml
+++ b/.github/workflows/docker-test-ubuntu.yml
@@ -3,9 +3,25 @@ name: Docker Test
 on:
   pull_request:
     types: [synchronize, opened]
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/docker-test-ubuntu.yml'
+      - 'cmake/**'
+      - 'global.json'
+      - 'opencv'
+      - 'opencv_contrib'
+      - 'packaging/docker/ubuntu24-dotnet10-opencv5.0.0/**'
+      - 'packaging/docker/ubuntu24-dotnet10-opencv5.0.0-slim/**'
+      - 'src/**'
+      - 'test/**'
+      - 'vcpkg.json'
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   DEBIAN_FRONTEND: noninteractive
@@ -34,11 +50,9 @@ jobs:
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
           outputs: type=cacheonly
           cache-from: |
-            type=gha,scope=full-test-native-${{ github.ref_name }}
             type=gha,scope=full-test-native-main
-            type=gha,scope=full-${{ github.ref_name }}
             type=gha,scope=full-main
-          cache-to: type=gha,mode=min,scope=full-test-native-${{ github.ref_name }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=full-test-native-main' || '' }}
 
       - name: Test .NET class libraries (full)
         uses: docker/build-push-action@v7
@@ -50,11 +64,9 @@ jobs:
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
           outputs: type=cacheonly
           cache-from: |
-            type=gha,scope=full-test-dotnet-${{ github.ref_name }}
             type=gha,scope=full-test-dotnet-main
-            type=gha,scope=full-${{ github.ref_name }}
             type=gha,scope=full-main
-          cache-to: type=gha,mode=min,scope=full-test-dotnet-${{ github.ref_name }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=full-test-dotnet-main' || '' }}
 
       - name: Build with Docker (full)
         uses: docker/build-push-action@v7
@@ -64,10 +76,8 @@ jobs:
           build-args: |
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
           outputs: type=docker,name=shimat/ubuntu24-dotnet10-opencv5.0.0:latest
-          cache-from: |
-            type=gha,scope=full-${{ github.ref_name }}
-            type=gha,scope=full-main
-          cache-to: type=gha,mode=min,scope=full-${{ github.ref_name }}
+          cache-from: type=gha,scope=full-main
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=full-main' || '' }}
 
   build_slim:
     name: Docker (slim)
@@ -89,11 +99,9 @@ jobs:
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
           outputs: type=cacheonly
           cache-from: |
-            type=gha,scope=slim-test-native-${{ github.ref_name }}
             type=gha,scope=slim-test-native-main
-            type=gha,scope=slim-${{ github.ref_name }}
             type=gha,scope=slim-main
-          cache-to: type=gha,mode=min,scope=slim-test-native-${{ github.ref_name }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=slim-test-native-main' || '' }}
 
       - name: Build with Docker (slim)
         uses: docker/build-push-action@v7
@@ -103,7 +111,5 @@ jobs:
           build-args: |
             OPENCV_VERSION=${{ env.OPENCV_VERSION }}
           outputs: type=docker,name=shimat/ubuntu24-dotnet10-opencv5.0.0-slim:latest
-          cache-from: |
-            type=gha,scope=slim-${{ github.ref_name }}
-            type=gha,scope=slim-main
-          cache-to: type=gha,mode=min,scope=slim-${{ github.ref_name }}
+          cache-from: type=gha,scope=slim-main
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=slim-main' || '' }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,10 +5,25 @@ on:
 
   pull_request:
     types: [synchronize, opened, reopened]
+    paths:
+      - '.github/actions/test-rtsp-macos/**'
+      - '.github/workflows/macos.yml'
+      - 'cmake/**'
+      - 'global.json'
+      - 'opencv'
+      - 'opencv_contrib'
+      - 'packaging/nuget/**'
+      - 'src/**'
+      - 'test/**'
+      - 'vcpkg.json'
 
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   OPENCV_VERSION: 5.0.0
@@ -66,7 +81,7 @@ jobs:
             --overlay-ports=${GITHUB_WORKSPACE}/cmake/vcpkg-overlay-ports
 
       - name: Save vcpkg package cache
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
@@ -84,7 +99,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('.github/workflows/macos.yml', 'vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -149,11 +164,11 @@ jobs:
           du -sh ${GITHUB_WORKSPACE}/opencv_artifacts/*/
 
       - name: Save OpenCV cache
-        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.opencv-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('.github/workflows/macos.yml', 'vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
 
       # -- OpenCvSharpExtern ---------------------------------------------------
       - name: Build OpenCvSharpExtern
@@ -227,7 +242,7 @@ jobs:
             --overlay-ports=${GITHUB_WORKSPACE}/cmake/vcpkg-overlay-ports
 
       - name: Save vcpkg package cache
-        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
@@ -245,7 +260,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('.github/workflows/macos.yml', 'vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
@@ -310,11 +325,11 @@ jobs:
           du -sh ${GITHUB_WORKSPACE}/opencv_artifacts/*/
 
       - name: Save OpenCV cache
-        if: steps.opencv-cache.outputs.cache-hit != 'true'
+        if: github.ref == 'refs/heads/main' && steps.opencv-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('.github/workflows/macos.yml', 'vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
 
       # -- OpenCvSharpExtern ---------------------------------------------------
       - name: Build OpenCvSharpExtern

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
     paths:
+      - '.gitmodules'
       - '.github/actions/test-rtsp-macos/**'
       - '.github/workflows/macos.yml'
       - 'cmake/**'
@@ -70,7 +71,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-x64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/libaec/**') }}
+          key: vcpkg-x64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/**') }}
 
       - name: Install packages via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -85,7 +86,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-x64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/libaec/**') }}
+          key: vcpkg-x64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/x64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/**') }}
 
       # -- OpenCV cache --------------------------------------------------------
       - name: Capture OpenCV revisions
@@ -99,19 +100,14 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/opencv_build_options_macos.cmake', 'cmake/triplets/x64-osx-static.cmake', 'cmake/vcpkg-overlay-ports/**') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
         run: |
-          # Disable the ASM language so OpenCV 5's vendored MLAS turns off and DNN
-          # falls back to its built-in SGEMM. The MLAS FP16/GQA path references
-          # MlasHGemmSupported(), which OpenCV 5.0.0 declares and calls but never
-          # defines, breaking the extern link (same fix as windows.yml / linux-arm64.yml).
-          # Image codecs come from vcpkg here, so no other ASM language is needed.
           cmake \
             -G Ninja \
-            -C cmake/opencv_build_options.cmake \
+            -C cmake/opencv_build_options_macos.cmake \
             -S opencv \
             -B opencv/build \
             -D OPENCV_EXTRA_MODULES_PATH=${GITHUB_WORKSPACE}/opencv_contrib/modules \
@@ -120,20 +116,6 @@ jobs:
             -D VCPKG_TARGET_TRIPLET=x64-osx-static \
             -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
             -D CMAKE_OSX_ARCHITECTURES=x86_64 \
-            -D CMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
-            -D BUILD_JPEG=OFF \
-            -D BUILD_PNG=OFF \
-            -D BUILD_TIFF=OFF \
-            -D BUILD_WEBP=OFF \
-            -D BUILD_ZLIB=ON \
-            -D WITH_TBB=OFF \
-            -D WITH_OPENEXR=OFF \
-            -D WITH_JASPER=OFF \
-            -D WITH_OPENGL=OFF \
-            -D WITH_VA=OFF \
-            -D WITH_VA_INTEL=OFF \
-            -D OPENCV_FFMPEG_SKIP_BUILD_CHECK=ON \
-            -D CMAKE_ASM_COMPILER="" \
             2>&1 | tee /tmp/opencv-configure.log
 
       - name: Verify OpenCV cmake features
@@ -168,7 +150,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/x64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-x64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/opencv_build_options_macos.cmake', 'cmake/triplets/x64-osx-static.cmake', 'cmake/vcpkg-overlay-ports/**') }}
 
       # -- OpenCvSharpExtern ---------------------------------------------------
       - name: Build OpenCvSharpExtern
@@ -231,7 +213,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-arm64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/arm64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/libaec/**') }}
+          key: vcpkg-arm64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/arm64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/**') }}
 
       - name: Install packages via vcpkg
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -246,7 +228,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/vcpkg_installed
-          key: vcpkg-arm64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/arm64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/libaec/**') }}
+          key: vcpkg-arm64-osx-static-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('cmake/triplets/arm64-osx-static.cmake') }}-${{ hashFiles('cmake/vcpkg-overlay-ports/**') }}
 
       # -- OpenCV cache --------------------------------------------------------
       - name: Capture OpenCV revisions
@@ -260,19 +242,14 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/opencv_build_options_macos.cmake', 'cmake/triplets/arm64-osx-static.cmake', 'cmake/vcpkg-overlay-ports/**') }}
 
       - name: Configure OpenCV
         if: steps.opencv-cache.outputs.cache-hit != 'true'
         run: |
-          # Disable the ASM language so OpenCV 5's vendored MLAS turns off and DNN
-          # falls back to its built-in SGEMM. The MLAS FP16/GQA path references
-          # MlasHGemmSupported(), which OpenCV 5.0.0 declares and calls but never
-          # defines, breaking the extern link (same fix as windows.yml / linux-arm64.yml).
-          # Image codecs come from vcpkg here, so no other ASM language is needed.
           cmake \
             -G Ninja \
-            -C cmake/opencv_build_options.cmake \
+            -C cmake/opencv_build_options_macos.cmake \
             -S opencv \
             -B opencv/build \
             -D OPENCV_EXTRA_MODULES_PATH=${GITHUB_WORKSPACE}/opencv_contrib/modules \
@@ -281,20 +258,6 @@ jobs:
             -D VCPKG_TARGET_TRIPLET=arm64-osx-static \
             -D VCPKG_INSTALLED_DIR=${GITHUB_WORKSPACE}/vcpkg_installed \
             -D CMAKE_OSX_ARCHITECTURES=arm64 \
-            -D CMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
-            -D BUILD_JPEG=OFF \
-            -D BUILD_PNG=OFF \
-            -D BUILD_TIFF=OFF \
-            -D BUILD_WEBP=OFF \
-            -D BUILD_ZLIB=ON \
-            -D WITH_TBB=OFF \
-            -D WITH_OPENEXR=OFF \
-            -D WITH_JASPER=OFF \
-            -D WITH_OPENGL=OFF \
-            -D WITH_VA=OFF \
-            -D WITH_VA_INTEL=OFF \
-            -D OPENCV_FFMPEG_SKIP_BUILD_CHECK=ON \
-            -D CMAKE_ASM_COMPILER="" \
             2>&1 | tee /tmp/opencv-configure.log
 
       - name: Verify OpenCV cmake features
@@ -329,7 +292,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ github.workspace }}/opencv_artifacts
-          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/triplets/arm64-osx-static.cmake') }}
+          key: opencv-${{ env.OPENCV_VERSION }}-macos-arm64-v${{ env.CACHE_VERSION }}-${{ steps.opencv-revs.outputs.opencv }}-${{ steps.opencv-revs.outputs.contrib }}-${{ hashFiles('vcpkg.json', 'cmake/opencv_build_options.cmake', 'cmake/opencv_build_options_macos.cmake', 'cmake/triplets/arm64-osx-static.cmake', 'cmake/vcpkg-overlay-ports/**') }}
 
       # -- OpenCvSharpExtern ---------------------------------------------------
       - name: Build OpenCvSharpExtern

--- a/cmake/opencv_build_options_macos.cmake
+++ b/cmake/opencv_build_options_macos.cmake
@@ -1,0 +1,28 @@
+# CMake initial cache for macOS OpenCV builds.
+# Keep macOS-specific options here so the workflow can include every effective
+# build option in the OpenCV artifact cache key.
+
+include("${CMAKE_CURRENT_LIST_DIR}/opencv_build_options.cmake")
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "" FORCE)
+
+# Image codecs are provided by vcpkg on macOS.
+set(BUILD_JPEG OFF CACHE BOOL "" FORCE)
+set(BUILD_PNG  OFF CACHE BOOL "" FORCE)
+set(BUILD_TIFF OFF CACHE BOOL "" FORCE)
+set(BUILD_WEBP OFF CACHE BOOL "" FORCE)
+set(BUILD_ZLIB ON  CACHE BOOL "" FORCE)
+
+set(WITH_TBB      OFF CACHE BOOL "" FORCE)
+set(WITH_OPENEXR  OFF CACHE BOOL "" FORCE)
+set(WITH_JASPER   OFF CACHE BOOL "" FORCE)
+set(WITH_OPENGL   OFF CACHE BOOL "" FORCE)
+set(WITH_VA       OFF CACHE BOOL "" FORCE)
+set(WITH_VA_INTEL OFF CACHE BOOL "" FORCE)
+
+set(OPENCV_FFMPEG_SKIP_BUILD_CHECK ON CACHE BOOL "" FORCE)
+
+# Disable the ASM language so OpenCV 5's vendored MLAS turns off and DNN falls
+# back to its built-in SGEMM. The MLAS FP16/GQA path references
+# MlasHGemmSupported(), which OpenCV 5.0.0 declares and calls but never defines.
+set(CMAKE_ASM_COMPILER "" CACHE FILEPATH "" FORCE)


### PR DESCRIPTION
Keep macOS and Docker pull request builds read-only for shared caches so merge-ref-scoped entries do not evict reusable main-branch caches. Cache updates now come only from `main`, while pull requests continue to restore them.

Limit the macOS and Docker workflows to relevant file changes, cancel superseded runs for the same pull request, and make the macOS OpenCV cache key depend on build inputs instead of the entire workflow file.

The repository had reached 10.42 GB across 113 cache entries, exceeding the default 10 GB limit and causing cache eviction.

## Test plan

- [x] Verify workflow diffs with `git diff --check`
- [x] Confirm the main-branch macOS cache reduces the x64 job from 57m 59s to 3m 11s
- [ ] Run the macOS x64 and arm64 workflows
- [ ] Run the Docker full and slim workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Pull-request validation now runs for relevant Docker, build, source, test, and configuration changes.
  - In-progress checks are automatically canceled when a newer run supersedes them.
  - Build and test workflows use consistent caching across branches, with cache updates limited to the main branch.
  - macOS validation now applies the same path filtering and concurrency controls across supported architectures.
  - macOS dependency and OpenCV caches are updated only from the main branch.
  - macOS builds now use centralized platform-specific configuration for more consistent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->